### PR TITLE
fix: allow direct providers without holaboss session

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ If a model id is unprefixed and does not start with `claude`, the runtime treats
       "kind": "openrouter",
       "base_url": "https://openrouter.ai/api/v1",
       "api_key": "sk-or-your-openrouter-key"
+    },
+    "ollama_direct": {
+      "kind": "openai_compatible",
+      "base_url": "http://localhost:11434/v1",
+      "api_key": "ollama"
     }
   },
   "models": {
@@ -205,6 +210,10 @@ If a model id is unprefixed and does not start with `claude`, the runtime treats
     "openrouter_direct/anthropic/claude-sonnet-4-5": {
       "provider": "openrouter_direct",
       "model": "anthropic/claude-sonnet-4-5"
+    },
+    "ollama_direct/qwen2.5:0.5b": {
+      "provider": "ollama_direct",
+      "model": "qwen2.5:0.5b"
     }
   }
 }
@@ -216,6 +225,45 @@ Provider `kind` values supported by the runtime resolver:
 - `openai_compatible`
 - `anthropic_native`
 - `openrouter`
+
+### Verify Ollama Through The Desktop UI
+
+This is the simplest end-to-end check for the local `ollama_direct` path.
+
+1. Install and start Ollama on your machine.
+2. Pull a minimal local model:
+
+```bash
+ollama pull qwen2.5:0.5b
+```
+
+3. Launch the desktop app.
+4. Open `Settings -> Models`.
+5. Connect `Ollama` with:
+   - base URL: `http://localhost:11434/v1`
+   - API key: `ollama`
+   - models: `qwen2.5:0.5b`
+6. Open a workspace chat and select `ollama_direct/qwen2.5:0.5b`.
+7. Send this prompt:
+
+```text
+Reply with exactly: OK
+```
+
+Expected result:
+
+- the run starts with provider `ollama_direct`
+- the model resolves to `qwen2.5:0.5b`
+- the assistant replies with `OK`
+
+If the model does not show up or the request fails, verify Ollama directly first:
+
+```bash
+curl http://localhost:11434/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer ollama' \
+  -d '{"model":"qwen2.5:0.5b","messages":[{"role":"user","content":"Reply with exactly: OK"}],"temperature":0}'
+```
 
 ### Environment Overrides
 

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -3959,6 +3959,8 @@ async function clearRuntimeBindingSecrets(reason: string): Promise<void> {
   const nextConfig = await writeRuntimeConfigFile({
     authToken: null,
     modelProxyApiKey: null,
+    userId: null,
+    sandboxId: null,
     modelProxyBaseUrl: null,
     controlPlaneBaseUrl: null
   });
@@ -6878,12 +6880,15 @@ function renderEmptyOnboardingGuide() {
 }
 
 async function createWorkspace(payload: HolabossCreateWorkspacePayload): Promise<WorkspaceResponsePayload> {
-  await ensureRuntimeBindingReadyForWorkspaceFlow("workspace_create");
   const mainSessionId = crypto.randomUUID();
   const harness = normalizeRequestedWorkspaceHarness(payload.harness);
   const templateMode = requestedWorkspaceTemplateMode(payload);
   const templateRootPath = payload.template_root_path?.trim() || "";
   const templateName = payload.template_name?.trim() || "";
+  const requiresRuntimeBinding = templateMode !== "empty" && !templateRootPath && Boolean(templateName);
+  if (requiresRuntimeBinding) {
+    await ensureRuntimeBindingReadyForWorkspaceFlow("workspace_create");
+  }
   if (templateMode !== "empty" && !templateRootPath && templateName) {
     const holabossUserId = (payload.holaboss_user_id || "").trim();
     if (controlPlaneApiKey() && holabossUserId && holabossUserId !== LOCAL_OSS_TEMPLATE_USER_ID) {
@@ -7028,15 +7033,36 @@ async function createWorkspace(payload: HolabossCreateWorkspacePayload): Promise
         }).catch(() => updated);
       }
     }
