### PR TITLE
feat: persistent app port allocation + PM2 in sandbox toolchain

### DIFF
--- a/runtime/api-server/package-lock.json
+++ b/runtime/api-server/package-lock.json
@@ -804,9 +804,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,9 +818,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,9 +832,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -855,9 +846,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -872,9 +860,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,9 +874,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,9 +888,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,9 +902,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -940,9 +916,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -957,9 +930,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -974,9 +944,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -991,9 +958,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1008,9 +972,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1579,6 +1540,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2021,6 +1983,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2445,6 +2408,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3212,6 +3176,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3246,6 +3211,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3345,6 +3311,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/runtime/deploy/Dockerfile.toolchain
+++ b/runtime/deploy/Dockerfile.toolchain
@@ -21,7 +21,7 @@ RUN apt-get update \
       > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs docker-ce docker-ce-cli containerd.io docker-compose-plugin fuse-overlayfs tini \
-    && npm install -g npm@latest \
+    && npm install -g npm@latest pm2 \
     && if [ "${INSTALL_QMD}" = "1" ]; then npm install -g @tobilu/qmd; fi \
     && if [ "${INSTALL_QMD}" = "1" ] && [ "${ENABLE_QMD_PREWARM}" = "1" ]; then \
          mkdir -p /tmp/qmd-preload-build \

--- a/runtime/state-store/package-lock.json
+++ b/runtime/state-store/package-lock.json
@@ -594,9 +594,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,9 +608,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -628,9 +622,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,9 +636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,9 +650,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,9 +664,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,9 +678,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,9 +692,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,9 +706,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,9 +720,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,9 +734,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,9 +748,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,9 +762,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,6 +1119,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1476,6 +1438,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1972,6 +1935,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2004,6 +1968,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/runtime/state-store/src/index.ts
+++ b/runtime/state-store/src/index.ts
@@ -1,5 +1,6 @@
 export {
   type AppBuildRecord,
+  type AppPortRecord,
   RuntimeStateStore,
   runtimeDbPath,
   sanitizeWorkspaceId,

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -513,3 +513,76 @@ test("task proposals round trip supports create, list, unreviewed, get, and stat
   assert.equal(updated.state, "accepted");
   store.close();
 });
