### PR TITLE
feat: deterministic port allocation, artifact auto-creation, and SIGTERM resilience

### DIFF
--- a/runtime/src/sandbox_agent_runtime/application_lifecycle.py
+++ b/runtime/src/sandbox_agent_runtime/application_lifecycle.py
@@ -5,7 +5,6 @@ import contextlib
 import logging
 import os
 import re
-import socket
 from pathlib import Path
 
 import httpx
@@ -19,64 +18,11 @@ _COMPOSE_COMMANDS = (["docker", "compose"], ["docker-compose"])
 # Port 8080 is reserved for the sandbox agent runtime uvicorn.
 _SANDBOX_AGENT_PORT = 8080
 
-# Port ranges for dynamic allocation.
+# Port ranges for deterministic allocation.
 # App HTTP ports: 18080, 18081, 18082, ...
 _APP_HTTP_PORT_BASE = 18080
 # MCP ports: 13100, 13101, 13102, ...
 _MCP_PORT_BASE = 13100
-
-
-def _is_port_available(port: int) -> bool:
-    """Check if a TCP port is available on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(0.5)
-        return sock.connect_ex(("127.0.0.1", port)) != 0
-
-
-def _allocate_ports(
-    apps: list[ResolvedApplication],
-) -> dict[str, tuple[int, int]]:
-    """Pre-allocate unique host ports for each app.
-
-    Returns a mapping of app_id → (http_host_port, mcp_host_port).
-    Checks that each allocated port is actually available before assigning it.
-    Raises RuntimeError if a required port cannot be allocated.
-    """
-    allocations: dict[str, tuple[int, int]] = {}
-    http_port = _APP_HTTP_PORT_BASE
-    mcp_port = _MCP_PORT_BASE
-
-    for app in apps:
-        # Find next available HTTP host port
-        while not _is_port_available(http_port):
-            logger.debug("Port %d in use, skipping", http_port)
-            http_port += 1
-            if http_port > _APP_HTTP_PORT_BASE + 100:
-                raise RuntimeError(
-                    f"Cannot allocate HTTP port for app '{app.app_id}': "
-                    f"ports {_APP_HTTP_PORT_BASE}-{http_port} exhausted"
-                )
-
-        # Find next available MCP host port
-        while not _is_port_available(mcp_port):
-            logger.debug("Port %d in use, skipping", mcp_port)
-            mcp_port += 1
-            if mcp_port > _MCP_PORT_BASE + 100:
-                raise RuntimeError(
-                    f"Cannot allocate MCP port for app '{app.app_id}': ports {_MCP_PORT_BASE}-{mcp_port} exhausted"
-                )
-
-        allocations[app.app_id] = (http_port, mcp_port)
-        logger.info(
-            "Allocated ports for '%s': HTTP=%d, MCP=%d",
-            app.app_id,
-            http_port,
-            mcp_port,
-        )
-        http_port += 1
-        mcp_port += 1
-
-    return allocations
 
 
 def _patch_compose_ports(
@@ -144,9 +90,21 @@ class ApplicationLifecycleManager:
         # Maps app_id → allocated (http_host_port, mcp_host_port)
         self._port_allocations: dict[str, tuple[int, int]] = {}
 
+    def assign_deterministic_ports(self, apps: list[ResolvedApplication]) -> None:
+        """Set port allocations deterministically based on app list order.
+
+        Uses the index of each app in the list (which matches workspace.yaml order)
+        to compute stable ports: HTTP = 18080 + index, MCP = 13100 + index.
+        This ensures the same app always gets the same port across runs.
+        """
+        self._port_allocations = {
+            app.app_id: (_APP_HTTP_PORT_BASE + index, _MCP_PORT_BASE + index)
+            for index, app in enumerate(apps)
+        }
+
     async def start_all(self, apps: list[ResolvedApplication], *, max_retries: int = 2) -> None:
-        # Pre-allocate ports for all apps before starting any of them.
-        self._port_allocations = _allocate_ports(apps)
+        # Assign deterministic ports so the same app always gets the same port.
+        self.assign_deterministic_ports(apps)
 
         for app in apps:
             mcp_host_port = self._get_mcp_host_port(app)
@@ -154,6 +112,9 @@ class ApplicationLifecycleManager:
                 logger.info("App '%s' already healthy on port %d, skipping start", app.app_id, mcp_host_port)
                 self._compose_apps.add(app.app_id)
                 continue
+            # Kill any stale process on this port from a previous sandbox lifecycle.
+            with contextlib.suppress(Exception):
+                await self._kill_allocated_port_listeners(app)
             await self._start_app(app)
             await self._wait_healthy_with_retry(app, max_retries=max_retries)
 
@@ -509,3 +470,40 @@ class ApplicationLifecycleManager:
         )
         with contextlib.suppress(Exception):
             await asyncio.wait_for(proc.wait(), timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace singleton factory
+# ---------------------------------------------------------------------------
+
+_lifecycle_managers: dict[str, ApplicationLifecycleManager] = {}
+
+
+def get_lifecycle_manager(
+    workspace_dir: str | Path,
+    *,
+    holaboss_user_id: str = "",
+) -> ApplicationLifecycleManager:
+    """Return a per-workspace singleton ``ApplicationLifecycleManager``.
+
+    The singleton is keyed by the resolved workspace directory path so that
+    every caller (runner, API endpoints) shares the same manager instance and
+    therefore the same port allocations and process tracking.
+    """
+    key = str(Path(workspace_dir))
+    if key not in _lifecycle_managers:
+        _lifecycle_managers[key] = ApplicationLifecycleManager(
+            workspace_dir=workspace_dir,
+            holaboss_user_id=holaboss_user_id,
+        )
+    manager = _lifecycle_managers[key]
+    if holaboss_user_id and manager._holaboss_user_id and manager._holaboss_user_id != holaboss_user_id:
+        logger.warning(
+            "Overwriting holaboss_user_id for workspace %s: %s → %s",
+            key,
+            manager._holaboss_user_id,
+            holaboss_user_id,
+        )
+    if holaboss_user_id:
+        manager._holaboss_user_id = holaboss_user_id
+    return manager

--- a/runtime/src/sandbox_agent_runtime/runner.py
+++ b/runtime/src/sandbox_agent_runtime/runner.py
@@ -27,7 +27,10 @@ import httpx
 import yaml
 from pydantic import BaseModel, Field
 
-from sandbox_agent_runtime.application_lifecycle import ApplicationLifecycleManager
+from sandbox_agent_runtime.application_lifecycle import (
+    _SANDBOX_AGENT_PORT,
+    ApplicationLifecycleManager,
+)
 from sandbox_agent_runtime.product_config import resolve_product_runtime_config
 from sandbox_agent_runtime.runtime_config_adapter import (
     CompiledWorkspaceRuntimePlan,
@@ -1883,8 +1886,12 @@ async def _restart_opencode_sidecar(
         except TimeoutError:
             pass
         else:
-            _clear_opencode_sidecar_state()
-            raise RuntimeError(f"OpenCode sidecar exited during startup with code {sidecar_process.returncode}")
+            # Exit code -15 (SIGTERM) likely means a concurrent restart killed our
+            # freshly spawned process.  Fall through to the readiness check — the
+            # other restart may have already brought up a healthy sidecar.
+            if sidecar_process.returncode != -15:
+                _clear_opencode_sidecar_state()
+                raise RuntimeError(f"OpenCode sidecar exited during startup with code {sidecar_process.returncode}")
 
         await _wait_for_opencode_ready(
             url=readiness_url,
@@ -2167,6 +2174,137 @@ async def _opencode_chat_submit(
         return
 
     await session_resource.chat(**chat_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Auto-create session artifacts from MCP tool results
+# ---------------------------------------------------------------------------
+
+_ARTIFACT_TOOL_PATTERNS = ("create_post", "create_draft", "publish_post")
+_KNOWN_PLATFORMS = frozenset({"twitter", "linkedin", "reddit"})
+_MODULE_URL_BASE = os.getenv("MODULE_URL_BASE", "http://{platform}.localhost:4000")
+
+# Strong references to fire-and-forget tasks so they aren't garbage-collected.
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+def _parse_tool_result_as_dict(result: Any) -> dict[str, Any] | None:
+    """Parse a tool result into a dict.  MCP tools return JSON-stringified
+    text, so the result may be a raw string that needs parsing."""
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def _extract_platform(tool_name: str) -> str:
+    """Derive the platform slug from a tool name.
+
+    Checks known platforms first (exact prefix match), then falls back to the
+    first underscore-delimited segment of the tool name.
+    """
+    for known in _KNOWN_PLATFORMS:
+        if tool_name.startswith(known):
+            return known
+    return tool_name.split("_")[0]
+
+
+def _extract_artifact_fields(
+    payload: dict[str, Any],
+) -> tuple[str, str, str, dict[str, Any]] | None:
+    """Extract (tool_name, platform, resource_id, parsed_result) from a
+    completed tool_call payload, or return ``None`` if the payload doesn't
+    match an artifact-producing tool."""
+    if payload.get("phase") != "completed" or payload.get("error"):
+        return None
+    tool_name = str(payload.get("tool_name", ""))
+    if not any(p in tool_name for p in _ARTIFACT_TOOL_PATTERNS):
+        return None
+    result = _parse_tool_result_as_dict(payload.get("result"))
+    if result is None:
+        return None
+    resource_id = str(result.get("id") or result.get("post_id") or "").strip()
+    if not resource_id:
+        return None
+    platform = _extract_platform(tool_name)
+    return tool_name, platform, resource_id, result
+
+
+def _enrich_tool_payload_with_module_url(
+    payload: dict[str, Any],
+    *,
+    holaboss_user_id: str,
+) -> dict[str, Any]:
+    """Inject ``module_url`` into a completed tool_call payload when the result
+    looks like a post-creation response, so the frontend can render an iframe
+    preview immediately."""
+    fields = _extract_artifact_fields(payload)
+    if fields is None:
+        return payload
+    _tool_name, platform, resource_id, result = fields
+
+    if platform and holaboss_user_id:
+        base = _MODULE_URL_BASE.format(platform=platform)
+        module_url_value = f"{base}/posts/{resource_id}?_uid={holaboss_user_id}"
+        enriched_result = {**result, "module_url": module_url_value}
+        return {**payload, "result": enriched_result}
+    return payload
+
+
+async def _maybe_create_tool_artifact(
+    *,
+    tool_payload: dict[str, Any],
+    session_id: str,
+    workspace_id: str,
+    input_id: str,
+    holaboss_user_id: str,
+) -> None:
+    """Fire-and-forget: create a session artifact + output when a tool call
+    produces a post-like resource.  Errors are logged, never propagated."""
+    try:
+        fields = _extract_artifact_fields(tool_payload)
+        if fields is None:
+            return
+        tool_name, platform, resource_id, result = fields
+
+        content_preview = str(result.get("title") or result.get("content") or "").strip()
+        title = content_preview[:80] if content_preview else f"{platform} post"
+
+        metadata = {
+            "input_id": input_id,
+            "tool_name": tool_name,
+            "module_id": platform,
+            "module_resource_id": resource_id,
+            "status": str(result.get("status", "")),
+        }
+
+        artifact_url = f"http://127.0.0.1:{_SANDBOX_AGENT_PORT}/api/v1/agent-sessions/{session_id}/artifacts"
+        body = {
+            "workspace_id": workspace_id,
+            "artifact_type": "draft",
+            "external_id": resource_id,
+            "platform": platform,
+            "title": title,
+            "metadata": metadata,
+        }
+
+        async with httpx.AsyncClient(trust_env=False) as client:
+            resp = await client.post(artifact_url, json=body, timeout=5)
+            if resp.status_code >= 400:
+                logger.warning(
+                    "Auto artifact creation returned %d for session=%s tool=%s",
+                    resp.status_code,
+                    session_id,
+                    tool_name,
+                )
+    except Exception as exc:
+        logger.debug("Auto artifact creation failed (non-fatal): %s", exc)
 
 
 async def _opencode_get_mcp_status(*, client: Any) -> dict[str, Any]:
@@ -3664,6 +3802,25 @@ async def _execute_request_opencode(request: RunnerRequest) -> int:
                                 instruction=request.instruction,
                             ):
                                 continue
+
+                            # Enrich tool_call payloads with module_url and auto-create artifacts.
+                            if event_type == _EVENT_TOOL_CALL:
+                                payload = _enrich_tool_payload_with_module_url(
+                                    payload,
+                                    holaboss_user_id=_explicit_holaboss_user_id(request.context),
+                                )
+                                if payload.get("phase") == "completed" and not payload.get("error"):
+                                    task = asyncio.create_task(
+                                        _maybe_create_tool_artifact(
+                                            tool_payload=payload,
+                                            session_id=request.session_id,
+                                            workspace_id=request.workspace_id,
+                                            input_id=request.input_id,
+                                            holaboss_user_id=_explicit_holaboss_user_id(request.context),
+                                        )
+                                    )
+                                    _background_tasks.add(task)
+                                    task.add_done_callback(_background_tasks.discard)
 
                             if event_type == _EVENT_OUTPUT_DELTA:
                                 delta = payload.get("delta")

--- a/runtime/tests/sandbox_agent_runtime/test_application_lifecycle.py
+++ b/runtime/tests/sandbox_agent_runtime/test_application_lifecycle.py
@@ -7,8 +7,6 @@ import httpx
 import pytest
 from sandbox_agent_runtime.application_lifecycle import (
     ApplicationLifecycleManager,
-    _allocate_ports,
-    _is_port_available,
     _patch_compose_ports,
 )
 from sandbox_agent_runtime.runtime_config.models import (
@@ -228,38 +226,21 @@ async def test_start_app_raises_when_no_start_command() -> None:
         await manager._start_app(app)
 
 
-# --- Port allocation tests ---
+# --- Deterministic port allocation tests ---
 
 
-def test_is_port_available_returns_true_for_unused_port() -> None:
-    # Port 19999 is very unlikely to be in use
-    assert _is_port_available(19999) is True
-
-
-def test_is_port_available_returns_false_for_used_port() -> None:
-    import socket
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.listen(1)
-    try:
-        assert _is_port_available(port) is False
-    finally:
-        sock.close()
-
-
-def test_allocate_ports_assigns_unique_ports_per_app() -> None:
+def test_assign_deterministic_ports_assigns_unique_ports_per_app() -> None:
+    manager = ApplicationLifecycleManager(workspace_dir="/workspace/test-ws")
     apps = [
         _make_app("twitter-module"),
         _make_app("linkedin-module"),
         _make_app("reddit-module"),
     ]
-    allocations = _allocate_ports(apps)
+    manager.assign_deterministic_ports(apps)
 
-    assert len(allocations) == 3
-    http_ports = [v[0] for v in allocations.values()]
-    mcp_ports = [v[1] for v in allocations.values()]
+    assert len(manager._port_allocations) == 3
+    http_ports = [v[0] for v in manager._port_allocations.values()]
+    mcp_ports = [v[1] for v in manager._port_allocations.values()]
 
     # All ports must be unique
     assert len(set(http_ports)) == 3
@@ -269,34 +250,28 @@ def test_allocate_ports_assigns_unique_ports_per_app() -> None:
     assert not set(http_ports) & set(mcp_ports)
 
 
-def test_allocate_ports_all_same_declared_port_still_unique() -> None:
-    """Even when all apps declare the same MCP port, allocated host ports are unique."""
+def test_assign_deterministic_ports_stable_across_calls() -> None:
+    """Same app list order always produces the same port assignments."""
+    manager = ApplicationLifecycleManager(workspace_dir="/workspace/test-ws")
     apps = [_make_app(f"app-{i}") for i in range(5)]
-    # All apps declare mcp.port=3099
-    allocations = _allocate_ports(apps)
 
-    mcp_ports = [v[1] for v in allocations.values()]
-    assert len(set(mcp_ports)) == 5
+    manager.assign_deterministic_ports(apps)
+    first = dict(manager._port_allocations)
+
+    manager.assign_deterministic_ports(apps)
+    second = dict(manager._port_allocations)
+
+    assert first == second
 
 
-def test_allocate_ports_skips_occupied_ports() -> None:
-    """If a port in the range is occupied, allocation skips it."""
-    import socket
+def test_assign_deterministic_ports_index_based() -> None:
+    """Ports are derived from list index: HTTP=18080+i, MCP=13100+i."""
+    manager = ApplicationLifecycleManager(workspace_dir="/workspace/test-ws")
+    apps = [_make_app("app-a"), _make_app("app-b")]
+    manager.assign_deterministic_ports(apps)
 
-    # Occupy the first MCP port in the range
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("127.0.0.1", 13100))
-    sock.listen(1)
-    try:
-        apps = [_make_app("my-app")]
-        allocations = _allocate_ports(apps)
-        allocated_mcp = allocations["my-app"][1]
-        # Should have skipped 13100 and allocated 13101+
-        assert allocated_mcp != 13100
-        assert allocated_mcp >= 13101
-    finally:
-        sock.close()
+    assert manager._port_allocations["app-a"] == (18080, 13100)
+    assert manager._port_allocations["app-b"] == (18081, 13101)
 
 
 def test_patch_compose_ports_rewrites_both_ports(tmp_path: object) -> None:


### PR DESCRIPTION
Ports three improvements from the upstream backend into the OSS runtime:

**Deterministic port allocation** — replaces dynamic free-port scanning with index-based assignment (`HTTP = 18080 + idx`, `MCP = 13100 + idx`). Apps now get the same port across restarts, eliminating port conflicts when modules restart concurrently. Adds `get_lifecycle_manager()` singleton so other components can look up allocated ports.

**Auto-create session artifacts from tool results** — when MCP tools like `create_post` or `publish_post` complete, the runtime automatically creates a session artifact record and injects a `module_url` into the event payload. This allows frontends to render inline previews without extra API calls.

**SIGTERM handling during sidecar restart** — exit code -15 (SIGTERM) during OpenCode sidecar startup is now treated as a non-fatal signal rather than raising `RuntimeError`. Concurrent restarts that kill a freshly spawned process fall through to the readiness check instead of crashing.

No breaking changes. No migration required.