-    try {
-      await emitWorkspaceReadyHeartbeat({
-        workspaceId,
-        holabossUserId: payload.holaboss_user_id
+    const runtimeConfigForHeartbeat = await readRuntimeConfigFile();
+    const runtimeHeartbeatToken = runtimeModelProxyApiKeyFromConfig(runtimeConfigForHeartbeat);
+    const runtimeHeartbeatUserId = (runtimeConfigForHeartbeat.user_id || "").trim();
+    const requestedHeartbeatUserId = (payload.holaboss_user_id || "").trim();
+    const shouldEmitWorkspaceReadyHeartbeat =
+      Boolean(runtimeHeartbeatToken) &&
+      Boolean(requestedHeartbeatUserId) &&
+      requestedHeartbeatUserId !== LOCAL_OSS_TEMPLATE_USER_ID &&
+      runtimeHeartbeatUserId === requestedHeartbeatUserId;
+
+    if (shouldEmitWorkspaceReadyHeartbeat) {
+      try {
+        await emitWorkspaceReadyHeartbeat({
+          workspaceId,
+          holabossUserId: requestedHeartbeatUserId
+        });
+      } catch (error) {
+        throw new Error(
+          contextualWorkspaceCreateError("Workspace created locally, but the workspace-ready heartbeat was not confirmed", error)
+        );
+      }
+    } else {
+      appendRuntimeEventLog({
+        category: "workspace",
+        event: "workspace.heartbeat.emit",
+        outcome: "skipped",
+        detail:
+          `workspace_id=${workspaceId} skipped=no_active_runtime_binding ` +
+          `requested_user_id=${requestedHeartbeatUserId || "missing"} runtime_user_id=${runtimeHeartbeatUserId || "missing"}`
       });
-    } catch (error) {
-      throw new Error(
-        contextualWorkspaceCreateError("Workspace created locally, but the workspace-ready heartbeat was not confirmed", error)
-      );
     }
     return updated;
   } catch (error) {

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import anthropicLogo from "@/assets/providers/anthropic.svg";
 import geminiLogo from "@/assets/providers/gemini.svg";
 import ollamaLogo from "@/assets/providers/ollama.svg";
@@ -50,7 +50,7 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
   },
   openai_direct: {
     id: "openai_direct",
-    label: "OpenAI Direct",
+    label: "OpenAI",
     description: "Direct OpenAI-compatible endpoint with your own API key.",
     kind: "openai_compatible",
     defaultBaseUrl: "https://api.openai.com/v1",
@@ -59,7 +59,7 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
   },
   anthropic_direct: {
     id: "anthropic_direct",
-    label: "Anthropic Direct",
+    label: "Anthropic",
     description: "Direct Anthropic native endpoint with your own API key.",
     kind: "anthropic_native",
     defaultBaseUrl: "https://api.anthropic.com/v1",
@@ -77,7 +77,7 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
   },
   gemini_direct: {
     id: "gemini_direct",
-    label: "Gemini Direct",
+    label: "Gemini",
     description: "Google Gemini OpenAI-compatible endpoint with your own API key.",
     kind: "openai_compatible",
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
@@ -196,6 +196,9 @@ function enabledProviderIdsForDrafts(providerDrafts: ProviderDraftMap, isSignedI
 }
 
 function ProviderBrandIcon({ providerId }: { providerId: KnownProviderId }) {
+  if (providerId === "holaboss") {
+    return <img src="/logo.svg" alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
+  }
   if (providerId === "openai_direct") {
     return <img src={openaiLogo} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
   }
@@ -211,11 +214,7 @@ function ProviderBrandIcon({ providerId }: { providerId: KnownProviderId }) {
   if (providerId === "ollama_direct") {
     return <img src={ollamaLogo} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
   }
-  return (
-    <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
-      <path d="M5 6h4v5h6V6h4v12h-4v-5H9v5H5V6Z" fill="currentColor" />
-    </svg>
-  );
+  return null;
 }
 
 function deriveProviderDraftsFromDocument(
@@ -361,6 +360,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   const [runtimeConfig, setRuntimeConfig] = useState<RuntimeConfigPayload | null>(null);
   const [runtimeConfigDocument, setRuntimeConfigDocument] = useState("");
   const [providerDrafts, setProviderDrafts] = useState<ProviderDraftMap>(() => createDefaultProviderDrafts());
+  const [expandedProviderId, setExpandedProviderId] = useState<KnownProviderId | null>(null);
   const [sandboxId, setSandboxId] = useState("");
   const [authError, setAuthError] = useState("");
   const [authMessage, setAuthMessage] = useState("");
@@ -461,6 +461,8 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   const isSignedIn = Boolean(sessionUserId(session));
   const providerEnabled = (providerId: KnownProviderId) =>
     providerId === "holaboss" ? isSignedIn : providerDrafts[providerId].enabled;
+  const connectedProviderIds = KNOWN_PROVIDER_ORDER.filter((providerId) => providerEnabled(providerId));
+  const availableProviderIds = KNOWN_PROVIDER_ORDER.filter((providerId) => !providerEnabled(providerId));
 
   const showAccountSection = view !== "runtime";
   const showRuntimeSection = view !== "account";
@@ -752,6 +754,161 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     }
   }
 
+  function renderProviderDrawerContent(providerId: KnownProviderId): ReactNode {
+    if (providerId === "holaboss") {
+      return null;
+    }
+
+    if (!providerEnabled(providerId)) {
+      return (
+        <div className="rounded-[12px] border border-panel-border/25 bg-black/10 px-3 py-2 text-[11px] leading-5 text-text-dim/76">
+          Connect this provider to edit its base URL, API key, and model list here.
+        </div>
+      );
+    }
+
+    const template = KNOWN_PROVIDER_TEMPLATES[providerId];
+    const draft = providerDrafts[providerId];
+    return (
+      <div className="grid gap-2">
+        <label className="grid gap-1">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">Base URL</span>
+          <input
+            className="theme-control-surface h-9 rounded-[10px] border border-panel-border/45 px-2.5 text-[11px] text-text-main outline-none transition focus:border-neon-green/55"
+            value={draft.baseUrl}
+            onChange={(event) => updateProviderDraft(providerId, { baseUrl: event.target.value })}
+            placeholder={template.defaultBaseUrl}
+            spellCheck={false}
+          />
+        </label>
+        <label className="grid gap-1">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">API Key</span>
+          <input
+            className="theme-control-surface h-9 rounded-[10px] border border-panel-border/45 px-2.5 text-[11px] text-text-main outline-none transition focus:border-neon-green/55"
+            type="password"
+            value={draft.apiKey}
+            onChange={(event) => updateProviderDraft(providerId, { apiKey: event.target.value })}
+            placeholder={template.apiKeyPlaceholder}
+            spellCheck={false}
+          />
+        </label>
+        <label className="grid gap-1">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">Models</span>
+          <textarea
+            className="theme-control-surface min-h-[60px] rounded-[10px] border border-panel-border/45 px-2.5 py-2 text-[11px] leading-5 text-text-main outline-none transition focus:border-neon-green/55"
+            value={draft.modelsText}
+            onChange={(event) => updateProviderDraft(providerId, { modelsText: event.target.value })}
+            placeholder={template.defaultModels.join(", ")}
+            spellCheck={false}
+          />
+          <span className="text-[10px] text-text-dim/68">Comma or newline separated model IDs.</span>
+        </label>
+      </div>
+    );
+  }
+
+  function renderProviderCard(providerId: KnownProviderId) {
+    const template = KNOWN_PROVIDER_TEMPLATES[providerId];
+    const isHolabossProvider = providerId === "holaboss";
+    const isEnabled = providerEnabled(providerId);
+    const isExpandable = !isHolabossProvider;
+    const isExpanded = isExpandable && expandedProviderId === providerId;
+    const sublabel = isHolabossProvider ? (isEnabled ? "Managed" : "Sign in required") : isEnabled ? "Connected" : template.description;
+    const actionButtonClassName =
+      "inline-flex h-9 min-w-[96px] shrink-0 items-center justify-center rounded-[10px] px-3 text-[11px] transition disabled:cursor-not-allowed disabled:opacity-50";
+
+    return (
+      <div
+        key={providerId}
+        className={`theme-control-surface overflow-hidden rounded-[14px] border transition ${
+          isExpanded ? "border-neon-green/35 bg-black/10" : "border-panel-border/30"
+        }`}
+      >
+        <div className="flex items-center justify-between gap-3 px-3 py-3">
+          {isExpandable ? (
+            <button
+              type="button"
+              onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
+              className="flex min-w-0 flex-1 items-center gap-3 rounded-[10px] text-left outline-none transition hover:text-text-main focus-visible:ring-2 focus-visible:ring-neon-green/45"
+              aria-expanded={isExpanded}
+            >
+              <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[12px] border border-panel-border/35 bg-black/14 text-text-main/86">
+                <ProviderBrandIcon providerId={providerId} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[13px] font-medium text-text-main">{template.label}</span>
+                <span className="mt-0.5 block text-[11px] text-text-muted/72">{sublabel}</span>
+              </span>
+              <span
+                className={`shrink-0 text-text-dim/72 transition ${isExpanded ? "rotate-180 text-neon-green" : ""}`}
+                aria-hidden="true"
+              >
+                <svg viewBox="0 0 16 16" className="h-4 w-4">
+                  <path d="m4 6 4 4 4-4" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+                </svg>
+              </span>
+            </button>
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[12px] border border-panel-border/35 bg-black/14 text-text-main/86">
+                <ProviderBrandIcon providerId={providerId} />
+              </span>
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-text-main">{template.label}</div>
+                <div className="mt-0.5 text-[11px] text-text-muted/72">{sublabel}</div>
+              </div>
+            </div>
+          )}
+
+          {isHolabossProvider ? (
+            isEnabled ? (
+              <div className="rounded-full border border-neon-green/30 bg-neon-green/8 px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-neon-green">
+                Enabled
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void handleStartSignIn()}
+                disabled={isStartingSignIn}
+                className={`${actionButtonClassName} border border-neon-green/40 bg-neon-green/10 text-neon-green hover:bg-neon-green/16`}
+              >
+                {isStartingSignIn ? "Opening..." : "Sign in"}
+              </button>
+            )
+          ) : isEnabled ? (
+            <button
+              type="button"
+              onClick={() => {
+                updateProviderDraft(providerId, { enabled: false });
+                setExpandedProviderId((current) => (current === providerId ? null : current));
+              }}
+              className={`${actionButtonClassName} border border-panel-border/45 text-text-main hover:border-[rgba(247,90,84,0.4)] hover:text-[rgba(206,92,84,0.92)]`}
+            >
+              Disconnect
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                updateProviderDraft(providerId, { enabled: true });
+                setExpandedProviderId(providerId);
+              }}
+              className={`${actionButtonClassName} border border-panel-border/45 text-text-main hover:border-neon-green/35 hover:text-neon-green`}
+            >
+              Connect
+            </button>
+          )}
+        </div>
+
+        {isExpanded && (
+          <div className="border-t border-panel-border/25 px-3 pb-3 pt-3">
+            {renderProviderDrawerContent(providerId)}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   const runtimeProviderSettings = (
     <div className="theme-subtle-surface mt-3 grid gap-4 rounded-[20px] border border-panel-border/35 p-4">
       <div>
@@ -764,43 +921,12 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
       <div className="rounded-[18px] border border-panel-border/35 bg-black/8 p-4">
         <div className="text-[11px] font-medium text-text-main/92">Connected providers</div>
         <div className="mt-3 grid gap-2">
-          {KNOWN_PROVIDER_ORDER.filter((providerId) => providerEnabled(providerId)).length === 0 ? (
+          {connectedProviderIds.length === 0 ? (
             <div className="rounded-[12px] border border-panel-border/30 bg-black/6 px-3 py-2 text-[11px] text-text-dim/78">
               No connected providers.
             </div>
           ) : (
-            KNOWN_PROVIDER_ORDER.filter((providerId) => providerEnabled(providerId)).map((providerId) => {
-              const template = KNOWN_PROVIDER_TEMPLATES[providerId];
-              const isHolabossProvider = providerId === "holaboss";
-              return (
-                <div key={providerId} className="theme-control-surface flex items-center justify-between gap-3 rounded-[14px] border border-panel-border/30 px-3 py-3">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[12px] border border-panel-border/35 bg-black/14 text-text-main/86">
-                      <ProviderBrandIcon providerId={providerId} />
-                    </span>
-                    <div className="min-w-0">
-                      <div className="text-[13px] font-medium text-text-main">{template.label}</div>
-                      <div className="mt-0.5 text-[11px] text-text-muted/72">
-                        {isHolabossProvider ? "Managed" : "Custom"}
-                      </div>
-                    </div>
-                  </div>
-                  {isHolabossProvider ? (
-                    <div className="rounded-full border border-neon-green/30 bg-neon-green/8 px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-neon-green">
-                      Enabled
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => updateProviderDraft(providerId, { enabled: false })}
-                      className="rounded-[10px] border border-panel-border/45 px-3 py-1.5 text-[11px] text-text-main transition hover:border-[rgba(247,90,84,0.4)] hover:text-[rgba(206,92,84,0.92)]"
-                    >
-                      Disconnect
-                    </button>
-                  )}
-                </div>
-              );
-            })
+            connectedProviderIds.map((providerId) => renderProviderCard(providerId))
           )}
         </div>
       </div>
@@ -808,102 +934,12 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
       <div className="rounded-[18px] border border-panel-border/35 bg-black/8 p-4">
         <div className="text-[11px] font-medium text-text-main/92">Popular providers</div>
         <div className="mt-3 grid gap-2">
-          {KNOWN_PROVIDER_ORDER.filter((providerId) => !providerEnabled(providerId)).map((providerId) => {
-            const template = KNOWN_PROVIDER_TEMPLATES[providerId];
-            const isHolabossProvider = providerId === "holaboss";
-            return (
-              <div key={providerId} className="theme-control-surface flex items-center justify-between gap-3 rounded-[14px] border border-panel-border/30 px-3 py-3">
-                <div className="flex min-w-0 items-center gap-3">
-                  <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[12px] border border-panel-border/35 bg-black/14 text-text-main/86">
-                    <ProviderBrandIcon providerId={providerId} />
-                  </span>
-                <div className="min-w-0">
-                  <div className="text-[13px] font-medium text-text-main">{template.label}</div>
-                  <div className="mt-0.5 text-[11px] text-text-muted/72">
-                    {isHolabossProvider ? "Sign in required" : template.description}
-                  </div>
-                </div>
-              </div>
-              {isHolabossProvider ? (
-                <button
-                  type="button"
-                  onClick={() => void handleStartSignIn()}
-                  disabled={isStartingSignIn}
-                  className="rounded-[10px] border border-neon-green/40 bg-neon-green/10 px-3 py-1.5 text-[11px] text-neon-green transition hover:bg-neon-green/16 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {isStartingSignIn ? "Opening..." : "Sign in"}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => updateProviderDraft(providerId, { enabled: true })}
-                    className="rounded-[10px] border border-panel-border/45 px-3 py-1.5 text-[11px] text-text-main transition hover:border-neon-green/35 hover:text-neon-green"
-                  >
-                    Connect
-                  </button>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="rounded-[18px] border border-panel-border/35 bg-black/8 p-4">
-        <div className="text-[11px] font-medium text-text-main/92">Connected provider settings</div>
-        <div className="mt-3 grid gap-3">
-          {KNOWN_PROVIDER_ORDER.filter((providerId) => providerEnabled(providerId) && providerId !== "holaboss").length === 0 ? (
+          {availableProviderIds.length === 0 ? (
             <div className="rounded-[12px] border border-panel-border/30 bg-black/6 px-3 py-2 text-[11px] text-text-dim/78">
-              Connect OpenAI, Anthropic, or OpenRouter to configure credentials and models.
+              All known providers are already connected.
             </div>
           ) : (
-            KNOWN_PROVIDER_ORDER.filter((providerId) => providerEnabled(providerId) && providerId !== "holaboss").map((providerId) => {
-              const template = KNOWN_PROVIDER_TEMPLATES[providerId];
-              const draft = providerDrafts[providerId];
-              return (
-                <div key={`${providerId}:settings`} className="rounded-[14px] border border-panel-border/30 bg-black/6 p-3">
-                  <div className="flex items-center gap-2 text-[12px] font-medium text-text-main">
-                    <span className="grid h-7 w-7 place-items-center rounded-[9px] border border-panel-border/35 bg-black/14 text-text-main/84">
-                      <ProviderBrandIcon providerId={providerId} />
-                    </span>
-                    <span>{template.label}</span>
-                  </div>
-                  <div className="mt-3 grid gap-2">
-                    <label className="grid gap-1">
-                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">Base URL</span>
-                      <input
-                        className="theme-control-surface h-9 rounded-[10px] border border-panel-border/45 px-2.5 text-[11px] text-text-main outline-none transition focus:border-neon-green/55"
-                        value={draft.baseUrl}
-                        onChange={(event) => updateProviderDraft(providerId, { baseUrl: event.target.value })}
-                        placeholder={template.defaultBaseUrl}
-                        spellCheck={false}
-                      />
-                    </label>
-                    <label className="grid gap-1">
-                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">API Key</span>
-                      <input
-                        className="theme-control-surface h-9 rounded-[10px] border border-panel-border/45 px-2.5 text-[11px] text-text-main outline-none transition focus:border-neon-green/55"
-                        type="password"
-                        value={draft.apiKey}
-                        onChange={(event) => updateProviderDraft(providerId, { apiKey: event.target.value })}
-                        placeholder={template.apiKeyPlaceholder}
-                        spellCheck={false}
-                      />
-                    </label>
-                    <label className="grid gap-1">
-                      <span className="text-[10px] uppercase tracking-[0.14em] text-text-dim/72">Models</span>
-                      <textarea
-                        className="theme-control-surface min-h-[60px] rounded-[10px] border border-panel-border/45 px-2.5 py-2 text-[11px] leading-5 text-text-main outline-none transition focus:border-neon-green/55"
-                        value={draft.modelsText}
-                        onChange={(event) => updateProviderDraft(providerId, { modelsText: event.target.value })}
-                        placeholder={template.defaultModels.join(", ")}
-                        spellCheck={false}
-                      />
-                      <span className="text-[10px] text-text-dim/68">Comma or newline separated model IDs.</span>
-                    </label>
-                  </div>
-                </div>
-              );
-            })
+            availableProviderIds.map((providerId) => renderProviderCard(providerId))
           )}
         </div>
       </div>

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -200,6 +200,20 @@ export function TopTabsBar({
     };
   }, [createPanelOpen, updateWorkspaceSwitcherPosition, workspaceSwitcherOpen]);
 
+  const workspaceErrorOverlay =
+    workspaceErrorMessage && typeof document !== "undefined"
+      ? createPortal(
+          <div className="pointer-events-none fixed inset-x-0 top-[72px] z-[90] flex justify-center px-4">
+            <div
+              className={`${integratedTitleBar ? "window-no-drag " : ""}theme-chat-system-bubble pointer-events-auto w-full max-w-[720px] rounded-[16px] border px-4 py-3 text-[12px] leading-6 shadow-card`}
+            >
+              {workspaceErrorMessage}
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
     <header
       onDoubleClick={handleTitleBarDoubleClick}
@@ -256,12 +270,6 @@ export function TopTabsBar({
           </button>
         </div>
       </div>
-
-      {workspaceErrorMessage ? (
-        <div className={`${integratedTitleBar ? "window-no-drag " : ""}theme-chat-system-bubble mt-2 rounded-[14px] border px-3 py-2 text-[11px] leading-6`}>
-          {workspaceErrorMessage}
-        </div>
-      ) : null}
 
       {workspaceSwitcherOpen && workspaceSwitcherPosition && typeof document !== "undefined"
         ? createPortal(
@@ -513,6 +521,7 @@ export function TopTabsBar({
             document.body
           )
         : null}
+      {workspaceErrorOverlay}
     </header>
   );
 }

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -862,7 +862,6 @@ export function ChatPane({
     runtimeConfig,
     runtimeStatus,
     selectedWorkspace,
-    resolvedUserId,
     isLoadingBootstrap,
     isActivatingWorkspace,
     workspaceAppsReady,
@@ -2134,10 +2133,6 @@ export function ChatPane({
       setChatErrorMessage("Create or select a workspace first.");
       return;
     }
-    if (!resolvedUserId) {
-      setChatErrorMessage("Sign in or set a runtime user id first.");
-      return;
-    }
     if ((runtimeStatus?.status || "").trim().toLowerCase() !== "running") {
       setChatErrorMessage("App is still starting up. Try again in a moment.");
       return;
@@ -2580,8 +2575,6 @@ export function ChatPane({
           : workspaceBlockingReason || (isActivatingWorkspace ? "Preparing workspace apps..." : "Workspace apps are still starting.");
   const composerDisabledReason = !selectedWorkspace
     ? "Select a workspace to start chatting."
-    : !resolvedUserId
-      ? "Sign in or set a runtime user id first."
     : runtimeNotReadyReason
       ? runtimeNotReadyReason
       : !isOnboardingVariant && !workspaceAppsReady
@@ -2599,7 +2592,6 @@ export function ChatPane({
   const rawShowStartupOverlay =
     !isOnboardingVariant &&
     Boolean(selectedWorkspace) &&
-    Boolean(resolvedUserId) &&
     (runtimeStartupBlocked || workspaceAppsStartupBlocked);
   const [showStartupOverlay, setShowStartupOverlay] = useState(false);
   const startupOverlayTone: StartupPhaseTone =

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -179,8 +179,10 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
   const [workspaceBlockingReasonState, setWorkspaceBlockingReasonState] = useState("");
   const [recentAuthCompletedAt, setRecentAuthCompletedAt] = useState<number | null>(null);
 
-  const isSignedIn = Boolean(sessionUserId(session));
-  const resolvedUserId = runtimeConfig?.userId?.trim() || sessionUserId(session);
+  const signedInUserId = sessionUserId(session);
+  const isSignedIn = Boolean(signedInUserId);
+  const runtimeBoundUserId = runtimeConfig?.authTokenPresent ? runtimeConfig?.userId?.trim() || "" : "";
+  const resolvedUserId = runtimeBoundUserId || signedInUserId;
   const canUseMarketplaceTemplates = Boolean(runtimeConfig?.authTokenPresent) && Boolean((resolvedUserId || "").trim());
   const selectedWorkspace = useMemo(
     () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null,

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -6,9 +6,11 @@ import test from "node:test";
 
 import JSZip from "jszip";
 import * as XLSX from "xlsx";
+import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 
 import type { HarnessHostPiRequest } from "./contracts.js";
 import {
+  buildPiProviderConfig,
   buildPiPromptPayload,
   buildPiMcpServerBindings,
   buildPiMcpToolName,
@@ -348,6 +350,43 @@ test("resolvePiSkillDirs returns existing source skill directories in order", ()
     assert.deepEqual(resolvePiSkillDirs(request), [skillAlphaDir, skillBetaDir]);
   } finally {
     fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("buildPiProviderConfig registers runtime-configured ollama models for the Pi harness", () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "hb-pi-model-registry-"));
+  try {
+    const request: HarnessHostPiRequest = {
+      ...baseRequest(),
+      provider_id: "ollama_direct",
+      model_id: "qwen2.5:0.5b",
+      model_client: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "ollama",
+        base_url: "http://localhost:11434/v1",
+        default_headers: {
+          Authorization: "Bearer ollama",
+        },
+      },
+    };
+
+    const authStorage = AuthStorage.create(path.join(stateDir, "auth.json"));
+    const modelRegistry = new ModelRegistry(authStorage, path.join(stateDir, "models.json"));
+    modelRegistry.registerProvider(request.provider_id, buildPiProviderConfig(request));
+
+    const model = modelRegistry.find("ollama_direct", "qwen2.5:0.5b");
+    assert.ok(model);
+    assert.equal(model.provider, "ollama_direct");
+    assert.equal(model.id, "qwen2.5:0.5b");
+    assert.equal(model.api, "openai-completions");
+    assert.equal(model.baseUrl, "http://localhost:11434/v1");
+    assert.deepEqual(model.compat, {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    });
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -21,7 +21,7 @@ import {
   type Skill,
   type ToolDefinition,
 } from "@mariozechner/pi-coding-agent";
-import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
 import type { ResourceDiagnostic } from "@mariozechner/pi-coding-agent";
 import * as XLSX from "xlsx";
 import { createCallResult, createRuntime, type Runtime as McporterRuntime, type ServerDefinition, type ServerToolInfo } from "mcporter";
@@ -892,16 +892,28 @@ function resolvePiModel(request: HarnessHostPiRequest, modelRegistry: ModelRegis
   throw new Error(`Pi model not found for provider=${request.provider_id} model=${request.model_id}`);
 }
 
-async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSessionHandle> {
-  const stateDir = resolvePiStateDir(request.workspace_dir);
-  const sessionDir = resolvePiSessionDir(request.workspace_dir);
-  fs.mkdirSync(stateDir, { recursive: true });
-  fs.mkdirSync(sessionDir, { recursive: true });
+function piApiForRequest(request: HarnessHostPiRequest): Api {
+  const normalizedProvider = request.model_client.model_proxy_provider.trim().toLowerCase();
+  if (normalizedProvider === "anthropic_native") {
+    return "anthropic-messages";
+  }
+  return "openai-completions";
+}
 
-  const authStorage = AuthStorage.create(path.join(stateDir, "auth.json"));
-  authStorage.setRuntimeApiKey(request.provider_id, request.model_client.api_key);
+function piOpenAiCompatForRequest(request: HarnessHostPiRequest): Model<"openai-completions">["compat"] | undefined {
+  const providerId = request.provider_id.trim().toLowerCase();
+  const baseUrl = firstNonEmptyString(request.model_client.base_url)?.toLowerCase() ?? "";
+  if (providerId.includes("ollama") || baseUrl.includes("localhost:11434") || baseUrl.includes("ollama")) {
+    return {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    };
+  }
+  return undefined;
+}
 
-  const modelRegistry = new ModelRegistry(authStorage, path.join(stateDir, "models.json"));
+export function buildPiProviderConfig(request: HarnessHostPiRequest) {
   const providerHeaders = isRecord(request.model_client.default_headers)
     ? Object.fromEntries(
         Object.entries(request.model_client.default_headers).filter(
@@ -913,12 +925,53 @@ async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSe
     const normalizedHeaderName = headerName.trim().toLowerCase();
     return normalizedHeaderName === "x-api-key" || normalizedHeaderName === "authorization";
   });
-  modelRegistry.registerProvider(request.provider_id, {
-    baseUrl: firstNonEmptyString(request.model_client.base_url),
+  const baseUrl = firstNonEmptyString(request.model_client.base_url);
+  if (!baseUrl) {
+    throw new Error(`Pi provider ${request.provider_id} is missing a model client base URL`);
+  }
+
+  const api = piApiForRequest(request);
+  const compat = api === "openai-completions" ? piOpenAiCompatForRequest(request) : undefined;
+
+  return {
+    baseUrl,
+    apiKey: request.model_client.api_key,
+    api,
     headers: providerHeaders,
     // Prefer runtime-managed auth headers when provided by the server, otherwise let Pi attach auth from api_key.
     authHeader: !hasExplicitAuthHeader,
-  });
+    models: [
+      {
+        id: request.model_id,
+        name: request.model_id,
+        api,
+        reasoning: false,
+        input: ["text", "image"] as Array<"text" | "image">,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: 65536,
+        maxTokens: 8192,
+        ...(compat ? { compat } : {}),
+      },
+    ],
+  };
+}
+
+async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSessionHandle> {
+  const stateDir = resolvePiStateDir(request.workspace_dir);
+  const sessionDir = resolvePiSessionDir(request.workspace_dir);
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const authStorage = AuthStorage.create(path.join(stateDir, "auth.json"));
+  authStorage.setRuntimeApiKey(request.provider_id, request.model_client.api_key);
+
+  const modelRegistry = new ModelRegistry(authStorage, path.join(stateDir, "models.json"));
+  modelRegistry.registerProvider(request.provider_id, buildPiProviderConfig(request));
 
   const model = resolvePiModel(request, modelRegistry);
   const settingsManager = SettingsManager.inMemory({


### PR DESCRIPTION
## Context

Direct provider chats could still fail after signing out of Holaboss.

Repro error:
`Error invoking remote method 'workspace:queueSessionInput': Error: Authentication session missing. Sign in again.`

The desktop queue path was always enforcing the Holaboss runtime binding gate, even when the selected model targeted a direct provider such as `openai_direct/...`. If stale Holaboss binding metadata was still present in `runtime-config.json`, queued chats were treated as control-plane managed and blocked on a Holaboss auth session.

## What Changed

- skip the Holaboss runtime binding check for queued chat inputs when the selected model resolves to a non-Holaboss provider
- clear stale Holaboss binding markers during sign-out so direct provider sessions stop inheriting control-plane managed state
- preserve the existing runtime binding flow for Holaboss models and Holaboss-resolved defaults

## Validation

- `npm run desktop:typecheck`
