### PR TITLE
fix: harden packaged desktop runtime bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ holaboss-runtime
 ### Notes
 
 - The packaged bundle includes the runtime app and its packaged runtime dependencies.
-- The current bootstrap still expects a working `node` binary on the host machine at runtime. Install Node.js 22+ on the target machine before starting the runtime.
+- The packaged runtime bundle includes a Node binary under `node-runtime/node_modules/.bin/node` that matches the packaging environment and starts it automatically.
 - The desktop app launches the same `bin/sandbox-runtime` entrypoint and passes the same bind host, bind port, sandbox root, and workflow-related environment variables.
 
 ## OSS Release Notes

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -8567,6 +8567,7 @@ async function fileExists(targetPath: string) {
 const REQUIRED_RUNTIME_BUNDLE_PATHS = [
   path.join("bin", "sandbox-runtime"),
   "package-metadata.json",
+  path.join("node-runtime", "node_modules", ".bin", "node"),
   path.join("runtime", "metadata.json"),
   path.join("runtime", "api-server", "dist", "index.mjs"),
 ] as const;

--- a/desktop/electron/runtime-bundle-validation.test.mjs
+++ b/desktop/electron/runtime-bundle-validation.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainPath = path.join(__dirname, "main.ts");
+const ensureRuntimeBundlePath = path.join(__dirname, "..", "scripts", "ensure-runtime-bundle.mjs");
+const stageRuntimeBundlePath = path.join(__dirname, "..", "scripts", "stage-runtime-bundle.mjs");
+
+test("desktop runtime validation requires the bundled node binary", async () => {
+  const source = await readFile(mainPath, "utf8");
+
+  assert.match(source, /path\.join\("node-runtime", "node_modules", "\.bin", "node"\)/);
+});
+
+test("desktop runtime staging checks the bundled node binary", async () => {
+  const [ensureSource, stageSource] = await Promise.all([
+    readFile(ensureRuntimeBundlePath, "utf8"),
+    readFile(stageRuntimeBundlePath, "utf8"),
+  ]);
+
+  assert.match(ensureSource, /path\.join\(runtimeRoot, "node-runtime", "node_modules", "\.bin", "node"\)/);
+  assert.match(stageSource, /path\.join\(stageDir, "node-runtime", "node_modules", "\.bin", "node"\)/);
+});

--- a/desktop/scripts/ensure-runtime-bundle.mjs
+++ b/desktop/scripts/ensure-runtime-bundle.mjs
@@ -8,6 +8,7 @@ const runtimeRoot = path.join(desktopRoot, "out", "runtime-macos");
 const requiredRuntimePaths = [
   path.join(runtimeRoot, "bin", "sandbox-runtime"),
   path.join(runtimeRoot, "package-metadata.json"),
+  path.join(runtimeRoot, "node-runtime", "node_modules", ".bin", "node"),
   path.join(runtimeRoot, "runtime", "metadata.json"),
   path.join(runtimeRoot, "runtime", "api-server", "dist", "index.mjs")
 ];

--- a/desktop/scripts/stage-runtime-bundle.mjs
+++ b/desktop/scripts/stage-runtime-bundle.mjs
@@ -160,6 +160,7 @@ async function validateStageDir() {
   const requiredPaths = [
     path.join(stageDir, "bin", "sandbox-runtime"),
     path.join(stageDir, "package-metadata.json"),
+    path.join(stageDir, "node-runtime", "node_modules", ".bin", "node"),
     path.join(stageDir, "runtime", "metadata.json"),
     path.join(stageDir, "runtime", "api-server", "dist", "index.mjs")
   ];

--- a/desktop/scripts/write-packaged-config.mjs
+++ b/desktop/scripts/write-packaged-config.mjs
@@ -1,22 +1,68 @@
 import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const desktopRoot = path.resolve(scriptDir, "..");
 const outputDir = path.join(desktopRoot, "out");
 const outputPath = path.join(outputDir, "holaboss-config.json");
 
+async function loadDesktopEnvDefaults() {
+  const envCandidates = [
+    path.join(desktopRoot, ".env"),
+    path.join(desktopRoot, ".env.production")
+  ];
+  const parsed = {};
+  for (const envPath of envCandidates) {
+    if (!existsSync(envPath)) {
+      continue;
+    }
+    try {
+      Object.assign(parsed, dotenv.parse(await fs.readFile(envPath, "utf8")));
+    } catch {
+      // Ignore malformed optional env files; explicit process env still applies.
+    }
+  }
+  return parsed;
+}
+
+const desktopEnvDefaults = await loadDesktopEnvDefaults();
+
+function resolveEnvValue(...names) {
+  for (const name of names) {
+    const fromProcess = process.env[name]?.trim();
+    if (fromProcess) {
+      return fromProcess;
+    }
+    const fromFile = desktopEnvDefaults[name]?.trim();
+    if (fromFile) {
+      return fromFile;
+    }
+  }
+  return "";
+}
+
 const config = {
-  authBaseUrl: process.env.HOLABOSS_AUTH_BASE_URL?.trim() || "",
-  authSignInUrl: process.env.HOLABOSS_AUTH_SIGN_IN_URL?.trim() || "",
-  backendBaseUrl: process.env.HOLABOSS_BACKEND_BASE_URL?.trim() || "",
-  desktopControlPlaneBaseUrl: process.env.HOLABOSS_DESKTOP_CONTROL_PLANE_BASE_URL?.trim() || "",
-  projectsUrl: process.env.HOLABOSS_PROJECTS_URL?.trim() || process.env.HOLABOSS_CLI_PROJECTS_URL?.trim() || "",
-  marketplaceUrl:
-    process.env.HOLABOSS_MARKETPLACE_URL?.trim() || process.env.HOLABOSS_CLI_MARKETPLACE_URL?.trim() || "",
-  proactiveUrl:
-    process.env.HOLABOSS_PROACTIVE_URL?.trim() || process.env.HOLABOSS_CLI_PROACTIVE_URL?.trim() || ""
+  authBaseUrl: resolveEnvValue("HOLABOSS_AUTH_BASE_URL"),
+  authSignInUrl: resolveEnvValue("HOLABOSS_AUTH_SIGN_IN_URL"),
+  backendBaseUrl: resolveEnvValue("HOLABOSS_BACKEND_BASE_URL"),
+  desktopControlPlaneBaseUrl: resolveEnvValue(
+    "HOLABOSS_DESKTOP_CONTROL_PLANE_BASE_URL"
+  ),
+  projectsUrl: resolveEnvValue(
+    "HOLABOSS_PROJECTS_URL",
+    "HOLABOSS_CLI_PROJECTS_URL"
+  ),
+  marketplaceUrl: resolveEnvValue(
+    "HOLABOSS_MARKETPLACE_URL",
+    "HOLABOSS_CLI_MARKETPLACE_URL"
+  ),
+  proactiveUrl: resolveEnvValue(
+    "HOLABOSS_PROACTIVE_URL",
+    "HOLABOSS_CLI_PROACTIVE_URL"
+  )
 };
 
 await fs.mkdir(outputDir, { recursive: true });

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -8,6 +8,7 @@ import {
   useDesktopAuthSession,
   type AuthSession
 } from "@/lib/auth/authClient";
+import { holabossLogoUrl } from "@/lib/assetPaths";
 
 type AuthPanelView = "full" | "account" | "runtime";
 
@@ -197,7 +198,7 @@ function enabledProviderIdsForDrafts(providerDrafts: ProviderDraftMap, isSignedI
 
 function ProviderBrandIcon({ providerId }: { providerId: KnownProviderId }) {
   if (providerId === "holaboss") {
-    return <img src="/logo.svg" alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
+    return <img src={holabossLogoUrl} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
   }
   if (providerId === "openai_direct") {
     return <img src={openaiLogo} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;

--- a/desktop/src/components/layout/AppShell.runtime-error.test.mjs
+++ b/desktop/src/components/layout/AppShell.runtime-error.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appShellPath = path.join(__dirname, "AppShell.tsx");
+
+test("app shell surfaces hydrated runtime startup errors for selected workspaces", async () => {
+  const source = await readFile(appShellPath, "utf8");
+
+  assert.match(source, /const hydratedRuntimeErrorMessage =/);
+  assert.match(source, /runtimeStatus\?\.status === "error"/);
+  assert.match(source, /!workspaceAppsReady/);
+  assert.match(source, /\) : hydratedRuntimeErrorMessage \? \(/);
+  assert.match(source, /<WorkspaceStartupErrorPane message=\{hydratedRuntimeErrorMessage\} \/>/);
+});

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -522,6 +522,8 @@ function AppShellContent() {
     hasHydratedWorkspaceList,
     selectedWorkspace,
     installedApps,
+    workspaceAppsReady,
+    workspaceBlockingReason,
     workspaceErrorMessage,
     onboardingModeActive,
   } = useWorkspaceDesktop();
@@ -1505,6 +1507,16 @@ function AppShellContent() {
         workspaceErrorMessage ||
         "Embedded runtime failed to start."
       : "";
+  const hydratedRuntimeErrorMessage =
+    hasHydratedWorkspaceList &&
+    hasSelectedWorkspace &&
+    runtimeStatus?.status === "error" &&
+    !workspaceAppsReady
+      ? runtimeStatus.lastError.trim() ||
+        workspaceBlockingReason ||
+        workspaceErrorMessage ||
+        "Embedded runtime failed to start."
+      : "";
   const isMacDesktop = window.electronAPI?.platform === "darwin";
   const mainGridClassName = appShellMainGridClassName({
     hasWorkspaces,
@@ -1831,6 +1843,8 @@ function AppShellContent() {
           )
         ) : !hasWorkspaces ? (
           <FirstWorkspacePane />
+        ) : hydratedRuntimeErrorMessage ? (
+          <WorkspaceStartupErrorPane message={hydratedRuntimeErrorMessage} />
         ) : showOnboardingTakeover ? (
           <WorkspaceOnboardingTakeover
             onOutputsChanged={() => void refreshRuntimeOutputs()}

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
+import { holabossLogoUrl } from "@/lib/assetPaths";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -221,7 +222,7 @@ export function TopTabsBar({
       >
         <div className="flex min-w-0 items-center gap-2">
           <img
-            src="/logo.svg"
+            src={holabossLogoUrl}
             alt="Holaboss"
             className="size-10 shrink-0"
           />

--- a/desktop/src/components/marketplace/MarketplaceGallery.tsx
+++ b/desktop/src/components/marketplace/MarketplaceGallery.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { holabossLogoUrl } from "@/lib/assetPaths";
 import { KitCard } from "./KitCard";
 import { FALLBACK_TEMPLATES } from "./fallbackTemplates";
 import { marketplaceGalleryBranding } from "./marketplaceGalleryBranding";
@@ -63,7 +64,7 @@ export function MarketplaceGallery({
         {branding.showLogo ? (
           <div className="mb-3 flex items-center gap-3">
             <div className="flex h-8 items-center gap-2 justify-center">
-              <img src="/logo.svg" alt="Holaboss" className="size-6" />
+              <img src={holabossLogoUrl} alt="Holaboss" className="size-6" />
               <h1 className="text-sm font-semibold tracking-tight">Holaboss</h1>
             </div>
             <div className="h-4 w-px bg-border" />

--- a/desktop/src/lib/assetPaths.test.mjs
+++ b/desktop/src/lib/assetPaths.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const assetPathsPath = path.join(__dirname, "assetPaths.ts");
+const topTabsBarPath = path.join(__dirname, "..", "components", "layout", "TopTabsBar.tsx");
+const authPanelPath = path.join(__dirname, "..", "components", "auth", "AuthPanel.tsx");
+const marketplaceGalleryPath = path.join(__dirname, "..", "components", "marketplace", "MarketplaceGallery.tsx");
+
+test("holaboss logo URL respects the Vite base URL", async () => {
+  const source = await readFile(assetPathsPath, "utf8");
+
+  assert.match(source, /export const holabossLogoUrl = `\$\{import\.meta\.env\.BASE_URL\}logo\.svg`;/);
+});
+
+test("packaged renderer logo usage goes through the shared asset URL", async () => {
+  const [topTabsBarSource, authPanelSource, marketplaceGallerySource] = await Promise.all([
+    readFile(topTabsBarPath, "utf8"),
+    readFile(authPanelPath, "utf8"),
+    readFile(marketplaceGalleryPath, "utf8")
+  ]);
+
+  for (const source of [topTabsBarSource, authPanelSource, marketplaceGallerySource]) {
+    assert.match(source, /holabossLogoUrl/);
+    assert.doesNotMatch(source, /["']\/logo\.svg["']/);
+  }
+});

--- a/desktop/src/lib/assetPaths.ts
+++ b/desktop/src/lib/assetPaths.ts
@@ -1,0 +1,1 @@
+export const holabossLogoUrl = `${import.meta.env.BASE_URL}logo.svg`;

--- a/runtime/api-server/src/memory.test.ts
+++ b/runtime/api-server/src/memory.test.ts
@@ -111,17 +111,17 @@ test("filesystem memory service preserves search/get/upsert/status/sync payload 
   });
 });
 
-test("filesystem memory service reports qmd fallback metadata when requested", async () => {
+test("filesystem memory service reports generic fallback metadata for unsupported backends", async () => {
   const root = makeTempDir("hb-memory-");
-  process.env.MEMORY_BACKEND = "qmd";
+  process.env.MEMORY_BACKEND = "sqlite";
   const service = new MemoryService({ workspaceRoot: path.join(root, "workspace") });
 
   const status = await service.status({ workspace_id: "workspace-1" });
 
   assert.equal(status.backend, "builtin");
-  assert.equal(status.requested_provider, "qmd");
+  assert.equal(status.requested_provider, "sqlite");
   assert.deepEqual(status.fallback, {
-    from: "qmd",
-    reason: "ts runtime uses builtin filesystem memory backend"
+    from: "sqlite",
+    reason: "ts runtime only supports the builtin filesystem memory backend"
   });
 });

--- a/runtime/api-server/src/memory.ts
+++ b/runtime/api-server/src/memory.ts
@@ -246,16 +246,16 @@ function snippetForMatch(text: string, query: string, maxChars = 700): {
 }
 
 function resolveMemoryBackend(): ResolvedMemoryBackend {
-  const requested = (process.env[MEMORY_BACKEND_ENV] ?? "qmd").trim().toLowerCase();
-  if (requested === "qmd") {
+  const requested = (process.env[MEMORY_BACKEND_ENV] ?? "").trim().toLowerCase();
+  if (!requested || requested === "builtin" || requested === "filesystem") {
     return {
-      requestedProvider: "qmd",
-      fallbackReason: "ts runtime uses builtin filesystem memory backend"
+      requestedProvider: null,
+      fallbackReason: null
     };
   }
   return {
-    requestedProvider: null,
-    fallbackReason: null
+    requestedProvider: requested,
+    fallbackReason: "ts runtime only supports the builtin filesystem memory backend"
   };
 }
 

--- a/runtime/deploy/Dockerfile.toolchain
+++ b/runtime/deploy/Dockerfile.toolchain
@@ -1,8 +1,6 @@
 FROM python:3.12-slim-bookworm@sha256:883fb7fcf461dc7ab7601180568ad4afbd9d018371afa41b18c8a1124a81a66e
 
 ARG NODE_MAJOR=22
-ARG INSTALL_QMD=1
-ARG ENABLE_QMD_PREWARM=0
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
@@ -22,14 +20,5 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs docker-ce docker-ce-cli containerd.io docker-compose-plugin fuse-overlayfs tini \
     && npm install -g pm2 \
-    && if [ "${INSTALL_QMD}" = "1" ]; then npm install -g @tobilu/qmd; fi \
-    && if [ "${INSTALL_QMD}" = "1" ] && [ "${ENABLE_QMD_PREWARM}" = "1" ]; then \
-         mkdir -p /tmp/qmd-preload-build \
-         && printf '%s\n' 'QMD build preload warmup document.' > /tmp/qmd-preload-build/preload.md \
-         && qmd --index qmd-preload-build collection add /tmp/qmd-preload-build --name preload \
-         && qmd --index qmd-preload-build update \
-         && qmd --index qmd-preload-build query "preload" --json -n 1 >/tmp/qmd-preload-build-query.json \
-         && rm -rf /tmp/qmd-preload-build /tmp/qmd-preload-build-query.json; \
-       fi \
     && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/*

--- a/runtime/deploy/package_linux_runtime.sh
+++ b/runtime/deploy/package_linux_runtime.sh
@@ -48,19 +48,21 @@ NODE_RUNTIME_DIR="${OUTPUT_ROOT}/node-runtime"
 BIN_DIR="${OUTPUT_ROOT}/bin"
 PACKAGE_METADATA_PATH="${OUTPUT_ROOT}/package-metadata.json"
 SKIP_NODE_DEPS="${HOLABOSS_SKIP_NODE_DEPS:-0}"
-INSTALL_QMD="${HOLABOSS_INSTALL_QMD:-1}"
+LOCAL_NODE_BIN="${NODE_RUNTIME_DIR}/node_modules/.bin/node"
+
+NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-}"
+if [ -z "${NODE_VERSION}" ]; then
+  require_cmd node
+  NODE_VERSION="$(node --version)"
+  NODE_VERSION="${NODE_VERSION#v}"
+fi
 
 mkdir -p "${BIN_DIR}"
 
-NODE_PACKAGES=()
-if [ "${INSTALL_QMD}" = "1" ]; then
-  NODE_PACKAGES+=("@tobilu/qmd@latest")
-fi
-
-if [ "${SKIP_NODE_DEPS}" != "1" ] && [ "${#NODE_PACKAGES[@]}" -gt 0 ]; then
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
   require_cmd npm
   mkdir -p "${NODE_RUNTIME_DIR}"
-  npm install --global --prefix "${NODE_RUNTIME_DIR}" "${NODE_PACKAGES[@]}"
+  npm install --prefix "${NODE_RUNTIME_DIR}" "node@${NODE_VERSION}"
   "${SCRIPT_DIR}/prune_packaged_tree.sh" "${NODE_RUNTIME_DIR}" "linux"
 fi
 
@@ -70,10 +72,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUNDLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUNDLED_NODE_BIN="${BUNDLE_ROOT}/node-runtime/node_modules/.bin/node"
 
 export HOLABOSS_RUNTIME_APP_ROOT="${BUNDLE_ROOT}/runtime"
 export HOLABOSS_RUNTIME_ROOT="${BUNDLE_ROOT}/runtime"
-export PATH="${BUNDLE_ROOT}/node-runtime/bin:${PATH}"
+export PATH="${BUNDLE_ROOT}/node-runtime/node_modules/.bin:${BUNDLE_ROOT}/node-runtime/bin:${PATH}"
+if [ -x "${BUNDLED_NODE_BIN}" ]; then
+  export HOLABOSS_RUNTIME_NODE_BIN="${BUNDLED_NODE_BIN}"
+fi
 
 exec "${BUNDLE_ROOT}/runtime/bootstrap/linux.sh" "$@"
 EOF
@@ -84,7 +90,8 @@ cat > "${PACKAGE_METADATA_PATH}" <<EOF
 {
   "platform": "linux",
   "node_deps_installed": $([ "${SKIP_NODE_DEPS}" = "1" ] && printf 'false' || printf 'true'),
-  "qmd_installed": $([ "${SKIP_NODE_DEPS}" = "1" ] || [ "${INSTALL_QMD}" != "1" ] && printf 'false' || printf 'true')
+  "bundled_node_bin": $([ "${SKIP_NODE_DEPS}" = "1" ] || [ ! -x "${LOCAL_NODE_BIN}" ] && printf 'false' || printf 'true'),
+  "bundled_node_version": $([ "${SKIP_NODE_DEPS}" = "1" ] && printf 'null' || printf '"%s"' "${NODE_VERSION}")
 }
 EOF
 

--- a/runtime/deploy/package_macos_runtime.sh
+++ b/runtime/deploy/package_macos_runtime.sh
@@ -48,19 +48,21 @@ NODE_RUNTIME_DIR="${OUTPUT_ROOT}/node-runtime"
 BIN_DIR="${OUTPUT_ROOT}/bin"
 PACKAGE_METADATA_PATH="${OUTPUT_ROOT}/package-metadata.json"
 SKIP_NODE_DEPS="${HOLABOSS_SKIP_NODE_DEPS:-0}"
-INSTALL_QMD="${HOLABOSS_INSTALL_QMD:-1}"
+LOCAL_NODE_BIN="${NODE_RUNTIME_DIR}/node_modules/.bin/node"
+
+NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-}"
+if [ -z "${NODE_VERSION}" ]; then
+  require_cmd node
+  NODE_VERSION="$(node --version)"
+  NODE_VERSION="${NODE_VERSION#v}"
+fi
 
 mkdir -p "${BIN_DIR}"
 
-NODE_PACKAGES=()
-if [ "${INSTALL_QMD}" = "1" ]; then
-  NODE_PACKAGES+=("@tobilu/qmd@latest")
-fi
-
-if [ "${SKIP_NODE_DEPS}" != "1" ] && [ "${#NODE_PACKAGES[@]}" -gt 0 ]; then
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
   require_cmd npm
   mkdir -p "${NODE_RUNTIME_DIR}"
-  npm install --global --prefix "${NODE_RUNTIME_DIR}" "${NODE_PACKAGES[@]}"
+  npm install --prefix "${NODE_RUNTIME_DIR}" "node@${NODE_VERSION}"
   "${SCRIPT_DIR}/prune_packaged_tree.sh" "${NODE_RUNTIME_DIR}" "macos"
 fi
 
@@ -70,10 +72,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUNDLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUNDLED_NODE_BIN="${BUNDLE_ROOT}/node-runtime/node_modules/.bin/node"
 
 export HOLABOSS_RUNTIME_APP_ROOT="${BUNDLE_ROOT}/runtime"
 export HOLABOSS_RUNTIME_ROOT="${BUNDLE_ROOT}/runtime"
-export PATH="${BUNDLE_ROOT}/node-runtime/bin:${PATH}"
+export PATH="${BUNDLE_ROOT}/node-runtime/node_modules/.bin:${BUNDLE_ROOT}/node-runtime/bin:${PATH}"
+if [ -x "${BUNDLED_NODE_BIN}" ]; then
+  export HOLABOSS_RUNTIME_NODE_BIN="${BUNDLED_NODE_BIN}"
+fi
 
 exec "${BUNDLE_ROOT}/runtime/bootstrap/macos.sh" "$@"
 EOF
@@ -84,7 +90,8 @@ cat > "${PACKAGE_METADATA_PATH}" <<EOF
 {
   "platform": "macos",
   "node_deps_installed": $([ "${SKIP_NODE_DEPS}" = "1" ] && printf 'false' || printf 'true'),
-  "qmd_installed": $([ "${SKIP_NODE_DEPS}" = "1" ] || [ "${INSTALL_QMD}" != "1" ] && printf 'false' || printf 'true')
+  "bundled_node_bin": $([ "${SKIP_NODE_DEPS}" = "1" ] || [ ! -x "${LOCAL_NODE_BIN}" ] && printf 'false' || printf 'true'),
+  "bundled_node_version": $([ "${SKIP_NODE_DEPS}" = "1" ] && printf 'null' || printf '"%s"' "${NODE_VERSION}")
 }
 EOF
 

--- a/runtime/deploy/package_runtime_node_bundle.test.mjs
+++ b/runtime/deploy/package_runtime_node_bundle.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const macosPackagerPath = path.join(__dirname, "package_macos_runtime.sh");
+const linuxPackagerPath = path.join(__dirname, "package_linux_runtime.sh");
+
+for (const targetPath of [macosPackagerPath, linuxPackagerPath]) {
+  test(`${path.basename(targetPath)} bundles a local node runtime and exports it`, async () => {
+    const source = await readFile(targetPath, "utf8");
+
+    assert.match(source, /npm install --prefix "\$\{NODE_RUNTIME_DIR\}" "node@\$\{NODE_VERSION\}"/);
+    assert.match(source, /BUNDLED_NODE_BIN="\$\{BUNDLE_ROOT\}\/node-runtime\/node_modules\/\.bin\/node"/);
+    assert.match(source, /export PATH="\$\{BUNDLE_ROOT\}\/node-runtime\/node_modules\/\.bin:\$\{BUNDLE_ROOT\}\/node-runtime\/bin:\$\{PATH\}"/);
+    assert.match(source, /export HOLABOSS_RUNTIME_NODE_BIN="\$\{BUNDLED_NODE_BIN\}"/);
+    assert.equal(/npm install --global --prefix "\$\{NODE_RUNTIME_DIR\}"/.test(source), false);
+    assert.equal(/HOLABOSS_INSTALL_[A-Z_]+/.test(source), false);
+  });
+}


### PR DESCRIPTION
## Context

This PR hardens the packaged desktop/runtime path so shipped builds do not depend on a host-installed Node binary or ad hoc shell environment variables.

It also fixes a few packaged-build regressions that showed up outside `npm run desktop:dev`:
- packaged renderer logo assets now resolve through the Vite base URL
- packaged config generation falls back to desktop env files when shell env is not exported
- hydrated workspace runtime startup failures render an explicit error pane instead of stalling on the workspace preparation screen

## What Changed

- bundle a local Node runtime into packaged macOS and Linux runtime artifacts and validate it during staging and desktop startup
- remove obsolete qmd packaging paths from the runtime toolchain and simplify TS memory fallback metadata for unsupported backends
- add regression tests for bundled runtime validation, packaged asset paths, runtime startup error rendering, and runtime node bundle packaging
- update the root README to document that packaged runtime bundles now ship their own Node binary

## Validation

- `npm run desktop:typecheck`
- `npm run runtime:api-server:test`
- `node --test desktop/electron/runtime-bundle-validation.test.mjs desktop/src/components/layout/AppShell.runtime-error.test.mjs desktop/src/lib/assetPaths.test.mjs runtime/deploy/package_runtime_node_bundle.test.mjs`
