### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -3454,6 +3454,9 @@ function runtimeProviderLabel(providerId: string): string {
   if (normalized.includes("ollama")) {
     return "Ollama";
   }
+  if (normalized.includes("minimax")) {
+    return "MiniMax";
+  }
   if (
     normalized === RUNTIME_HOLABOSS_PROVIDER_ID ||
     normalized === "holaboss" ||
@@ -3520,7 +3523,8 @@ function runtimeModelIdFromToken(token: string): string {
     normalizedPrefix.includes("openrouter") ||
     normalizedPrefix.includes("gemini") ||
     normalizedPrefix.includes("google") ||
-    normalizedPrefix.includes("ollama")
+    normalizedPrefix.includes("ollama") ||
+    normalizedPrefix.includes("minimax")
   ) {
     return rest.join("/").trim();
   }

--- a/desktop/electron/runtime-provider-models.test.mjs
+++ b/desktop/electron/runtime-provider-models.test.mjs
@@ -31,3 +31,10 @@ test("desktop runtime normalizes stale direct-provider model aliases for Anthrop
   assert.match(source, /gemini_direct:\s*\{[\s\S]*"gemini-3.1-pro-preview": "gemini-2.5-pro"/);
   assert.match(source, /function normalizeRuntimeProviderModelId\(/);
 });
+
+test("desktop runtime recognizes minimax provider label and strips minimax token prefix", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /normalized\.includes\("minimax"\)[\s\S]*?return "MiniMax"/);
+  assert.match(source, /normalizedPrefix\.includes\("minimax"\)/);
+});

--- a/desktop/src/assets/providers/minimax.svg
+++ b/desktop/src/assets/providers/minimax.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" height="1em" width="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>MiniMax</title><path d="M4 4h4v16H4V4zm6 0h4v16h-4V4zm6 0h4v16h-4V4z"/></svg>

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import anthropicLogo from "@/assets/providers/anthropic.svg";
 import geminiLogo from "@/assets/providers/gemini.svg";
+import minimaxLogo from "@/assets/providers/minimax.svg";
 import ollamaLogo from "@/assets/providers/ollama.svg";
 import openaiLogo from "@/assets/providers/openai.svg";
 import openrouterLogo from "@/assets/providers/openrouter.svg";
@@ -16,7 +17,7 @@ interface AuthPanelProps {
   view?: AuthPanelView;
 }
 
-const KNOWN_PROVIDER_ORDER = ["holaboss", "openai_direct", "anthropic_direct", "openrouter_direct", "gemini_direct", "ollama_direct"] as const;
+const KNOWN_PROVIDER_ORDER = ["holaboss", "openai_direct", "anthropic_direct", "openrouter_direct", "gemini_direct", "ollama_direct", "minimax_direct"] as const;
 type KnownProviderId = (typeof KNOWN_PROVIDER_ORDER)[number];
 const PROVIDER_AUTOSAVE_DELAY_MS = 800;
 const LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<string, Record<string, string>> = {
@@ -102,6 +103,15 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
     defaultBaseUrl: "http://localhost:11434/v1",
     defaultModels: ["llama3.1:8b", "qwen3:8b", "gpt-oss:20b"],
     apiKeyPlaceholder: "Optional. Use 'ollama' for strict OpenAI SDK compatibility."
+  },
+  minimax_direct: {
+    id: "minimax_direct",
+    label: "MiniMax",
+    description: "MiniMax OpenAI-compatible endpoint with your own API key.",
+    kind: "openai_compatible",
+    defaultBaseUrl: "https://api.minimax.io/v1",
+    defaultModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+    apiKeyPlaceholder: "sk-your-minimax-api-key"
   }
 };
 
@@ -146,6 +156,12 @@ function createDefaultProviderDrafts(): ProviderDraftMap {
       baseUrl: KNOWN_PROVIDER_TEMPLATES.ollama_direct.defaultBaseUrl,
       apiKey: "",
       modelsText: KNOWN_PROVIDER_TEMPLATES.ollama_direct.defaultModels.join(", ")
+    },
+    minimax_direct: {
+      enabled: false,
+      baseUrl: KNOWN_PROVIDER_TEMPLATES.minimax_direct.defaultBaseUrl,
+      apiKey: "",
+      modelsText: KNOWN_PROVIDER_TEMPLATES.minimax_direct.defaultModels.join(", ")
     }
   };
 }
@@ -232,6 +248,9 @@ function ProviderBrandIcon({ providerId }: { providerId: KnownProviderId }) {
   }
   if (providerId === "ollama_direct") {
     return <img src={ollamaLogo} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
+  }
+  if (providerId === "minimax_direct") {
+    return <img src={minimaxLogo} alt="" className="h-4 w-4 object-contain" aria-hidden="true" />;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a supported LLM provider in the Holaboss Model Providers settings panel.

### Changes

- **`desktop/src/components/auth/AuthPanel.tsx`**: Add `minimax_direct` to `KNOWN_PROVIDER_ORDER` and `KNOWN_PROVIDER_TEMPLATES`, with OpenAI-compatible endpoint (`https://api.minimax.io/v1`), default models `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`, and appropriate UI defaults
- **`desktop/electron/main.ts`**: Add MiniMax label to `runtimeProviderLabel()` and add `minimax` prefix stripping in `runtimeModelIdFromToken()`
- **`desktop/src/assets/providers/minimax.svg`**: Add MiniMax brand icon for the provider card
- **`desktop/electron/runtime-provider-models.test.mjs`**: Add unit test verifying MiniMax provider label and token prefix stripping

### How it works

Users can now connect MiniMax in the **Settings → Model Providers** panel by providing their `MINIMAX_API_KEY`. The provider uses MiniMax's OpenAI-compatible API endpoint (`https://api.minimax.io/v1`), so no additional code changes are needed in the runtime layer — it is treated as a standard `openai_compatible` provider.

## API References

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api