### PR TITLE
fix: restore agent-owned onboarding opener flow

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -1548,13 +1548,6 @@ interface HolabossCreateWorkspacePayload {
   template_commit?: string | null;
 }
 
-interface WorkspaceOnboardingGuidePayload {
-  absolute_path: string;
-  body_markdown: string;
-  is_structured: boolean;
-  opening_sentence: string | null;
-}
-
 interface TemplateFolderSelectionPayload {
   canceled: boolean;
   rootPath: string | null;
@@ -5368,8 +5361,6 @@ function renderEmptyWorkspaceYaml() {
 
 function renderEmptyOnboardingGuide() {
   return [
-    "opening_sentence: What is the primary goal for this workspace?",
-    "",
     "# Workspace Onboarding",
     "",
     "Use this conversation to set up the workspace before regular execution starts.",
@@ -5394,58 +5385,6 @@ function renderEmptyOnboardingGuide() {
     "- Ask the user to confirm the summary is correct.",
     "- When the user confirms, request onboarding completion."
   ].join("\n");
-}
-
-function parseOnboardingGuideContent(content: string): {
-  openingSentence: string;
-  bodyMarkdown: string;
-  isStructured: boolean;
-} {
-  const lines = content.replace(/\r\n/g, "\n").split("\n");
-  let index = 0;
-  while (index < lines.length && !lines[index]?.trim()) {
-    index += 1;
-  }
-
-  let openingSentence = "";
-  let isStructured = false;
-  const openingLine = lines[index] ?? "";
-  const openingMatch = openingLine.match(/^opening_sentence\s*:\s*(.+)$/i);
-  if (openingMatch) {
-    isStructured = true;
-    openingSentence = openingMatch[1].trim().replace(/^['"]|['"]$/g, "").trim();
-    index += 1;
-    while (index < lines.length && !lines[index]?.trim()) {
-      index += 1;
-    }
-  }
-
-  return {
-    openingSentence,
-    bodyMarkdown: lines.slice(index).join("\n").trim(),
-    isStructured
-  };
-}
-
-async function readWorkspaceOnboardingGuide(workspaceId: string): Promise<WorkspaceOnboardingGuidePayload> {
-  const absolutePath = path.join(workspaceDirectoryPath(workspaceId), "ONBOARD.md");
-  try {
-    const content = await fs.readFile(absolutePath, "utf-8");
-    const parsed = parseOnboardingGuideContent(content);
-    return {
-      absolute_path: absolutePath,
-      body_markdown: parsed.bodyMarkdown,
-      is_structured: parsed.isStructured,
-      opening_sentence: parsed.openingSentence || null
-    };
-  } catch {
-    return {
-      absolute_path: absolutePath,
-      body_markdown: "",
-      is_structured: false,
-      opening_sentence: null
-    };
-  }
 }
 
 async function createWorkspace(payload: HolabossCreateWorkspacePayload): Promise<WorkspaceResponsePayload> {
@@ -5553,19 +5492,15 @@ async function createWorkspace(payload: HolabossCreateWorkspacePayload): Promise
 
     let onboardingStatus = "NOT_REQUIRED";
     let onboardingSessionId: string | null = null;
-    let shouldQueueOnboardingBootstrap = false;
     try {
       const onboardContent = await fs.readFile(path.join(workspaceDir, "ONBOARD.md"), "utf-8");
       if (onboardContent.trim()) {
-        const parsedOnboardingGuide = parseOnboardingGuideContent(onboardContent);
         onboardingStatus = "PENDING";
         onboardingSessionId = crypto.randomUUID();
-        shouldQueueOnboardingBootstrap = !parsedOnboardingGuide.openingSentence;
       }
     } catch {
       onboardingStatus = "NOT_REQUIRED";
       onboardingSessionId = null;
-      shouldQueueOnboardingBootstrap = false;
     }
 
     let updated = await requestRuntimeJson<WorkspaceResponsePayload>({
@@ -5578,7 +5513,7 @@ async function createWorkspace(payload: HolabossCreateWorkspacePayload): Promise
         error_message: null
       }
     });
-    if (onboardingSessionId && shouldQueueOnboardingBootstrap) {
+    if (onboardingSessionId) {
       try {
         await requestRuntimeJson<EnqueueSessionInputResponsePayload>({
           method: "POST",
@@ -9335,9 +9270,6 @@ app.whenReady().then(async () => {
   handleTrustedIpc("workspace:listOutputs", ["main"], async (_event, workspaceId: string) => listOutputs(workspaceId));
   handleTrustedIpc("workspace:listSkills", ["main"], async (_event, workspaceId: string) => listWorkspaceSkills(workspaceId));
   handleTrustedIpc("workspace:getWorkspaceRoot", ["main"], async (_event, workspaceId: string) => workspaceDirectoryPath(workspaceId));
-  handleTrustedIpc("workspace:getOnboardingGuide", ["main"], async (_event, workspaceId: string) =>
-    readWorkspaceOnboardingGuide(workspaceId)
-  );
   handleTrustedIpc("workspace:createWorkspace", ["main"], async (_event, payload: HolabossCreateWorkspacePayload) => createWorkspace(payload));
   handleTrustedIpc("workspace:deleteWorkspace", ["main"], async (_event, workspaceId: string) => deleteWorkspace(workspaceId));
   handleTrustedIpc("workspace:listCronjobs", ["main"], async (_event, workspaceId: string, enabledOnly?: boolean) =>

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -597,8 +597,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
     listSkills: (workspaceId: string) =>
       ipcRenderer.invoke("workspace:listSkills", workspaceId) as Promise<WorkspaceSkillListResponsePayload>,
     getWorkspaceRoot: (workspaceId: string) => ipcRenderer.invoke("workspace:getWorkspaceRoot", workspaceId) as Promise<string>,
-    getOnboardingGuide: (workspaceId: string) =>
-      ipcRenderer.invoke("workspace:getOnboardingGuide", workspaceId) as Promise<WorkspaceOnboardingGuidePayload>,
     createWorkspace: (payload: HolabossCreateWorkspacePayload) =>
       ipcRenderer.invoke("workspace:createWorkspace", payload) as Promise<WorkspaceResponsePayload>,
     deleteWorkspace: (workspaceId: string) =>

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -571,7 +571,6 @@ export function ChatPane({
     clientHeight: 0
   });
   const [streamTelemetry, setStreamTelemetry] = useState<StreamTelemetryEntry[]>([]);
-  const [onboardingGuide, setOnboardingGuide] = useState<WorkspaceOnboardingGuidePayload | null>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesContentRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -895,39 +894,79 @@ export function ChatPane({
           }
         }
 
-        setMessages(
-          history.messages
-            .map((message) => {
-              const attachments = attachmentsFromMetadata(message.metadata);
-              const nextMessage: ChatMessage = {
-                id: message.id || `history-${message.created_at ?? crypto.randomUUID()}`,
-                role: message.role as ChatMessage["role"],
-                text: message.text,
-                attachments
-              };
+        const nextMessages = history.messages
+          .map((message) => {
+            const attachments = attachmentsFromMetadata(message.metadata);
+            const nextMessage: ChatMessage = {
+              id: message.id || `history-${message.created_at ?? crypto.randomUUID()}`,
+              role: message.role as ChatMessage["role"],
+              text: message.text,
+              attachments
+            };
 
-              if (nextMessage.role === "assistant") {
-                const inputId = inputIdFromMessageId(nextMessage.id, "assistant");
-                if (inputId) {
-                  const restoredAssistantState = assistantHistoryStateFromOutputEvents(outputEventsByInputId.get(inputId) ?? []);
-                  if (restoredAssistantState.thinkingText) {
-                    nextMessage.thinkingText = restoredAssistantState.thinkingText;
-                  }
-                  if (restoredAssistantState.traceSteps) {
-                    nextMessage.traceSteps = restoredAssistantState.traceSteps;
-                  }
+            if (nextMessage.role === "assistant") {
+              const inputId = inputIdFromMessageId(nextMessage.id, "assistant");
+              if (inputId) {
+                const restoredAssistantState = assistantHistoryStateFromOutputEvents(outputEventsByInputId.get(inputId) ?? []);
+                if (restoredAssistantState.thinkingText) {
+                  nextMessage.thinkingText = restoredAssistantState.thinkingText;
+                }
+                if (restoredAssistantState.traceSteps) {
+                  nextMessage.traceSteps = restoredAssistantState.traceSteps;
                 }
               }
+            }
 
-              return nextMessage;
-            })
-            .filter(
-              (message) =>
-                (message.role === "user" || message.role === "assistant") &&
-                hasRenderableMessageContent(message.text, message.attachments ?? [])
-            )
-        );
+            return nextMessage;
+          })
+          .filter(
+            (message) =>
+              (message.role === "user" || message.role === "assistant") &&
+              hasRenderableMessageContent(message.text, message.attachments ?? [])
+          );
+
+        setMessages(nextMessages);
         resetLiveTurn();
+
+        const onboardingSessionId = (selectedWorkspaceRef.current?.onboarding_session_id || "").trim();
+        const currentRuntimeState = runtimeStates.items.find((item) => item.session_id === nextSessionId);
+        const hasAssistantMessage = nextMessages.some((message) => message.role === "assistant");
+        const shouldAttachOnboardingBootstrapStream =
+          isOnboardingVariant &&
+          nextSessionId === onboardingSessionId &&
+          !hasAssistantMessage &&
+          !activeStreamIdRef.current &&
+          !pendingInputIdRef.current &&
+          ["BUSY", "QUEUED"].includes(runtimeStateStatus(currentRuntimeState?.status));
+
+        if (shouldAttachOnboardingBootstrapStream) {
+          setIsResponding(true);
+          setLiveAgentStatus("Preparing first question...");
+          setChatErrorMessage("");
+          const stream = await window.electronAPI.workspace.openSessionOutputStream({
+            sessionId: nextSessionId,
+            workspaceId: selectedWorkspaceId,
+            includeHistory: true,
+            stopOnTerminal: true
+          });
+          if (cancelled) {
+            await closeStreamWithReason(stream.streamId, "load_history_cancelled").catch(() => undefined);
+            return;
+          }
+          activeStreamIdRef.current = stream.streamId;
+          appendStreamTelemetry({
+            streamId: stream.streamId,
+            transportType: "client",
+            eventName: "openSessionOutputStream",
+            eventType: "stream_open_onboarding_bootstrap",
+            inputId: "",
+            sessionId: nextSessionId,
+            action: "stream_requested_onboarding_bootstrap",
+            detail: "attached to in-flight onboarding opener"
+          });
+        } else if (!activeStreamIdRef.current && !pendingInputIdRef.current) {
+          setIsResponding(false);
+        }
       } catch (error) {
         if (!cancelled) {
           setChatErrorMessage(normalizeErrorMessage(error));
@@ -944,6 +983,7 @@ export function ChatPane({
       cancelled = true;
     };
   }, [
+    isOnboardingVariant,
     selectedWorkspaceId,
     selectedWorkspace?.main_session_id,
     selectedWorkspace?.onboarding_session_id,
@@ -964,32 +1004,6 @@ export function ChatPane({
       cancelled = true;
     };
   }, []);
-
-  useEffect(() => {
-    if (!selectedWorkspaceId || !isOnboardingVariant) {
-      setOnboardingGuide(null);
-      return;
-    }
-
-    setOnboardingGuide(null);
-    let cancelled = false;
-    void window.electronAPI.workspace
-      .getOnboardingGuide(selectedWorkspaceId)
-      .then((guide) => {
-        if (!cancelled) {
-          setOnboardingGuide(guide);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setOnboardingGuide(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOnboardingVariant, selectedWorkspaceId]);
 
   useEffect(() => {
     if (!verboseTelemetryEnabled) {
@@ -1735,17 +1749,10 @@ export function ChatPane({
   const assistantMode = isOnboardingVariant
     ? "workspace setup"
     : assistantMetaLabel(selectedWorkspace?.harness, runtimeConfig?.defaultModel);
-  const onboardingOpeningSentence = isOnboardingVariant ? (onboardingGuide?.opening_sentence || "").trim() : "";
-  const shouldShowOnboardingOpeningSentence =
-    Boolean(onboardingOpeningSentence) &&
-    !messages.some((message) => message.role === "assistant" && message.text.trim() === onboardingOpeningSentence);
+  const showLiveAssistantTurn = isResponding || Boolean(liveAssistantText) || Boolean(liveThinkingText) || liveTraceSteps.length > 0;
   const hasMessages =
     messages.length > 0 ||
-    shouldShowOnboardingOpeningSentence ||
-    Boolean(liveAssistantText) ||
-    Boolean(liveThinkingText) ||
-    liveTraceSteps.length > 0;
-  const showLiveAssistantTurn = isResponding || Boolean(liveAssistantText) || Boolean(liveThinkingText) || liveTraceSteps.length > 0;
+    showLiveAssistantTurn;
   const streamTelemetryTail = useMemo(() => streamTelemetry.slice(-80).reverse(), [streamTelemetry]);
   const pendingAttachmentItems = useMemo(
     () =>
@@ -1976,19 +1983,6 @@ export function ChatPane({
                   ref={messagesContentRef}
                   className="mx-auto flex w-full max-w-[860px] flex-col gap-7 pb-3 pl-4 pr-10 pt-5 sm:pl-5 sm:pr-11"
                 >
-                  {shouldShowOnboardingOpeningSentence ? (
-                    <AssistantTurn
-                      label={assistantLabel}
-                      mode={assistantMode}
-                      text={onboardingOpeningSentence}
-                      thinkingCollapsed
-                      onToggleThinking={() => undefined}
-                      traceSteps={[]}
-                      collapsedTraceByStepId={{}}
-                      onToggleTraceStep={() => undefined}
-                    />
-                  ) : null}
-
                   {messages.map((message) =>
                     message.role === "user" ? (
                       <UserTurn key={message.id} text={message.text} attachments={message.attachments ?? []} />

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -39,13 +39,6 @@ declare global {
     createdAt: string;
   }
 
-  interface WorkspaceOnboardingGuidePayload {
-    absolute_path: string;
-    body_markdown: string;
-    is_structured: boolean;
-    opening_sentence: string | null;
-  }
-
   interface BrowserBoundsPayload {
     x: number;
     y: number;
@@ -662,7 +655,6 @@ declare global {
       listOutputs: (workspaceId: string) => Promise<WorkspaceOutputListResponsePayload>;
       listSkills: (workspaceId: string) => Promise<WorkspaceSkillListResponsePayload>;
       getWorkspaceRoot: (workspaceId: string) => Promise<string>;
-      getOnboardingGuide: (workspaceId: string) => Promise<WorkspaceOnboardingGuidePayload>;
       createWorkspace: (payload: HolabossCreateWorkspacePayload) => Promise<WorkspaceResponsePayload>;
       deleteWorkspace: (workspaceId: string) => Promise<WorkspaceResponsePayload>;
       listCronjobs: (workspaceId: string, enabledOnly?: boolean) => Promise<CronjobListResponsePayload>;

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -555,6 +555,64 @@ test("claimed onboarding input instructs native onboarding tools directly", asyn
   store.close();
 });
 
+test("claimed onboarding input includes ONBOARD.md verbatim", async () => {
+  const store = makeStore("hb-claimed-input-onboarding-verbatim-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "opencode",
+    status: "active",
+    mainSessionId: "session-main",
+    onboardingStatus: "pending",
+    onboardingSessionId: "session-onboarding"
+  });
+  fs.writeFileSync(
+    path.join(store.workspaceDir(workspace.id), "ONBOARD.md"),
+    "opening_sentence: What is the primary goal for this workspace?\n\n# Workspace Onboarding\n\nAsk concise setup questions.\n",
+    "utf8"
+  );
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-onboarding",
+    payload: { text: "yes" }
+  });
+
+  let capturedInstruction = "";
+  await processClaimedInput({
+    store,
+    record: queued,
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      capturedInstruction = String(payload.instruction ?? "");
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 1,
+        event_type: "run_started",
+        payload: { instruction_preview: capturedInstruction.slice(0, 120) }
+      });
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 2,
+        event_type: "run_completed",
+        payload: { status: "ok" }
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true
+      };
+    }
+  });
+
+  assert.match(capturedInstruction, /opening_sentence: What is the primary goal for this workspace\?/);
+  assert.doesNotMatch(capturedInstruction, /opening_sentence may already be visible/);
+
+  store.close();
+});
+
 test("claimed input persists replacement harness session id from terminal runner event", async () => {
   const store = makeStore("hb-claimed-input-harness-session-");
   const workspace = store.createWorkspace({

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -119,8 +119,6 @@ function buildOnboardingInstruction(params: {
   if (!rawOnboardPrompt || trimmed.startsWith(ONBOARD_PROMPT_HEADER)) {
     return trimmed;
   }
-  const parsedOnboardingGuide = parseOnboardingGuideContent(rawOnboardPrompt);
-  const onboardPrompt = (parsedOnboardingGuide.bodyMarkdown || rawOnboardPrompt).trim();
 
   return [
     ONBOARD_PROMPT_HEADER,
@@ -129,9 +127,6 @@ function buildOnboardingInstruction(params: {
     `- The onboarding guide file is ./${params.workspaceId}/ONBOARD.md (absolute path: ${onboardPath}).`,
     "- Use that workspace-scoped ONBOARD.md to drive the conversation and gather required details.",
     "- ONBOARD.md content is already included below; do not re-read it unless needed.",
-    parsedOnboardingGuide.openingSentence
-      ? "- The guide's opening_sentence may already be visible to the user. Treat the next user response as a reply to that opener unless the conversation indicates otherwise."
-      : "",
     `- If file reads are needed, use ./${params.workspaceId}/... paths rather than files directly under ${params.workspaceRoot}.`,
     "- Ask concise questions and collect durable facts/preferences.",
     "- Do not start regular execution work until onboarding is complete.",
@@ -141,38 +136,11 @@ function buildOnboardingInstruction(params: {
     "- When all onboarding requirements are satisfied and the user confirms, call `holaboss_onboarding_complete` with a concise durable summary.",
     "",
     "[ONBOARD.md]",
-    onboardPrompt,
+    rawOnboardPrompt,
     "[/ONBOARD.md]",
     "",
     trimmed
   ].join("\n").trim();
-}
-
-function parseOnboardingGuideContent(content: string): {
-  openingSentence: string;
-  bodyMarkdown: string;
-} {
-  const lines = content.replace(/\r\n/g, "\n").split("\n");
-  let index = 0;
-  while (index < lines.length && !lines[index]?.trim()) {
-    index += 1;
-  }
-
-  let openingSentence = "";
-  const openingLine = lines[index] ?? "";
-  const openingMatch = openingLine.match(/^opening_sentence\s*:\s*(.+)$/i);
-  if (openingMatch) {
-    openingSentence = openingMatch[1].trim().replace(/^['"]|['"]$/g, "").trim();
-    index += 1;
-    while (index < lines.length && !lines[index]?.trim()) {
-      index += 1;
-    }
-  }
-
-  return {
-    openingSentence,
-    bodyMarkdown: lines.slice(index).join("\n").trim()
-  };
 }
 
 function createdAtForEvent(event: RunnerEvent): string | undefined {


### PR DESCRIPTION
## Context

The onboarding flow had drifted away from the original design. `ONBOARD.md` was no longer the sole contract, and the onboarding chat could enter a state where the user landed in the pane without seeing the first real assistant question.

## What Changed

- remove `opening_sentence` scaffolding and guide IPC so `ONBOARD.md` remains the sole onboarding contract
- always queue onboarding bootstrap when `ONBOARD.md` exists during workspace creation
- make onboarding chat attach to the in-flight onboarding session until the first assistant message appears
- keep runtime onboarding prompt injection verbatim and add a regression test for raw `ONBOARD.md` handling

## Validation

- `npm run typecheck` in `desktop`
- `npm run typecheck` in `runtime/api-server`
- `npm test -- --test-name-pattern='claimed onboarding input'` in `runtime/api-server`

## Impact

- no migrations
- no Supabase changes
- no environment changes required

## Notes

- UI-affecting change in onboarding chat behavior
- branch was validated from the dedicated worktree used for the fix