### PR TITLE
fix: improve automation session routing and provider navigation

### DIFF
--- a/desktop/electron/authPopupPreload.ts
+++ b/desktop/electron/authPopupPreload.ts
@@ -76,7 +76,7 @@ interface WorkspaceListResponsePayload {
   offset: number;
 }
 
-type UiSettingsPaneSection = "account" | "models" | "appearance" | "about";
+type UiSettingsPaneSection = "account" | "providers" | "settings" | "about";
 
 const INTERNAL_DEV_BACKEND_OVERRIDES_ENABLED =
   Boolean(process.env.VITE_DEV_SERVER_URL) || process.env.HOLABOSS_INTERNAL_DEV?.trim() === "1";

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -234,7 +234,7 @@ interface BrowserAnchorBoundsPayload {
   height: number;
 }
 
-type UiSettingsPaneSection = "account" | "settings" | "about";
+type UiSettingsPaneSection = "account" | "providers" | "settings" | "about";
 
 interface AddressSuggestionPayload {
   id: string;

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -52,7 +52,7 @@ interface BrowserAnchorBoundsPayload {
   height: number;
 }
 
-type UiSettingsPaneSection = "account" | "settings" | "about";
+type UiSettingsPaneSection = "account" | "providers" | "settings" | "about";
 
 interface BrowserStatePayload {
   id: string;

--- a/desktop/electron/settings-pane-routing.test.mjs
+++ b/desktop/electron/settings-pane-routing.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const PRELOAD_PATH = new URL("./preload.ts", import.meta.url);
+const AUTH_POPUP_PRELOAD_PATH = new URL("./authPopupPreload.ts", import.meta.url);
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const APP_SHELL_PATH = new URL("../src/components/layout/AppShell.tsx", import.meta.url);
+
+test("settings pane routing keeps the providers section available across Electron bridges", async () => {
+  const [preloadSource, authPopupPreloadSource, mainSource, appShellSource] = await Promise.all([
+    readFile(PRELOAD_PATH, "utf8"),
+    readFile(AUTH_POPUP_PRELOAD_PATH, "utf8"),
+    readFile(MAIN_PATH, "utf8"),
+    readFile(APP_SHELL_PATH, "utf8")
+  ]);
+
+  assert.match(preloadSource, /type UiSettingsPaneSection = "account" \| "providers" \| "settings" \| "about";/);
+  assert.match(authPopupPreloadSource, /type UiSettingsPaneSection = "account" \| "providers" \| "settings" \| "about";/);
+  assert.match(mainSource, /type UiSettingsPaneSection = "account" \| "providers" \| "settings" \| "about";/);
+  assert.match(appShellSource, /return value === "account" \|\| value === "providers" \|\| value === "settings" \|\| value === "about";/);
+});

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -121,7 +121,7 @@ function isAppTheme(value: string): value is AppTheme {
 }
 
 function isSettingsPaneSection(value: string): value is UiSettingsPaneSection {
-  return value === "account" || value === "settings" || value === "about";
+  return value === "account" || value === "providers" || value === "settings" || value === "about";
 }
 
 type AgentView =
@@ -1800,6 +1800,7 @@ function AppShellContent() {
                     void dismissTaskProposal(proposal)
                   }
                   hasWorkspace={hasSelectedWorkspace}
+                  selectedWorkspaceId={selectedWorkspaceId}
                 />
               </div>
             ) : null}

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Bell, Check, ChevronRight, Clock3, Loader2, RefreshCcw, Sparkles, X } from "lucide-react";
 import { getWorkspaceAppDefinition, type WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
 
@@ -49,6 +49,16 @@ interface OperationsDrawerProps {
   onAcceptProposal: (proposal: TaskProposalRecordPayload) => void;
   onDismissProposal: (proposal: TaskProposalRecordPayload) => void;
   hasWorkspace: boolean;
+  selectedWorkspaceId: string | null;
+}
+
+interface RunningSessionEntry {
+  sessionId: string;
+  status: string;
+  title: string;
+  kind: string;
+  updatedAt: string;
+  lastError: string | null;
 }
 
 export function OperationsDrawer({
@@ -68,7 +78,8 @@ export function OperationsDrawer({
   onTriggerProposal,
   onAcceptProposal,
   onDismissProposal,
-  hasWorkspace
+  hasWorkspace,
+  selectedWorkspaceId
 }: OperationsDrawerProps) {
   const selectedOutput = useMemo(() => {
     if (!outputs.length) {
@@ -76,6 +87,74 @@ export function OperationsDrawer({
     }
     return outputs.find((entry) => entry.id === selectedOutputId) ?? outputs[0];
   }, [outputs, selectedOutputId]);
+  const [runningSessions, setRunningSessions] = useState<RunningSessionEntry[]>([]);
+  const [isLoadingRunningSessions, setIsLoadingRunningSessions] = useState(false);
+  const [runningSessionsError, setRunningSessionsError] = useState("");
+
+  useEffect(() => {
+    if (activeTab !== "running") {
+      return;
+    }
+    if (!selectedWorkspaceId) {
+      setRunningSessions([]);
+      setRunningSessionsError("");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadRunningSessions = async () => {
+      setIsLoadingRunningSessions(true);
+      try {
+        const [runtimeStatesResponse, sessionsResponse] = await Promise.all([
+          window.electronAPI.workspace.listRuntimeStates(selectedWorkspaceId),
+          window.electronAPI.workspace.listAgentSessions(selectedWorkspaceId)
+        ]);
+        if (cancelled) {
+          return;
+        }
+
+        const sessionById = new Map(
+          sessionsResponse.items.map((session) => [session.session_id, session])
+        );
+        const nextEntries = runtimeStatesResponse.items
+          .filter((state) => state.status !== "IDLE")
+          .map((state) => {
+            const session = sessionById.get(state.session_id);
+            return {
+              sessionId: state.session_id,
+              status: state.status,
+              title: session?.title?.trim() || defaultSessionTitle(session?.kind, state.session_id),
+              kind: session?.kind?.trim() || "session",
+              updatedAt: state.updated_at,
+              lastError: runtimeStateErrorMessage(state.last_error)
+            };
+          })
+          .sort(compareRunningSessionEntries);
+
+        setRunningSessions(nextEntries);
+        setRunningSessionsError("");
+      } catch (error) {
+        if (!cancelled) {
+          setRunningSessionsError(normalizeOperationError(error));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingRunningSessions(false);
+        }
+      }
+    };
+
+    void loadRunningSessions();
+    const intervalId = window.setInterval(() => {
+      void loadRunningSessions();
+    }, 3000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [activeTab, selectedWorkspaceId]);
 
   return (
     <aside className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-[360px] max-w-[420px] flex-col overflow-hidden rounded-[var(--radius-xl)] shadow-lg">
@@ -113,7 +192,14 @@ export function OperationsDrawer({
           />
         ) : null}
 
-        {activeTab === "running" ? <RunningPanel /> : null}
+        {activeTab === "running" ? (
+          <RunningPanel
+            hasWorkspace={hasWorkspace}
+            isLoading={isLoadingRunningSessions}
+            sessions={runningSessions}
+            errorMessage={runningSessionsError}
+          />
+        ) : null}
 
         {activeTab === "outputs" ? (
           <OutputsPanel
@@ -127,6 +213,73 @@ export function OperationsDrawer({
       </div>
     </aside>
   );
+}
+
+function normalizeOperationError(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+function runtimeStateErrorMessage(value: Record<string, unknown> | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const message = typeof value.message === "string" && value.message.trim() ? value.message.trim() : "";
+  if (message) {
+    return message;
+  }
+  const rawMessage = typeof value.raw_message === "string" && value.raw_message.trim() ? value.raw_message.trim() : "";
+  return rawMessage || null;
+}
+
+function defaultSessionTitle(kind: string | null | undefined, sessionId: string): string {
+  if (kind === "cronjob") {
+    return "Cronjob run";
+  }
+  if (kind === "task_proposal") {
+    return "Task proposal run";
+  }
+  if (kind === "main") {
+    return "Main session";
+  }
+  return `Session ${sessionId.slice(0, 8)}`;
+}
+
+function runningSessionStatusRank(status: string): number {
+  switch (status) {
+    case "BUSY":
+      return 0;
+    case "QUEUED":
+      return 1;
+    case "WAITING_USER":
+      return 2;
+    case "ERROR":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function compareRunningSessionEntries(left: RunningSessionEntry, right: RunningSessionEntry): number {
+  const statusDiff = runningSessionStatusRank(left.status) - runningSessionStatusRank(right.status);
+  if (statusDiff !== 0) {
+    return statusDiff;
+  }
+  return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+}
+
+function runningStatusClasses(status: string): string {
+  switch (status) {
+    case "BUSY":
+      return "border-primary/45 bg-primary/10 text-primary";
+    case "QUEUED":
+      return "border-primary/35 bg-primary/8 text-primary";
+    case "WAITING_USER":
+      return "border-border/45 bg-muted text-foreground/82";
+    case "ERROR":
+      return "border-destructive/35 bg-destructive/10 text-destructive";
+    default:
+      return "border-border/45 bg-muted text-muted-foreground";
+  }
 }
 
 function DrawerTabButton({
@@ -274,15 +427,64 @@ function InboxPanel({
   );
 }
 
-function RunningPanel() {
+function RunningPanel({
+  hasWorkspace,
+  isLoading,
+  sessions,
+  errorMessage
+}: {
+  hasWorkspace: boolean;
+  isLoading: boolean;
+  sessions: RunningSessionEntry[];
+  errorMessage: string;
+}) {
   return (
-    <div className="flex h-full items-center justify-center p-6">
-      <div className="theme-subtle-surface max-w-[260px] rounded-[20px] border border-border/35 px-5 py-5 text-center">
-        <div className="text-[11px] uppercase tracking-[0.16em] text-primary/76">Running</div>
-        <div className="mt-2 text-[15px] font-medium text-foreground">Execution stream coming next</div>
-        <div className="mt-2 text-[12px] leading-6 text-muted-foreground/82">
-          This panel is reserved for active runs. For now it stays as a placeholder while Inbox and Outputs take over the right rail.
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 border-b border-border/35 px-4 py-4">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-primary/76">Running</div>
+        <div className="mt-1 text-[12px] leading-6 text-foreground/88">
+          Active and failed runtime sessions for the current workspace, including cronjob runs.
         </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {!hasWorkspace ? (
+          <CenteredNotice message="Choose a workspace to inspect active runtime sessions." />
+        ) : errorMessage ? (
+          <CenteredNotice message={errorMessage} tone="error" />
+        ) : isLoading && sessions.length === 0 ? (
+          <CenteredNotice message="Loading runtime sessions..." />
+        ) : sessions.length === 0 ? (
+          <CenteredNotice message="No active or failed runtime sessions right now." />
+        ) : (
+          <div className="grid gap-3">
+            {sessions.map((session) => (
+              <article key={session.sessionId} className="theme-subtle-surface rounded-[18px] border border-border/35 px-4 py-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[13px] font-medium text-foreground">{session.title}</div>
+                    <div className="mt-1 text-[11px] uppercase tracking-[0.12em] text-muted-foreground/76">
+                      {session.kind.replace(/_/g, " ")}
+                    </div>
+                  </div>
+                  <div className={`shrink-0 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${runningStatusClasses(session.status)}`}>
+                    {session.status}
+                  </div>
+                </div>
+
+                <div className="mt-3 text-[11px] text-muted-foreground/82">
+                  Updated {formatTimestamp(session.updatedAt)}
+                </div>
+
+                {session.lastError ? (
+                  <div className="mt-3 rounded-[14px] border border-destructive/25 bg-destructive/8 px-3 py-2 text-[11px] leading-5 text-destructive">
+                    {session.lastError}
+                  </div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -360,6 +562,26 @@ function OutputsPanel({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function CenteredNotice({
+  message,
+  tone = "default"
+}: {
+  message: string;
+  tone?: "default" | "error";
+}) {
+  return (
+    <div className="flex items-center justify-center p-6">
+      <div
+        className={`theme-subtle-surface max-w-[280px] rounded-[20px] border px-5 py-5 text-center ${
+          tone === "error" ? "border-destructive/25 text-destructive" : "border-border/35"
+        }`}
+      >
+        <div className="text-[12px] leading-6">{message}</div>
+      </div>
     </div>
   );
 }

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -20,6 +20,61 @@ function formatTimestamp(value: string | null): string {
   return new Date(parsed).toLocaleString();
 }
 
+type AutomationSectionKey = "system_notification" | "session_run" | "other";
+
+const AUTOMATION_SECTIONS: Array<{
+  key: AutomationSectionKey;
+  title: string;
+  description: string;
+  emptyMessage: string;
+}> = [
+  {
+    key: "system_notification",
+    title: "System Notifications",
+    description: "Reminder-style automations. They do not create agent sessions or appear in Running.",
+    emptyMessage: "No system notification automations in this workspace."
+  },
+  {
+    key: "session_run",
+    title: "Agent Tasks",
+    description: "Queued work that runs in an agent session and can appear in Running.",
+    emptyMessage: "No agent task automations in this workspace."
+  },
+  {
+    key: "other",
+    title: "Other Delivery",
+    description: "Automations using an unrecognized delivery channel.",
+    emptyMessage: "No automations with other delivery channels."
+  }
+];
+
+function automationSectionKey(job: CronjobRecordPayload): AutomationSectionKey {
+  const channel = job.delivery?.channel?.trim();
+  if (channel === "system_notification") {
+    return "system_notification";
+  }
+  if (channel === "session_run") {
+    return "session_run";
+  }
+  return "other";
+}
+
+function deliveryLabel(job: CronjobRecordPayload): string {
+  switch (automationSectionKey(job)) {
+    case "system_notification":
+      return "System Notification";
+    case "session_run":
+      return "Agent Task";
+    default:
+      return job.delivery?.channel?.trim() || "Unknown Delivery";
+  }
+}
+
+function notificationMessage(job: CronjobRecordPayload): string | null {
+  const value = job.metadata?.message;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 export function AutomationsPane() {
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const [cronjobs, setCronjobs] = useState<CronjobRecordPayload[]>([]);
@@ -28,8 +83,17 @@ export function AutomationsPane() {
   const [statusMessage, setStatusMessage] = useState("");
   const [statusTone, setStatusTone] = useState<"info" | "success" | "error">("info");
 
-  const sortedCronjobs = useMemo(() => {
-    return [...cronjobs].sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
+  const cronjobsBySection = useMemo(() => {
+    const grouped: Record<AutomationSectionKey, CronjobRecordPayload[]> = {
+      system_notification: [],
+      session_run: [],
+      other: []
+    };
+    const sorted = [...cronjobs].sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
+    for (const job of sorted) {
+      grouped[automationSectionKey(job)].push(job);
+    }
+    return grouped;
   }, [cronjobs]);
 
   async function refreshCronjobs() {
@@ -108,62 +172,87 @@ export function AutomationsPane() {
 
         <div
           className={
-            !selectedWorkspaceId || sortedCronjobs.length === 0
+            !selectedWorkspaceId || cronjobs.length === 0
               ? "min-h-0 flex flex-1 items-center justify-center p-4"
               : "min-h-0 flex-1 overflow-y-auto p-4"
           }
         >
           {!selectedWorkspaceId ? (
             <EmptyState message="Choose a workspace from the top bar to view and manage cronjobs." />
-          ) : sortedCronjobs.length === 0 ? (
+          ) : cronjobs.length === 0 ? (
             <EmptyState message={isLoading ? "Loading cronjobs..." : "No cronjobs found for this workspace."} />
           ) : (
             <div className="grid gap-3">
-              {sortedCronjobs.map((job) => {
-                const isBusy = busyJobId === job.id;
-                return (
-                  <div key={job.id} className="rounded-xl border border-border bg-muted px-4 py-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-xs font-medium text-foreground">{job.name || job.description}</div>
-                        <div className="mt-1 truncate text-xs text-muted-foreground">{job.cron}</div>
-                      </div>
-                      <Badge variant={job.enabled ? "default" : "secondary"}>
-                        {job.enabled ? "Enabled" : "Disabled"}
-                      </Badge>
+              {AUTOMATION_SECTIONS.filter((section) => section.key !== "other" || cronjobsBySection.other.length > 0).map((section) => (
+                <section key={section.key} className="rounded-2xl border border-border bg-card/60 px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-semibold text-foreground">{section.title}</div>
+                      <div className="mt-0.5 max-w-2xl text-[11px] leading-4 text-muted-foreground">{section.description}</div>
                     </div>
-
-                    <div className="mt-3 grid gap-1 text-[10px] text-muted-foreground">
-                      <div>Next run: {formatTimestamp(job.next_run_at)}</div>
-                      <div>Last run: {formatTimestamp(job.last_run_at)}</div>
-                      <div>Runs: {job.run_count}</div>
-                      {job.last_status ? <div>Status: {job.last_status}</div> : null}
-                      {job.last_error ? <div>Last error: {job.last_error}</div> : null}
-                    </div>
-
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => void handleToggleEnabled(job)}
-                        disabled={isBusy}
-                      >
-                        {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
-                        <span>{job.enabled ? "Disable" : "Enable"}</span>
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => void handleDelete(job)}
-                        disabled={isBusy}
-                      >
-                        {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
-                        <span>Delete</span>
-                      </Button>
-                    </div>
+                    <Badge variant="outline">{cronjobsBySection[section.key].length}</Badge>
                   </div>
-                );
-              })}
+
+                  {cronjobsBySection[section.key].length === 0 ? (
+                    <div className="mt-3 rounded-xl border border-dashed border-border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+                      {section.emptyMessage}
+                    </div>
+                  ) : (
+                    <div className="mt-3 grid gap-2.5">
+                      {cronjobsBySection[section.key].map((job) => {
+                        const isBusy = busyJobId === job.id;
+                        const message = notificationMessage(job);
+                        return (
+                          <div key={job.id} className="rounded-xl border border-border bg-muted px-3 py-3 sm:px-4">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                <div className="truncate text-sm font-medium text-foreground">{job.name || job.description}</div>
+                                <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{job.cron}</div>
+                              </div>
+                              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                                <Badge variant="outline">{deliveryLabel(job)}</Badge>
+                                <Badge variant={job.enabled ? "default" : "secondary"}>
+                                  {job.enabled ? "Enabled" : "Disabled"}
+                                </Badge>
+                              </div>
+                            </div>
+
+                            <div className="mt-2 grid gap-x-4 gap-y-1 text-[11px] text-muted-foreground sm:grid-cols-2 xl:grid-cols-3">
+                              <div>Next run: {formatTimestamp(job.next_run_at)}</div>
+                              <div>Last run: {formatTimestamp(job.last_run_at)}</div>
+                              <div>Runs: {job.run_count}</div>
+                              {message ? <div className="sm:col-span-2 xl:col-span-3">Message: {message}</div> : null}
+                              {job.last_status ? <div>Status: {job.last_status}</div> : null}
+                              {job.last_error ? <div className="sm:col-span-2 xl:col-span-3">Last error: {job.last_error}</div> : null}
+                            </div>
+
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => void handleToggleEnabled(job)}
+                                disabled={isBusy}
+                              >
+                                {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+                                <span>{job.enabled ? "Disable" : "Enable"}</span>
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => void handleDelete(job)}
+                                disabled={isBusy}
+                              >
+                                {isBusy ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
+                                <span>Delete</span>
+                              </Button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </section>
+              ))}
             </div>
           )}
         </div>

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -27,3 +27,13 @@ test("chat pane shows provider setup CTA when no chat models are available", asy
   );
   assert.doesNotMatch(source, /if \(!resolvedUserId\) \{/);
 });
+
+test("chat pane exposes a return path from sub-sessions back to the main session", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const showMainSessionReturn =[\s\S]*activeSessionId !== mainSessionId;/);
+  assert.match(source, /You are viewing a separate run session\. Return to the main workspace chat to continue there\./);
+  assert.match(source, /Back to main session/);
+  assert.match(source, /await loadSessionConversation\(mainSessionId, selectedWorkspaceId, runtimeStates\.items\);/);
+  assert.match(source, /const targetSessionId = activeSessionIdRef\.current \|\| preferredSessionId\(selectedWorkspace, \[\]\);/);
+});

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -716,6 +716,168 @@ export function ChatPane({
     setLiveTraceSteps([]);
   }
 
+  function clearSessionView() {
+    setMessages([]);
+    resetLiveTurn();
+    setCollapsedThinkingByMessageId({});
+    setCollapsedTraceByStepId({});
+    shouldAutoScrollRef.current = true;
+  }
+
+  function historyMessagesFromSessionState(
+    historyMessages: SessionHistoryMessagePayload[],
+    outputEvents: SessionOutputEventPayload[]
+  ): ChatMessage[] {
+    const outputEventsByInputId = new Map<string, SessionOutputEventPayload[]>();
+    for (const event of outputEvents) {
+      const inputId = event.input_id.trim();
+      if (!inputId) {
+        continue;
+      }
+      const existing = outputEventsByInputId.get(inputId);
+      if (existing) {
+        existing.push(event);
+      } else {
+        outputEventsByInputId.set(inputId, [event]);
+      }
+    }
+
+    return historyMessages
+      .map((message) => {
+        const attachments = attachmentsFromMetadata(message.metadata);
+        const nextMessage: ChatMessage = {
+          id: message.id || `history-${message.created_at ?? crypto.randomUUID()}`,
+          role: message.role as ChatMessage["role"],
+          text: message.text,
+          attachments
+        };
+
+        if (nextMessage.role === "assistant") {
+          const inputId = inputIdFromMessageId(nextMessage.id, "assistant");
+          if (inputId) {
+            const restoredAssistantState = assistantHistoryStateFromOutputEvents(outputEventsByInputId.get(inputId) ?? []);
+            if (restoredAssistantState.thinkingText) {
+              nextMessage.thinkingText = restoredAssistantState.thinkingText;
+            }
+            if (restoredAssistantState.traceSteps) {
+              nextMessage.traceSteps = restoredAssistantState.traceSteps;
+            }
+          }
+        }
+
+        return nextMessage;
+      })
+      .filter(
+        (message) =>
+          (message.role === "user" || message.role === "assistant") &&
+          hasRenderableMessageContent(message.text, message.attachments ?? [])
+      );
+  }
+
+  async function loadSessionConversation(
+    nextSessionId: string | null,
+    workspaceId: string,
+    runtimeStates: SessionRuntimeRecordPayload[],
+    options?: {
+      cancelled?: () => boolean;
+    }
+  ) {
+    const cancelled = options?.cancelled ?? (() => false);
+
+    if (activeSessionIdRef.current !== nextSessionId) {
+      clearSessionView();
+    }
+    setActiveSession(nextSessionId);
+    if (!nextSessionId) {
+      return;
+    }
+
+    const [history, outputEventHistory] = await Promise.all([
+      window.electronAPI.workspace.getSessionHistory({
+        sessionId: nextSessionId,
+        workspaceId
+      }),
+      window.electronAPI.workspace.getSessionOutputEvents({
+        sessionId: nextSessionId
+      })
+    ]);
+    if (cancelled()) {
+      return;
+    }
+
+    const nextMessages = historyMessagesFromSessionState(history.messages, outputEventHistory.items);
+    setMessages(nextMessages);
+    resetLiveTurn();
+
+    const onboardingSessionId = (selectedWorkspaceRef.current?.onboarding_session_id || "").trim();
+    const currentRuntimeState = runtimeStates.find((item) => item.session_id === nextSessionId);
+    const hasAssistantMessage = nextMessages.some((message) => message.role === "assistant");
+    const shouldAttachOnboardingBootstrapStream =
+      isOnboardingVariant &&
+      nextSessionId === onboardingSessionId &&
+      !hasAssistantMessage &&
+      !activeStreamIdRef.current &&
+      !pendingInputIdRef.current &&
+      ["BUSY", "QUEUED"].includes(runtimeStateStatus(currentRuntimeState?.status));
+
+    if (shouldAttachOnboardingBootstrapStream) {
+      setIsResponding(true);
+      setLiveAgentStatus("Preparing first question...");
+      setChatErrorMessage("");
+      const stream = await window.electronAPI.workspace.openSessionOutputStream({
+        sessionId: nextSessionId,
+        workspaceId,
+        includeHistory: true,
+        stopOnTerminal: true
+      });
+      if (cancelled()) {
+        await closeStreamWithReason(stream.streamId, "load_history_cancelled").catch(() => undefined);
+        return;
+      }
+      activeStreamIdRef.current = stream.streamId;
+      appendStreamTelemetry({
+        streamId: stream.streamId,
+        transportType: "client",
+        eventName: "openSessionOutputStream",
+        eventType: "stream_open_onboarding_bootstrap",
+        inputId: "",
+        sessionId: nextSessionId,
+        action: "stream_requested_onboarding_bootstrap",
+        detail: "attached to in-flight onboarding opener"
+      });
+    } else if (!activeStreamIdRef.current && !pendingInputIdRef.current) {
+      setIsResponding(false);
+    }
+  }
+
+  async function returnToMainSession() {
+    const mainSessionId = (selectedWorkspace?.main_session_id || "").trim();
+    if (!selectedWorkspaceId || !mainSessionId || activeSessionIdRef.current === mainSessionId) {
+      return;
+    }
+
+    setIsLoadingHistory(true);
+    setChatErrorMessage("");
+    pendingInputIdRef.current = null;
+    activeAssistantMessageIdRef.current = null;
+    setIsResponding(false);
+
+    const activeStreamId = activeStreamIdRef.current;
+    activeStreamIdRef.current = null;
+    if (activeStreamId) {
+      await closeStreamWithReason(activeStreamId, "chatpane_return_to_main_session").catch(() => undefined);
+    }
+
+    try {
+      const runtimeStates = await window.electronAPI.workspace.listRuntimeStates(selectedWorkspaceId);
+      await loadSessionConversation(mainSessionId, selectedWorkspaceId, runtimeStates.items);
+    } catch (error) {
+      setChatErrorMessage(normalizeErrorMessage(error));
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  }
+
   function appendLiveAssistantDelta(delta: string) {
     flushSync(() => {
       setLiveAssistantText((prev) => {
@@ -905,13 +1067,9 @@ export function ChatPane({
 
   useEffect(() => {
     if (!selectedWorkspaceId) {
-      setMessages([]);
-      resetLiveTurn();
-      setCollapsedThinkingByMessageId({});
-      setCollapsedTraceByStepId({});
+      clearSessionView();
       setPendingAttachments([]);
       setActiveSession(null);
-      shouldAutoScrollRef.current = true;
       pendingInputIdRef.current = null;
       return;
     }
@@ -929,118 +1087,9 @@ export function ChatPane({
         }
 
         const nextSessionId = preferredSessionId(selectedWorkspaceRef.current, runtimeStates.items);
-        if (activeSessionIdRef.current !== nextSessionId) {
-          setMessages([]);
-          resetLiveTurn();
-          setCollapsedThinkingByMessageId({});
-          setCollapsedTraceByStepId({});
-          shouldAutoScrollRef.current = true;
-        }
-        setActiveSession(nextSessionId);
-        if (!nextSessionId) {
-          return;
-        }
-
-        const [history, outputEventHistory] = await Promise.all([
-          window.electronAPI.workspace.getSessionHistory({
-            sessionId: nextSessionId,
-            workspaceId: selectedWorkspaceId
-          }),
-          window.electronAPI.workspace.getSessionOutputEvents({
-            sessionId: nextSessionId
-          })
-        ]);
-        if (cancelled) {
-          return;
-        }
-
-        const outputEventsByInputId = new Map<string, SessionOutputEventPayload[]>();
-        for (const event of outputEventHistory.items) {
-          const inputId = event.input_id.trim();
-          if (!inputId) {
-            continue;
-          }
-          const existing = outputEventsByInputId.get(inputId);
-          if (existing) {
-            existing.push(event);
-          } else {
-            outputEventsByInputId.set(inputId, [event]);
-          }
-        }
-
-        const nextMessages = history.messages
-          .map((message) => {
-            const attachments = attachmentsFromMetadata(message.metadata);
-            const nextMessage: ChatMessage = {
-              id: message.id || `history-${message.created_at ?? crypto.randomUUID()}`,
-              role: message.role as ChatMessage["role"],
-              text: message.text,
-              attachments
-            };
-
-            if (nextMessage.role === "assistant") {
-              const inputId = inputIdFromMessageId(nextMessage.id, "assistant");
-              if (inputId) {
-                const restoredAssistantState = assistantHistoryStateFromOutputEvents(outputEventsByInputId.get(inputId) ?? []);
-                if (restoredAssistantState.thinkingText) {
-                  nextMessage.thinkingText = restoredAssistantState.thinkingText;
-                }
-                if (restoredAssistantState.traceSteps) {
-                  nextMessage.traceSteps = restoredAssistantState.traceSteps;
-                }
-              }
-            }
-
-            return nextMessage;
-          })
-          .filter(
-            (message) =>
-              (message.role === "user" || message.role === "assistant") &&
-              hasRenderableMessageContent(message.text, message.attachments ?? [])
-          );
-
-        setMessages(nextMessages);
-        resetLiveTurn();
-
-        const onboardingSessionId = (selectedWorkspaceRef.current?.onboarding_session_id || "").trim();
-        const currentRuntimeState = runtimeStates.items.find((item) => item.session_id === nextSessionId);
-        const hasAssistantMessage = nextMessages.some((message) => message.role === "assistant");
-        const shouldAttachOnboardingBootstrapStream =
-          isOnboardingVariant &&
-          nextSessionId === onboardingSessionId &&
-          !hasAssistantMessage &&
-          !activeStreamIdRef.current &&
-          !pendingInputIdRef.current &&
-          ["BUSY", "QUEUED"].includes(runtimeStateStatus(currentRuntimeState?.status));
-
-        if (shouldAttachOnboardingBootstrapStream) {
-          setIsResponding(true);
-          setLiveAgentStatus("Preparing first question...");
-          setChatErrorMessage("");
-          const stream = await window.electronAPI.workspace.openSessionOutputStream({
-            sessionId: nextSessionId,
-            workspaceId: selectedWorkspaceId,
-            includeHistory: true,
-            stopOnTerminal: true
-          });
-          if (cancelled) {
-            await closeStreamWithReason(stream.streamId, "load_history_cancelled").catch(() => undefined);
-            return;
-          }
-          activeStreamIdRef.current = stream.streamId;
-          appendStreamTelemetry({
-            streamId: stream.streamId,
-            transportType: "client",
-            eventName: "openSessionOutputStream",
-            eventType: "stream_open_onboarding_bootstrap",
-            inputId: "",
-            sessionId: nextSessionId,
-            action: "stream_requested_onboarding_bootstrap",
-            detail: "attached to in-flight onboarding opener"
-          });
-        } else if (!activeStreamIdRef.current && !pendingInputIdRef.current) {
-          setIsResponding(false);
-        }
+        await loadSessionConversation(nextSessionId, selectedWorkspaceId, runtimeStates.items, {
+          cancelled: () => cancelled
+        });
       } catch (error) {
         if (!cancelled) {
           setChatErrorMessage(normalizeErrorMessage(error));
@@ -1569,7 +1618,7 @@ export function ChatPane({
       setChatErrorMessage(modelSelectionUnavailableReason || "No models available.");
       return;
     }
-    const targetSessionId = preferredSessionId(selectedWorkspace, []) || activeSessionIdRef.current;
+    const targetSessionId = activeSessionIdRef.current || preferredSessionId(selectedWorkspace, []);
     if (!targetSessionId) {
       setChatErrorMessage("No active session found for this workspace.");
       return;
@@ -1966,6 +2015,12 @@ export function ChatPane({
   const textareaPlaceholder = isOnboardingVariant
     ? "Answer the onboarding prompt or share setup details"
     : "Ask anything";
+  const mainSessionId = (selectedWorkspace?.main_session_id || "").trim();
+  const showMainSessionReturn =
+    !isOnboardingVariant &&
+    Boolean(mainSessionId) &&
+    Boolean(activeSessionId) &&
+    activeSessionId !== mainSessionId;
   const chatScrollRange = Math.max(0, chatScrollMetrics.scrollHeight - chatScrollMetrics.clientHeight);
   const showCustomChatScrollbar = hasMessages && chatScrollMetrics.clientHeight > 0 && chatScrollRange > 1;
   const chatScrollbarRailInset = composerBlockHeight > 0 ? composerBlockHeight / 2 : 0;
@@ -2067,6 +2122,29 @@ export function ChatPane({
                   </div>
                 </div>
               </div>
+            </div>
+          </div>
+        ) : null}
+
+        {showMainSessionReturn ? (
+          <div className="shrink-0 px-4 pt-3 sm:px-5">
+            <div className="bg-muted/72 flex flex-wrap items-center justify-between gap-3 rounded-[16px] border border-border/55 px-3 py-2.5">
+              <div className="min-w-0">
+                <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  Sub-session
+                </div>
+                <div className="mt-1 text-[12px] leading-5 text-muted-foreground">
+                  You are viewing a separate run session. Return to the main workspace chat to continue there.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void returnToMainSession()}
+                disabled={isLoadingHistory}
+                className="inline-flex shrink-0 items-center rounded-full border border-border/60 bg-background px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Back to main session
+              </button>
             </div>
           </div>
         ) : null}

--- a/desktop/src/lib/sessionRouting.test.mjs
+++ b/desktop/src/lib/sessionRouting.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "sessionRouting.ts");
+
+test("preferred session routing keeps the main session ahead of transient runtime sessions", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  const mainSessionIndex = source.indexOf('const mainSessionId = (workspace.main_session_id || "").trim();');
+  const runtimeFallbackIndex = source.indexOf("if (runtimeStates.length > 0) {");
+
+  assert.notEqual(mainSessionIndex, -1);
+  assert.notEqual(runtimeFallbackIndex, -1);
+  assert.ok(mainSessionIndex < runtimeFallbackIndex);
+});

--- a/desktop/src/lib/sessionRouting.ts
+++ b/desktop/src/lib/sessionRouting.ts
@@ -26,13 +26,13 @@ export function preferredSessionId(
     }
   }
 
-  if (runtimeStates.length > 0) {
-    return runtimeStates[0]?.session_id ?? null;
-  }
-
   const mainSessionId = (workspace.main_session_id || "").trim();
   if (mainSessionId) {
     return mainSessionId;
+  }
+
+  if (runtimeStates.length > 0) {
+    return runtimeStates[0]?.session_id ?? null;
   }
   return null;
 }

--- a/runtime/api-server/src/agent-capability-registry.ts
+++ b/runtime/api-server/src/agent-capability-registry.ts
@@ -541,6 +541,10 @@ export function renderCapabilityPolicyPromptSection(manifest: AgentCapabilityMan
   if (manifest.runtime_tools.length > 0) {
     lines.push(`Runtime capabilities available now: ${summarizeList(namesForCapabilities(manifest.runtime_tools))}`);
   }
+  if (manifest.runtime_tools.some((capability) => capability.id === "holaboss_cronjobs_create")) {
+    lines.push("Cronjob delivery routing: use `session_run` for recurring agent work such as running instructions, tasks, analysis, browsing, or writing.");
+    lines.push("Use `system_notification` only for lightweight reminders or notifications where the primary outcome is a short message rather than agent execution.");
+  }
   if (manifest.workspace_commands.length > 0) {
     lines.push(`Workspace commands available now: ${summarizeList(manifest.workspace_commands)}`);
   }

--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -84,3 +84,29 @@ test("composeBaseAgentPrompt includes recent runtime context only when provided"
   assert.match(prompt.systemPrompt, /waiting for user input/i);
   assert.match(prompt.systemPrompt, /Previous runtime error: config parse error\./);
 });
+
+test("composeBaseAgentPrompt includes cronjob delivery routing guidance when cronjob tools are available", () => {
+  const capabilityManifest = buildAgentCapabilityManifest({
+    defaultTools: ["read"],
+    extraTools: ["holaboss_cronjobs_create"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    sessionKind: "main",
+    harnessId: "pi",
+  });
+
+  const prompt = composeBaseAgentPrompt("", {
+    defaultTools: ["read"],
+    extraTools: ["holaboss_cronjobs_create"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    sessionKind: "main",
+    sessionMode: "code",
+    harnessId: "pi",
+    capabilityManifest,
+  });
+
+  assert.match(prompt.systemPrompt, /Cronjob delivery routing:/);
+  assert.match(prompt.systemPrompt, /use `session_run` for recurring agent work/i);
+  assert.match(prompt.systemPrompt, /Use `system_notification` only for lightweight reminders or notifications/i);
+});

--- a/runtime/harness-host/src/pi-runtime-tools.ts
+++ b/runtime/harness-host/src/pi-runtime-tools.ts
@@ -164,10 +164,20 @@ function runtimeToolParameters(toolId: RuntimeAgentToolId) {
           initiated_by: Type.Optional(Type.String({ description: "Actor creating the cronjob." })),
           name: Type.Optional(Type.String({ description: "Optional cronjob name." })),
           enabled: Type.Optional(Type.Boolean({ description: "Whether the cronjob is enabled." })),
-          delivery_channel: Type.Optional(Type.String({ description: "Delivery channel." })),
+          delivery_channel: Type.Optional(
+            Type.String({
+              description:
+                "Delivery channel. Use `session_run` for recurring agent work such as running instructions, tasks, analysis, browsing, or writing. Use `system_notification` only for lightweight reminder/notification messages."
+            })
+          ),
           delivery_mode: Type.Optional(Type.String({ description: "Delivery mode." })),
           delivery_to: Type.Optional(Type.String({ description: "Optional delivery target." })),
-          metadata_json: Type.Optional(Type.String({ description: "JSON object string for cronjob metadata." })),
+          metadata_json: Type.Optional(
+            Type.String({
+              description:
+                "JSON object string for cronjob metadata. For `system_notification`, include a short `message`. For `session_run`, use metadata for execution context only; keep the actual task instruction in `description`."
+            })
+          ),
         },
         { additionalProperties: false }
       );
@@ -179,10 +189,20 @@ function runtimeToolParameters(toolId: RuntimeAgentToolId) {
           cron: Type.Optional(Type.String({ description: "Cron expression." })),
           description: Type.Optional(Type.String({ description: "Human-readable cronjob description." })),
           enabled: Type.Optional(Type.Boolean({ description: "Whether the cronjob is enabled." })),
-          delivery_channel: Type.Optional(Type.String({ description: "Delivery channel." })),
+          delivery_channel: Type.Optional(
+            Type.String({
+              description:
+                "Delivery channel. Use `session_run` for recurring agent work such as running instructions, tasks, analysis, browsing, or writing. Use `system_notification` only for lightweight reminder/notification messages."
+            })
+          ),
           delivery_mode: Type.Optional(Type.String({ description: "Delivery mode." })),
           delivery_to: Type.Optional(Type.String({ description: "Optional delivery target." })),
-          metadata_json: Type.Optional(Type.String({ description: "JSON object string for cronjob metadata." })),
+          metadata_json: Type.Optional(
+            Type.String({
+              description:
+                "JSON object string for cronjob metadata. For `system_notification`, include a short `message`. For `session_run`, use metadata for execution context only; keep the actual task instruction in `description`."
+            })
+          ),
         },
         { additionalProperties: false }
       );


### PR DESCRIPTION
## Context

This PR tightens the automations UX and session behavior after cronjobs were being confused with reminders, sub-sessions could hijack the main chat pane, and the provider setup CTA was opening the wrong settings section.

## Changes

- split the Automations pane into explicit `System Notifications` and `Agent Tasks` sections and compact the cronjob cards
- replace the `Running` placeholder with real runtime-session state from the selected workspace
- keep chat pinned to the workspace main session by default and add a `Back to main session` path when viewing a sub-session
- route the chat `Set up providers` CTA to the Model Providers settings section across the Electron bridge
- tighten cronjob tool guidance so recurring agent instructions prefer `session_run` over `system_notification`
- add regression coverage for settings-pane routing and session-routing behavior

## Validation

- `cd desktop && npm run typecheck`
- `cd desktop && node --test electron/settings-pane-routing.test.mjs src/components/panes/ChatPane.test.mjs src/lib/sessionRouting.test.mjs src/components/layout/SettingsDialog.test.mjs`
- Runtime package test/typecheck commands remain blocked locally because required `tsx` / `tsc` binaries are missing in this checkout

## Linked Issues

- None provided

## Screenshots / Logs

- Not attached from CLI session