+
+test("allocateAppPort assigns sequential ports starting from 3001", () => {
+  const root = makeTempDir("hb-store-ports-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "test.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  const p1 = store.allocateAppPort({ workspaceId: "ws-1", appId: "gmail" });
+  const p2 = store.allocateAppPort({ workspaceId: "ws-1", appId: "sheets" });
+
+  assert.equal(p1.port, 3001);
+  assert.equal(p2.port, 3002);
+  assert.equal(p1.appId, "gmail");
+  assert.equal(p2.appId, "sheets");
+
+  store.close();
+});
+
+test("allocateAppPort reuses existing port for same app", () => {
+  const root = makeTempDir("hb-store-ports-reuse-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "test.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  const p1 = store.allocateAppPort({ workspaceId: "ws-1", appId: "gmail" });
+  const p2 = store.allocateAppPort({ workspaceId: "ws-1", appId: "gmail" });
+
+  assert.equal(p1.port, p2.port);
+
+  store.close();
+});
+
+test("listAppPorts returns all ports for workspace", () => {
+  const root = makeTempDir("hb-store-ports-list-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "test.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  store.allocateAppPort({ workspaceId: "ws-1", appId: "gmail" });
+  store.allocateAppPort({ workspaceId: "ws-1", appId: "sheets" });
+  store.allocateAppPort({ workspaceId: "ws-2", appId: "github" });
+
+  const ws1Ports = store.listAppPorts({ workspaceId: "ws-1" });
+  assert.equal(ws1Ports.length, 2);
+
+  const ws2Ports = store.listAppPorts({ workspaceId: "ws-2" });
+  assert.equal(ws2Ports.length, 1);
+
+  store.close();
+});
+
+test("deleteAppPort removes port and frees it for reuse", () => {
+  const root = makeTempDir("hb-store-ports-delete-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "test.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  const p1 = store.allocateAppPort({ workspaceId: "ws-1", appId: "gmail" });
+  store.deleteAppPort({ workspaceId: "ws-1", appId: "gmail" });
+
+  const deleted = store.getAppPort({ workspaceId: "ws-1", appId: "gmail" });
+  assert.equal(deleted, null);
+
+  // Port should be available again
+  const p2 = store.allocateAppPort({ workspaceId: "ws-1", appId: "twitter" });
+  assert.equal(p2.port, p1.port);
+
+  store.close();
+});

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -135,6 +135,14 @@ export interface AppBuildRecord {
   updatedAt: string;
 }
 
+export interface AppPortRecord {
+  workspaceId: string;
+  appId: string;
+  port: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CronjobRecord {
   id: string;
   workspaceId: string;
@@ -1268,6 +1276,94 @@ export class RuntimeStateStore {
     return result.changes > 0;
   }
 
+  // --- App Ports ---
+
+  allocateAppPort(params: { workspaceId: string; appId: string }): AppPortRecord {
+    const now = utcNowIso();
+
+    // Check if this app already has a port assigned
+    const existing = this.getAppPort({ workspaceId: params.workspaceId, appId: params.appId });
+    if (existing) {
+      return existing;
+    }
+
+    // Find next available port
+    const port = this.findAvailablePort();
+
+    // Upsert
+    this.db().prepare(`
+      INSERT INTO app_ports (workspace_id, app_id, port, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT (workspace_id, app_id)
+      DO UPDATE SET port = ?, updated_at = ?
+    `).run(params.workspaceId, params.appId, port, now, now, port, now);
+
+    return { workspaceId: params.workspaceId, appId: params.appId, port, createdAt: now, updatedAt: now };
+  }
+
+  getAppPort(params: { workspaceId: string; appId: string }): AppPortRecord | null {
+    const row = this.db()
+      .prepare<[string, string], Record<string, unknown>>(
+        "SELECT * FROM app_ports WHERE workspace_id = ? AND app_id = ? LIMIT 1"
+      )
+      .get(params.workspaceId, params.appId);
+    return row ? this.rowToAppPort(row) : null;
+  }
+
+  listAppPorts(params: { workspaceId: string }): AppPortRecord[] {
+    const rows = this.db()
+      .prepare<[string], Record<string, unknown>>(
+        "SELECT * FROM app_ports WHERE workspace_id = ?"
+      )
+      .all(params.workspaceId);
+    return rows.map((row) => this.rowToAppPort(row));
+  }
+
+  listAllAppPorts(): AppPortRecord[] {
+    const rows = this.db()
+      .prepare<[], Record<string, unknown>>(
+        "SELECT * FROM app_ports"
+      )
+      .all();
+    return rows.map((row) => this.rowToAppPort(row));
+  }
+
+  deleteAppPort(params: { workspaceId: string; appId: string }): boolean {
+    const result = this.db()
+      .prepare("DELETE FROM app_ports WHERE workspace_id = ? AND app_id = ?")
+      .run(params.workspaceId, params.appId);
+    return result.changes > 0;
+  }
+
+  private findAvailablePort(): number {
+    const BASE_PORT = 3001;
+    const MAX_PORT = 3100;
+
+    const allocated = new Set(
+      this.db()
+        .prepare<[], { port: number }>("SELECT port FROM app_ports")
+        .all()
+        .map((r) => r.port)
+    );
+
+    for (let port = BASE_PORT; port <= MAX_PORT; port++) {
+      if (!allocated.has(port)) {
+        return port;
+      }
+    }
+    throw new Error("No available ports in range 3001-3100");
+  }
+
+  private rowToAppPort(row: Record<string, unknown>): AppPortRecord {
+    return {
+      workspaceId: String(row.workspace_id ?? ""),
+      appId: String(row.app_id ?? ""),
+      port: Number(row.port ?? 0),
+      createdAt: String(row.created_at ?? ""),
+      updatedAt: String(row.updated_at ?? ""),
+    };
+  }
+
   createCronjob(params: {
     workspaceId: string;
     initiatedBy: string;
@@ -1696,6 +1792,18 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_app_builds_workspace
           ON app_builds (workspace_id);
+
+      CREATE TABLE IF NOT EXISTS app_ports (
+          workspace_id TEXT NOT NULL,
+          app_id TEXT NOT NULL,
+          port INTEGER NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (workspace_id, app_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_app_ports_workspace
+          ON app_ports (workspace_id);
 
       CREATE TABLE IF NOT EXISTS cronjobs (
           id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

Replace the fragile index-based port calculation for sandbox apps with persistent SQLite-backed port allocation, and add PM2 to the sandbox toolchain image for future process management improvements.

## Problem

Current port assignment calculates ports from an app's array index in `workspace.yaml`:
- `apps[0]` → 18080/13100, `apps[1]` → 18081/13101
- If an app is removed, all subsequent apps' ports shift — orphaning running processes
- Port records exist only in memory — lost on API server restart
- Health checks probe calculated ports that may not match actual bound ports

## Changes

**State-store (`runtime/state-store/`):**
- New `app_ports` table: `(workspace_id, app_id, port)` with composite PK
- `allocateAppPort()` — allocates next available port in 3001-3100 range, reuses existing allocation for same app
- `getAppPort()` / `listAppPorts()` / `listAllAppPorts()` / `deleteAppPort()`
- 4 tests: sequential allocation, idempotent reuse, workspace-scoped listing, delete + reuse

**Dockerfile.toolchain:**
- Add `pm2` to global npm packages (alongside npm, qmd, opencode-ai)

## What this does NOT change (yet)

- App start/stop still uses raw `spawn` — PM2 lifecycle integration is a follow-up
- Port allocation is not yet wired into the start route — follow-up PR
- These are additive, non-breaking changes

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [x] `npm run build` succeeds (state-store + api-server)
- [x] state-store tests: 23 pass (including 4 new app_ports tests)
- [x] api-server tests: 154 pass