### PR TITLE
fix: restore desktop runtime config and integration flows

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -74,11 +74,28 @@ const HOLABOSS_HOME_URL = "https://holaboss.ai";
 const HOLABOSS_DOCS_URL = `https://github.com/${GITHUB_RELEASES_OWNER}/${GITHUB_RELEASES_REPO}`;
 const HOLABOSS_HELP_URL = `${HOLABOSS_DOCS_URL}/issues`;
 const APP_DISPLAY_NAME = "Holaboss";
+const RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY = "holaboss_proxy";
+const RUNTIME_PROVIDER_KIND_OPENAI_COMPATIBLE = "openai_compatible";
+const RUNTIME_PROVIDER_KIND_ANTHROPIC_NATIVE = "anthropic_native";
+const RUNTIME_PROVIDER_KIND_OPENROUTER = "openrouter";
 const RUNTIME_HOLABOSS_PROVIDER_ID = "holaboss_model_proxy";
 const RUNTIME_HOLABOSS_PROVIDER_ALIASES = [
   "holaboss",
   RUNTIME_HOLABOSS_PROVIDER_ID,
 ] as const;
+const RUNTIME_HOLABOSS_LEGACY_PROXY_MODELS = [
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.3-codex",
+  "claude-sonnet-4-5",
+  "claude-opus-4-1",
+] as const;
+const RUNTIME_DEPRECATED_MODEL_IDS = new Set([
+  "gpt-5.1",
+  "gpt-5.1-codex",
+  "gpt-5.1-codex-mini",
+  "gpt-5.1-codex-max",
+]);
 
 interface DirectoryEntryPayload {
   name: string;
@@ -257,6 +274,19 @@ interface RuntimeConfigPayload {
   modelProxyBaseUrl: string | null;
   defaultModel: string | null;
   controlPlaneBaseUrl: string | null;
+  providerModelGroups: RuntimeProviderModelGroupPayload[];
+}
+
+interface RuntimeProviderModelPayload {
+  token: string;
+  modelId: string;
+}
+
+interface RuntimeProviderModelGroupPayload {
+  providerId: string;
+  providerLabel: string;
+  kind: string;
+  models: RuntimeProviderModelPayload[];
 }
 
 interface RuntimeConfigUpdatePayload {
@@ -2475,37 +2505,80 @@ async function readRuntimeConfigFile(): Promise<Record<string, string>> {
   try {
     const raw = await fs.readFile(configPath, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object") {
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return {};
     }
     const parsedRecord = parsed as Record<string, unknown>;
-    const holabossSection = parsedRecord.holaboss;
-    const source =
-      typeof holabossSection === "object" && holabossSection
-        ? (holabossSection as Record<string, unknown>)
+    const runtimePayload = runtimeConfigObject(parsedRecord.runtime);
+    const providersPayload = runtimeConfigObject(parsedRecord.providers);
+    const integrationsPayload = runtimeConfigObject(parsedRecord.integrations);
+    const holabossIntegration = runtimeConfigObject(integrationsPayload.holaboss);
+    const holabossProvider = runtimeConfigObject(
+      providersPayload[RUNTIME_HOLABOSS_PROVIDER_ID],
+    );
+    const holabossLegacyPayload = runtimeConfigObject(parsedRecord.holaboss);
+    const legacyPayload =
+      Object.keys(holabossLegacyPayload).length > 0
+        ? holabossLegacyPayload
         : parsedRecord;
 
     const normalized: Record<string, string> = {};
-    for (const key of [
-      "auth_token",
-      "model_proxy_api_key",
-      "user_id",
-      "sandbox_id",
-      "model_proxy_base_url",
-      "default_model",
-      "control_plane_base_url",
-    ] as const) {
-      const value = source[key];
-      if (typeof value === "string" && value.trim()) {
-        normalized[key] = value.trim();
-      }
+    const authToken = runtimeFirstNonEmptyString(
+      holabossIntegration.auth_token as string | undefined,
+      holabossProvider.api_key as string | undefined,
+      legacyPayload.auth_token as string | undefined,
+      legacyPayload.model_proxy_api_key as string | undefined,
+    );
+    const userId = runtimeFirstNonEmptyString(
+      holabossIntegration.user_id as string | undefined,
+      legacyPayload.user_id as string | undefined,
+    );
+    const sandboxId = runtimeFirstNonEmptyString(
+      runtimePayload.sandbox_id as string | undefined,
+      holabossIntegration.sandbox_id as string | undefined,
+      legacyPayload.sandbox_id as string | undefined,
+    );
+    const modelProxyBaseUrl = runtimeFirstNonEmptyString(
+      holabossProvider.base_url as string | undefined,
+      legacyPayload.model_proxy_base_url as string | undefined,
+    );
+    const defaultModel = normalizeLegacyRuntimeModelToken(
+      runtimeFirstNonEmptyString(
+        runtimePayload.default_model as string | undefined,
+        legacyPayload.default_model as string | undefined,
+      ),
+    );
+    const defaultProvider = runtimeFirstNonEmptyString(
+      runtimePayload.default_provider as string | undefined,
+      legacyPayload.default_provider as string | undefined,
+    );
+    const controlPlaneBaseUrl = runtimeFirstNonEmptyString(
+      legacyPayload.control_plane_base_url as string | undefined,
+    );
+
+    if (authToken) {
+      normalized.auth_token = authToken;
+      normalized.model_proxy_api_key = authToken;
     }
-    if (!normalized.auth_token && normalized.model_proxy_api_key) {
-      normalized.auth_token = normalized.model_proxy_api_key;
+    if (userId) {
+      normalized.user_id = userId;
     }
-    if (!normalized.model_proxy_api_key && normalized.auth_token) {
-      normalized.model_proxy_api_key = normalized.auth_token;
+    if (sandboxId) {
+      normalized.sandbox_id = sandboxId;
     }
+    if (modelProxyBaseUrl) {
+      normalized.model_proxy_base_url = modelProxyBaseUrl;
+    }
+    if (defaultModel) {
+      normalized.default_model = defaultModel;
+    }
+    if (defaultProvider) {
+      normalized.default_provider = defaultProvider;
+    }
+    if (controlPlaneBaseUrl) {
+      normalized.control_plane_base_url = controlPlaneBaseUrl;
+    }
+
     return normalized;
   } catch {
     return {};
@@ -2992,8 +3065,319 @@ function runtimeConfigField(value: string | undefined): string {
   return (value || "").trim();
 }
 
+function runtimeConfigObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function runtimeFirstNonEmptyString(
+  ...values: Array<string | null | undefined>
+): string {
+  for (const value of values) {
+    const normalized = (value ?? "").trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return "";
+}
+
 function normalizeLegacyRuntimeModelToken(token: string): string {
   return token.trim();
+}
+
+function runtimeProviderLabel(providerId: string): string {
+  const normalized = providerId.trim().toLowerCase();
+  if (normalized === "openai" || normalized.includes("openai")) {
+    return "OpenAI";
+  }
+  if (normalized === "anthropic" || normalized.includes("anthropic")) {
+    return "Anthropic";
+  }
+  if (normalized.includes("openrouter")) {
+    return "OpenRouter";
+  }
+  if (normalized.includes("gemini") || normalized.includes("google")) {
+    return "Gemini";
+  }
+  if (normalized.includes("ollama")) {
+    return "Ollama";
+  }
+  if (
+    normalized === RUNTIME_HOLABOSS_PROVIDER_ID ||
+    normalized === "holaboss" ||
+    normalized.includes("holaboss")
+  ) {
+    return "Holaboss Proxy";
+  }
+  return providerId
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizeRuntimeProviderKind(
+  rawKind: string,
+  providerId: string,
+  baseUrl: string,
+): string {
+  const normalizedProviderId = providerId.trim().toLowerCase();
+  const normalizedKind = rawKind.trim().toLowerCase();
+  const normalizedBaseUrl = baseUrl.trim().toLowerCase();
+  if (
+    normalizedKind === RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY ||
+    normalizedProviderId === RUNTIME_HOLABOSS_PROVIDER_ID ||
+    normalizedProviderId === "holaboss" ||
+    normalizedProviderId.includes("holaboss")
+  ) {
+    return RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY;
+  }
+  if (!normalizedKind && normalizedBaseUrl.includes("model-proxy")) {
+    return RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY;
+  }
+  if (
+    normalizedKind === RUNTIME_PROVIDER_KIND_OPENROUTER ||
+    normalizedProviderId.includes("openrouter")
+  ) {
+    return RUNTIME_PROVIDER_KIND_OPENROUTER;
+  }
+  if (
+    normalizedKind === RUNTIME_PROVIDER_KIND_ANTHROPIC_NATIVE ||
+    normalizedKind === "anthropic" ||
+    normalizedProviderId.includes("anthropic")
+  ) {
+    return RUNTIME_PROVIDER_KIND_ANTHROPIC_NATIVE;
+  }
+  return RUNTIME_PROVIDER_KIND_OPENAI_COMPATIBLE;
+}
+
+function runtimeModelIdFromToken(token: string): string {
+  const normalizedToken = token.trim();
+  if (!normalizedToken) {
+    return "";
+  }
+  if (!normalizedToken.includes("/")) {
+    return normalizedToken;
+  }
+  const [prefix, ...rest] = normalizedToken.split("/");
+  const normalizedPrefix = prefix.trim().toLowerCase();
+  if (
+    normalizedPrefix.includes("openai") ||
+    normalizedPrefix.includes("anthropic") ||
+    normalizedPrefix.includes("holaboss") ||
+    normalizedPrefix.includes("openrouter") ||
+    normalizedPrefix.includes("gemini") ||
+    normalizedPrefix.includes("google") ||
+    normalizedPrefix.includes("ollama")
+  ) {
+    return rest.join("/").trim();
+  }
+  return normalizedToken;
+}
+
+function isDeprecatedRuntimeModelId(modelId: string): boolean {
+  const normalized = runtimeModelIdFromToken(modelId).toLowerCase();
+  return RUNTIME_DEPRECATED_MODEL_IDS.has(normalized);
+}
+
+function runtimeProviderModelGroups(
+  document: Record<string, unknown>,
+  loadedLegacy: Record<string, string>,
+): RuntimeProviderModelGroupPayload[] {
+  const runtimePayload = runtimeConfigObject(document.runtime);
+  const providersPayload = runtimeConfigObject(document.providers);
+  const modelsPayload = runtimeConfigObject(document.models);
+  const integrationsPayload = runtimeConfigObject(document.integrations);
+  const holabossIntegration = runtimeConfigObject(integrationsPayload.holaboss);
+
+  const providers = new Map<string, { id: string; kind: string; label: string }>();
+  for (const [providerId, rawProvider] of Object.entries(providersPayload)) {
+    const providerPayload = runtimeConfigObject(rawProvider);
+    const optionsPayload = runtimeConfigObject(providerPayload.options);
+    const baseUrl = runtimeFirstNonEmptyString(
+      providerPayload.base_url as string | undefined,
+      providerPayload.baseURL as string | undefined,
+      optionsPayload.baseURL as string | undefined,
+      optionsPayload.base_url as string | undefined,
+    );
+    const kind = normalizeRuntimeProviderKind(
+      runtimeFirstNonEmptyString(
+        providerPayload.kind as string | undefined,
+        providerPayload.type as string | undefined,
+        optionsPayload.kind as string | undefined,
+      ),
+      providerId,
+      baseUrl,
+    );
+    providers.set(providerId, {
+      id: providerId,
+      kind,
+      label: runtimeProviderLabel(providerId),
+    });
+  }
+
+  const runtimeDefaultProvider = runtimeFirstNonEmptyString(
+    runtimePayload.default_provider as string | undefined,
+    loadedLegacy.default_provider,
+    RUNTIME_HOLABOSS_PROVIDER_ID,
+  );
+  const legacyBaseUrl = runtimeFirstNonEmptyString(
+    loadedLegacy.model_proxy_base_url,
+    holabossIntegration.model_proxy_base_url as string | undefined,
+  );
+  const legacyApiKey = runtimeFirstNonEmptyString(
+    loadedLegacy.model_proxy_api_key,
+    loadedLegacy.auth_token,
+    holabossIntegration.auth_token as string | undefined,
+  );
+  const hasLegacyProxyBinding = Boolean(legacyBaseUrl && legacyApiKey);
+  if (
+    hasLegacyProxyBinding &&
+    runtimeDefaultProvider &&
+    !providers.has(runtimeDefaultProvider)
+  ) {
+    providers.set(runtimeDefaultProvider, {
+      id: runtimeDefaultProvider,
+      kind: normalizeRuntimeProviderKind(
+        "",
+        runtimeDefaultProvider,
+        legacyBaseUrl,
+      ),
+      label: runtimeProviderLabel(runtimeDefaultProvider),
+    });
+  }
+
+  const groupedModels = new Map<string, Map<string, RuntimeProviderModelPayload>>();
+  const ensureProviderGroup = (providerId: string) => {
+    if (!groupedModels.has(providerId)) {
+      groupedModels.set(providerId, new Map<string, RuntimeProviderModelPayload>());
+    }
+    return groupedModels.get(providerId)!;
+  };
+  const addModel = (providerId: string, token: string, modelId: string) => {
+    const normalizedProviderId = providerId.trim();
+    const normalizedModelId = modelId.trim();
+    if (
+      !normalizedProviderId ||
+      !normalizedModelId ||
+      isDeprecatedRuntimeModelId(normalizedModelId)
+    ) {
+      return;
+    }
+    const normalizedToken =
+      token.trim() || `${normalizedProviderId}/${normalizedModelId}`;
+    if (isDeprecatedRuntimeModelId(normalizedToken)) {
+      return;
+    }
+    const group = ensureProviderGroup(normalizedProviderId);
+    if (!group.has(normalizedToken)) {
+      group.set(normalizedToken, {
+        token: normalizedToken,
+        modelId: normalizedModelId,
+      });
+    }
+  };
+  const seedLegacyHolabossProxyModels = (providerId: string, defaultModelToken: string) => {
+    if (!providers.has(providerId)) {
+      providers.set(providerId, {
+        id: providerId,
+        kind: RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY,
+        label: runtimeProviderLabel(providerId),
+      });
+    }
+
+    const seededModelIds = new Set<string>();
+    const preferredModelId = runtimeModelIdFromToken(defaultModelToken);
+    if (preferredModelId && !isDeprecatedRuntimeModelId(preferredModelId)) {
+      seededModelIds.add(preferredModelId);
+    }
+    for (const modelId of RUNTIME_HOLABOSS_LEGACY_PROXY_MODELS) {
+      seededModelIds.add(modelId);
+    }
+    for (const modelId of seededModelIds) {
+      addModel(providerId, `${providerId}/${modelId}`, modelId);
+    }
+  };
+
+  const configuredModelsCount = Object.keys(modelsPayload).length;
+  for (const [token, rawModel] of Object.entries(modelsPayload)) {
+    const modelPayload = runtimeConfigObject(rawModel);
+    let providerId = runtimeFirstNonEmptyString(
+      modelPayload.provider_id as string | undefined,
+      modelPayload.provider as string | undefined,
+    );
+    let modelId = runtimeFirstNonEmptyString(
+      modelPayload.model_id as string | undefined,
+      modelPayload.model as string | undefined,
+    );
+    if (!providerId && token.includes("/")) {
+      const [prefix, ...rest] = token.split("/");
+      if (providers.has(prefix) && rest.length > 0) {
+        providerId = prefix;
+        modelId = modelId || rest.join("/");
+      }
+    }
+    if (providerId && modelId) {
+      const normalizedProviderId = providerId.trim();
+      if (providers.has(normalizedProviderId)) {
+        addModel(normalizedProviderId, token, modelId);
+      }
+    }
+  }
+
+  const fallbackDefaultModel = normalizeLegacyRuntimeModelToken(
+    runtimeFirstNonEmptyString(
+      runtimePayload.default_model as string | undefined,
+      loadedLegacy.default_model,
+    ),
+  );
+  const hasExplicitProviderCatalog =
+    Object.keys(providersPayload).length > 0 ||
+    Object.keys(modelsPayload).length > 0;
+  if (
+    fallbackDefaultModel &&
+    configuredModelsCount === 0 &&
+    !hasExplicitProviderCatalog &&
+    hasLegacyProxyBinding
+  ) {
+    seedLegacyHolabossProxyModels(
+      RUNTIME_HOLABOSS_PROVIDER_ID,
+      fallbackDefaultModel,
+    );
+  }
+
+  if (hasLegacyProxyBinding) {
+    const legacyProxyProviderId = runtimeDefaultProvider || RUNTIME_HOLABOSS_PROVIDER_ID;
+    const hasExplicitHolabossModels =
+      (groupedModels.get(legacyProxyProviderId)?.size ?? 0) > 0;
+    if (!hasExplicitHolabossModels) {
+      seedLegacyHolabossProxyModels(
+        legacyProxyProviderId,
+        fallbackDefaultModel,
+      );
+    }
+  }
+
+  const groups: RuntimeProviderModelGroupPayload[] = [];
+  const providerIds = new Set<string>([
+    ...Array.from(providers.keys()),
+    ...Array.from(groupedModels.keys()),
+  ]);
+  for (const providerId of providerIds) {
+    const modelMap =
+      groupedModels.get(providerId) ?? new Map<string, RuntimeProviderModelPayload>();
+    const provider = providers.get(providerId);
+    groups.push({
+      providerId,
+      providerLabel: provider?.label ?? runtimeProviderLabel(providerId),
+      kind: provider?.kind ?? normalizeRuntimeProviderKind("", providerId, ""),
+      models: Array.from(modelMap.values()),
+    });
+  }
+  return groups;
 }
 
 function isHolabossProviderAlias(providerId: string): boolean {
@@ -3071,16 +3455,76 @@ async function withRuntimeBindingRefreshLock<T>(
 async function getRuntimeConfig(): Promise<RuntimeConfigPayload> {
   const configPath = runtimeConfigPath();
   const loaded = await readRuntimeConfigFile();
+  const document = await readRuntimeConfigDocument();
   return {
     configPath,
-    loadedFromFile: Object.keys(loaded).length > 0,
+    loadedFromFile: Object.keys(document).length > 0 || Object.keys(loaded).length > 0,
     authTokenPresent: Boolean(runtimeModelProxyApiKeyFromConfig(loaded)),
     userId: loaded.user_id ?? null,
     sandboxId: loaded.sandbox_id ?? null,
     modelProxyBaseUrl: loaded.model_proxy_base_url ?? null,
     defaultModel: loaded.default_model ?? null,
     controlPlaneBaseUrl: loaded.control_plane_base_url ?? null,
+    providerModelGroups: runtimeProviderModelGroups(document, loaded),
   };
+}
+
+async function getRuntimeConfigDocumentText(): Promise<string> {
+  const document = await readRuntimeConfigDocument();
+  if (Object.keys(document).length > 0) {
+    return `${JSON.stringify(document, null, 2)}\n`;
+  }
+  return `{
+  "runtime": {
+    "sandbox_id": "desktop:replace-me"
+  },
+  "providers": {},
+  "models": {}
+}
+`;
+}
+
+async function setRuntimeConfigDocument(
+  rawDocument: string,
+): Promise<RuntimeConfigPayload> {
+  const trimmed = rawDocument.trim();
+  if (!trimmed) {
+    throw new Error("Runtime config JSON is required.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Invalid runtime config JSON: ${error.message}`
+        : "Invalid runtime config JSON.",
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Runtime config must be a JSON object.");
+  }
+
+  const configPath = runtimeConfigPath();
+  const nextText = `${JSON.stringify(parsed, null, 2)}\n`;
+  const currentDocument = await readRuntimeConfigDocument();
+  const currentText =
+    Object.keys(currentDocument).length > 0
+      ? `${JSON.stringify(currentDocument, null, 2)}\n`
+      : "";
+
+  if (currentText !== nextText) {
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, nextText, "utf-8");
+    await stopEmbeddedRuntime();
+    void startEmbeddedRuntime();
+  }
+
+  const config = await getRuntimeConfig();
+  await emitRuntimeConfig(config);
+  return config;
 }
 
 async function exchangeDesktopRuntimeBinding(
@@ -4054,6 +4498,209 @@ async function listTaskProposals(
   });
 }
 
+function secondsSinceIso(value: string | null): number | null {
+  const trimmed = value?.trim() || "";
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Date.parse(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Math.max(0, Math.round((Date.now() - parsed) / 1000));
+}
+
+async function acceptTaskProposal(
+  payload: TaskProposalAcceptPayload,
+): Promise<TaskProposalAcceptResponsePayload> {
+  return requestRuntimeJson<TaskProposalAcceptResponsePayload>({
+    method: "POST",
+    path: `/api/v1/task-proposals/${encodeURIComponent(payload.proposal_id)}/accept`,
+    payload: {
+      task_name: payload.task_name,
+      task_prompt: payload.task_prompt,
+      session_id: payload.session_id,
+      parent_session_id: payload.parent_session_id,
+      created_by: payload.created_by,
+      priority: payload.priority ?? 0,
+      model: payload.model ?? null,
+    },
+  });
+}
+
+async function getProactiveStatus(
+  workspaceId: string,
+): Promise<ProactiveAgentStatusPayload> {
+  const normalizedWorkspaceId = workspaceId.trim();
+  const fallbackHeartbeat: ProactiveStatusSnapshotPayload = {
+    state: "unknown",
+    detail: null,
+    recorded_at: null,
+  };
+  const fallbackBridge: ProactiveStatusSnapshotPayload = {
+    state: "unknown",
+    detail: null,
+    recorded_at: null,
+  };
+  if (!normalizedWorkspaceId) {
+    return {
+      workspace_id: "",
+      proposal_count: 0,
+      heartbeat: fallbackHeartbeat,
+      bridge: fallbackBridge,
+      delivery_state: "idle",
+      delivery_summary: "Select a workspace to inspect proactive status.",
+      delivery_detail: null,
+    };
+  }
+
+  let proposalCount = 0;
+  let heartbeat = fallbackHeartbeat;
+  const database = openRuntimeDatabase();
+  try {
+    const proposalRow = database
+      .prepare(
+        `
+          SELECT COUNT(*) AS proposal_count
+          FROM task_proposals
+          WHERE workspace_id = ?
+        `,
+      )
+      .get(normalizedWorkspaceId) as { proposal_count?: number } | undefined;
+    proposalCount = Number(proposalRow?.proposal_count ?? 0);
+
+    const correlationId = `workspace-ready-${normalizedWorkspaceId}`;
+    const heartbeatRow = database
+      .prepare(
+        `
+          SELECT outcome, detail, created_at
+          FROM event_log
+          WHERE category = 'workspace'
+            AND event = 'workspace.heartbeat.emit'
+            AND (
+              detail LIKE ?
+              OR detail LIKE ?
+            )
+          ORDER BY created_at DESC
+          LIMIT 1
+        `,
+      )
+      .get(
+        `%workspace_id=${normalizedWorkspaceId}%`,
+        `%${correlationId}%`,
+      ) as
+      | {
+          outcome?: string | null;
+          detail?: string | null;
+          created_at?: string | null;
+        }
+      | undefined;
+    if (heartbeatRow) {
+      const outcome = (heartbeatRow.outcome || "").trim().toLowerCase();
+      heartbeat = {
+        state:
+          outcome === "success"
+            ? "published"
+            : outcome === "error"
+              ? "failed"
+              : outcome === "skipped"
+                ? "skipped"
+                : outcome === "start" || outcome === "retry"
+                  ? "pending"
+                  : "unknown",
+        detail: heartbeatRow.detail?.trim() || null,
+        recorded_at: heartbeatRow.created_at?.trim() || null,
+      };
+    }
+  } catch {
+    heartbeat = fallbackHeartbeat;
+  } finally {
+    database.close();
+  }
+
+  const runtimeConfig = await readRuntimeConfigFile().catch(() => ({}));
+  const runtimeToken = runtimeModelProxyApiKeyFromConfig(runtimeConfig);
+  let bridge: ProactiveStatusSnapshotPayload;
+  if (!runtimeToken) {
+    bridge = {
+      state: "inactive",
+      detail: "Sign in to enable proactive delivery.",
+      recorded_at: null,
+    };
+  } else if (runtimeStatus.status === "running") {
+    bridge = {
+      state: "healthy",
+      detail: "Embedded runtime is ready to receive proactive work.",
+      recorded_at: null,
+    };
+  } else if (runtimeStatus.status === "starting") {
+    bridge = {
+      state: "pending",
+      detail: "Embedded runtime is still starting.",
+      recorded_at: null,
+    };
+  } else if (runtimeStatus.status === "error") {
+    bridge = {
+      state: "error",
+      detail: runtimeStatus.lastError?.trim() || "Embedded runtime reported an error.",
+      recorded_at: null,
+    };
+  } else {
+    bridge = {
+      state: "inactive",
+      detail: runtimeStatus.lastError?.trim() || "Embedded runtime is not running.",
+      recorded_at: null,
+    };
+  }
+
+  let deliveryState = "idle";
+  let deliverySummary = "No proactive activity recorded yet.";
+  let deliveryDetail: string | null = null;
+  const heartbeatAgeSeconds = secondsSinceIso(heartbeat.recorded_at);
+  const heartbeatSettled = heartbeatAgeSeconds !== null && heartbeatAgeSeconds >= 120;
+  if (proposalCount > 0) {
+    deliveryState = "delivered";
+    deliverySummary = `${proposalCount} proactive proposal${proposalCount === 1 ? "" : "s"} available in this runtime.`;
+  } else if (heartbeat.state === "published" && bridge.state === "error") {
+    deliveryState = "blocked";
+    deliverySummary = "Heartbeat was sent, but proposal delivery into this runtime is blocked.";
+    deliveryDetail = bridge.detail;
+  } else if (heartbeat.state === "published" && !heartbeatSettled) {
+    deliveryState = "analyzing";
+    deliverySummary = "Heartbeat was sent. Remote proactive analysis is still in progress.";
+  } else if (heartbeat.state === "published") {
+    deliveryState = "no_proposal";
+    deliverySummary = "No proposal has been delivered since the last heartbeat.";
+    deliveryDetail =
+      "A heartbeat only asks the remote proactive agent to analyze the workspace. It may decide not to create a proposal.";
+  } else if (heartbeat.state === "failed") {
+    deliveryState = "error";
+    deliverySummary = "Workspace creation finished, but the proactive heartbeat failed.";
+    deliveryDetail = heartbeat.detail;
+  } else if (heartbeat.state === "skipped") {
+    deliveryState = "inactive";
+    deliverySummary = "Proactive delivery is disabled for this workspace.";
+    deliveryDetail = heartbeat.detail;
+  } else if (bridge.state === "error") {
+    deliveryState = "blocked";
+    deliverySummary = "The runtime cannot currently receive proactive jobs.";
+    deliveryDetail = bridge.detail;
+  } else if (bridge.state === "inactive") {
+    deliveryState = "inactive";
+    deliverySummary = bridge.detail || "Proactive delivery is inactive.";
+  }
+
+  return {
+    workspace_id: normalizedWorkspaceId,
+    proposal_count: proposalCount,
+    heartbeat,
+    bridge,
+    delivery_state: deliveryState,
+    delivery_summary: deliverySummary,
+    delivery_detail: deliveryDetail,
+  };
+}
+
 async function listCronjobs(
   workspaceId: string,
   enabledOnly = false,
@@ -4264,6 +4911,9 @@ interface ComposioToolkit {
 }
 
 async function composioListToolkits(): Promise<{ toolkits: ComposioToolkit[] }> {
+  if (!authCookieHeader()) {
+    return { toolkits: [] };
+  }
   return composioFetch<{ toolkits: ComposioToolkit[] }>("/api/composio/toolkits", "GET");
 }
 
@@ -6671,6 +7321,24 @@ async function listRuntimeStates(
     method: "GET",
     path: `/api/v1/agent-sessions/by-workspace/${workspaceId}/runtime-states`,
     params: {
+      limit: 100,
+      offset: 0,
+    },
+  });
+}
+
+async function listAgentSessions(
+  workspaceId: string,
+): Promise<AgentSessionListResponsePayload> {
+  if (!workspaceId.trim()) {
+    return { items: [], count: 0 };
+  }
+  return requestRuntimeJson<AgentSessionListResponsePayload>({
+    method: "GET",
+    path: "/api/v1/agent-sessions",
+    params: {
+      workspace_id: workspaceId,
+      include_archived: false,
       limit: 100,
       offset: 0,
     },
@@ -10761,6 +11429,11 @@ app.whenReady().then(async () => {
     getRuntimeConfig(),
   );
   handleTrustedIpc(
+    "runtime:getConfigDocument",
+    ["main", "auth-popup"],
+    () => getRuntimeConfigDocumentText(),
+  );
+  handleTrustedIpc(
     "runtime:setConfig",
     ["main", "auth-popup"],
     async (_event, payload: RuntimeConfigUpdatePayload) => {
@@ -10771,6 +11444,11 @@ app.whenReady().then(async () => {
       await emitRuntimeConfig(config);
       return config;
     },
+  );
+  handleTrustedIpc(
+    "runtime:setConfigDocument",
+    ["main", "auth-popup"],
+    async (_event, rawDocument: string) => setRuntimeConfigDocument(rawDocument),
   );
   handleTrustedIpc(
     "ui:getTheme",
@@ -10992,6 +11670,17 @@ app.whenReady().then(async () => {
     async (_event, workspaceId: string) => listTaskProposals(workspaceId),
   );
   handleTrustedIpc(
+    "workspace:acceptTaskProposal",
+    ["main"],
+    async (_event, payload: TaskProposalAcceptPayload) =>
+      acceptTaskProposal(payload),
+  );
+  handleTrustedIpc(
+    "workspace:getProactiveStatus",
+    ["main"],
+    async (_event, workspaceId: string) => getProactiveStatus(workspaceId),
+  );
+  handleTrustedIpc(
     "workspace:updateTaskProposalState",
     ["main"],
     async (_event, proposalId: string, state: string) =>
@@ -11007,6 +11696,11 @@ app.whenReady().then(async () => {
     "workspace:listRuntimeStates",
     ["main"],
     async (_event, workspaceId: string) => listRuntimeStates(workspaceId),
+  );
+  handleTrustedIpc(
+    "workspace:listAgentSessions",
+    ["main"],
+    async (_event, workspaceId: string) => listAgentSessions(workspaceId),
   );
   handleTrustedIpc(
     "workspace:getSessionHistory",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -86,7 +86,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -343,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.5.tgz",
       "integrity": "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -477,14 +475,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
       "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "peer": true
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -904,6 +900,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -925,6 +922,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -941,6 +939,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -955,6 +954,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1745,6 +1745,7 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
       "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -2711,7 +2712,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2748,13 +2748,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -2763,7 +2765,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2854,7 +2855,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3361,7 +3361,6 @@
       "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.5.tgz",
       "integrity": "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -3467,7 +3466,6 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
       "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -3489,7 +3487,6 @@
       "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3536,7 +3533,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3586,7 +3582,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3606,6 +3601,7 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
       "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4187,7 +4183,6 @@
       "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
       "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -4301,7 +4296,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -4452,7 +4448,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4471,7 +4466,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4515,7 +4509,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4581,7 +4574,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4761,7 +4753,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -4920,6 +4911,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4940,6 +4932,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5060,7 +5053,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5070,7 +5063,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5109,7 +5102,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5120,7 +5112,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5170,7 +5161,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5702,7 +5692,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -5721,7 +5710,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -5735,7 +5723,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5753,7 +5740,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5809,7 +5796,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6243,7 +6229,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6315,7 +6300,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6371,7 +6355,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.14.tgz",
       "integrity": "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -6771,7 +6754,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6795,7 +6777,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7086,6 +7069,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7164,6 +7148,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -7221,7 +7206,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -7433,7 +7417,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7628,7 +7611,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7750,7 +7732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7901,6 +7882,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -7918,6 +7900,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8099,7 +8082,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8109,7 +8091,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8327,6 +8308,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8338,7 +8320,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -8549,7 +8530,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8557,7 +8537,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8730,7 +8709,6 @@
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -8801,6 +8779,7 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -8809,7 +8788,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -9109,6 +9087,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9271,6 +9250,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -9411,7 +9391,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -9427,7 +9406,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9600,7 +9578,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -9735,6 +9712,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9744,6 +9722,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -9849,7 +9828,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -2141,6 +2141,10 @@ export function ChatPane({
       setChatErrorMessage(workspaceBlockingReason || "Workspace apps are still starting.");
       return;
     }
+    if (!isOnboardingVariant && !resolvedChatModelToken) {
+      setChatErrorMessage(modelSelectionUnavailableReason || "No models available.");
+      return;
+    }
     const targetSessionId = activeSessionIdRef.current || preferredSessionId(selectedWorkspace, []);
     if (!targetSessionId) {
       setChatErrorMessage("No active session found for this workspace.");
@@ -2573,14 +2577,13 @@ export function ChatPane({
         : isOnboardingVariant || workspaceAppsReady
           ? ""
           : workspaceBlockingReason || (isActivatingWorkspace ? "Preparing workspace apps..." : "Workspace apps are still starting.");
-  const composerDisabledReason = !selectedWorkspace
+  const baseComposerDisabledReason = !selectedWorkspace
     ? "Select a workspace to start chatting."
     : runtimeNotReadyReason
       ? runtimeNotReadyReason
       : !isOnboardingVariant && !workspaceAppsReady
         ? readinessMessage || "Workspace apps are still starting."
         : "";
-  const composerDisabled = Boolean(composerDisabledReason);
   const runtimeStartupBlocked =
     isLoadingBootstrap ||
     !runtimeLifecycleStatus ||
@@ -2719,6 +2722,12 @@ export function ChatPane({
     availableChatModelOptions.length > 0
       ? ""
       : "No models available. Sign in to use Holaboss or add a provider.";
+  const composerDisabledReason =
+    baseComposerDisabledReason ||
+    (!isOnboardingVariant && !effectiveChatModelPreference
+      ? modelSelectionUnavailableReason
+      : "");
+  const composerDisabled = Boolean(composerDisabledReason);
 
   useEffect(() => {
     if (!effectiveChatModelPreference) {

--- a/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/desktop/src/components/panes/IntegrationsPane.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Check, Loader2, Plus, Search } from "lucide-react";
-import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+import { Check, Loader2, Plus, Search, ShieldAlert } from "lucide-react";
 
-interface Toolkit {
+import { useDesktopAuthSession } from "@/lib/auth/authClient";
+
+interface ComposioToolkit {
   slug: string;
   name: string;
   description: string;
@@ -11,27 +12,165 @@ interface Toolkit {
   categories: string[];
 }
 
+interface IntegrationCard {
+  slug: string;
+  providerId: string;
+  name: string;
+  description: string;
+  logo: string | null;
+  authSchemes: string[];
+  categories: string[];
+  supportsManaged: boolean;
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+function normalizedText(value: string | null | undefined): string {
+  return (value || "").trim();
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const items: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    items.push(normalized);
+  }
+  return items;
+}
+
+function providerIdForToolkit(slug: string): string {
+  const normalizedSlug = slug.trim().toLowerCase();
+  return (TOOLKIT_SLUG_TO_PROVIDER[normalizedSlug] || normalizedSlug).trim().toLowerCase();
+}
+
+function providerCategories(providerId: string): string[] {
+  return PROVIDER_CATEGORY_GROUPS[providerId] || ["other"];
+}
+
+function toolkitPreferenceRank(providerId: string, slug: string): number {
+  const normalizedSlug = slug.trim().toLowerCase();
+  const preferredSlugs = PROVIDER_TOOLKIT_PREFERENCE[providerId] || [];
+  const index = preferredSlugs.indexOf(normalizedSlug);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+function preferredToolkitForProvider(
+  providerId: string,
+  current: ComposioToolkit | undefined,
+  candidate: ComposioToolkit,
+): ComposioToolkit {
+  if (!current) {
+    return candidate;
+  }
+  return toolkitPreferenceRank(providerId, candidate.slug) < toolkitPreferenceRank(providerId, current.slug)
+    ? candidate
+    : current;
+}
+
+function mergeIntegrationCards(
+  catalogProviders: IntegrationCatalogProviderPayload[],
+  toolkits: ComposioToolkit[],
+): IntegrationCard[] {
+  const toolkitByProvider = new Map<string, ComposioToolkit>();
+  for (const toolkit of toolkits) {
+    const providerId = providerIdForToolkit(toolkit.slug);
+    toolkitByProvider.set(
+      providerId,
+      preferredToolkitForProvider(providerId, toolkitByProvider.get(providerId), toolkit),
+    );
+  }
+
+  const cards: IntegrationCard[] = [];
+  const seenProviderIds = new Set<string>();
+
+  for (const provider of catalogProviders) {
+    const providerId = normalizedText(provider.provider_id).toLowerCase();
+    if (!providerId) {
+      continue;
+    }
+    seenProviderIds.add(providerId);
+    const toolkit = toolkitByProvider.get(providerId);
+    const toolkitCategories = uniqueStrings(toolkit?.categories || []);
+
+    cards.push({
+      slug: providerId,
+      providerId,
+      name:
+        normalizedText(provider.display_name) ||
+        normalizedText(toolkit?.name) ||
+        providerId,
+      description:
+        normalizedText(toolkit?.description) ||
+        normalizedText(provider.description) ||
+        normalizedText(provider.display_name) ||
+        providerId,
+      logo: toolkit?.logo ?? null,
+      authSchemes: uniqueStrings([
+        ...(toolkit?.auth_schemes || []),
+        ...(provider.auth_modes || []),
+      ]),
+      categories:
+        toolkitCategories.length > 0
+          ? toolkitCategories
+          : providerCategories(providerId),
+      supportsManaged: provider.supports_managed !== false,
+    });
+  }
+
+  for (const [providerId, toolkit] of toolkitByProvider.entries()) {
+    if (seenProviderIds.has(providerId)) {
+      continue;
+    }
+    cards.push({
+      slug: providerId,
+      providerId,
+      name: normalizedText(toolkit.name) || providerId,
+      description: normalizedText(toolkit.description) || providerId,
+      logo: toolkit.logo,
+      authSchemes: uniqueStrings(toolkit.auth_schemes || []),
+      categories:
+        uniqueStrings(toolkit.categories || []).length > 0
+          ? uniqueStrings(toolkit.categories || [])
+          : providerCategories(providerId),
+      supportsManaged: true,
+    });
+  }
+
+  return cards.sort((left, right) => left.name.localeCompare(right.name));
+}
+
 export function IntegrationsPane() {
-  const { selectedWorkspaceId } = useWorkspaceSelection();
-  const [toolkits, setToolkits] = useState<Toolkit[]>([]);
+  const authSessionState = useDesktopAuthSession();
+  const isSignedIn = Boolean(authSessionState.data?.user?.id?.trim());
+  const [integrations, setIntegrations] = useState<IntegrationCard[]>([]);
   const [connections, setConnections] = useState<IntegrationConnectionPayload[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [query, setQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
-  const [connectingSlug, setConnectingSlug] = useState<string | null>(null);
-  const [connectStatus, setConnectStatus] = useState("");
+  const [connectingProviderId, setConnectingProviderId] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState("");
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [toolkitResult, connectionResult] = await Promise.all([
-        window.electronAPI.workspace.composioListToolkits(),
+      const [catalogResult, connectionResult, toolkitResult] = await Promise.all([
+        window.electronAPI.workspace.listIntegrationCatalog(),
         window.electronAPI.workspace.listIntegrationConnections(),
+        window.electronAPI.workspace.composioListToolkits().catch(() => ({ toolkits: [] as ComposioToolkit[] })),
       ]);
-      setToolkits(toolkitResult.toolkits);
+      setIntegrations(mergeIntegrationCards(catalogResult.providers, toolkitResult.toolkits));
       setConnections(connectionResult.connections);
-    } catch {
-      // Silently fail — toolkits will be empty
+    } catch (error) {
+      setIntegrations([]);
+      setConnections([]);
+      setStatusMessage(normalizeErrorMessage(error));
     } finally {
       setIsLoading(false);
     }
@@ -39,103 +178,114 @@ export function IntegrationsPane() {
 
   useEffect(() => {
     void loadData();
-  }, [loadData]);
+  }, [isSignedIn, loadData]);
 
-  const connectedSlugs = useMemo(() => {
-    const slugs = new Set<string>();
-    for (const conn of connections) {
-      if (conn.status === "active" && conn.auth_mode === "composio") {
-        // Map provider_id back to toolkit slug
-        const toolkit = toolkits.find((t) => {
-          const providerSlug = t.slug.toLowerCase();
-          const connProvider = conn.provider_id.toLowerCase();
-          return providerSlug === connProvider || PROVIDER_TO_TOOLKIT_SLUG[connProvider] === providerSlug;
-        });
-        if (toolkit) {
-          slugs.add(toolkit.slug);
+  const connectedProviderIds = useMemo(() => {
+    const providerIds = new Set<string>();
+    for (const connection of connections) {
+      if (normalizedText(connection.status).toLowerCase() === "active") {
+        providerIds.add(normalizedText(connection.provider_id).toLowerCase());
+      }
+    }
+    return providerIds;
+  }, [connections]);
+
+  const categories = useMemo(() => {
+    const items = new Set<string>();
+    for (const integration of integrations) {
+      for (const category of integration.categories) {
+        if (category) {
+          items.add(category);
         }
       }
     }
-    return slugs;
-  }, [connections, toolkits]);
+    return Array.from(items).sort();
+  }, [integrations]);
 
-  const categories = useMemo(() => {
-    const cats = new Set<string>();
-    for (const t of toolkits) {
-      for (const c of t.categories) {
-        if (c) cats.add(c);
-      }
-    }
-    return [...cats].sort();
-  }, [toolkits]);
-
-  const connectedToolkits = useMemo(
-    () => toolkits.filter((t) => connectedSlugs.has(t.slug)),
-    [toolkits, connectedSlugs]
+  const connectedIntegrations = useMemo(
+    () => integrations.filter((integration) => connectedProviderIds.has(integration.providerId)),
+    [connectedProviderIds, integrations],
   );
 
-  const filteredToolkits = useMemo(() => {
-    let list = toolkits.filter((t) => !connectedSlugs.has(t.slug));
+  const filteredIntegrations = useMemo(() => {
+    let items = integrations.filter((integration) => !connectedProviderIds.has(integration.providerId));
     if (query.trim()) {
-      const q = query.toLowerCase();
-      list = list.filter(
-        (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q)
+      const normalizedQuery = query.trim().toLowerCase();
+      items = items.filter((integration) =>
+        [
+          integration.providerId,
+          integration.name,
+          integration.description,
+        ].some((value) => value.toLowerCase().includes(normalizedQuery)),
       );
     }
     if (categoryFilter !== "all") {
-      list = list.filter((t) => t.categories.includes(categoryFilter));
+      items = items.filter((integration) => integration.categories.includes(categoryFilter));
     }
-    return list;
-  }, [toolkits, connectedSlugs, query, categoryFilter]);
+    return items;
+  }, [categoryFilter, connectedProviderIds, integrations, query]);
 
-  const groupedToolkits = useMemo(() => {
-    const groups: Record<string, Toolkit[]> = {};
-    for (const t of filteredToolkits) {
-      const cat = t.categories[0] || "other";
-      if (!groups[cat]) groups[cat] = [];
-      groups[cat].push(t);
+  const groupedIntegrations = useMemo(() => {
+    const groups: Record<string, IntegrationCard[]> = {};
+    for (const integration of filteredIntegrations) {
+      const category = integration.categories[0] || "other";
+      if (!groups[category]) {
+        groups[category] = [];
+      }
+      groups[category].push(integration);
     }
-    return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
-  }, [filteredToolkits]);
+    return Object.entries(groups).sort(([left], [right]) => left.localeCompare(right));
+  }, [filteredIntegrations]);
 
-  async function handleConnect(toolkit: Toolkit) {
-    setConnectingSlug(toolkit.slug);
-    setConnectStatus("Complete authorization in your browser...");
+  async function handleConnect(integration: IntegrationCard) {
+    setConnectingProviderId(integration.providerId);
+    setStatusMessage("Complete authorization in your browser...");
     try {
+      if (!isSignedIn) {
+        setStatusMessage("Sign in first to connect managed integrations.");
+        return;
+      }
+      if (!integration.supportsManaged) {
+        setStatusMessage(`${integration.name} does not support managed sign-in in this runtime.`);
+        return;
+      }
+
       const runtimeConfig = await window.electronAPI.runtime.getConfig();
-      const userId = runtimeConfig.userId ?? "local";
-      const provider = TOOLKIT_SLUG_TO_PROVIDER[toolkit.slug] ?? toolkit.slug;
+      const userId =
+        runtimeConfig.userId ||
+        authSessionState.data?.user?.id?.trim() ||
+        "local";
 
       const link = await window.electronAPI.workspace.composioConnect({
-        provider,
+        provider: integration.providerId,
         owner_user_id: userId,
       });
 
       await window.electronAPI.ui.openExternalUrl(link.redirect_url);
 
-      for (let i = 0; i < 100; i++) {
-        await new Promise((r) => setTimeout(r, 3000));
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
         const status = await window.electronAPI.workspace.composioAccountStatus(
-          link.connected_account_id
+          link.connected_account_id,
         );
         if (status.status === "ACTIVE") {
           await window.electronAPI.workspace.composioFinalize({
             connected_account_id: link.connected_account_id,
-            provider,
+            provider: integration.providerId,
             owner_user_id: userId,
-            account_label: `${toolkit.name} (Managed)`,
+            account_label: `${integration.name} (Managed)`,
           });
-          setConnectStatus("");
-          setConnectingSlug(null);
+          setStatusMessage("");
           void loadData();
           return;
         }
       }
-      setConnectStatus("Connection timed out.");
+
+      setStatusMessage("Connection timed out.");
     } catch (error) {
-      setConnectStatus(error instanceof Error ? error.message : "Connection failed.");
+      setStatusMessage(normalizeErrorMessage(error));
     } finally {
-      setConnectingSlug(null);
+      setConnectingProviderId(null);
     }
   }
 
@@ -151,73 +301,119 @@ export function IntegrationsPane() {
     <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-[var(--theme-radius-card)] shadow-card">
       <div className="relative min-h-0 flex-1 overflow-auto">
         <div className="mx-auto max-w-5xl px-6 py-6">
-          {/* Header */}
           <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-text-main">
             Integrations
           </h1>
           <p className="mt-1 text-[13px] text-text-muted/80">
             Connect your accounts to use them in workspaces.
           </p>
+          {!authSessionState.isPending && !isSignedIn ? (
+            <div className="mt-4 flex items-center justify-between gap-4 rounded-[16px] border border-[rgba(206,92,84,0.18)] bg-[rgba(206,92,84,0.06)] px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-[rgba(206,92,84,0.92)]">
+                  <ShieldAlert size={13} />
+                  <span>Sign-In Required</span>
+                </div>
+                <div className="mt-1 text-[13px] font-medium text-text-main">
+                  Managed integrations are unavailable until you sign in.
+                </div>
+                <div className="mt-1 text-[12px] leading-6 text-text-muted/76">
+                  You can browse the local provider catalog below, but connecting Google, GitHub, Reddit, LinkedIn, or X requires an authenticated Holaboss session.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void authSessionState.requestAuth()}
+                className="shrink-0 rounded-[12px] border border-[rgba(206,92,84,0.28)] bg-[rgba(206,92,84,0.1)] px-3 py-2 text-[12px] font-medium text-[rgba(206,92,84,0.96)] transition hover:bg-[rgba(206,92,84,0.14)]"
+              >
+                Sign in
+              </button>
+            </div>
+          ) : null}
 
-          {/* Search + Filter */}
           <div className="mt-5 flex items-center gap-3">
             <div className="relative flex-1">
               <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-dim/50" />
               <input
                 value={query}
-                onChange={(e) => setQuery(e.target.value)}
+                onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search integrations..."
                 className="h-9 w-full rounded-[10px] border border-panel-border/40 bg-panel-bg/60 pl-8 pr-3 text-[13px] text-text-main outline-none placeholder:text-text-dim/40"
               />
             </div>
             <select
               value={categoryFilter}
-              onChange={(e) => setCategoryFilter(e.target.value)}
+              onChange={(event) => setCategoryFilter(event.target.value)}
               className="h-9 rounded-[10px] border border-panel-border/40 bg-panel-bg/60 px-3 text-[13px] text-text-main outline-none"
             >
               <option value="all">All</option>
-              {categories.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category.charAt(0).toUpperCase() + category.slice(1)}
                 </option>
               ))}
             </select>
           </div>
 
-          {/* Connected */}
-          {connectedToolkits.length > 0 ? (
+          {connectedIntegrations.length > 0 ? (
             <div className="mt-6">
               <h2 className="text-[11px] font-medium uppercase tracking-[0.2em] text-text-dim/70">
                 Connected
               </h2>
               <div className="mt-3 grid grid-cols-2 gap-2">
-                {connectedToolkits.map((t) => (
-                  <ToolkitRow key={t.slug} toolkit={t} connected onConnect={() => void handleConnect(t)} connecting={connectingSlug === t.slug} />
+                {connectedIntegrations.map((integration) => (
+                  <IntegrationRow
+                    key={integration.slug}
+                    integration={integration}
+                    connected
+                    canConnect={false}
+                    connectDisabledReason=""
+                    onConnect={() => void handleConnect(integration)}
+                    connecting={connectingProviderId === integration.providerId}
+                    actionMode="connected"
+                  />
                 ))}
               </div>
             </div>
           ) : null}
 
-          {/* Status message */}
-          {connectStatus ? (
-            <div className="mt-4 text-[12px] text-text-muted">{connectStatus}</div>
+          {statusMessage ? (
+            <div className="mt-4 text-[12px] text-text-muted">{statusMessage}</div>
           ) : null}
 
-          {/* Available — grouped by category */}
-          {groupedToolkits.map(([category, items]) => (
+          {groupedIntegrations.map(([category, items]) => (
             <div key={category} className="mt-6">
               <h2 className="text-[11px] font-medium uppercase tracking-[0.2em] text-text-dim/70">
                 {category.charAt(0).toUpperCase() + category.slice(1)}
               </h2>
               <div className="mt-3 grid grid-cols-2 gap-2">
-                {items.map((t) => (
-                  <ToolkitRow key={t.slug} toolkit={t} connected={false} onConnect={() => void handleConnect(t)} connecting={connectingSlug === t.slug} />
+                {items.map((integration) => (
+                  <IntegrationRow
+                    key={integration.slug}
+                    integration={integration}
+                    connected={false}
+                    canConnect={isSignedIn && integration.supportsManaged}
+                    connectDisabledReason={
+                      integration.supportsManaged
+                        ? "Sign in first to connect managed integrations."
+                        : "Managed sign-in is not supported for this provider."
+                    }
+                    onConnect={() => void handleConnect(integration)}
+                    connecting={connectingProviderId === integration.providerId}
+                    actionMode={
+                      !integration.supportsManaged
+                        ? "unavailable"
+                        : isSignedIn
+                          ? "connect"
+                          : "disabled"
+                    }
+                  />
                 ))}
               </div>
             </div>
           ))}
 
-          {filteredToolkits.length === 0 && connectedToolkits.length === 0 ? (
+          {filteredIntegrations.length === 0 && connectedIntegrations.length === 0 ? (
             <div className="mt-12 text-center text-[13px] text-text-muted/60">
               No integrations found.
             </div>
@@ -228,47 +424,67 @@ export function IntegrationsPane() {
   );
 }
 
-function ToolkitRow({
-  toolkit,
+function IntegrationRow({
+  integration,
   connected,
+  canConnect,
+  connectDisabledReason,
   onConnect,
   connecting,
+  actionMode,
 }: {
-  toolkit: Toolkit;
+  integration: IntegrationCard;
   connected: boolean;
+  canConnect: boolean;
+  connectDisabledReason: string;
   onConnect: () => void;
   connecting: boolean;
+  actionMode: "connected" | "connect" | "disabled" | "unavailable";
 }) {
+  const muted = actionMode === "disabled";
   return (
-    <div className="flex items-center gap-3 rounded-[12px] border border-panel-border/30 px-3 py-2.5 transition-colors hover:bg-panel-bg/40">
-      {/* Logo */}
+    <div
+      className={`flex items-center gap-3 rounded-[12px] border border-panel-border/30 px-3 py-2.5 transition-colors ${
+        muted ? "opacity-50" : "hover:bg-panel-bg/40"
+      }`}
+    >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-[8px] border border-panel-border/20 bg-panel-bg/50">
-        {toolkit.logo ? (
-          <img src={toolkit.logo} alt="" className="h-full w-full object-cover" />
+        {integration.logo ? (
+          <img src={integration.logo} alt="" className="h-full w-full object-cover" />
         ) : (
           <span className="text-[14px] font-semibold text-text-dim/50">
-            {toolkit.name.charAt(0)}
+            {integration.name.charAt(0)}
           </span>
         )}
       </div>
 
-      {/* Info */}
       <div className="min-w-0 flex-1">
-        <div className="truncate text-[13px] font-medium text-text-main">{toolkit.name}</div>
-        <div className="truncate text-[11px] text-text-muted/70">{toolkit.description}</div>
+        <div className="truncate text-[13px] font-medium text-text-main">
+          {integration.name}
+        </div>
+        <div className="truncate text-[11px] text-text-muted/70">
+          {integration.description}
+        </div>
       </div>
 
-      {/* Action */}
       {connected ? (
         <span className="inline-flex items-center gap-1 text-[11px] font-medium text-neon-green">
           <Check size={12} />
         </span>
+      ) : actionMode === "unavailable" ? (
+        <span
+          title={connectDisabledReason}
+          className="inline-flex h-7 shrink-0 items-center rounded-[8px] border border-panel-border/28 px-2.5 text-[11px] font-medium text-text-dim/64"
+        >
+          Unavailable
+        </span>
       ) : (
         <button
           type="button"
-          disabled={connecting}
+          disabled={connecting || !canConnect}
           onClick={onConnect}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-panel-border/30 text-text-dim/60 transition-colors hover:bg-panel-bg/60 hover:text-text-main disabled:opacity-40"
+          title={canConnect ? `Connect ${integration.name}` : connectDisabledReason}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-panel-border/30 text-text-dim/60 transition-colors hover:bg-panel-bg/60 hover:text-text-main disabled:cursor-not-allowed disabled:opacity-40"
         >
           {connecting ? <Loader2 size={13} className="animate-spin" /> : <Plus size={14} />}
         </button>
@@ -277,17 +493,22 @@ function ToolkitRow({
   );
 }
 
-/**
- * Maps Holaboss provider_id → Composio toolkit slug.
- * e.g. a connection with provider_id "google" maps to toolkit "gmail".
- */
-const PROVIDER_TO_TOOLKIT_SLUG: Record<string, string> = {
-  google: "gmail",
+const PROVIDER_CATEGORY_GROUPS: Record<string, string[]> = {
+  google: ["productivity"],
+  github: ["developer"],
+  reddit: ["community"],
+  twitter: ["social"],
+  linkedin: ["social"],
 };
 
-/**
- * Maps Composio toolkit slug → Holaboss provider_id for the connect flow.
- */
+const PROVIDER_TOOLKIT_PREFERENCE: Record<string, string[]> = {
+  google: ["gmail", "googledrive", "googlecalendar", "googlesheets"],
+  github: ["github"],
+  reddit: ["reddit"],
+  twitter: ["twitter"],
+  linkedin: ["linkedin"],
+};
+
 const TOOLKIT_SLUG_TO_PROVIDER: Record<string, string> = {
   gmail: "google",
   googlesheets: "google",


### PR DESCRIPTION
## Context

Follow-up desktop fixes after the PR 56 merge-conflict resolution. This bundles the runtime-config, model-selection, and integrations-pane regressions that showed up during local Electron testing.

## What Changed

- restore missing Electron IPC handlers for runtime config documents and workspace proactive/session flows
- expose runtime provider model groups from the desktop main process so saved provider settings unlock chat model selection and show both direct providers and the Holaboss proxy catalog
- harden the chat composer for missing-model states so the input disables correctly when no model is available
- rebuild the integrations pane from the local provider catalog, keep managed integrations explicit when signed out, and avoid noisy signed-out Composio toolkit failures
- include the current desktop lockfile updates from the active dependency graph

## Validation

- `npm --prefix desktop run typecheck`

## Notes

- UI-affecting desktop follow-up only
- no environment changes required
