### PR TITLE
chore: polish desktop workspace ui

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -1023,6 +1023,9 @@ function popupThemeCss(theme = currentTheme) {
   const isLightTheme = theme === "holaboss" || theme === "claude" || theme === "paper";
   const surfaceSoft = `color-mix(in srgb, ${palette.controlBg} 72%, ${palette.panelBgAlt} 28%)`;
   const surfaceSubtle = `color-mix(in srgb, ${palette.controlBg} 52%, ${palette.panelBgAlt} 48%)`;
+  const scrollTrack = `color-mix(in srgb, ${palette.borderSoft} 58%, transparent)`;
+  const scrollThumbTop = `color-mix(in srgb, ${palette.accent} 30%, ${palette.borderSoft})`;
+  const scrollThumbBottom = `color-mix(in srgb, ${palette.accentStrong} 22%, ${palette.borderSoft})`;
   return `
       :root {
         color-scheme: ${isLightTheme ? "light" : "dark"};
@@ -1055,6 +1058,22 @@ function popupThemeCss(theme = currentTheme) {
       }
       .content {
         background: color-mix(in srgb, ${palette.panelBg} 90%, transparent);
+        scrollbar-width: thin;
+        scrollbar-color: ${scrollThumbTop} ${scrollTrack};
+      }
+      .content::-webkit-scrollbar {
+        width: 7px;
+        height: 7px;
+      }
+      .content::-webkit-scrollbar-track {
+        background: ${scrollTrack};
+        border-radius: 999px;
+      }
+      .content::-webkit-scrollbar-thumb {
+        background: linear-gradient(180deg, ${scrollThumbTop}, ${scrollThumbBottom});
+        border-radius: 999px;
+        border: 1px solid transparent;
+        background-clip: padding-box;
       }
       .avatar {
         border-color: color-mix(in srgb, ${palette.accent} 30%, ${palette.borderSoft});
@@ -7367,25 +7386,6 @@ function createAuthPopupHtml() {
         letter-spacing: 0.14em;
         text-transform: uppercase;
       }
-      .runtimeLine {
-        margin-top: 14px;
-        border-radius: 16px;
-        border: 1px solid var(--popup-border-soft);
-        background: color-mix(in srgb, var(--popup-control-bg) 68%, transparent);
-        padding: 12px 14px;
-      }
-      .runtimeLabel {
-        font-size: 10px;
-        letter-spacing: 0.16em;
-        text-transform: uppercase;
-        color: var(--popup-text-subtle);
-      }
-      .runtimeValue {
-        margin-top: 6px;
-        font-size: 12px;
-        line-height: 1.5;
-        color: var(--popup-text);
-      }
       .content {
         flex: 1 1 auto;
         min-height: 0;
@@ -7447,6 +7447,13 @@ function createAuthPopupHtml() {
         transform: translateY(-1px);
         border-color: var(--popup-border-soft);
         background: color-mix(in srgb, var(--popup-control-bg) 72%, transparent);
+      }
+      .menuItem:focus,
+      .menuItem:focus-visible,
+      .button:focus,
+      .button:focus-visible {
+        outline: none;
+        box-shadow: none;
       }
       .menuLead {
         min-width: 0;
@@ -7534,11 +7541,6 @@ function createAuthPopupHtml() {
             <div id="identity" class="identity">Loading session...</div>
           </div>
           <div id="badge" class="badge idle">Checking</div>
-        </div>
-
-        <div class="runtimeLine">
-          <div class="runtimeLabel">Desktop status</div>
-          <div id="runtimeValue" class="runtimeValue">Checking local runtime connection...</div>
         </div>
       </div>
 
@@ -7644,7 +7646,6 @@ function createAuthPopupHtml() {
         identityName: document.getElementById("identityName"),
         identity: document.getElementById("identity"),
         badge: document.getElementById("badge"),
-        runtimeValue: document.getElementById("runtimeValue"),
         notice: document.getElementById("notice"),
         signIn: document.getElementById("signIn"),
         signOut: document.getElementById("signOut"),
@@ -7680,23 +7681,14 @@ function createAuthPopupHtml() {
         && Boolean((state.runtimeConfig?.sandboxId || "").trim())
         && Boolean((state.runtimeConfig?.modelProxyBaseUrl || "").trim());
 
-      const runtimeStatusLabel = (isSignedIn) => {
-        if (state.runtimeStatus?.status === "running") {
-          return "Runtime connected and running.";
-        }
-        if (state.runtimeStatus?.status === "starting") {
-          return "Runtime is starting.";
-        }
-        if (state.runtimeStatus?.status === "error") {
-          return state.runtimeStatus?.lastError || "Runtime needs attention.";
-        }
-        if (runtimeBindingReady()) {
-          return "Runtime connected and ready.";
-        }
-        return isSignedIn ? "Finishing runtime setup." : "Sign in to connect desktop features.";
-      };
+      let lastOpenAnimationAt = 0;
 
       const restartOpenAnimation = () => {
+        const now = performance.now();
+        if (now - lastOpenAnimationAt < 220) {
+          return;
+        }
+        lastOpenAnimationAt = now;
         document.body.classList.remove("popup-opening");
         void document.body.offsetWidth;
         document.body.classList.add("popup-opening");
@@ -7704,6 +7696,7 @@ function createAuthPopupHtml() {
 
       const render = () => {
         const isSignedIn = Boolean(sessionUserId(state.user));
+        const isCheckingSession = state.isPending;
         const hasError = Boolean(state.authError);
         const ready = runtimeBindingReady();
         const badgeTone = hasError ? "error" : ready ? "ready" : isSignedIn ? "syncing" : "idle";
@@ -7715,14 +7708,13 @@ function createAuthPopupHtml() {
         els.identity.textContent = isSignedIn ? (sessionEmail(state.user) || sessionUserId(state.user) || "Signed in") : "Not connected";
         els.badge.className = "badge " + badgeTone;
         els.badge.textContent = badgeLabel;
-        els.runtimeValue.textContent = runtimeStatusLabel(isSignedIn);
-        els.accountMeta.textContent = isSignedIn ? (ready ? "Connected" : "Syncing setup") : "Sign in required";
+        els.accountMeta.textContent = isCheckingSession ? "Checking session" : isSignedIn ? (ready ? "Connected" : "Syncing setup") : "Sign in required";
 
-        els.signIn.hidden = isSignedIn;
+        els.signIn.hidden = isSignedIn || isCheckingSession;
         els.signIn.disabled = state.isStartingSignIn;
         els.signIn.textContent = state.isStartingSignIn ? "Opening sign-in..." : "Connect account";
 
-        els.signOut.hidden = !isSignedIn;
+        els.signOut.hidden = !isSignedIn || isCheckingSession;
         els.signOut.disabled = state.isSigningOut;
         els.notice.hidden = !noticeText;
         els.notice.className = "message " + (state.authError ? "error" : "success");
@@ -7863,6 +7855,7 @@ function createAuthPopupHtml() {
         restartOpenAnimation();
       });
 
+      render();
       Promise.all([refreshSession(), refreshConfig(), refreshRuntimeStatus()]).then(() => render());
     </script>
   </body>

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -305,7 +305,7 @@ export function AuthPanel() {
   }
 
   return (
-    <section className="theme-shell soft-vignette w-full max-w-[560px] overflow-hidden rounded-[24px] border border-panel-border/40 text-[11px] text-text-main/88 shadow-card">
+    <section className="theme-shell w-full max-w-none overflow-hidden rounded-[24px] border border-panel-border/40 text-[11px] text-text-main/88 shadow-card">
       <div className="border-b border-panel-border/40 px-4 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-3">
@@ -376,7 +376,7 @@ export function AuthPanel() {
           </button>
 
           <button
-            className="theme-control-surface inline-flex h-[42px] items-center justify-center rounded-[16px] border border-panel-border/45 px-4 text-[12px] text-text-main transition hover:border-neon-green/35 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-[42px] items-center justify-center rounded-[16px] border border-[rgba(247,90,84,0.28)] bg-[rgba(247,90,84,0.08)] px-4 text-[12px] text-[rgba(206,92,84,0.96)] transition hover:border-[rgba(247,90,84,0.4)] hover:bg-[rgba(247,90,84,0.12)] disabled:cursor-not-allowed disabled:opacity-50"
             type="button"
             onClick={() => void handleSignOut()}
             disabled={!isSignedIn}
@@ -388,12 +388,6 @@ export function AuthPanel() {
         {isFinishingSetup && !isExchangingRuntimeBinding && (
           <div className="mt-3 rounded-[16px] border border-amber-300/25 bg-amber-400/10 px-4 py-3 text-[11px] text-amber-300">
             Sign-in completed. Holaboss is finishing local runtime setup.
-          </div>
-        )}
-
-        {runtimeBindingReady && !authMessage && !authError && (
-          <div className="mt-3 rounded-[16px] border border-neon-green/18 bg-neon-green/8 px-4 py-3 text-[11px] text-neon-green">
-            Connected. Remote proactive and marketplace features are available on this desktop runtime.
           </div>
         )}
 

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -2422,7 +2422,7 @@ function AppShellContent() {
           <div
             className={`relative grid h-full min-h-0 gap-y-3 overflow-hidden transition-[grid-template-columns,column-gap] duration-300 ease-in-out ${
               showOperationsDrawer
-                ? "lg:grid-cols-[60px_minmax(0,1fr)_304px]"
+                ? "lg:grid-cols-[60px_minmax(0,1fr)_352px]"
                 : "lg:grid-cols-[60px_minmax(0,1fr)]"
             }`}
             style={{ columnGap: "0.5rem" }}
@@ -2573,7 +2573,6 @@ function AppShellContent() {
                   activeTab={activeOperationsTab}
                   onTabChange={setActiveOperationsTab}
                   proposals={taskProposals}
-                  proactiveStatus={proactiveStatus}
                   isLoadingProposals={isLoadingTaskProposals}
                   isTriggeringProposal={isTriggeringTaskProposal}
                   proposalStatusMessage={taskProposalStatusMessage}
@@ -2606,6 +2605,11 @@ function AppShellContent() {
         themes={THEMES}
         onThemeChange={handleThemeChange}
         onOpenExternalUrl={handleOpenExternalUrl}
+        hasWorkspace={hasSelectedWorkspace}
+        selectedWorkspaceName={selectedWorkspace?.name ?? null}
+        selectedWorkspaceId={selectedWorkspace?.id ?? null}
+        proactiveStatus={proactiveStatus}
+        isLoadingProactiveStatus={isLoadingTaskProposals}
       />
     </main>
   );

--- a/desktop/src/components/layout/LeftNavigationRail.tsx
+++ b/desktop/src/components/layout/LeftNavigationRail.tsx
@@ -100,6 +100,7 @@ export function LeftNavigationRail({
                     key={app.id}
                     className="group relative"
                     onMouseEnter={(event) => showAppTooltip(event.currentTarget, app.label)}
+                    onMouseLeave={() => setAppTooltip(null)}
                     onFocus={(event) => showAppTooltip(event.currentTarget, app.label)}
                     onBlur={() => setAppTooltip(null)}
                   >

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -42,7 +42,6 @@ interface OperationsDrawerProps {
   activeTab: OperationsDrawerTab;
   onTabChange: (tab: OperationsDrawerTab) => void;
   proposals: TaskProposalRecordPayload[];
-  proactiveStatus: ProactiveAgentStatusPayload | null;
   isLoadingProposals: boolean;
   isTriggeringProposal: boolean;
   proposalStatusMessage: string;
@@ -68,7 +67,6 @@ export function OperationsDrawer({
   activeTab,
   onTabChange,
   proposals,
-  proactiveStatus,
   isLoadingProposals,
   isTriggeringProposal,
   proposalStatusMessage,
@@ -94,9 +92,9 @@ export function OperationsDrawer({
   }, [outputs, selectedOutputId]);
 
   return (
-    <aside className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-[280px] max-w-[312px] flex-col overflow-hidden rounded-[var(--theme-radius-card)] shadow-card">
-      <header className="theme-header-surface flex shrink-0 items-center justify-between gap-3 border-b border-neon-green/15 px-4 py-3">
-        <div className="flex items-center gap-2">
+    <aside className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-[var(--theme-radius-card)] shadow-card">
+      <header className="theme-header-surface flex shrink-0 items-center gap-2 border-b border-neon-green/15 px-3 py-3 pr-14">
+        <div className="grid min-w-0 flex-1 grid-cols-3 gap-1.5">
           <DrawerTabButton active={activeTab === "inbox"} icon={<Bell size={14} />} label="Inbox" onClick={() => onTabChange("inbox")} />
           <DrawerTabButton
             active={activeTab === "running"}
@@ -117,7 +115,6 @@ export function OperationsDrawer({
         {activeTab === "inbox" ? (
           <InboxPanel
             proposals={proposals}
-            proactiveStatus={proactiveStatus}
             isLoadingProposals={isLoadingProposals}
             isTriggeringProposal={isTriggeringProposal}
             proposalStatusMessage={proposalStatusMessage}
@@ -167,84 +164,20 @@ function DrawerTabButton({
     <button
       type="button"
       onClick={onClick}
-      className={`inline-flex h-10 items-center gap-2 rounded-[16px] border px-3 text-[12px] transition ${
+      className={`inline-flex h-9 w-full min-w-0 items-center justify-center gap-1.5 rounded-[14px] border px-2.5 text-[11px] transition ${
         active
           ? "border-neon-green/45 bg-neon-green/10 text-neon-green"
           : "border-panel-border/45 text-text-muted hover:border-neon-green/35 hover:text-text-main"
       }`}
     >
       {icon}
-      <span>{label}</span>
+      <span className="truncate">{label}</span>
     </button>
-  );
-}
-
-function proactiveStateLabel(state: string): string {
-  switch (state) {
-    case "healthy":
-      return "Healthy";
-    case "published":
-      return "Published";
-    case "failed":
-      return "Failed";
-    case "skipped":
-      return "Skipped";
-    case "pending":
-      return "Pending";
-    case "delivered":
-      return "Delivered";
-    case "analyzing":
-      return "Analyzing";
-    case "no_proposal":
-      return "No proposal";
-    case "blocked":
-      return "Blocked";
-    case "inactive":
-      return "Inactive";
-    case "error":
-      return "Error";
-    default:
-      return "Checking";
-  }
-}
-
-function proactiveStateClasses(state: string): string {
-  if (["healthy", "published", "delivered"].includes(state)) {
-    return "border-neon-green/40 bg-neon-green/10 text-neon-green";
-  }
-  if (["failed", "blocked", "error"].includes(state)) {
-    return "border-[rgba(206,92,84,0.32)] bg-[rgba(206,92,84,0.12)] text-[rgba(255,172,164,0.96)]";
-  }
-  if (["inactive", "skipped"].includes(state)) {
-    return "border-panel-border/45 bg-panel-border/10 text-text-muted";
-  }
-  return "border-panel-border/45 bg-panel-border/10 text-text-main/78";
-}
-
-function ProactiveStatusRow({
-  label,
-  snapshot
-}: {
-  label: string;
-  snapshot: ProactiveStatusSnapshotPayload;
-}) {
-  return (
-    <div className="rounded-[14px] border border-panel-border/35 px-3 py-2">
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-[10px] uppercase tracking-[0.12em] text-text-dim">{label}</div>
-        <div className={`rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${proactiveStateClasses(snapshot.state)}`}>
-          {proactiveStateLabel(snapshot.state)}
-        </div>
-      </div>
-      {snapshot.detail ? <div className="mt-2 text-[11px] leading-5 text-text-muted">{snapshot.detail}</div> : null}
-      {snapshot.recorded_at ? <div className="mt-2 text-[10px] text-text-dim/78">{formatTimestamp(snapshot.recorded_at)}</div> : null}
-    </div>
   );
 }
 
 function InboxPanel({
   proposals,
-  proactiveStatus,
   isLoadingProposals,
   isTriggeringProposal,
   proposalStatusMessage,
@@ -255,7 +188,6 @@ function InboxPanel({
   onDismissProposal
 }: {
   proposals: TaskProposalRecordPayload[];
-  proactiveStatus: ProactiveAgentStatusPayload | null;
   isLoadingProposals: boolean;
   isTriggeringProposal: boolean;
   proposalStatusMessage: string;
@@ -274,9 +206,6 @@ function InboxPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="text-[10px] uppercase tracking-[0.16em] text-neon-green/76">Remote proposals</div>
-            <div className="mt-1 text-[12px] leading-6 text-text-main/88">
-              Review backend-delivered task ideas and either queue them immediately or dismiss them at the source.
-            </div>
           </div>
           <button
             type="button"
@@ -288,52 +217,6 @@ function InboxPanel({
             <span>Trigger</span>
           </button>
         </div>
-
-        {hasWorkspace ? (
-          <div className="theme-subtle-surface mt-3 rounded-[16px] border border-panel-border/35 px-3 py-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="text-[10px] uppercase tracking-[0.14em] text-neon-green/76">Proactive agent</div>
-                <div className="mt-1 text-[12px] leading-6 text-text-main/90">
-                  {proactiveStatus?.delivery_summary || (isLoadingProposals ? "Checking proactive delivery status..." : "No proactive status available yet.")}
-                </div>
-                {proactiveStatus?.delivery_detail ? (
-                  <div className="mt-2 text-[11px] leading-5 text-text-muted">{proactiveStatus.delivery_detail}</div>
-                ) : null}
-              </div>
-              <div
-                className={`shrink-0 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${
-                  proactiveStateClasses(proactiveStatus?.delivery_state || "unknown")
-                }`}
-              >
-                {proactiveStateLabel(proactiveStatus?.delivery_state || "unknown")}
-              </div>
-            </div>
-
-            <div className="mt-3 grid gap-2">
-              <ProactiveStatusRow
-                label="Heartbeat"
-                snapshot={
-                  proactiveStatus?.heartbeat || {
-                    state: isLoadingProposals ? "pending" : "unknown",
-                    detail: null,
-                    recorded_at: null
-                  }
-                }
-              />
-              <ProactiveStatusRow
-                label="Bridge"
-                snapshot={
-                  proactiveStatus?.bridge || {
-                    state: isLoadingProposals ? "pending" : "unknown",
-                    detail: null,
-                    recorded_at: null
-                  }
-                }
-              />
-            </div>
-          </div>
-        ) : null}
 
         {proposalStatusMessage ? (
           <div className="theme-subtle-surface mt-3 rounded-[14px] border border-panel-border/35 px-3 py-2 text-[11px] text-text-muted">
@@ -351,16 +234,12 @@ function InboxPanel({
           <div className="grid gap-3">
             {proposals.map((proposal) => {
               const isActing = proposalAction?.proposalId === proposal.proposal_id;
+              const previewPrompt = truncateWordPreview(proposal.task_prompt, 24);
               return (
                 <article key={proposal.proposal_id} className="theme-subtle-surface rounded-[18px] border border-panel-border/35 px-4 py-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-[12px] font-medium text-text-main">{proposal.task_name}</div>
-                      <div className="mt-2 whitespace-pre-wrap text-[11px] leading-6 text-text-muted">{proposal.task_prompt}</div>
-                    </div>
-                    <div className="shrink-0 rounded-full border border-panel-border/45 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-text-dim">
-                      {proposal.state}
-                    </div>
+                  <div className="min-w-0">
+                    <div className="text-[12px] font-medium text-text-main">{proposal.task_name}</div>
+                    <div className="mt-2 text-[11px] leading-6 text-text-muted">{previewPrompt}</div>
                   </div>
 
                   <div className="mt-3 text-[10px] text-text-dim/78">{formatTimestamp(proposal.created_at)}</div>
@@ -573,6 +452,18 @@ function EmptyNotice({ message }: { message: string }) {
       {message}
     </div>
   );
+}
+
+function truncateWordPreview(value: string, wordLimit: number): string {
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  const words = normalized.split(" ");
+  if (words.length <= wordLimit) {
+    return normalized;
+  }
+  return `${words.slice(0, wordLimit).join(" ")}...`;
 }
 
 function formatTimestamp(value: string): string {

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -1,0 +1,144 @@
+function proactiveStateLabel(state: string): string {
+  switch (state) {
+    case "healthy":
+      return "Healthy";
+    case "published":
+      return "Published";
+    case "failed":
+      return "Failed";
+    case "skipped":
+      return "Skipped";
+    case "pending":
+      return "Pending";
+    case "delivered":
+      return "Delivered";
+    case "analyzing":
+      return "Analyzing";
+    case "no_proposal":
+      return "No proposal";
+    case "blocked":
+      return "Blocked";
+    case "inactive":
+      return "Inactive";
+    case "error":
+      return "Error";
+    default:
+      return "Checking";
+  }
+}
+
+function proactiveStateClasses(state: string): string {
+  if (["healthy", "published", "delivered"].includes(state)) {
+    return "border-neon-green/40 bg-neon-green/10 text-neon-green";
+  }
+  if (["failed", "blocked", "error"].includes(state)) {
+    return "border-[rgba(206,92,84,0.32)] bg-[rgba(206,92,84,0.12)] text-[rgba(255,172,164,0.96)]";
+  }
+  if (["inactive", "skipped"].includes(state)) {
+    return "border-panel-border/45 bg-panel-border/10 text-text-muted";
+  }
+  return "border-panel-border/45 bg-panel-border/10 text-text-main/78";
+}
+
+function formatTimestamp(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return value;
+  }
+  return new Date(timestamp).toLocaleString();
+}
+
+function ProactiveStatusRow({
+  label,
+  snapshot
+}: {
+  label: string;
+  snapshot: ProactiveStatusSnapshotPayload;
+}) {
+  return (
+    <div className="rounded-[14px] border border-panel-border/35 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-[10px] uppercase tracking-[0.12em] text-text-dim">{label}</div>
+        <div className={`rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${proactiveStateClasses(snapshot.state)}`}>
+          {proactiveStateLabel(snapshot.state)}
+        </div>
+      </div>
+      {snapshot.detail ? <div className="mt-2 text-[11px] leading-5 text-text-muted">{snapshot.detail}</div> : null}
+      {snapshot.recorded_at ? <div className="mt-2 text-[10px] text-text-dim/78">{formatTimestamp(snapshot.recorded_at)}</div> : null}
+    </div>
+  );
+}
+
+interface ProactiveStatusCardProps {
+  hasWorkspace: boolean;
+  workspaceName?: string | null;
+  workspaceId?: string | null;
+  proactiveStatus: ProactiveAgentStatusPayload | null;
+  isLoading: boolean;
+}
+
+export function ProactiveStatusCard({
+  hasWorkspace,
+  workspaceName,
+  workspaceId,
+  proactiveStatus,
+  isLoading
+}: ProactiveStatusCardProps) {
+  const fallbackState = isLoading ? "pending" : "unknown";
+  const deliveryState = proactiveStatus?.delivery_state || fallbackState;
+  const summary = hasWorkspace
+    ? proactiveStatus?.delivery_summary || (isLoading ? "Checking proactive delivery status..." : "No proactive status available yet.")
+    : "Select a workspace to inspect proactive delivery status.";
+  const detail = hasWorkspace
+    ? proactiveStatus?.delivery_detail
+    : "Proactive delivery is tracked per workspace, so this follows the workspace currently open in the desktop.";
+
+  return (
+    <section className="theme-shell w-full max-w-none overflow-hidden rounded-[24px] border border-panel-border/40 text-[11px] text-text-main/88 shadow-card">
+      <div className="border-b border-panel-border/40 px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[11px] uppercase tracking-[0.18em] text-text-dim/68">Proactive agent</div>
+            <div className="mt-2 text-[13px] leading-6 text-text-main/92">{summary}</div>
+            {detail ? <div className="mt-2 text-[11px] leading-5 text-text-muted/82">{detail}</div> : null}
+          </div>
+          <div className={`shrink-0 rounded-full border px-3 py-1 text-[10px] tracking-[0.14em] ${proactiveStateClasses(deliveryState)}`}>
+            {proactiveStateLabel(deliveryState)}
+          </div>
+        </div>
+
+        {hasWorkspace ? (
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-text-dim/72">
+            <span className="rounded-full border border-panel-border/35 px-2.5 py-1">{workspaceName || "Selected workspace"}</span>
+            {workspaceId ? <span className="truncate text-text-dim/58">workspace_id={workspaceId}</span> : null}
+          </div>
+        ) : null}
+      </div>
+
+      {hasWorkspace ? (
+        <div className="grid gap-2 px-4 py-4">
+          <ProactiveStatusRow
+            label="Heartbeat"
+            snapshot={
+              proactiveStatus?.heartbeat || {
+                state: fallbackState,
+                detail: null,
+                recorded_at: null
+              }
+            }
+          />
+          <ProactiveStatusRow
+            label="Bridge"
+            snapshot={
+              proactiveStatus?.bridge || {
+                state: fallbackState,
+                detail: null,
+                recorded_at: null
+              }
+            }
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { CircleHelp, ExternalLink, Globe, Info, Palette, User2, X } from "lucide-react";
+import { CircleHelp, Globe, Info, Palette, User2, X } from "lucide-react";
 import { AuthPanel } from "@/components/auth/AuthPanel";
+import { ProactiveStatusCard } from "@/components/layout/ProactiveStatusCard";
 
 const THEME_SWATCHES: Record<string, [string, string, string]> = {
   holaboss: ["#fff7f2", "#f75a54", "#d7dde8"],
@@ -24,6 +25,11 @@ interface SettingsDialogProps {
   themes: readonly string[];
   onThemeChange: (theme: string) => void;
   onOpenExternalUrl: (url: string) => void;
+  hasWorkspace: boolean;
+  selectedWorkspaceName?: string | null;
+  selectedWorkspaceId?: string | null;
+  proactiveStatus: ProactiveAgentStatusPayload | null;
+  isLoadingProactiveStatus: boolean;
 }
 
 const SETTINGS_SECTIONS: Array<{
@@ -67,7 +73,7 @@ function titleForSection(section: UiSettingsPaneSection): string {
 function subtitleForSection(section: UiSettingsPaneSection): string {
   switch (section) {
     case "account":
-      return "Manage your desktop session and runtime binding.";
+      return "Manage your desktop session, runtime binding, and proactive delivery.";
     case "about":
       return "Open product resources and support channels.";
     case "settings":
@@ -88,7 +94,12 @@ export function SettingsDialog({
   theme,
   themes,
   onThemeChange,
-  onOpenExternalUrl
+  onOpenExternalUrl,
+  hasWorkspace,
+  selectedWorkspaceName,
+  selectedWorkspaceId,
+  proactiveStatus,
+  isLoadingProactiveStatus
 }: SettingsDialogProps) {
   useEffect(() => {
     if (!open) {
@@ -124,7 +135,7 @@ export function SettingsDialog({
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
-        className="theme-shell soft-vignette neon-border pointer-events-auto relative z-10 grid max-h-[min(760px,calc(100vh-40px))] w-[min(980px,calc(100vw-32px))] min-w-0 overflow-hidden rounded-[28px] shadow-card lg:grid-cols-[240px_minmax(0,1fr)]"
+        className="theme-shell neon-border pointer-events-auto relative z-10 grid h-[min(760px,calc(100vh-40px))] w-[min(980px,calc(100vw-32px))] min-w-0 overflow-hidden rounded-[28px] shadow-card lg:grid-cols-[240px_minmax(0,1fr)]"
       >
         <aside className="theme-header-surface border-b border-panel-border/35 p-4 lg:border-b-0 lg:border-r">
           <div className="flex items-center gap-3">
@@ -145,14 +156,14 @@ export function SettingsDialog({
                   key={id}
                   type="button"
                   onClick={() => onSectionChange(id)}
-                  className={`flex items-start gap-3 rounded-[18px] border px-3.5 py-3 text-left transition ${
+                  className={`grid min-h-[92px] w-full grid-cols-[32px_minmax(0,1fr)] items-center gap-3 rounded-[18px] border px-3.5 py-3 text-left transition ${
                     active
                       ? "border-neon-green/40 bg-neon-green/10 text-text-main shadow-[0_12px_36px_rgba(0,0,0,0.16)]"
                       : "border-transparent text-text-muted hover:border-panel-border/45 hover:bg-[var(--theme-hover-bg)] hover:text-text-main"
                   }`}
                 >
                   <span
-                    className={`mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-[12px] border ${
+                    className={`grid h-8 w-8 shrink-0 place-items-center self-start rounded-[12px] border ${
                       active
                         ? "border-neon-green/35 bg-neon-green/12 text-neon-green"
                         : "border-panel-border/35 text-text-dim/80"
@@ -160,7 +171,7 @@ export function SettingsDialog({
                   >
                     <Icon size={15} />
                   </span>
-                  <span className="min-w-0">
+                  <span className="flex min-h-[52px] min-w-0 flex-col justify-center">
                     <span className="block text-[13px] font-medium">{label}</span>
                     <span className="mt-1 block text-[11px] leading-5 text-text-dim/72">{description}</span>
                   </span>
@@ -168,13 +179,9 @@ export function SettingsDialog({
               );
             })}
           </nav>
-
-          <div className="mt-6 hidden rounded-[18px] border border-panel-border/35 bg-black/10 p-3 text-[11px] leading-5 text-text-dim/74 lg:block">
-            The account dropdown stays lightweight. Deeper preferences live here in one shared desktop pane.
-          </div>
         </aside>
 
-        <section className="min-h-0 min-w-0 overflow-hidden">
+        <section className="flex min-h-0 min-w-0 flex-col overflow-hidden">
           <header className="theme-header-surface flex items-start justify-between gap-4 border-b border-panel-border/35 px-5 py-4">
             <div>
               <div className="text-[20px] font-semibold text-text-main">{titleForSection(activeSection)}</div>
@@ -191,10 +198,17 @@ export function SettingsDialog({
             </button>
           </header>
 
-          <div className="min-h-0 overflow-y-auto px-5 py-5">
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
             {activeSection === "account" ? (
-              <div className="max-w-[560px]">
+              <div className="grid w-full max-w-none gap-6">
                 <AuthPanel />
+                <ProactiveStatusCard
+                  hasWorkspace={hasWorkspace}
+                  workspaceName={selectedWorkspaceName}
+                  workspaceId={selectedWorkspaceId}
+                  proactiveStatus={proactiveStatus}
+                  isLoading={isLoadingProactiveStatus}
+                />
               </div>
             ) : null}
 
@@ -295,18 +309,18 @@ export function SettingsDialog({
                         key={id}
                         type="button"
                         onClick={() => onOpenExternalUrl(href)}
-                        className="flex items-center justify-between gap-3 rounded-[18px] border border-panel-border/40 bg-black/10 px-4 py-3 text-left transition hover:border-neon-green/30 hover:bg-[var(--theme-hover-bg)]"
+                        className="group relative overflow-hidden rounded-[20px] border border-[rgba(247,90,84,0.14)] bg-[linear-gradient(145deg,rgba(247,90,84,0.06),rgba(255,255,255,0.02))] px-4 py-3 text-left transition hover:border-[rgba(247,90,84,0.28)] hover:bg-[linear-gradient(145deg,rgba(247,90,84,0.1),rgba(255,255,255,0.04))]"
                       >
+                        <span className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(247,90,84,0.12),transparent_34%)] opacity-80" />
                         <span className="flex min-w-0 items-center gap-3">
-                          <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[14px] border border-panel-border/35 text-text-muted/82">
+                          <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[14px] border border-neon-green/30 bg-neon-green/10 text-neon-green shadow-[0_10px_24px_rgba(247,90,84,0.08)]">
                             <Icon size={16} />
                           </span>
-                          <span className="min-w-0">
+                          <span className="relative min-w-0">
                             <span className="block text-[13px] font-medium text-text-main">{label}</span>
-                            <span className="mt-1 block text-[11px] leading-5 text-text-dim/72">{detail}</span>
+                            <span className="mt-1 block text-[11px] leading-5 text-text-muted/78">{detail}</span>
                           </span>
                         </span>
-                        <ExternalLink size={15} className="shrink-0 text-text-dim/70" />
                       </button>
                     ))}
                   </div>

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, Clock3, Loader2, Trash2 } from "lucide-react";
-import { PaneCard } from "@/components/ui/PaneCard";
+import { Check, Clock3, Loader2, RefreshCw, Sparkles, Trash2, TriangleAlert, Workflow } from "lucide-react";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
 function normalizeErrorMessage(error: unknown) {
@@ -15,12 +14,38 @@ function formatTimestamp(value: string | null): string {
   if (Number.isNaN(parsed)) {
     return value;
   }
-  return new Date(parsed).toLocaleString();
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(parsed));
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatDeliverySummary(job: CronjobRecordPayload): string {
+  const parts = [job.delivery.channel, job.delivery.mode, job.delivery.to].filter((value): value is string => Boolean(value?.trim()));
+  return parts.length ? parts.join(" / ") : "Workspace delivery";
+}
+
+function formatStatusLabel(status: string | null): string {
+  if (!status) {
+    return "No recent status";
+  }
+  return status
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
 }
 
 export function AutomationsPane() {
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const [cronjobs, setCronjobs] = useState<CronjobRecordPayload[]>([]);
+  const [selectedJobId, setSelectedJobId] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [busyJobId, setBusyJobId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState("");
@@ -30,9 +55,15 @@ export function AutomationsPane() {
     return [...cronjobs].sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
   }, [cronjobs]);
 
+  const selectedJob = useMemo(
+    () => sortedCronjobs.find((job) => job.id === selectedJobId) ?? null,
+    [selectedJobId, sortedCronjobs]
+  );
+
   async function refreshCronjobs() {
     if (!selectedWorkspaceId) {
       setCronjobs([]);
+      setSelectedJobId("");
       return;
     }
     setIsLoading(true);
@@ -48,8 +79,23 @@ export function AutomationsPane() {
   }
 
   useEffect(() => {
+    if (!selectedWorkspaceId) {
+      setCronjobs([]);
+      setSelectedJobId("");
+      setStatusMessage("");
+      return;
+    }
     void refreshCronjobs();
   }, [selectedWorkspaceId]);
+
+  useEffect(() => {
+    setSelectedJobId((current) => {
+      if (current && sortedCronjobs.some((job) => job.id === current)) {
+        return current;
+      }
+      return sortedCronjobs[0]?.id ?? "";
+    });
+  }, [sortedCronjobs]);
 
   const handleDelete = async (job: CronjobRecordPayload) => {
     setBusyJobId(job.id);
@@ -86,106 +132,257 @@ export function AutomationsPane() {
   };
 
   return (
-    <PaneCard className="shadow-glow">
-      <div className="flex h-full min-h-0 flex-col">
-        {statusMessage ? (
-          <div className="shrink-0 border-b border-panel-border/35 px-4 py-3">
-            <div
-              className={`rounded-[14px] border px-3 py-2 text-[11px] ${
-                statusTone === "success"
-                  ? "border-neon-green/30 bg-neon-green/10 text-text-main/92"
-                  : statusTone === "error"
-                    ? "border-[rgba(255,153,102,0.24)] bg-[rgba(255,153,102,0.08)] text-[rgba(255,212,189,0.92)]"
-                    : "border-panel-border/35 bg-black/10 text-text-muted"
-              }`}
-            >
-              {statusMessage}
-            </div>
-          </div>
-        ) : null}
+    <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-[var(--theme-radius-card)] shadow-card">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.03),transparent_24%)]" />
 
-        <div
-          className={
-            !selectedWorkspaceId || sortedCronjobs.length === 0
-              ? "min-h-0 flex flex-1 items-center justify-center p-4"
-              : "min-h-0 flex-1 overflow-y-auto p-4"
-          }
-        >
-          {!selectedWorkspaceId ? (
-            <EmptyState message="Choose a workspace from the top bar to view and manage cronjobs." />
-          ) : sortedCronjobs.length === 0 ? (
-            <EmptyState message={isLoading ? "Loading cronjobs..." : "No cronjobs found for this workspace."} />
-          ) : (
-            <div className="grid gap-3">
-              {sortedCronjobs.map((job) => {
-                const isBusy = busyJobId === job.id;
-                return (
-                  <div key={job.id} className="rounded-[16px] border border-panel-border/35 bg-black/10 px-4 py-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-[12px] font-medium text-text-main">{job.name || job.description}</div>
-                        <div className="mt-1 truncate text-[11px] text-text-muted">{job.cron}</div>
-                      </div>
-                      <span
-                        className={`rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${
-                          job.enabled
-                            ? "border-neon-green/35 bg-neon-green/10 text-neon-green"
-                            : "border-panel-border/45 text-text-dim"
+      <div className="relative min-h-0 flex-1 p-4">
+        {!selectedWorkspaceId ? (
+          <EmptyState title="No workspace selected" detail="Select a workspace to review its scheduled automations." />
+        ) : isLoading && sortedCronjobs.length === 0 ? (
+          <LoadingState label="Loading workspace automations..." />
+        ) : statusTone === "error" && sortedCronjobs.length === 0 && statusMessage ? (
+          <EmptyState title="Automations failed to load" detail={statusMessage} tone="error" />
+        ) : sortedCronjobs.length === 0 ? (
+          <EmptyState
+            title="No automations yet"
+            detail="This workspace does not have any cronjobs configured yet."
+          />
+        ) : (
+          <div className="grid h-full min-h-0 gap-4 xl:grid-cols-[340px_minmax(0,1fr)]">
+            <aside className="theme-subtle-surface flex h-full min-h-0 flex-col overflow-hidden rounded-[28px] border border-panel-border/35 shadow-card">
+              <div className="border-b border-panel-border/35 px-4 py-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-text-dim/72">Schedule</div>
+                    <div className="mt-1 text-[14px] font-medium text-text-main">Workspace automations</div>
+                  </div>
+                </div>
+
+                <div className="mt-4 flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void refreshCronjobs()}
+                    disabled={isLoading}
+                    className="theme-control-surface inline-flex h-9 items-center gap-2 rounded-[14px] border border-panel-border/45 px-3 text-[11px] text-text-muted transition hover:border-[rgba(247,90,84,0.24)] hover:text-text-main disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <RefreshCw size={12} className={isLoading ? "animate-spin" : ""} />
+                    <span>Refresh</span>
+                  </button>
+                </div>
+
+                {statusMessage ? (
+                  <div
+                    className={`mt-4 rounded-[16px] border px-3 py-2 text-[11px] leading-5 ${
+                      statusTone === "success"
+                        ? "border-[rgba(247,90,84,0.22)] bg-[rgba(247,90,84,0.08)] text-text-main/88"
+                        : statusTone === "error"
+                          ? "border-[rgba(255,153,102,0.24)] bg-[rgba(255,153,102,0.08)] text-[rgba(255,212,189,0.92)]"
+                          : "border-panel-border/35 bg-black/10 text-text-muted"
+                    }`}
+                  >
+                    {statusMessage}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+                <div className="grid gap-2">
+                  {sortedCronjobs.map((job) => {
+                    const active = job.id === selectedJobId;
+                    return (
+                      <button
+                        key={job.id}
+                        type="button"
+                        onClick={() => setSelectedJobId(job.id)}
+                        className={`group relative overflow-hidden rounded-[20px] border px-4 py-4 text-left transition-all duration-200 ${
+                          active
+                            ? "border-[rgba(247,90,84,0.3)] bg-[linear-gradient(145deg,rgba(247,90,84,0.08),rgba(255,255,255,0.02))] shadow-card"
+                            : "border-panel-border/35 bg-panel-bg/18 hover:border-[rgba(247,90,84,0.24)] hover:bg-[var(--theme-hover-bg)]"
                         }`}
                       >
-                        {job.enabled ? "Enabled" : "Disabled"}
-                      </span>
+                        <div
+                          className={`absolute inset-y-4 left-0 w-1 rounded-r-full transition-all duration-200 ${
+                            active ? "bg-[rgba(247,90,84,0.82)]" : "bg-transparent group-hover:bg-[rgba(247,90,84,0.35)]"
+                          }`}
+                        />
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-[13px] font-medium text-text-main">{job.name || job.description}</div>
+                            <div className="mt-1 truncate text-[11px] uppercase tracking-[0.14em] text-text-dim/72">
+                              {job.cron}
+                            </div>
+                          </div>
+                          <span
+                            className={`shrink-0 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.14em] ${
+                              job.enabled
+                                ? "border-[rgba(247,90,84,0.24)] bg-[rgba(247,90,84,0.08)] text-[rgba(206,92,84,0.92)]"
+                                : "border-panel-border/35 bg-black/10 text-text-dim/74"
+                            }`}
+                          >
+                            {job.enabled ? "Enabled" : "Paused"}
+                          </span>
+                        </div>
+                        <div
+                          className="mt-2 text-[12px] leading-6 text-text-muted/82"
+                          style={{
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical",
+                            overflow: "hidden"
+                          }}
+                        >
+                          {job.description}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </aside>
+
+            <div className="theme-subtle-surface flex h-full min-h-0 flex-col overflow-hidden rounded-[28px] border border-panel-border/35 shadow-card">
+              {selectedJob ? (
+                <>
+                  <div className="relative overflow-hidden border-b border-panel-border/35 px-5 py-5">
+                    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(247,90,84,0.08),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.04),transparent_32%)]" />
+                    <div className="relative">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="inline-flex items-center gap-2 rounded-full border border-panel-border/35 bg-black/10 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-text-dim/76">
+                            <Workflow size={12} className="text-text-dim/78" />
+                            <span>{selectedJob.cron}</span>
+                          </div>
+                          <div className="mt-3 text-[28px] font-semibold tracking-[-0.04em] text-text-main">
+                            {selectedJob.name || selectedJob.description}
+                          </div>
+                          <div className="mt-2 max-w-[760px] text-[13px] leading-7 text-text-muted/84">
+                            {selectedJob.description}
+                          </div>
+                        </div>
+                        <div
+                          className={`rounded-full border px-3 py-1.5 text-[11px] uppercase tracking-[0.14em] ${
+                            selectedJob.enabled
+                              ? "border-[rgba(247,90,84,0.24)] bg-[rgba(247,90,84,0.08)] text-[rgba(206,92,84,0.92)]"
+                              : "border-panel-border/35 bg-black/10 text-text-dim/74"
+                          }`}
+                        >
+                          {selectedJob.enabled ? "Enabled" : "Paused"}
+                        </div>
+                      </div>
+
+                      <div className="mt-5 grid gap-3 md:grid-cols-2">
+                        <MetadataRow label="Delivery" value={formatDeliverySummary(selectedJob)} />
+                        <MetadataRow label="Last status" value={formatStatusLabel(selectedJob.last_status)} />
+                        <MetadataRow label="Next run" value={formatTimestamp(selectedJob.next_run_at)} />
+                        <MetadataRow label="Last run" value={formatTimestamp(selectedJob.last_run_at)} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="grid min-h-0 flex-1 gap-4 p-4">
+                    <div className="rounded-[24px] border border-panel-border/35 bg-[var(--theme-subtle-bg)] p-4">
+                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.16em] text-text-dim/76">
+                        <Clock3 size={13} className="text-[rgba(247,138,132,0.86)]" />
+                        <span>Run summary</span>
+                      </div>
+                      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                        <MetadataRow label="Runs" value={formatCount(selectedJob.run_count)} />
+                        <MetadataRow label="Initiated by" value={selectedJob.initiated_by || "Unknown"} />
+                      </div>
+
+                      {selectedJob.last_error ? (
+                        <div className="mt-4 rounded-[16px] border border-[rgba(255,153,102,0.24)] bg-[rgba(255,153,102,0.08)] px-4 py-3 text-[12px] leading-6 text-[rgba(255,212,189,0.92)]">
+                          <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.16em]">
+                            <TriangleAlert size={12} />
+                            <span>Last error</span>
+                          </div>
+                          <div className="mt-2">{selectedJob.last_error}</div>
+                        </div>
+                      ) : null}
                     </div>
 
-                    <div className="mt-3 grid gap-1 text-[10px] text-text-dim/78">
-                      <div>Next run: {formatTimestamp(job.next_run_at)}</div>
-                      <div>Last run: {formatTimestamp(job.last_run_at)}</div>
-                      <div>Runs: {job.run_count}</div>
-                      {job.last_status ? <div>Status: {job.last_status}</div> : null}
-                      {job.last_error ? <div>Last error: {job.last_error}</div> : null}
-                    </div>
-
-                    <div className="mt-3 flex flex-wrap gap-2">
+                    <div className="mt-auto flex flex-wrap gap-2">
                       <button
                         type="button"
-                        onClick={() => void handleToggleEnabled(job)}
-                        disabled={isBusy}
-                        className="inline-flex h-8 items-center justify-center gap-2 rounded-[12px] border border-panel-border/45 px-3 text-[10px] text-text-muted transition hover:border-neon-green/35 hover:text-text-main disabled:cursor-not-allowed disabled:opacity-50"
+                        onClick={() => void handleToggleEnabled(selectedJob)}
+                        disabled={busyJobId === selectedJob.id}
+                        className="theme-control-surface inline-flex h-10 items-center justify-center gap-2 rounded-[14px] border border-panel-border/45 px-4 text-[11px] text-text-muted transition hover:border-[rgba(247,90,84,0.24)] hover:text-text-main disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
-                        <span>{job.enabled ? "Disable" : "Enable"}</span>
+                        {busyJobId === selectedJob.id ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+                        <span>{selectedJob.enabled ? "Disable" : "Enable"}</span>
                       </button>
                       <button
                         type="button"
-                        onClick={() => void handleDelete(job)}
-                        disabled={isBusy}
-                        className="inline-flex h-8 items-center justify-center gap-2 rounded-[12px] border border-[rgba(255,153,102,0.24)] px-3 text-[10px] text-[rgba(255,212,189,0.92)] transition hover:bg-[rgba(255,153,102,0.08)] disabled:cursor-not-allowed disabled:opacity-50"
+                        onClick={() => void handleDelete(selectedJob)}
+                        disabled={busyJobId === selectedJob.id}
+                        className="inline-flex h-10 items-center justify-center gap-2 rounded-[14px] border border-[rgba(255,153,102,0.24)] px-4 text-[11px] text-[rgba(255,212,189,0.92)] transition hover:bg-[rgba(255,153,102,0.08)] disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
+                        {busyJobId === selectedJob.id ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
                         <span>Delete</span>
                       </button>
                     </div>
                   </div>
-                );
-              })}
+                </>
+              ) : (
+                <EmptyState title="No automation selected" detail="Choose an automation from the list to inspect it." />
+              )}
             </div>
-          )}
-        </div>
-
+          </div>
+        )}
       </div>
-    </PaneCard>
+    </section>
   );
 }
 
-function EmptyState({ message }: { message: string }) {
+function MetadataRow({ label, value, className = "" }: { label: string; value: string; className?: string }) {
   return (
-    <div className="flex h-full min-h-full w-full items-center justify-center px-6 py-8">
-      <div className="w-full max-w-[420px] rounded-[24px] border border-panel-border/30 bg-[linear-gradient(180deg,rgba(255,255,255,0.74),rgba(255,255,255,0.42))] px-8 py-9 text-center shadow-card">
-        <div className="mx-auto grid h-10 w-10 place-items-center rounded-full border border-[rgba(247,90,84,0.18)] text-[rgba(247,90,84,0.84)]">
-          <Clock3 size={18} />
+    <div className={`rounded-[16px] border border-panel-border/35 bg-[var(--theme-subtle-bg)] px-3 py-2 ${className}`.trim()}>
+      <div className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">{label}</div>
+      <div className="mt-1 break-all text-[12px] text-text-main/86">{value}</div>
+    </div>
+  );
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex h-full min-h-[320px] items-center justify-center px-6 py-8">
+      <div className="inline-flex items-center gap-2 text-[12px] text-text-muted">
+        <Loader2 size={14} className="animate-spin" />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  detail,
+  tone = "neutral"
+}: {
+  title: string;
+  detail: string;
+  tone?: "neutral" | "error";
+}) {
+  return (
+    <div className="flex h-full min-h-[320px] items-center justify-center px-6 py-8">
+      <div
+        className={`w-full max-w-[420px] rounded-[24px] border px-8 py-9 text-center shadow-card ${
+          tone === "error"
+            ? "border-[rgba(255,153,102,0.24)] bg-[linear-gradient(180deg,rgba(255,153,102,0.08),rgba(255,255,255,0.38))]"
+            : "border-panel-border/30 bg-[linear-gradient(180deg,rgba(255,255,255,0.74),rgba(255,255,255,0.42))]"
+        }`}
+      >
+        <div
+          className={`mx-auto grid h-10 w-10 place-items-center rounded-full border ${
+            tone === "error"
+              ? "border-[rgba(255,153,102,0.24)] text-[rgba(255,153,102,0.92)]"
+              : "border-[rgba(247,90,84,0.18)] text-[rgba(247,90,84,0.84)]"
+          }`}
+        >
+          {tone === "error" ? <TriangleAlert size={18} /> : <Sparkles size={18} />}
         </div>
-        <div className="mt-3 text-[15px] font-medium text-text-main">No automations yet</div>
-        <div className="mt-2 text-[12px] leading-6 text-text-muted/82">{message}</div>
+        <div className="mt-3 text-[16px] font-medium text-text-main">{title}</div>
+        <div className="mt-2 text-[12px] leading-6 text-text-muted/82">{detail}</div>
       </div>
     </div>
   );

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -107,6 +107,9 @@ interface PendingExplorerAttachmentFile {
 type PendingAttachment = PendingLocalAttachmentFile | PendingExplorerAttachmentFile;
 type StartupPhaseTone = "loading" | "ready" | "error" | "waiting";
 
+const STARTUP_OVERLAY_INITIAL_DELAY_MS = 320;
+const STARTUP_OVERLAY_REPEAT_DELAY_MS = 1400;
+
 interface StreamTelemetryEntry {
   id: string;
   at: string;
@@ -390,16 +393,6 @@ function summarizeUnknown(value: unknown, maxLength = 140): string {
     return "";
   }
   return String(value);
-}
-
-function assistantMetaLabel(harness: string | null | undefined, model: string | null | undefined) {
-  const harnessLabel = harness ? startCase(harness) : "";
-  if (harnessLabel) {
-    return harnessLabel;
-  }
-
-  const modelLabel = (model || "").trim();
-  return modelLabel || "Local runtime";
 }
 
 function toolTraceStepId(payload: Record<string, unknown>) {
@@ -762,6 +755,7 @@ export function ChatPane({
   const pendingInputIdRef = useRef<string | null>(null);
   const seenMainDebugKeysRef = useRef<Set<string>>(new Set());
   const selectedWorkspaceRef = useRef<WorkspaceRecordPayload | null>(null);
+  const startupUnlockedWorkspaceIdsRef = useRef<Set<string>>(new Set());
   const isOnboardingVariant = variant === "onboarding";
   const managedMode = !isOnboardingVariant && Boolean(onManagedSessionObserved && onManagedQueueSessionInput);
   const pendingFocusRequestKeyRef = useRef<number | null>(focusRequestKey);
@@ -2383,9 +2377,6 @@ export function ChatPane({
   };
 
   const assistantLabel = "Holaboss";
-  const assistantMode = isOnboardingVariant
-    ? "workspace setup"
-    : assistantMetaLabel(selectedWorkspace?.harness, runtimeConfig?.defaultModel);
   const hasMessages =
     messages.length > 0 ||
     Boolean(effectiveLiveAssistantText) ||
@@ -2455,11 +2446,12 @@ export function ChatPane({
     runtimeLifecycleStatus === "stopping" ||
     runtimeLifecycleStatus === "stopped";
   const workspaceAppsStartupBlocked = !isOnboardingVariant && runtimeLifecycleStatus === "running" && !workspaceAppsReady;
-  const showStartupOverlay =
+  const rawShowStartupOverlay =
     !isOnboardingVariant &&
     Boolean(selectedWorkspace) &&
     Boolean(resolvedUserId) &&
     (runtimeStartupBlocked || workspaceAppsStartupBlocked);
+  const [showStartupOverlay, setShowStartupOverlay] = useState(false);
   const startupOverlayTone: StartupPhaseTone =
     runtimeLifecycleStatus === "error" ? "error" : showStartupOverlay ? "loading" : "ready";
   const startupOverlayTitle =
@@ -2542,6 +2534,38 @@ export function ChatPane({
       ? (chatScrollMetrics.scrollTop / chatScrollRange) * chatScrollbarThumbTravel
       : 0
     : 0;
+
+  useEffect(() => {
+    if (!selectedWorkspace?.id || isOnboardingVariant) {
+      return;
+    }
+    if (!runtimeStartupBlocked && !workspaceAppsStartupBlocked) {
+      startupUnlockedWorkspaceIdsRef.current.add(selectedWorkspace.id);
+    }
+  }, [isOnboardingVariant, runtimeStartupBlocked, selectedWorkspace?.id, workspaceAppsStartupBlocked]);
+
+  useEffect(() => {
+    if (!rawShowStartupOverlay) {
+      setShowStartupOverlay(false);
+      return;
+    }
+
+    if (runtimeLifecycleStatus === "error") {
+      setShowStartupOverlay(true);
+      return;
+    }
+
+    const workspaceId = selectedWorkspace?.id || "";
+    const hasUnlockedWorkspace = workspaceId ? startupUnlockedWorkspaceIdsRef.current.has(workspaceId) : false;
+    const delayMs = hasUnlockedWorkspace ? STARTUP_OVERLAY_REPEAT_DELAY_MS : STARTUP_OVERLAY_INITIAL_DELAY_MS;
+    const timer = window.setTimeout(() => {
+      setShowStartupOverlay(true);
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [rawShowStartupOverlay, runtimeLifecycleStatus, selectedWorkspace?.id]);
 
   useEffect(() => {
     if (!hasMessages) {
@@ -2786,7 +2810,6 @@ export function ChatPane({
                       <AssistantTurn
                         key={message.id}
                         label={assistantLabel}
-                        mode={assistantMode}
                         text={message.text}
                         contentBlocks={message.contentBlocks ?? []}
                         traceSteps={message.traceSteps ?? []}
@@ -2800,7 +2823,6 @@ export function ChatPane({
                     <div ref={liveAssistantTurnRef} className="scroll-mb-6">
                       <AssistantTurn
                         label={assistantLabel}
-                        mode={assistantMode}
                         text={effectiveLiveAssistantText}
                         contentBlocks={effectiveLiveContentBlocks}
                         traceSteps={effectiveLiveTraceSteps}
@@ -3003,7 +3025,6 @@ function UserTurn({
 
 function AssistantTurn({
   label,
-  mode,
   text,
   contentBlocks,
   traceSteps,
@@ -3013,7 +3034,6 @@ function AssistantTurn({
   live = false
 }: {
   label: string;
-  mode: string;
   text: string;
   contentBlocks: ChatTurnBlock[];
   traceSteps: ChatTraceStep[];
@@ -3048,9 +3068,6 @@ function AssistantTurn({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <div className="text-[12px] font-medium text-text-main/94">{label}</div>
-              <div className="rounded-full border border-panel-border/35 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-text-dim/76">
-                {mode}
-              </div>
               {live ? (
                 <div className="rounded-full border border-[rgba(247,90,84,0.18)] bg-[rgba(247,90,84,0.08)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[rgba(206,92,84,0.92)]">
                   Live

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -61,6 +61,8 @@ const LANGUAGE_BY_EXTENSION: Record<string, string> = {
   ".csv": "plaintext"
 };
 
+const HIDDEN_WORKSPACE_ENTRY_NAMES = new Set([".opencode", ".holaboss"]);
+
 function getFolderName(targetPath: string) {
   const normalized = targetPath.replace(/[\\/]+$/, "");
   if (/^[a-zA-Z]:$/.test(normalized)) {
@@ -321,9 +323,10 @@ export function FileExplorerPane() {
   const canGoForward = historyIndex >= 0 && historyIndex < history.length - 1;
 
   const filteredEntries = useMemo(() => {
+    const visibleEntries = entries.filter((entry) => !HIDDEN_WORKSPACE_ENTRY_NAMES.has(entry.name));
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) return entries;
-    return entries.filter((entry) => entry.name.toLowerCase().includes(normalizedQuery));
+    if (!normalizedQuery) return visibleEntries;
+    return visibleEntries.filter((entry) => entry.name.toLowerCase().includes(normalizedQuery));
   }, [entries, query]);
 
   const selectedEntry = entries.find((entry) => entry.absolutePath === selectedPath);
@@ -602,7 +605,7 @@ export function FileExplorerPane() {
         <div ref={containerRef} className="flex h-full min-h-0">
           {fileBookmarks.length > 0 ? (
             <aside className="theme-subtle-surface flex w-12 flex-col items-center gap-2 border-r border-neon-green/15 py-3">
-              <div className="chat-scrollbar-hidden flex min-h-0 flex-1 flex-col items-center gap-2 overflow-x-hidden overflow-y-auto px-1">
+              <div className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-x-hidden overflow-y-auto px-1">
                 {fileBookmarks.map((bookmark) => {
                   const isActive = activeBookmarkId === bookmark.targetPath;
                   const Icon = bookmark.isDirectory ? Folder : FileText;
@@ -693,7 +696,7 @@ export function FileExplorerPane() {
               </div>
             ) : null}
 
-            <div className="chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2 pt-1">
+            <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2 pt-1">
               {loading ? <div className="px-3 py-4 text-xs text-text-muted/75">Loading directory...</div> : null}
 
               {error ? <div className="px-3 py-3 text-xs text-rose-300/90">{error}</div> : null}

--- a/desktop/src/components/panes/SkillsPane.tsx
+++ b/desktop/src/components/panes/SkillsPane.tsx
@@ -2,15 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { CheckCircle2, FileWarning, FolderTree, Loader2, ScrollText, Search, Sparkles } from "lucide-react";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
-function formatModifiedAt(value: string) {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit"
-  }).format(new Date(value));
-}
-
 function normalizeErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Request failed.";
 }
@@ -126,7 +117,6 @@ export function SkillsPane() {
 
   const hasWorkspace = Boolean(selectedWorkspaceId);
   const hasSkills = Boolean(catalog?.skills.length);
-  const selectedSkillStatusLabel = selectedSkill?.enabled ? "Enabled in workspace.yaml" : "Available in skills path";
 
   return (
     <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-[var(--theme-radius-card)] shadow-card">
@@ -156,9 +146,6 @@ export function SkillsPane() {
                   <div>
                     <div className="text-[10px] uppercase tracking-[0.16em] text-text-dim/72">Registry</div>
                     <div className="mt-1 text-[14px] font-medium text-text-main">Workspace skill catalog</div>
-                  </div>
-                  <div className="rounded-full border border-panel-border/35 bg-black/10 px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-text-dim/72">
-                    {filteredSkills.length} shown
                   </div>
                 </div>
 
@@ -206,15 +193,6 @@ export function SkillsPane() {
                             {skill.skill_id}
                           </div>
                         </div>
-                        <span
-                          className={`shrink-0 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.14em] ${
-                            skill.enabled
-                              ? "border-[rgba(247,90,84,0.24)] bg-[rgba(247,90,84,0.08)] text-[rgba(206,92,84,0.92)]"
-                              : "border-panel-border/35 bg-black/10 text-text-dim/74"
-                          }`}
-                        >
-                          {skill.enabled ? "Enabled" : "Detected"}
-                        </span>
                       </div>
                       <div
                         className="mt-2 text-[12px] leading-6 text-text-muted/82"
@@ -226,10 +204,6 @@ export function SkillsPane() {
                         }}
                       >
                         {skill.summary}
-                      </div>
-                      <div className="mt-3 flex items-center justify-between gap-3 text-[10px] uppercase tracking-[0.14em] text-text-dim/68">
-                        <span>{formatModifiedAt(skill.modified_at)}</span>
-                        <span>{skill.enabled ? "Configured" : "Detected"}</span>
                       </div>
                     </button>
                   );
@@ -254,13 +228,11 @@ export function SkillsPane() {
                           <div className="mt-3 text-[28px] font-semibold tracking-[-0.04em] text-text-main">{selectedSkill.title}</div>
                           <div className="mt-2 max-w-[760px] text-[13px] leading-7 text-text-muted/84">{selectedSkill.summary}</div>
                         </div>
-                        <StatusPill active={selectedSkill.enabled} label={selectedSkillStatusLabel} />
                       </div>
 
                       <div className="mt-5 grid gap-3 md:grid-cols-3">
-                        <MetadataRow label="Modified" value={formatModifiedAt(selectedSkill.modified_at)} />
                         <MetadataRow label="Source directory" value={selectedSkill.source_dir} />
-                        <MetadataRow label="SKILL.md" value={selectedSkill.skill_file_path} />
+                        <MetadataRow label="SKILL.md" value={selectedSkill.skill_file_path} className="md:col-span-2" />
                       </div>
                     </div>
                   </div>
@@ -296,20 +268,6 @@ export function SkillsPane() {
         )}
       </div>
     </section>
-  );
-}
-
-function StatusPill({ active, label }: { active: boolean; label: string }) {
-  return (
-    <div
-      className={`rounded-full border px-3 py-1.5 text-[11px] uppercase tracking-[0.14em] ${
-        active
-          ? "border-[rgba(247,90,84,0.24)] bg-[rgba(247,90,84,0.08)] text-[rgba(206,92,84,0.92)]"
-          : "border-panel-border/35 bg-black/10 text-text-dim/74"
-      }`}
-    >
-      {label}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- polish desktop account, chat, skills, automations, and right-panel UI
- simplify the automations pane to match the skills-pane structure
- remove extra badges and smooth a few popup/startup interaction issues

## Verification
- npm --prefix desktop run typecheck