### PR TITLE
feat: redesign desktop space layout and navigation

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -81,7 +81,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -558,7 +557,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.5.tgz",
       "integrity": "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -692,14 +690,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
       "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "peer": true
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -1264,6 +1260,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1285,6 +1282,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1301,6 +1299,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1315,6 +1314,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2335,6 +2335,7 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
       "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -3645,7 +3646,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3667,7 +3667,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3732,13 +3731,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -3747,7 +3748,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3893,7 +3893,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4527,7 +4526,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4651,7 +4649,6 @@
       "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.5.tgz",
       "integrity": "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -4757,7 +4754,6 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
       "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -4779,7 +4775,6 @@
       "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4881,7 +4876,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4928,7 +4922,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4948,6 +4941,7 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
       "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -5714,7 +5708,6 @@
       "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
       "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -5973,7 +5966,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -6199,7 +6193,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6230,7 +6223,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6292,7 +6284,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6366,7 +6357,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -6596,7 +6586,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6645,7 +6634,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -6866,6 +6854,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6886,6 +6875,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -7064,7 +7054,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7075,7 +7064,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7130,7 +7118,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8161,7 +8148,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -8180,7 +8166,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -8194,7 +8179,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8275,7 +8259,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8385,7 +8368,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8985,7 +8967,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -9060,7 +9041,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -9166,7 +9146,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.14.tgz",
       "integrity": "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -9698,7 +9677,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10012,7 +9990,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -10955,6 +10934,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -11091,7 +11071,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -11367,7 +11346,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11866,6 +11844,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11883,6 +11862,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -12208,7 +12188,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12218,7 +12197,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12553,7 +12531,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -12809,7 +12786,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12868,7 +12844,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13453,7 +13428,6 @@
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -13533,6 +13507,7 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -13541,7 +13516,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -13938,6 +13912,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -14157,6 +14132,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -14358,7 +14334,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -14413,7 +14388,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14813,7 +14787,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.6.tgz",
       "integrity": "sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -14956,6 +14929,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14965,6 +14939,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -15087,7 +15062,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15232,7 +15206,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const APP_SHELL_PATH = new URL("./AppShell.tsx", import.meta.url);
 
-test("app shell routes file outputs into the file explorer while keeping chat active", async () => {
+test("app shell routes file outputs into the explorer and universal display while keeping chat active", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(
@@ -19,7 +19,13 @@ test("app shell routes file outputs into the file explorer while keeping chat ac
     source,
     /setSpaceVisibility\(\(previous\) => \(\{\s*\.\.\.previous,\s*agent: true,\s*files: true,\s*\}\)\);/
   );
+  assert.match(source, /setSpaceExplorerMode\("files"\);/);
+  assert.match(source, /setSpaceExplorerCollapsed\(false\);/);
   assert.match(source, /setAgentView\(\{ type: "chat" \}\);/);
+  assert.match(
+    source,
+    /setSpaceDisplayView\(\{\s*type: "internal",\s*surface: target\.surface,\s*resourceId: target\.resourceId,\s*\}\);/
+  );
   assert.match(
     source,
     /setFileExplorerFocusRequest\(\{\s*path: target\.resourceId,\s*requestKey: Date\.now\(\),\s*\}\);/
@@ -30,9 +36,47 @@ test("app shell clears a consumed file explorer focus request", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /<FileExplorerPane[\s\S]*focusRequest=\{fileExplorerFocusRequest\}/);
+  assert.match(source, /<FileExplorerPane[\s\S]*previewInPane=\{false\}/);
+  assert.match(
+    source,
+    /onFileOpen=\{\(path\) => \{\s*setSpaceDisplayView\(\{\s*type: "internal",\s*surface: "file",\s*resourceId: path,\s*\}\);/
+  );
   assert.match(
     source,
     /onFocusRequestConsumed=\{\(requestKey\) => \{\s*setFileExplorerFocusRequest\(\(current\) =>\s*current\?\.requestKey === requestKey \? null : current,\s*\);\s*\}\}/
+  );
+});
+
+test("app shell restores the last non-browser display when returning to files mode", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(
+    source,
+    /type RestorableSpaceDisplayView = Exclude<\s*SpaceDisplayView,\s*\{ type: "browser" \} \| \{ type: "empty" \}\s*>;/,
+  );
+  assert.match(
+    source,
+    /const lastRestorableSpaceDisplayViewByWorkspaceRef =\s*useRef<\s*Record<string, RestorableSpaceDisplayView>\s*>\(\{\}\);/,
+  );
+  assert.match(
+    source,
+    /if \(\s*!selectedWorkspaceId \|\|\s*spaceDisplayView\.type === "browser" \|\|\s*spaceDisplayView\.type === "empty"\s*\) \{\s*return;\s*\}\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[selectedWorkspaceId\] =\s*spaceDisplayView;/,
+  );
+  assert.match(
+    source,
+    /const restoreLastSpaceDisplayView = useCallback\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const lastDisplayView =\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*setSpaceDisplayView\(lastDisplayView \?\? \{ type: "browser" \}\);\s*\}, \[selectedWorkspaceId\]\);/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const nextDisplayView =\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*if \(!nextDisplayView\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*setSpaceDisplayView\(nextDisplayView\);\s*\}, \[selectedWorkspaceId\]\);/,
+  );
+  assert.match(
+    source,
+    /onClick=\{\(\) => \{\s*setSpaceExplorerMode\("files"\);\s*restoreLastSpaceDisplayView\(\);\s*\}\}/,
+  );
+  assert.match(
+    source,
+    /onClick=\{\(\) => \{\s*setSpaceExplorerMode\("files"\);\s*restoreLastSpaceDisplayView\(\);\s*setSpaceExplorerCollapsed\(false\);\s*\}\}/,
   );
 });
 
@@ -64,7 +108,7 @@ test("app shell keeps desktop updates separate from runtime notification state",
   assert.match(source, /void window\.electronAPI\.ui\.openExternalUrl\(changelogUrl\);/);
   assert.doesNotMatch(source, /combinedNotifications/);
   assert.doesNotMatch(source, /syntheticNotificationStates/);
-  assert.match(source, /<BrowserPane[\s\S]*suspendNativeView=\{shouldSuspendBrowserNativeView\}/);
+  assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*suspendNativeView=\{shouldSuspendBrowserNativeView\}/);
 });
 
 test("app shell opens cronjob session-run notifications in the sub-session chat", async () => {
@@ -138,23 +182,49 @@ test("app shell no longer reserves a separate safe pane region for update toasts
     source,
     /const shouldSuspendBrowserNativeView =\s*isUtilityPaneResizing \|\|[\s\S]*workspaceSwitcherOpen \|\|[\s\S]*settingsDialogOpen \|\|[\s\S]*createWorkspacePanelOpen \|\|[\s\S]*publishOpen;/,
   );
-  assert.match(source, /<BrowserPane[\s\S]*suspendNativeView=\{shouldSuspendBrowserNativeView\}/);
+  assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*suspendNativeView=\{shouldSuspendBrowserNativeView\}/);
 });
 
-test("app shell uses a wider minimum for the file explorer than for the browser pane", async () => {
+test("app shell keeps a fixed explorer width and resizes the display against chat in space mode", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /const MIN_FILES_PANE_WIDTH = 220;/);
   assert.match(source, /const MIN_BROWSER_PANE_WIDTH = 120;/);
   assert.match(source, /const MIN_AGENT_CONTENT_WIDTH = 380;/);
   assert.match(source, /const DEFAULT_FILES_PANE_WIDTH = MIN_FILES_PANE_WIDTH;/);
-  assert.match(source, /function utilityPaneMinWidth\(paneId: UtilityPaneId\): number \{/);
+  assert.match(source, /const SPACE_EXPLORER_WIDTH = DEFAULT_FILES_PANE_WIDTH;/);
+  assert.match(source, /const SPACE_AGENT_PANE_WIDTH = 420;/);
+  assert.match(source, /const SPACE_DISPLAY_MIN_WIDTH = 420;/);
+  assert.match(source, /const SPACE_EXPLORER_COLLAPSED_WIDTH = 68;/);
   assert.match(
     source,
-    /pane\.flex\s*\?\s*\{\s*minWidth: `\$\{MIN_AGENT_CONTENT_WIDTH\}px`,\s*\}\s*:\s*\{ width: `\$\{pane\.width\}px` \}/,
+    /const \[spaceAgentPaneWidth, setSpaceAgentPaneWidth\] = useState\(\s*SPACE_AGENT_PANE_WIDTH,\s*\);/,
   );
-  assert.match(source, /const syncUtilityPaneWidths = useCallback\(\(\) => \{/);
-  assert.match(source, /new ResizeObserver\(\(\) => \{\s*syncUtilityPaneWidths\(\);\s*\}\)/);
+  assert.match(source, /const clampSpaceAgentPaneWidth = useCallback\(\(width: number\) => \{/);
+  assert.match(
+    source,
+    /const explorerWidth = spaceExplorerCollapsed\s*\?\s*SPACE_EXPLORER_COLLAPSED_WIDTH\s*:\s*filesPaneWidth;/,
+  );
+  assert.match(
+    source,
+    /hostWidth -\s*explorerWidth -\s*SPACE_DISPLAY_MIN_WIDTH -\s*UTILITY_PANE_RESIZER_WIDTH/,
+  );
+  assert.match(source, /new ResizeObserver\(\(\) => \{\s*syncDisplayWidth\(\);\s*\}\)/);
+});
+
+test("app shell always opens the file explorer at minimum width", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(
+    source,
+    /const \[filesPaneWidth, setFilesPaneWidth\] = useState\(\s*DEFAULT_FILES_PANE_WIDTH,\s*\);/,
+  );
+  assert.match(
+    source,
+    /width: `\$\{showSpaceExplorer \? SPACE_EXPLORER_WIDTH : SPACE_EXPLORER_COLLAPSED_WIDTH\}px`,/,
+  );
+  assert.doesNotMatch(source, /function loadFilesPaneWidth\(\): number \{/);
+  assert.doesNotMatch(source, /holaboss-files-pane-width-v1/);
 });
 
 test("app shell passes the app version label into the left rail", async () => {
@@ -163,6 +233,20 @@ test("app shell passes the app version label into the left rail", async () => {
   assert.match(source, /const appVersionLabel =[\s\S]*effectiveAppUpdateStatus\?\.currentVersion\?\.trim\(\) \|\| "";/);
   assert.match(source, /<LeftNavigationRail[\s\S]*appVersionLabel=\{appVersionLabel\}/);
   assert.doesNotMatch(source, /absolute bottom-3 left-4/);
+});
+
+test("app shell hides the left rail in space mode until the cursor reaches the left edge", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /const \[spaceLeftRailVisible, setSpaceLeftRailVisible\] = useState\(false\);/);
+  assert.match(source, /const shouldOverlayLeftRail = spaceMode;/);
+  assert.match(source, /useEffect\(\(\) => \{\s*if \(spaceMode\) \{\s*setSpaceLeftRailVisible\(false\);\s*\}\s*\}, \[spaceMode\]\);/);
+  assert.match(source, /shouldOverlayLeftRail\s*\?\s*"lg:grid-cols-\[minmax\(0,1fr\)\]"\s*:\s*"lg:grid-cols-\[60px_minmax\(0,1fr\)\]"/);
+  assert.match(source, /style=\{\{ columnGap: shouldOverlayLeftRail \? "0rem" : "0\.5rem" \}\}/);
+  assert.match(source, /className="absolute inset-y-0 left-0 z-30 hidden w-4 lg:block"/);
+  assert.match(source, /onMouseEnter=\{\(\) => setSpaceLeftRailVisible\(true\)\}/);
+  assert.match(source, /spaceLeftRailVisible\s*\?\s*"translate-x-0"\s*:\s*"-translate-x-full"/);
+  assert.match(source, /onMouseLeave=\{\(\) => setSpaceLeftRailVisible\(false\)\}/);
 });
 
 test("app shell requests remote task proposal generation without a separate success banner", async () => {
@@ -181,13 +265,20 @@ test("app shell tracks unread task proposals and badges the inbox control", asyn
   assert.match(source, /const \[seenTaskProposalIdsByWorkspace, setSeenTaskProposalIdsByWorkspace\] =\s*useState<Record<string, string\[]>>\(loadSeenTaskProposalIdsByWorkspace\);/);
   assert.match(source, /const unreadTaskProposalCount = useMemo\(\(\) => \{/);
   assert.match(source, /const markTaskProposalsSeen = useCallback\(/);
+  assert.match(
+    source,
+    /if \(\s*agentView\.type !== "inbox" \|\|\s*!selectedWorkspaceId \|\|\s*taskProposals.length === 0\s*\) \{\s*return;\s*\}\s*markTaskProposalsSeen\(selectedWorkspaceId, taskProposals\);/,
+  );
   assert.match(source, /if \(tab === "inbox" && selectedWorkspaceId\) \{\s*markTaskProposalsSeen\(selectedWorkspaceId, taskProposals\);\s*\}/);
-  assert.match(source, /unreadProposalCount=\{unreadTaskProposalCount\}/);
-  assert.match(source, /className="relative inline-flex h-8 w-8 items-center justify-center rounded-\[12px\] border border-border\/45 text-muted-foreground transition-all duration-200 hover:border-primary\/45 hover:text-primary active:scale-95"/);
-  assert.match(source, /unreadTaskProposalCount > 0 \? \(\s*<span className="absolute -right-0\.5 -top-0\.5 size-2\.5 rounded-full border-2 border-card bg-destructive" \/>\s*\) : null/);
+  assert.match(source, /const handleOpenInboxPane = useCallback\(\(\) => \{/);
+  assert.match(source, /setAgentView\(\{ type: "inbox" \}\);/);
+  assert.match(source, /inboxUnreadCount=\{unreadTaskProposalCount\}/);
+  assert.match(source, /onOpenInbox=\{handleOpenInboxPane\}/);
+  assert.doesNotMatch(source, /unreadProposalCount=\{unreadTaskProposalCount\}/);
+  assert.doesNotMatch(source, /aria-label="Open inbox"/);
 });
 
-test("app shell restores pane visibility without manual files and browser toggles", async () => {
+test("app shell renders a collapsible explorer and universal display in space mode", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /function loadSpaceVisibility\(\): SpaceVisibilityState \{/);
@@ -200,10 +291,23 @@ test("app shell restores pane visibility without manual files and browser toggle
   assert.doesNotMatch(source, /className="mr-1\.5 flex w-9 shrink-0 flex-col items-center gap-1\.5 py-1"/);
   assert.doesNotMatch(source, /aria-label="Toggle files pane"/);
   assert.doesNotMatch(source, /aria-label="Toggle browser pane"/);
+  assert.match(source, /type SpaceExplorerMode = "files" \| "browser";/);
+  assert.match(source, /const \[spaceExplorerMode, setSpaceExplorerMode\] =\s*useState<SpaceExplorerMode>\("files"\);/);
+  assert.match(source, /const \[spaceExplorerCollapsed, setSpaceExplorerCollapsed\] = useState\(false\);/);
+  assert.match(source, /const \[spaceDisplayView, setSpaceDisplayView\] = useState<SpaceDisplayView>\(\{\s*type: "browser",\s*\}\);/);
+  assert.match(
+    source,
+    /<section className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-border bg-card\/80 shadow-md backdrop-blur-sm">/,
+  );
   assert.match(source, /<FileExplorerPane[\s\S]*focusRequest=\{fileExplorerFocusRequest\}/);
-  assert.doesNotMatch(source, /<FileExplorerPane[\s\S]*onClosePane=/);
-  assert.match(source, /<BrowserPane[\s\S]*layoutSyncKey=\{/);
-  assert.doesNotMatch(source, /<BrowserPane[\s\S]*onClosePane=/);
+  assert.match(source, /<FileExplorerPane[\s\S]*previewInPane=\{false\}/);
+  assert.match(source, /<SpaceBrowserExplorerPane[\s\S]*browserSpace=\{spaceBrowserSpace\}/);
+  assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*layoutSyncKey=\{spaceDisplayLayoutSyncKey\}/);
+  assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*embedded/);
+  assert.match(source, /aria-label="Collapse explorer"/);
+  assert.match(source, /aria-label="Expand explorer"/);
+  assert.match(source, /aria-label="Resize display pane"/);
+  assert.doesNotMatch(source, /aria-label="Resize explorer pane"/);
   assert.doesNotMatch(source, /inline-flex h-8 items-center gap-2 rounded-full border px-3/);
   assert.doesNotMatch(source, /spaceDrawerToggleLabel/);
   assert.doesNotMatch(source, /utilityPaneRenderWidth/);
@@ -222,11 +326,11 @@ test("app shell polls proactive status for the selected workspace", async () => 
 
   assert.match(source, /const \[proactiveStatus, setProactiveStatus\]/);
   assert.match(source, /workspace\.getProactiveStatus\(\s*selectedWorkspace\.id,/);
-  assert.match(source, /proactiveStatus=\{proactiveStatus\}/);
-  assert.match(source, /isLoadingProactiveStatus=\{isLoadingProactiveStatus\}/);
   assert.match(source, /runtimeConfig\?\.authTokenPresent/);
   assert.match(source, /runtimeConfig\?\.modelProxyBaseUrl/);
   assert.match(source, /runtimeStatus\?\.status/);
+  assert.match(source, /<OperationsInboxPane[\s\S]*proactiveStatus=\{proactiveStatus\}/);
+  assert.match(source, /<OperationsInboxPane[\s\S]*isLoadingProactiveStatus=\{isLoadingProactiveStatus\}/);
 });
 
 test("app shell reloads proactive preference after workspace hydration completes", async () => {
@@ -237,21 +341,17 @@ test("app shell reloads proactive preference after workspace hydration completes
   assert.match(source, /\}, \[hasHydratedWorkspaceList, selectedWorkspaceId\]\);/);
 });
 
-test("app shell renames the running panel button to sessions", async () => {
+test("app shell no longer renders a separate right panel in space mode", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
-  assert.match(source, /aria-label="Open sessions panel"/);
-  assert.doesNotMatch(source, /aria-label="Open running panel"/);
-  assert.match(source, /lg:grid-cols-\[60px_minmax\(0,1fr\)_336px\]/);
-});
-
-test("app shell keeps the operations drawer collapsed by default on a fresh install", async () => {
-  const source = await readFile(APP_SHELL_PATH, "utf8");
-
-  assert.match(
-    source,
-    /function loadOperationsDrawerOpen\(\): boolean \{[\s\S]*if \(raw === "1" \|\| raw === "true"\) \{\s*return true;\s*\}[\s\S]*if \(raw === "0" \|\| raw === "false"\) \{\s*return false;\s*\}[\s\S]*return false;\s*\}/,
-  );
+  assert.match(source, /const showOperationsDrawer = false;/);
+  assert.match(source, /lg:grid-cols-\[60px_minmax\(0,1fr\)\]/);
+  assert.doesNotMatch(source, /lg:grid-cols-\[60px_minmax\(0,1fr\)_336px\]/);
+  assert.doesNotMatch(source, /<OperationsDrawer(?:\s|>)/);
+  assert.doesNotMatch(source, /aria-label="Open inbox panel"/);
+  assert.doesNotMatch(source, /aria-label="Open sessions panel"/);
+  assert.doesNotMatch(source, /aria-label="Show right panel"/);
+  assert.doesNotMatch(source, /aria-label="Hide right panel"/);
 });
 
 test("app shell can route new schedule creation into a prefilled workspace chat", async () => {
@@ -270,14 +370,20 @@ test("app shell can route new schedule creation into a prefilled workspace chat"
   assert.match(source, /onCreateSchedule=\{handleCreateScheduleInChat\}/);
 });
 
-test("app shell can create and open a new session from the right panel", async () => {
+test("app shell passes new session requests into the chat pane selector", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /type ChatSessionOpenRequest = \{\s*sessionId: string;\s*requestKey: number;\s*mode\?: "session" \| "draft";\s*parentSessionId\?: string \| null;\s*\};/);
   assert.match(source, /const handleCreateSession = useCallback\(\(\) => \{/);
+  assert.match(source, /const handleChatSessionOpenRequestConsumed = useCallback\(\s*\(requestKey: number\) => \{/);
+  assert.match(source, /setChatSessionOpenRequest\(\(current\) =>\s*current\?\.requestKey === requestKey \? null : current,\s*\);/);
   assert.match(source, /setChatSessionOpenRequest\(\(previous\) => \(\{\s*sessionId: "",\s*mode: "draft",\s*parentSessionId: null,\s*requestKey: \(previous\?\.requestKey \?\? 0\) \+ 1,\s*\}\)\);/);
   assert.match(source, /setChatFocusRequestKey\(\(current\) => current \+ 1\);/);
   assert.doesNotMatch(source, /const \[isCreatingSession, setIsCreatingSession\] = useState\(false\);/);
   assert.doesNotMatch(source, /window\.electronAPI\.workspace\.createAgentSession\(\{/);
-  assert.match(source, /onCreateSession=\{\(\) => void handleCreateSession\(\)\}/);
+  assert.match(source, /const handleReturnToChatPane = useCallback\(\(\) => \{/);
+  assert.match(source, /aria-label="Return to chat"/);
+  assert.match(source, /<OperationsInboxPane[\s\S]*proposals=\{taskProposals\}/);
+  assert.match(source, /onRequestCreateSession=\{\(\) => void handleCreateSession\(\)\}/);
+  assert.match(source, /onSessionOpenRequestConsumed=\{handleChatSessionOpenRequestConsumed\}/);
 });

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/components/layout/LeftNavigationRail";
 import { NotificationToastStack } from "@/components/layout/NotificationToastStack";
 import {
-    OperationsDrawer,
+    OperationsInboxPane,
     type OperationsDrawerTab,
 } from "@/components/layout/OperationsDrawer";
 import { SettingsDialog } from "@/components/layout/SettingsDialog";
@@ -23,6 +23,8 @@ import {
 import { InternalSurfacePane } from "@/components/panes/InternalSurfacePane";
 import { MarketplacePane } from "@/components/panes/MarketplacePane";
 import { OnboardingPane } from "@/components/panes/OnboardingPane";
+import { SpaceBrowserDisplayPane } from "@/components/panes/SpaceBrowserDisplayPane";
+import { SpaceBrowserExplorerPane } from "@/components/panes/SpaceBrowserExplorerPane";
 import { SkillsPane } from "@/components/panes/SkillsPane";
 import { PublishDialog } from "@/components/publish/PublishDialog";
 import { UpdateReminder } from "@/components/ui/UpdateReminder";
@@ -37,12 +39,14 @@ import {
     WorkspaceSelectionProvider,
 } from "@/lib/workspaceSelection";
 import {
+    ArrowLeft,
     CircleCheck,
-    Clock3,
-    Inbox as InboxIcon,
+    Folder,
+    Globe,
+    Inbox,
     Loader2,
-    PanelRightClose,
-    PanelRightOpen,
+    PanelLeftClose,
+    PanelLeftOpen,
     TriangleAlert,
     XCircle,
 } from "lucide-react";
@@ -62,7 +66,6 @@ const DEV_NOTIFICATION_TOAST_PREVIEW_ID_PREFIX =
 const OPERATIONS_DRAWER_OPEN_STORAGE_KEY = "holaboss-operations-drawer-open-v1";
 const OPERATIONS_DRAWER_TAB_STORAGE_KEY = "holaboss-operations-drawer-tab-v1";
 const TASK_PROPOSAL_SEEN_STORAGE_KEY = "holaboss-task-proposal-seen-v1";
-const FILES_PANE_WIDTH_STORAGE_KEY = "holaboss-files-pane-width-v1";
 const BROWSER_PANE_WIDTH_STORAGE_KEY = "holaboss-browser-pane-width-v1";
 const SPACE_VISIBILITY_STORAGE_KEY = "holaboss-space-visibility-v1";
 const THEMES = [
@@ -84,10 +87,13 @@ const THEMES = [
 const MIN_FILES_PANE_WIDTH = 220;
 const MIN_BROWSER_PANE_WIDTH = 120;
 const MAX_UTILITY_PANE_WIDTH = 720;
-const LEGACY_DEFAULT_FILES_PANE_WIDTH = 420;
 const DEFAULT_FILES_PANE_WIDTH = MIN_FILES_PANE_WIDTH;
 const DEFAULT_BROWSER_PANE_WIDTH = 460;
 const MIN_AGENT_CONTENT_WIDTH = 380;
+const SPACE_EXPLORER_WIDTH = DEFAULT_FILES_PANE_WIDTH;
+const SPACE_AGENT_PANE_WIDTH = 420;
+const SPACE_DISPLAY_MIN_WIDTH = 420;
+const SPACE_EXPLORER_COLLAPSED_WIDTH = 68;
 const UTILITY_PANE_RESIZER_WIDTH = 16;
 const APP_UPDATE_CHANGELOG_BASE_URL =
   "https://github.com/holaboss-ai/holaboss-ai/releases/tag";
@@ -99,6 +105,7 @@ const MAX_SEEN_TASK_PROPOSAL_IDS_PER_WORKSPACE = 200;
 type SpaceComponentId = "agent" | "files" | "browser";
 type UtilityPaneId = "files" | "browser";
 type DevAppUpdatePreviewMode = "off" | "downloading" | "ready";
+type SpaceExplorerMode = "files" | "browser";
 
 type SpaceVisibilityState = Record<SpaceComponentId, boolean>;
 
@@ -158,6 +165,7 @@ function isSettingsPaneSection(value: string): value is UiSettingsPaneSection {
 
 type AgentView =
   | { type: "chat" }
+  | { type: "inbox" }
   | {
       type: "app";
       appId: string;
@@ -170,6 +178,27 @@ type AgentView =
       resourceId?: string | null;
       htmlContent?: string | null;
     };
+
+type SpaceDisplayView =
+  | { type: "browser" }
+  | {
+      type: "app";
+      appId: string;
+      resourceId?: string | null;
+      view?: string | null;
+    }
+  | {
+      type: "internal";
+      surface: "document" | "preview" | "file" | "event";
+      resourceId?: string | null;
+      htmlContent?: string | null;
+    }
+  | { type: "empty" };
+
+type RestorableSpaceDisplayView = Exclude<
+  SpaceDisplayView,
+  { type: "browser" } | { type: "empty" }
+>;
 
 type ChatSessionOpenRequest = {
   sessionId: string;
@@ -357,26 +386,6 @@ function loadSpaceVisibility(): SpaceVisibilityState {
     // ignore invalid persisted layout state
   }
   return DEFAULT_SPACE_VISIBILITY;
-}
-
-function loadFilesPaneWidth(): number {
-  try {
-    const raw = localStorage.getItem(FILES_PANE_WIDTH_STORAGE_KEY);
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed)) {
-      if (parsed === LEGACY_DEFAULT_FILES_PANE_WIDTH) {
-        return DEFAULT_FILES_PANE_WIDTH;
-      }
-      return Math.max(
-        MIN_FILES_PANE_WIDTH,
-        Math.min(parsed, MAX_UTILITY_PANE_WIDTH),
-      );
-    }
-  } catch {
-    // ignore
-  }
-
-  return DEFAULT_FILES_PANE_WIDTH;
 }
 
 function loadBrowserPaneWidth(): number {
@@ -834,6 +843,7 @@ function AppShellContent() {
   ] = useState("");
   const [activeLeftRailItem, setActiveLeftRailItem] =
     useState<LeftRailItem>("space");
+  const [spaceLeftRailVisible, setSpaceLeftRailVisible] = useState(false);
   const [agentView, setAgentView] = useState<AgentView>({ type: "chat" });
   const [chatFocusRequestKey, setChatFocusRequestKey] = useState(1);
   const [chatSessionJumpRequest, setChatSessionJumpRequest] = useState<{
@@ -846,13 +856,26 @@ function AppShellContent() {
     useState<ChatComposerPrefillRequest | null>(null);
   const [fileExplorerFocusRequest, setFileExplorerFocusRequest] =
     useState<FileExplorerFocusRequest | null>(null);
+  const [spaceExplorerMode, setSpaceExplorerMode] =
+    useState<SpaceExplorerMode>("files");
+  const [spaceExplorerCollapsed, setSpaceExplorerCollapsed] = useState(false);
+  const [spaceBrowserSpace, setSpaceBrowserSpace] =
+    useState<BrowserSpaceId>("user");
+  const [spaceDisplayView, setSpaceDisplayView] = useState<SpaceDisplayView>({
+    type: "browser",
+  });
+  const [spaceAgentPaneWidth, setSpaceAgentPaneWidth] = useState(
+    SPACE_AGENT_PANE_WIDTH,
+  );
   const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(
     null,
   );
   const [workspaceSwitcherOpen, setWorkspaceSwitcherOpen] = useState(false);
   const [spaceVisibility, setSpaceVisibility] =
     useState<SpaceVisibilityState>(loadSpaceVisibility);
-  const [filesPaneWidth, setFilesPaneWidth] = useState(loadFilesPaneWidth);
+  const [filesPaneWidth, setFilesPaneWidth] = useState(
+    DEFAULT_FILES_PANE_WIDTH,
+  );
   const [browserPaneWidth, setBrowserPaneWidth] =
     useState(loadBrowserPaneWidth);
   const [isUtilityPaneResizing, setIsUtilityPaneResizing] = useState(false);
@@ -918,6 +941,13 @@ function AppShellContent() {
   const notificationsHydratedRef = useRef(false);
   const seenNotificationIdsRef = useRef(new Set<string>());
   const notificationToastTimeoutsRef = useRef(new Map<string, number>());
+  const lastRestorableSpaceDisplayViewByWorkspaceRef = useRef<
+    Record<string, RestorableSpaceDisplayView>
+  >({});
+  const spaceDisplayResizeStateRef = useRef<{
+    startWidth: number;
+    startX: number;
+  } | null>(null);
 
   filesPaneWidthRef.current = filesPaneWidth;
   browserPaneWidthRef.current = browserPaneWidth;
@@ -1307,15 +1337,19 @@ function AppShellContent() {
           return;
         }
 
+        const targetBrowserSpace =
+          payload.space === "agent" ? "agent" : "user";
         const openBrowserPane = () => {
           setActiveLeftRailItem("space");
+          setSpaceExplorerMode("browser");
+          setSpaceBrowserSpace(targetBrowserSpace);
+          setSpaceDisplayView({ type: "browser" });
+          setSpaceExplorerCollapsed(false);
           setSpaceVisibility((previous) => ({
             ...previous,
             browser: true,
           }));
         };
-        const targetBrowserSpace =
-          payload.space === "agent" ? "agent" : "user";
 
         const requestedUrl =
           typeof payload.url === "string" ? payload.url.trim() : "";
@@ -1608,8 +1642,12 @@ function AppShellContent() {
     void window.electronAPI.ui.openExternalUrl(url);
   }, []);
 
-  const revealBrowserPane = useCallback(() => {
+  const revealBrowserPane = useCallback((space: BrowserSpaceId = "user") => {
     setActiveLeftRailItem("space");
+    setSpaceExplorerMode("browser");
+    setSpaceBrowserSpace(space);
+    setSpaceDisplayView({ type: "browser" });
+    setSpaceExplorerCollapsed(false);
     setSpaceVisibility((previous) => ({
       ...previous,
       browser: true,
@@ -1623,7 +1661,7 @@ function AppShellContent() {
         return;
       }
 
-      revealBrowserPane();
+      revealBrowserPane("user");
       const targetWorkspaceId =
         workspaceIdOverride !== undefined
           ? workspaceIdOverride
@@ -1687,10 +1725,6 @@ function AppShellContent() {
       JSON.stringify(seenTaskProposalIdsByWorkspace),
     );
   }, [seenTaskProposalIdsByWorkspace]);
-
-  useEffect(() => {
-    localStorage.setItem(FILES_PANE_WIDTH_STORAGE_KEY, String(filesPaneWidth));
-  }, [filesPaneWidth]);
 
   useEffect(() => {
     localStorage.setItem(
@@ -2065,6 +2099,22 @@ function AppShellContent() {
 
   useEffect(() => {
     if (
+      agentView.type !== "inbox" ||
+      !selectedWorkspaceId ||
+      taskProposals.length === 0
+    ) {
+      return;
+    }
+    markTaskProposalsSeen(selectedWorkspaceId, taskProposals);
+  }, [
+    agentView.type,
+    markTaskProposalsSeen,
+    selectedWorkspaceId,
+    taskProposals,
+  ]);
+
+  useEffect(() => {
+    if (
       !operationsDrawerOpen ||
       activeOperationsTab !== "inbox" ||
       !selectedWorkspaceId ||
@@ -2282,11 +2332,82 @@ function AppShellContent() {
     setChatFocusRequestKey((current) => current + 1);
   }, [selectedWorkspaceId]);
 
+  const handleOpenInboxPane = useCallback(() => {
+    setActiveLeftRailItem("space");
+    setSpaceVisibility((previous) => ({
+      ...previous,
+      agent: true,
+    }));
+    setAgentView({ type: "inbox" });
+    if (selectedWorkspaceId && taskProposals.length > 0) {
+      markTaskProposalsSeen(selectedWorkspaceId, taskProposals);
+    }
+  }, [markTaskProposalsSeen, selectedWorkspaceId, taskProposals]);
+
+  const handleReturnToChatPane = useCallback(() => {
+    setAgentView({ type: "chat" });
+    setChatFocusRequestKey((current) => current + 1);
+  }, []);
+
   const handleChatComposerPrefillConsumed = useCallback((requestKey: number) => {
     setChatComposerPrefillRequest((current) =>
       current?.requestKey === requestKey ? null : current,
     );
   }, []);
+
+  const handleChatSessionOpenRequestConsumed = useCallback(
+    (requestKey: number) => {
+      setChatSessionOpenRequest((current) =>
+        current?.requestKey === requestKey ? null : current,
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      !selectedWorkspaceId ||
+      spaceDisplayView.type === "browser" ||
+      spaceDisplayView.type === "empty"
+    ) {
+      return;
+    }
+    lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId] =
+      spaceDisplayView;
+  }, [selectedWorkspaceId, spaceDisplayView]);
+
+  const restoreLastSpaceDisplayView = useCallback(() => {
+    if (!selectedWorkspaceId) {
+      setSpaceDisplayView({ type: "browser" });
+      return;
+    }
+
+    const lastDisplayView =
+      lastRestorableSpaceDisplayViewByWorkspaceRef.current[
+        selectedWorkspaceId
+      ];
+    setSpaceDisplayView(lastDisplayView ?? { type: "browser" });
+  }, [selectedWorkspaceId]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) {
+      setSpaceExplorerMode("browser");
+      setSpaceDisplayView({ type: "browser" });
+      return;
+    }
+
+    const nextDisplayView =
+      lastRestorableSpaceDisplayViewByWorkspaceRef.current[
+        selectedWorkspaceId
+      ];
+    if (!nextDisplayView) {
+      setSpaceExplorerMode("browser");
+      setSpaceDisplayView({ type: "browser" });
+      return;
+    }
+
+    setSpaceDisplayView(nextDisplayView);
+  }, [selectedWorkspaceId]);
 
   const handleOpenWorkspaceOutput = useCallback(
     (output: WorkspaceOutputRecordPayload) => {
@@ -2302,21 +2423,21 @@ function AppShellContent() {
         void window.electronAPI.appSurface
           .resolveUrl(selectedWorkspaceId, target.appId, routePath)
           .then((url) => {
-            revealBrowserPane();
+            revealBrowserPane("user");
             void window.electronAPI.browser
               .setActiveWorkspace(selectedWorkspaceId)
               .then(() => window.electronAPI.browser.navigate(url))
               .catch(() => undefined);
           })
           .catch(() => {
-            // Fallback: open in full app view if URL resolution fails
-            setActiveLeftRailItem("app");
-            setAgentView({
+            setActiveLeftRailItem("space");
+            setSpaceDisplayView({
               type: "app",
               appId: target.appId,
               resourceId: target.resourceId,
               view: target.view,
             });
+            setAgentView({ type: "chat" });
           });
         return;
       }
@@ -2327,12 +2448,19 @@ function AppShellContent() {
           target.resourceId?.trim()
         ) {
           setActiveLeftRailItem("space");
+          setSpaceExplorerMode("files");
+          setSpaceExplorerCollapsed(false);
           setSpaceVisibility((previous) => ({
             ...previous,
             agent: true,
             files: true,
           }));
           setAgentView({ type: "chat" });
+          setSpaceDisplayView({
+            type: "internal",
+            surface: target.surface,
+            resourceId: target.resourceId,
+          });
           setFileExplorerFocusRequest({
             path: target.resourceId,
             requestKey: Date.now(),
@@ -2345,7 +2473,8 @@ function AppShellContent() {
           ...previous,
           agent: true,
         }));
-        setAgentView({
+        setAgentView({ type: "chat" });
+        setSpaceDisplayView({
           type: "internal",
           surface: target.surface,
           resourceId: target.resourceId ?? output.id,
@@ -2390,8 +2519,8 @@ function AppShellContent() {
   const flexSpacePaneId = visibleSpacePaneIds.includes("agent")
     ? "agent"
     : (visibleSpacePaneIds[visibleSpacePaneIds.length - 1] ?? null);
-  const showOperationsDrawer =
-    spaceMode && spaceVisibility.agent && operationsDrawerOpen;
+  const showOperationsDrawer = false;
+  const showSpaceExplorer = !spaceExplorerCollapsed;
   const shouldShowAppUpdateReminder = Boolean(
     effectiveAppUpdateStatus &&
       effectiveAppUpdateStatus.downloaded,
@@ -2436,10 +2565,80 @@ function AppShellContent() {
     hasWorkspaces &&
     hasSelectedWorkspace &&
     onboardingModeActive;
+  const shouldOverlayLeftRail = spaceMode;
+
+  useEffect(() => {
+    if (spaceMode) {
+      setSpaceLeftRailVisible(false);
+    }
+  }, [spaceMode]);
 
   const agentContent = useMemo(() => {
     if (!hasSelectedWorkspace) {
       return <EmptyWorkspacePane />;
+    }
+
+    if (agentView.type === "inbox") {
+      return (
+        <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+          <div className="shrink-0 border-b border-border/45 px-4 py-2.5 sm:px-5">
+            <div className="flex items-center justify-between gap-3">
+              <div className="inline-flex min-w-0 items-center gap-2 text-[15px] font-semibold tracking-[-0.02em] text-foreground">
+                <Inbox size={14} className="shrink-0 text-muted-foreground" />
+                <span className="truncate">Inbox</span>
+              </div>
+              <button
+                type="button"
+                onClick={handleReturnToChatPane}
+                aria-label="Return to chat"
+                className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+              >
+                <ArrowLeft size={15} />
+              </button>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <OperationsInboxPane
+              proposals={taskProposals}
+              proactiveStatus={proactiveStatus}
+              isLoadingProactiveStatus={isLoadingProactiveStatus}
+              proactiveWorkspaceEnabled={proactiveWorkspaceEnabled}
+              isLoadingProactiveWorkspaceEnabled={
+                isLoadingProactiveWorkspaceEnabled
+              }
+              isUpdatingProactiveWorkspaceEnabled={
+                isUpdatingProactiveWorkspaceEnabled
+              }
+              proactiveHeartbeatCron={
+                proactiveHeartbeatConfig?.cron?.trim() ||
+                DEFAULT_PROACTIVE_HEARTBEAT_CRON
+              }
+              isLoadingProactiveHeartbeatConfig={
+                isLoadingProactiveHeartbeatConfig
+              }
+              isUpdatingProactiveHeartbeatConfig={
+                isUpdatingProactiveHeartbeatConfig
+              }
+              proactiveTaskProposalsError={proactiveTaskProposalsError}
+              proactiveHeartbeatError={proactiveHeartbeatError}
+              isLoadingProposals={isLoadingTaskProposals}
+              isTriggeringProposal={isTriggeringTaskProposal}
+              proposalStatusMessage={taskProposalStatusMessage}
+              proposalAction={proposalAction}
+              onTriggerProposal={triggerRemoteTaskProposal}
+              onProactiveWorkspaceEnabledChange={
+                handleProactiveWorkspaceEnabledChange
+              }
+              onProactiveHeartbeatCronChange={handleProactiveHeartbeatCronChange}
+              onAcceptProposal={acceptTaskProposal}
+              onDismissProposal={dismissTaskProposal}
+              hasWorkspace={hasSelectedWorkspace}
+              selectedWorkspaceId={selectedWorkspaceId}
+              selectedWorkspaceName={selectedWorkspace?.name ?? null}
+            />
+          </div>
+        </section>
+      );
     }
 
     if (agentView.type === "chat") {
@@ -2456,9 +2655,13 @@ function AppShellContent() {
           sessionJumpSessionId={chatSessionJumpRequest?.sessionId ?? null}
           sessionJumpRequestKey={chatSessionJumpRequest?.requestKey ?? 0}
           sessionOpenRequest={chatSessionOpenRequest}
+          onSessionOpenRequestConsumed={handleChatSessionOpenRequestConsumed}
           composerPrefillRequest={chatComposerPrefillRequest}
           onComposerPrefillConsumed={handleChatComposerPrefillConsumed}
           onActiveSessionIdChange={setActiveChatSessionId}
+          onOpenInbox={handleOpenInboxPane}
+          inboxUnreadCount={unreadTaskProposalCount}
+          onRequestCreateSession={() => void handleCreateSession()}
         />
       );
     }
@@ -2489,12 +2692,110 @@ function AppShellContent() {
     activeApp,
     activeAppId,
     agentView,
-    chatSessionJumpRequest,
     chatFocusRequestKey,
+    chatSessionJumpRequest,
+    chatSessionOpenRequest,
+    chatComposerPrefillRequest,
+    handleChatComposerPrefillConsumed,
+    handleOpenInboxPane,
+    handleReturnToChatPane,
+    handleCreateSession,
+    handleProactiveHeartbeatCronChange,
+    handleProactiveWorkspaceEnabledChange,
+    handleOpenLinkInAppBrowser,
     handleOpenWorkspaceOutput,
     hasSelectedWorkspace,
-    handleOpenLinkInAppBrowser,
+    isLoadingProactiveHeartbeatConfig,
+    isLoadingProactiveStatus,
+    isLoadingProactiveWorkspaceEnabled,
+    isLoadingTaskProposals,
+    isTriggeringTaskProposal,
+    proposalAction,
+    proactiveHeartbeatConfig?.cron,
+    proactiveHeartbeatError,
+    proactiveStatus,
+    proactiveTaskProposalsError,
+    proactiveWorkspaceEnabled,
+    selectedWorkspace?.name,
+    selectedWorkspaceId,
+    taskProposalStatusMessage,
+    taskProposals,
+    unreadTaskProposalCount,
+    acceptTaskProposal,
+    dismissTaskProposal,
+    isUpdatingProactiveHeartbeatConfig,
+    isUpdatingProactiveWorkspaceEnabled,
     onboardingModeActive,
+    triggerRemoteTaskProposal,
+  ]);
+
+  const spaceDisplayLayoutSyncKey = `${spaceExplorerMode}:${spaceBrowserSpace}:${spaceExplorerCollapsed ? "collapsed" : "open"}:${spaceAgentPaneWidth}:${showOperationsDrawer ? 1 : 0}`;
+  const spaceDisplayContent = useMemo(() => {
+    if (!hasSelectedWorkspace) {
+      return <EmptyWorkspacePane />;
+    }
+
+    if (spaceDisplayView.type === "browser") {
+      return (
+        <SpaceBrowserDisplayPane
+          browserSpace={spaceBrowserSpace}
+          suspendNativeView={shouldSuspendBrowserNativeView}
+          layoutSyncKey={spaceDisplayLayoutSyncKey}
+          embedded
+        />
+      );
+    }
+
+    if (spaceDisplayView.type === "app") {
+      return (
+        <div className="h-full min-h-0 p-3">
+          <AppSurfacePane
+            appId={spaceDisplayView.appId}
+            app={
+              activeAppId === spaceDisplayView.appId
+                ? activeApp
+                : getWorkspaceAppDefinition(spaceDisplayView.appId, installedApps)
+            }
+            resourceId={spaceDisplayView.resourceId}
+            view={spaceDisplayView.view}
+          />
+        </div>
+      );
+    }
+
+    if (spaceDisplayView.type === "internal") {
+      return (
+        <div className="h-full min-h-0 p-3">
+          <InternalSurfacePane
+            surface={spaceDisplayView.surface}
+            resourceId={spaceDisplayView.resourceId}
+            htmlContent={spaceDisplayView.htmlContent}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className="h-full min-h-0 p-3">
+        <FocusPlaceholder
+          eyebrow="Display"
+          title="Universal display"
+          description="Select a file from the explorer or switch into browser mode to project tabs and bookmarks here."
+        />
+      </div>
+    );
+  }, [
+    activeApp,
+    activeAppId,
+    hasSelectedWorkspace,
+    installedApps,
+    shouldSuspendBrowserNativeView,
+    showOperationsDrawer,
+    spaceAgentPaneWidth,
+    spaceBrowserSpace,
+    spaceDisplayView,
+    spaceExplorerCollapsed,
+    spaceExplorerMode,
   ]);
 
   const spacePanes = useMemo(
@@ -2538,6 +2839,118 @@ function AppShellContent() {
       visibleSpacePaneIds,
     ],
   );
+
+  const clampSpaceAgentPaneWidth = useCallback((width: number) => {
+    const hostWidth =
+      utilityPaneHostRef.current?.getBoundingClientRect().width ?? 0;
+    const explorerWidth = spaceExplorerCollapsed
+      ? SPACE_EXPLORER_COLLAPSED_WIDTH
+      : filesPaneWidth;
+    const maxWidth =
+      hostWidth > 0
+        ? Math.min(
+            MAX_UTILITY_PANE_WIDTH,
+            Math.max(
+              MIN_AGENT_CONTENT_WIDTH,
+              hostWidth -
+                explorerWidth -
+                SPACE_DISPLAY_MIN_WIDTH -
+                UTILITY_PANE_RESIZER_WIDTH,
+            ),
+          )
+        : MAX_UTILITY_PANE_WIDTH;
+    return Math.max(MIN_AGENT_CONTENT_WIDTH, Math.min(width, maxWidth));
+  }, [filesPaneWidth, spaceExplorerCollapsed]);
+
+  useEffect(() => {
+    if (!spaceMode) {
+      return;
+    }
+
+    const syncDisplayWidth = () => {
+      setSpaceAgentPaneWidth((current) => clampSpaceAgentPaneWidth(current));
+    };
+
+    syncDisplayWidth();
+    window.addEventListener("resize", syncDisplayWidth);
+
+    const host = utilityPaneHostRef.current;
+    const observer =
+      host && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            syncDisplayWidth();
+          })
+        : null;
+    if (observer && host) {
+      observer.observe(host);
+    }
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", syncDisplayWidth);
+    };
+  }, [clampSpaceAgentPaneWidth, showOperationsDrawer, spaceMode]);
+
+  const startSpaceDisplayResize = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      spaceDisplayResizeStateRef.current = {
+        startWidth: spaceAgentPaneWidth,
+        startX: event.clientX,
+      };
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // BrowserView resizing falls back to the window listeners below.
+      }
+      void window.electronAPI.browser.setBounds({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      });
+      setIsUtilityPaneResizing(true);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      event.preventDefault();
+    },
+    [spaceAgentPaneWidth],
+  );
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const resizeState = spaceDisplayResizeStateRef.current;
+      if (!resizeState) {
+        return;
+      }
+
+      setSpaceAgentPaneWidth(
+        clampSpaceAgentPaneWidth(
+          resizeState.startWidth - (event.clientX - resizeState.startX),
+        ),
+      );
+    };
+
+    const stopResize = () => {
+      if (!spaceDisplayResizeStateRef.current) {
+        return;
+      }
+
+      spaceDisplayResizeStateRef.current = null;
+      setIsUtilityPaneResizing(false);
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", stopResize);
+    window.addEventListener("pointercancel", stopResize);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+      stopResize();
+    };
+  }, [clampSpaceAgentPaneWidth]);
 
   const startUtilityPaneResize = useCallback(
     (
@@ -2757,20 +3170,48 @@ function AppShellContent() {
         ) : (
           <div
             className={`relative grid h-full min-h-0 gap-y-3 overflow-hidden transition-[grid-template-columns,column-gap] duration-300 ease-in-out ${
-              showOperationsDrawer
-                ? "lg:grid-cols-[60px_minmax(0,1fr)_336px]"
+              shouldOverlayLeftRail
+                ? "lg:grid-cols-[minmax(0,1fr)]"
                 : "lg:grid-cols-[60px_minmax(0,1fr)]"
             }`}
-            style={{ columnGap: "0.5rem" }}
+            style={{ columnGap: shouldOverlayLeftRail ? "0rem" : "0.5rem" }}
           >
-            <LeftNavigationRail
-              activeItem={activeLeftRailItem}
-              onSelectItem={handleLeftRailSelect}
-              installedApps={installedApps}
-              activeAppId={activeAppId}
-              onSelectApp={handleOpenInstalledApp}
-              appVersionLabel={appVersionLabel}
-            />
+            {shouldOverlayLeftRail ? (
+              <>
+                <div
+                  className="absolute inset-y-0 left-0 z-30 hidden w-4 lg:block"
+                  onMouseEnter={() => setSpaceLeftRailVisible(true)}
+                  aria-hidden="true"
+                />
+                <div
+                  className={`absolute inset-y-0 left-0 z-40 hidden transition-transform duration-200 ease-out lg:block ${
+                    spaceLeftRailVisible
+                      ? "translate-x-0"
+                      : "-translate-x-full"
+                  }`}
+                  onMouseEnter={() => setSpaceLeftRailVisible(true)}
+                  onMouseLeave={() => setSpaceLeftRailVisible(false)}
+                >
+                  <LeftNavigationRail
+                    activeItem={activeLeftRailItem}
+                    onSelectItem={handleLeftRailSelect}
+                    installedApps={installedApps}
+                    activeAppId={activeAppId}
+                    onSelectApp={handleOpenInstalledApp}
+                    appVersionLabel={appVersionLabel}
+                  />
+                </div>
+              </>
+            ) : (
+              <LeftNavigationRail
+                activeItem={activeLeftRailItem}
+                onSelectItem={handleLeftRailSelect}
+                installedApps={installedApps}
+                activeAppId={activeAppId}
+                onSelectApp={handleOpenInstalledApp}
+                appVersionLabel={appVersionLabel}
+              />
+            )}
 
             <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
               <div className="min-h-0 flex-1 overflow-hidden">
@@ -2778,66 +3219,172 @@ function AppShellContent() {
                   <div className="relative flex h-full min-h-0 min-w-0 overflow-hidden">
                     <div
                       ref={utilityPaneHostRef}
-                      className="min-h-0 min-w-0 flex-1 overflow-hidden"
+                      className="flex min-h-0 min-w-0 flex-1 items-stretch overflow-hidden"
                     >
-                      {spacePanes.length > 0 ? (
-                        <div className="flex h-full min-h-0 min-w-0 items-stretch overflow-hidden">
-                          {spacePanes.map((pane, index) => {
-                            const nextPane = spacePanes[index + 1] ?? null;
-                            const resizeHandle = nextPane
-                              ? spaceResizeHandleSpec(pane.id, nextPane.id)
-                              : null;
-
-                            return (
-                              <div key={pane.id} className="contents">
-                                <div
-                                  className={`relative min-h-0 min-w-0 overflow-hidden rounded-[var(--radius-xl)] ${pane.flex ? "flex-1" : "shrink-0"}`}
-                                  style={
-                                    pane.flex
-                                      ? {
-                                          minWidth: `${MIN_AGENT_CONTENT_WIDTH}px`,
-                                        }
-                                      : { width: `${pane.width}px` }
-                                  }
-                                >
-                                  {pane.content}
+                      <section className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+                        <div
+                          className="shrink-0 overflow-hidden border-r border-border/45 bg-card/45 transition-[width] duration-200 ease-out"
+                          style={{
+                            width: `${showSpaceExplorer ? SPACE_EXPLORER_WIDTH : SPACE_EXPLORER_COLLAPSED_WIDTH}px`,
+                          }}
+                        >
+                          <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+                            {showSpaceExplorer ? (
+                              <>
+                                <div className="shrink-0 border-b border-border/45 px-3 py-3">
+                                  <div className="flex items-center gap-2">
+                                    <div className="inline-flex min-w-0 flex-1 items-center rounded-md border border-border bg-muted/50 p-0.5">
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          setSpaceExplorerMode("files");
+                                          restoreLastSpaceDisplayView();
+                                        }}
+                                        className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-3 py-2 text-[12px] font-medium transition ${
+                                          spaceExplorerMode === "files"
+                                            ? "bg-background text-foreground shadow-sm"
+                                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                                        }`}
+                                      >
+                                        <Folder size={13} />
+                                        <span>Files</span>
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          setSpaceExplorerMode("browser");
+                                          setSpaceDisplayView({ type: "browser" });
+                                        }}
+                                        className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-3 py-2 text-[12px] font-medium transition ${
+                                          spaceExplorerMode === "browser"
+                                            ? "bg-background text-foreground shadow-sm"
+                                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                                        }`}
+                                      >
+                                        <Globe size={13} />
+                                        <span>Browser</span>
+                                      </button>
+                                    </div>
+                                    <button
+                                      type="button"
+                                      onClick={() => setSpaceExplorerCollapsed(true)}
+                                      aria-label="Collapse explorer"
+                                      className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-card/80 text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+                                    >
+                                      <PanelLeftClose size={14} />
+                                    </button>
+                                  </div>
                                 </div>
 
-                                {resizeHandle ? (
-                                  <div
-                                    role="separator"
-                                    aria-label={resizeHandle.label}
-                                    aria-orientation="vertical"
-                                    onPointerDown={(event) =>
-                                      startUtilityPaneResize(
-                                        resizeHandle.leftPaneId,
-                                        resizeHandle.rightPaneId,
-                                        event,
-                                      )
-                                    }
-                                    className="group relative z-10 flex w-4 shrink-0 cursor-col-resize touch-none items-center justify-center"
-                                  >
-                                    <div className="pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-border/55 transition-all duration-150 group-hover:w-[2px] group-hover:bg-[rgba(247,90,84,0.5)]" />
-                                    <div className="pointer-events-none absolute left-1/2 top-1/2 h-14 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[rgba(247,90,84,0.08)] opacity-0 transition duration-150 group-hover:opacity-100" />
-                                  </div>
-                                ) : null}
+                                <div className="min-h-0 flex-1 overflow-hidden">
+                                  {spaceExplorerMode === "files" ? (
+                                    <FileExplorerPane
+                                      focusRequest={fileExplorerFocusRequest}
+                                      onFocusRequestConsumed={(requestKey) => {
+                                        setFileExplorerFocusRequest((current) =>
+                                          current?.requestKey === requestKey ? null : current,
+                                        );
+                                      }}
+                                      previewInPane={false}
+                                      embedded
+                                      onFileOpen={(path) => {
+                                        setSpaceDisplayView({
+                                          type: "internal",
+                                          surface: "file",
+                                          resourceId: path,
+                                        });
+                                      }}
+                                    />
+                                  ) : spaceExplorerMode === "browser" ? (
+                                    <SpaceBrowserExplorerPane
+                                      browserSpace={spaceBrowserSpace}
+                                      onBrowserSpaceChange={(space) => {
+                                        setSpaceBrowserSpace(space);
+                                        setSpaceDisplayView({ type: "browser" });
+                                      }}
+                                      onActivateDisplay={() =>
+                                        setSpaceDisplayView({ type: "browser" })
+                                      }
+                                    />
+                                  ) : null}
+                                </div>
+                              </>
+                            ) : (
+                              <div className="flex h-full min-h-0 flex-col items-center gap-2 px-2 py-3">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setSpaceExplorerMode("files");
+                                    restoreLastSpaceDisplayView();
+                                    setSpaceExplorerCollapsed(false);
+                                  }}
+                                  aria-label="Open file explorer"
+                                  className={`inline-flex size-11 items-center justify-center rounded-[16px] border transition ${
+                                    spaceExplorerMode === "files"
+                                      ? "border-primary/45 bg-primary/12 text-primary"
+                                      : "border-border bg-card/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                                  }`}
+                                >
+                                  <Folder size={16} />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setSpaceExplorerMode("browser");
+                                    setSpaceDisplayView({ type: "browser" });
+                                    setSpaceExplorerCollapsed(false);
+                                  }}
+                                  aria-label="Open browser explorer"
+                                  className={`inline-flex size-11 items-center justify-center rounded-[16px] border transition ${
+                                    spaceExplorerMode === "browser"
+                                      ? "border-primary/45 bg-primary/12 text-primary"
+                                      : "border-border bg-card/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                                  }`}
+                                >
+                                  <Globe size={16} />
+                                </button>
+                                <div className="min-h-0 flex-1" />
+                                <button
+                                  type="button"
+                                  onClick={() => setSpaceExplorerCollapsed(false)}
+                                  aria-label="Expand explorer"
+                                  className="inline-flex size-11 items-center justify-center rounded-[16px] border border-border bg-card/80 text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+                                >
+                                  <PanelLeftOpen size={16} />
+                                </button>
                               </div>
-                            );
-                          })}
-                        </div>
-                      ) : (
-                        <section className="theme-shell flex h-full min-h-0 items-center justify-center rounded-[var(--radius-xl)] border border-border/45 shadow-lg">
-                          <div className="max-w-[360px] px-6 text-center">
-                            <div className="text-[22px] font-medium tracking-[-0.03em] text-foreground">
-                              Turn on a space surface
-                            </div>
-                            <div className="mt-3 text-[13px] leading-6 text-muted-foreground/78">
-                              Space keeps your files, browser, and agent panes
-                              available together.
-                            </div>
+                            )}
                           </div>
-                        </section>
-                      )}
+                        </div>
+
+                        <div
+                          className="min-h-0 min-w-0 flex-1 overflow-hidden"
+                          style={{ minWidth: `${SPACE_DISPLAY_MIN_WIDTH}px` }}
+                        >
+                          {spaceDisplayContent}
+                        </div>
+                      </section>
+
+                      <div
+                        role="separator"
+                        aria-label="Resize display pane"
+                        aria-orientation="vertical"
+                        onPointerDown={startSpaceDisplayResize}
+                        className="group relative z-10 flex w-4 shrink-0 cursor-col-resize touch-none items-center justify-center"
+                      >
+                        <div className="pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-border/55 transition-all duration-150 group-hover:w-[2px] group-hover:bg-[rgba(247,90,84,0.5)]" />
+                        <div className="pointer-events-none absolute left-1/2 top-1/2 h-14 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[rgba(247,90,84,0.08)] opacity-0 transition duration-150 group-hover:opacity-100" />
+                      </div>
+
+                      <div
+                        className="min-h-0 shrink-0 overflow-hidden rounded-[var(--radius-xl)]"
+                        style={{
+                          width: `${spaceAgentPaneWidth}px`,
+                          minWidth: `${MIN_AGENT_CONTENT_WIDTH}px`,
+                        }}
+                      >
+                        {agentContent}
+                      </div>
                     </div>
                   </div>
                 ) : activeLeftRailItem === "app" ? (
@@ -2889,111 +3436,6 @@ function AppShellContent() {
               </div>
             </div>
 
-            {spaceMode && spaceVisibility.agent ? (
-              <div className="pointer-events-none absolute right-0 top-0 z-20 hidden lg:block">
-                <div className="pointer-events-auto inline-flex items-center gap-1 rounded-bl-[16px] rounded-tr-[var(--radius-xl)] border border-border/50 border-r-0 border-t-0 bg-card/94 px-2 py-2 text-muted-foreground shadow-lg backdrop-blur">
-                  {showOperationsDrawer ? (
-                    <button
-                      type="button"
-                      onClick={() => toggleOperationsDrawer()}
-                      aria-label="Hide right panel"
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-[12px] border border-primary/45 bg-primary/10 text-primary transition-all duration-200 hover:border-primary/60 hover:bg-primary/14 active:scale-95"
-                    >
-                      <PanelRightClose size={14} />
-                    </button>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => openOperationsDrawerTab("inbox")}
-                        aria-label={
-                          unreadTaskProposalCount > 0
-                            ? `Open inbox panel with ${unreadTaskProposalCount} unread proposal${unreadTaskProposalCount === 1 ? "" : "s"}`
-                            : "Open inbox panel"
-                        }
-                        className="relative inline-flex h-8 w-8 items-center justify-center rounded-[12px] border border-border/45 text-muted-foreground transition-all duration-200 hover:border-primary/45 hover:text-primary active:scale-95"
-                      >
-                        <InboxIcon size={13} />
-                        {unreadTaskProposalCount > 0 ? (
-                          <span className="absolute -right-0.5 -top-0.5 size-2.5 rounded-full border-2 border-card bg-destructive" />
-                        ) : null}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => openOperationsDrawerTab("running")}
-                        aria-label="Open sessions panel"
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-[12px] border border-border/45 text-muted-foreground transition-all duration-200 hover:border-primary/45 hover:text-primary active:scale-95"
-                      >
-                        <Clock3 size={13} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => toggleOperationsDrawer()}
-                        aria-label="Show right panel"
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-[12px] border border-border/45 text-muted-foreground transition-all duration-200 hover:border-primary/45 hover:text-primary active:scale-95"
-                      >
-                        <PanelRightOpen size={14} />
-                      </button>
-                    </>
-                  )}
-                </div>
-              </div>
-            ) : null}
-
-            {showOperationsDrawer ? (
-              <div className="min-h-0 min-w-0 overflow-hidden transition-all duration-300 ease-out">
-                <OperationsDrawer
-                  activeTab={activeOperationsTab}
-                  onTabChange={openOperationsDrawerTab}
-                  proposals={taskProposals}
-                  unreadProposalCount={unreadTaskProposalCount}
-                  proactiveStatus={proactiveStatus}
-                  isLoadingProactiveStatus={isLoadingProactiveStatus}
-                  proactiveWorkspaceEnabled={proactiveWorkspaceEnabled}
-                  isLoadingProactiveWorkspaceEnabled={
-                    isLoadingProactiveWorkspaceEnabled
-                  }
-                  isUpdatingProactiveWorkspaceEnabled={
-                    isUpdatingProactiveWorkspaceEnabled
-                  }
-                  proactiveHeartbeatCron={
-                    proactiveHeartbeatConfig?.cron ||
-                    DEFAULT_PROACTIVE_HEARTBEAT_CRON
-                  }
-                  isLoadingProactiveHeartbeatConfig={
-                    isLoadingProactiveHeartbeatConfig
-                  }
-                  isUpdatingProactiveHeartbeatConfig={
-                    isUpdatingProactiveHeartbeatConfig
-                  }
-                  proactiveTaskProposalsError={proactiveTaskProposalsError}
-                  proactiveHeartbeatError={proactiveHeartbeatError}
-                  isLoadingProposals={isLoadingTaskProposals}
-                  isTriggeringProposal={isTriggeringTaskProposal}
-                  proposalStatusMessage={taskProposalStatusMessage}
-                  proposalAction={proposalAction}
-                  onTriggerProposal={() => void triggerRemoteTaskProposal()}
-                  onProactiveWorkspaceEnabledChange={(enabled) =>
-                    void handleProactiveWorkspaceEnabledChange(enabled)
-                  }
-                  onProactiveHeartbeatCronChange={(cron) =>
-                    void handleProactiveHeartbeatCronChange(cron)
-                  }
-                  onAcceptProposal={(proposal) =>
-                    void acceptTaskProposal(proposal)
-                  }
-                  onDismissProposal={(proposal) =>
-                    void dismissTaskProposal(proposal)
-                  }
-                  onOpenRunningSession={handleOpenRunningSession}
-                  onCreateSession={() => void handleCreateSession()}
-                  activeRunningSessionId={activeChatSessionId}
-                  hasWorkspace={hasSelectedWorkspace}
-                  selectedWorkspaceId={selectedWorkspaceId}
-                  selectedWorkspaceName={selectedWorkspace?.name || null}
-                />
-              </div>
-            ) : null}
           </div>
         )}
       </div>

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -22,6 +22,35 @@ import {
 
 export type OperationsDrawerTab = "inbox" | "running";
 
+export interface OperationsInboxPaneProps {
+  proposals: TaskProposalRecordPayload[];
+  proactiveStatus: ProactiveAgentStatusPayload | null;
+  isLoadingProactiveStatus: boolean;
+  proactiveWorkspaceEnabled: boolean;
+  isLoadingProactiveWorkspaceEnabled: boolean;
+  isUpdatingProactiveWorkspaceEnabled: boolean;
+  proactiveHeartbeatCron: string;
+  isLoadingProactiveHeartbeatConfig: boolean;
+  isUpdatingProactiveHeartbeatConfig: boolean;
+  proactiveTaskProposalsError: string;
+  proactiveHeartbeatError: string;
+  isLoadingProposals: boolean;
+  isTriggeringProposal: boolean;
+  proposalStatusMessage: string;
+  proposalAction: {
+    proposalId: string;
+    action: "accept" | "dismiss";
+  } | null;
+  onTriggerProposal: () => void;
+  onProactiveWorkspaceEnabledChange: (enabled: boolean) => void;
+  onProactiveHeartbeatCronChange: (cron: string) => void;
+  onAcceptProposal: (proposal: TaskProposalRecordPayload) => void;
+  onDismissProposal: (proposal: TaskProposalRecordPayload) => void;
+  hasWorkspace: boolean;
+  selectedWorkspaceId: string | null;
+  selectedWorkspaceName: string | null;
+}
+
 interface OperationsDrawerProps {
   activeTab: OperationsDrawerTab;
   onTabChange: (tab: OperationsDrawerTab) => void;
@@ -102,16 +131,6 @@ export function OperationsDrawer({
   selectedWorkspaceId,
   selectedWorkspaceName,
 }: OperationsDrawerProps) {
-  const {
-    data: authSession,
-    isPending: isAuthPending,
-    requestAuth,
-  } = useDesktopAuthSession();
-  const isSignedIn = Boolean(authSession?.user?.id);
-  const onRequestSignIn = () => {
-    void requestAuth();
-  };
-
   const [runningSessions, setRunningSessions] = useState<RunningSessionEntry[]>(
     [],
   );
@@ -243,10 +262,7 @@ export function OperationsDrawer({
 
       <div className="min-h-0 flex-1 overflow-hidden">
         {activeTab === "inbox" ? (
-          <InboxPanel
-            isSignedIn={isSignedIn}
-            onRequestSignIn={onRequestSignIn}
-            isAuthPending={isAuthPending}
+          <OperationsInboxPane
             proposals={proposals}
             proactiveStatus={proactiveStatus}
             isLoadingProactiveStatus={isLoadingProactiveStatus}
@@ -298,6 +314,75 @@ export function OperationsDrawer({
         ) : null}
       </div>
     </aside>
+  );
+}
+
+export function OperationsInboxPane({
+  proposals,
+  proactiveStatus,
+  isLoadingProactiveStatus,
+  proactiveWorkspaceEnabled,
+  isLoadingProactiveWorkspaceEnabled,
+  isUpdatingProactiveWorkspaceEnabled,
+  proactiveHeartbeatCron,
+  isLoadingProactiveHeartbeatConfig,
+  isUpdatingProactiveHeartbeatConfig,
+  proactiveTaskProposalsError,
+  proactiveHeartbeatError,
+  isLoadingProposals,
+  isTriggeringProposal,
+  proposalStatusMessage,
+  proposalAction,
+  onTriggerProposal,
+  onProactiveWorkspaceEnabledChange,
+  onProactiveHeartbeatCronChange,
+  onAcceptProposal,
+  onDismissProposal,
+  hasWorkspace,
+  selectedWorkspaceId,
+  selectedWorkspaceName,
+}: OperationsInboxPaneProps) {
+  const {
+    data: authSession,
+    isPending: isAuthPending,
+    requestAuth,
+  } = useDesktopAuthSession();
+  const isSignedIn = Boolean(authSession?.user?.id);
+  const onRequestSignIn = () => {
+    void requestAuth();
+  };
+
+  return (
+    <InboxPanel
+      isSignedIn={isSignedIn}
+      onRequestSignIn={onRequestSignIn}
+      isAuthPending={isAuthPending}
+      proposals={proposals}
+      proactiveStatus={proactiveStatus}
+      isLoadingProactiveStatus={isLoadingProactiveStatus}
+      proactiveTaskProposalsError={proactiveTaskProposalsError}
+      proactiveHeartbeatError={proactiveHeartbeatError}
+      isLoadingProposals={isLoadingProposals}
+      proposalStatusMessage={proposalStatusMessage}
+      proposalAction={proposalAction}
+      hasWorkspace={hasWorkspace}
+      selectedWorkspaceId={selectedWorkspaceId}
+      selectedWorkspaceName={selectedWorkspaceName}
+      proactiveWorkspaceEnabled={proactiveWorkspaceEnabled}
+      isLoadingProactiveWorkspaceEnabled={isLoadingProactiveWorkspaceEnabled}
+      isUpdatingProactiveWorkspaceEnabled={
+        isUpdatingProactiveWorkspaceEnabled
+      }
+      proactiveHeartbeatCron={proactiveHeartbeatCron}
+      isLoadingProactiveHeartbeatConfig={isLoadingProactiveHeartbeatConfig}
+      isUpdatingProactiveHeartbeatConfig={isUpdatingProactiveHeartbeatConfig}
+      isTriggeringProposal={isTriggeringProposal}
+      onTriggerProposal={onTriggerProposal}
+      onProactiveWorkspaceEnabledChange={onProactiveWorkspaceEnabledChange}
+      onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
+      onAcceptProposal={onAcceptProposal}
+      onDismissProposal={onDismissProposal}
+    />
   );
 }
 

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -302,7 +302,7 @@ test("chat pane exposes an in-pane session dropdown for switching agent sessions
   assert.match(source, /aria-label="Show inbox"/);
   assert.match(source, /aria-label="Create new session"/);
   assert.match(source, /placeholder="Search sessions\.\.\."/);
-  assert.match(source, /open\s*\?\s*"rotate-180 group-hover:-translate-y-0\.5 group-hover:scale-125"\s*:\s*"rotate-0 group-hover:translate-y-0\.5 group-hover:scale-125"/);
+  assert.match(source, /open\s*\?\s*"rotate-180 group-hover:-translate-y-1 group-hover:scale-150"\s*:\s*"rotate-0 group-hover:translate-y-1 group-hover:scale-150"/);
   assert.match(source, /filteredSessions\.map\(\(session\) => \{/);
   assert.match(source, /inboxUnreadCount > 0 \? \(/);
   assert.match(source, /onOpenInbox\(\);/);

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -283,6 +283,34 @@ test("chat pane can create a workspace session when none exists yet", async () =
   );
 });
 
+test("chat pane exposes an in-pane session dropdown for switching agent sessions", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /onOpenInbox\?: \(\) => void;/);
+  assert.match(source, /inboxUnreadCount\?: number;/);
+  assert.match(source, /onRequestCreateSession\?: \(\) => void;/);
+  assert.match(source, /onSessionOpenRequestConsumed\?: \(requestKey: number\) => void;/);
+  assert.match(source, /const \[availableSessions, setAvailableSessions\] = useState<ChatSessionOption\[]>\(\s*\[\],\s*\);/);
+  assert.match(source, /const \[localSessionOpenRequest, setLocalSessionOpenRequest\] =\s*useState<ChatPaneSessionOpenRequest \| null>\(null\);/);
+  assert.match(source, /const effectiveSessionOpenRequest =\s*sessionOpenRequest \?\? localSessionOpenRequest;/);
+  assert.match(source, /function sessionStatusIndicator\(statusLabel: string\)/);
+  assert.match(source, /window\.electronAPI\.workspace\.listAgentSessions\(selectedWorkspaceId\)/);
+  assert.match(source, /window\.electronAPI\.workspace\.listRuntimeStates\(selectedWorkspaceId\)/);
+  assert.match(source, /<div className="shrink-0 border-b border-border\/45 px-4 py-2\.5 sm:px-5">[\s\S]*<SessionSelector/);
+  assert.match(source, /<SessionSelector[\s\S]*sessions=\{availableSessions\}[\s\S]*onSelectSession=\{openSessionFromPicker\}[\s\S]*onOpenInbox=\{onOpenInbox\}[\s\S]*inboxUnreadCount=\{inboxUnreadCount\}[\s\S]*onCreateSession=\{requestDraftSessionFromPicker\}/);
+  assert.match(source, /aria-label="Select agent session"/);
+  assert.match(source, /aria-label="Show inbox"/);
+  assert.match(source, /aria-label="Create new session"/);
+  assert.match(source, /placeholder="Search sessions\.\.\."/);
+  assert.match(source, /open\s*\?\s*"rotate-180 group-hover:-translate-y-0\.5 group-hover:scale-125"\s*:\s*"rotate-0 group-hover:translate-y-0\.5 group-hover:scale-125"/);
+  assert.match(source, /filteredSessions\.map\(\(session\) => \{/);
+  assert.match(source, /inboxUnreadCount > 0 \? \(/);
+  assert.match(source, /onOpenInbox\(\);/);
+  assert.match(source, /if \(\(sessionOpenRequest\?\.requestKey \?\? 0\) === requestKey\) \{\s*onSessionOpenRequestConsumed\?\.\(requestKey\);\s*\}/);
+  assert.match(source, /setLocalSessionOpenRequest\(\{\s*sessionId: normalizedSessionId,\s*requestKey: Date\.now\(\),\s*\}\);/);
+  assert.match(source, /setLocalSessionOpenRequest\(\{\s*sessionId: "",\s*mode: "draft",\s*parentSessionId: null,\s*requestKey: Date\.now\(\),\s*\}\);/);
+});
+
 test("chat pane hides restored history until the viewport snaps to the latest message", async () => {
   const source = await readFile(sourcePath, "utf8");
 
@@ -461,7 +489,7 @@ test("chat pane can jump to a requested sub-session run", async () => {
   );
   assert.match(
     source,
-    /const requestMode = sessionOpenRequest\?\.mode \?\? "session";[\s\S]*const requestedParentSessionId =[\s\S]*sessionOpenRequest\?\.parentSessionId\?\.trim\(\) \|\| null;/,
+    /const requestMode = effectiveSessionOpenRequest\?\.mode \?\? "session";[\s\S]*const requestedParentSessionId =[\s\S]*effectiveSessionOpenRequest\?\.parentSessionId\?\.trim\(\) \|\| null;/,
   );
   assert.match(
     source,

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -4818,8 +4818,8 @@ function SessionSelector({
                   size={13}
                   className={`shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
                     open
-                      ? "rotate-180 group-hover:-translate-y-0.5 group-hover:scale-125"
-                      : "rotate-0 group-hover:translate-y-0.5 group-hover:scale-125"
+                      ? "rotate-180 group-hover:-translate-y-1 group-hover:scale-150"
+                      : "rotate-0 group-hover:translate-y-1 group-hover:scale-150"
                   } motion-reduce:transform-none`}
                 />
               </button>

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -24,10 +24,12 @@ import {
   Copy,
   FileText,
   Image as ImageIcon,
+  Inbox,
   Lightbulb,
   Loader2,
   Paperclip,
   PencilLine,
+  Plus,
   Search,
   Square,
   Waypoints,
@@ -147,6 +149,15 @@ interface ChatModelOption {
 interface ChatModelOptionGroup {
   label: string;
   options: ChatModelOption[];
+}
+
+interface ChatSessionOption {
+  sessionId: string;
+  title: string;
+  statusLabel: string;
+  updatedAt: string;
+  updatedLabel: string;
+  searchText: string;
 }
 
 interface StreamTelemetryEntry {
@@ -591,6 +602,132 @@ function pendingAttachmentId(seed: string) {
 
 function runtimeStateStatus(value: string | null | undefined): string {
   return (value || "").trim().toUpperCase();
+}
+
+function normalizeSessionTurnStatus(value: string | null | undefined): string {
+  return (value || "").trim().toLowerCase();
+}
+
+function defaultWorkspaceSessionTitle(
+  kind: string | null | undefined,
+  sessionId: string,
+): string {
+  const normalizedKind = (kind || "").trim().toLowerCase();
+  if (normalizedKind === "cronjob") {
+    return "Cronjob run";
+  }
+  if (normalizedKind === "task_proposal") {
+    return "Task proposal run";
+  }
+  return `Session ${sessionId.slice(0, 8)}`;
+}
+
+function chatSessionStatusLabel(
+  runtimeState:
+    | Pick<SessionRuntimeRecordPayload, "status" | "last_turn_status">
+    | null
+    | undefined,
+): string {
+  const status = runtimeStateStatus(runtimeState?.status);
+  if (status === "BUSY") {
+    return "Running";
+  }
+  if (status === "QUEUED") {
+    return "Queued";
+  }
+  if (status === "WAITING_USER") {
+    return "Waiting";
+  }
+  if (status === "PAUSED") {
+    return "Paused";
+  }
+  if (status === "ERROR") {
+    return "Error";
+  }
+
+  const turnStatus = normalizeSessionTurnStatus(runtimeState?.last_turn_status);
+  if (turnStatus === "completed") {
+    return "Completed";
+  }
+  if (turnStatus === "waiting_user") {
+    return "Waiting";
+  }
+  if (turnStatus === "error" || turnStatus === "failed") {
+    return "Error";
+  }
+  return "Idle";
+}
+
+function formatSessionUpdatedLabel(value: string | null | undefined): string {
+  if (!value) {
+    return "Updated recently";
+  }
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    return "Updated recently";
+  }
+  return timestamp.toLocaleString();
+}
+
+function compareChatSessionOptions(
+  left: ChatSessionOption,
+  right: ChatSessionOption,
+): number {
+  const leftUpdatedAt = Date.parse(left.updatedAt);
+  const rightUpdatedAt = Date.parse(right.updatedAt);
+  if (!Number.isNaN(leftUpdatedAt) || !Number.isNaN(rightUpdatedAt)) {
+    const normalizedLeft = Number.isNaN(leftUpdatedAt) ? 0 : leftUpdatedAt;
+    const normalizedRight = Number.isNaN(rightUpdatedAt) ? 0 : rightUpdatedAt;
+    if (normalizedLeft !== normalizedRight) {
+      return normalizedRight - normalizedLeft;
+    }
+  }
+  return right.updatedAt.localeCompare(left.updatedAt) ||
+    left.title.localeCompare(right.title);
+}
+
+function sessionStatusIndicator(statusLabel: string) {
+  const normalized = statusLabel.trim().toLowerCase();
+  if (normalized === "running") {
+    return {
+      className: "text-primary",
+      icon: <Loader2 size={12} className="animate-spin" />,
+    };
+  }
+  if (normalized === "queued") {
+    return {
+      className: "text-sky-600",
+      icon: <Clock3 size={12} />,
+    };
+  }
+  if (normalized === "waiting") {
+    return {
+      className: "text-amber-600",
+      icon: <Clock3 size={12} />,
+    };
+  }
+  if (normalized === "paused") {
+    return {
+      className: "text-orange-600",
+      icon: <Square size={9} className="fill-current" />,
+    };
+  }
+  if (normalized === "error") {
+    return {
+      className: "text-destructive",
+      icon: <AlertTriangle size={12} />,
+    };
+  }
+  if (normalized === "completed") {
+    return {
+      className: "text-emerald-600",
+      icon: <Check size={12} />,
+    };
+  }
+  return {
+    className: "text-muted-foreground",
+    icon: <Clock3 size={12} />,
+  };
 }
 
 function runtimeStateErrorDetail(value: unknown): string {
@@ -1585,9 +1722,13 @@ interface ChatPaneProps {
   sessionJumpSessionId?: string | null;
   sessionJumpRequestKey?: number;
   sessionOpenRequest?: ChatPaneSessionOpenRequest | null;
+  onSessionOpenRequestConsumed?: (requestKey: number) => void;
   composerPrefillRequest?: ChatPaneComposerPrefillRequest | null;
   onComposerPrefillConsumed?: (requestKey: number) => void;
   onActiveSessionIdChange?: (sessionId: string | null) => void;
+  onOpenInbox?: () => void;
+  inboxUnreadCount?: number;
+  onRequestCreateSession?: () => void;
 }
 
 export function ChatPane({
@@ -1598,9 +1739,13 @@ export function ChatPane({
   sessionJumpSessionId = null,
   sessionJumpRequestKey = 0,
   sessionOpenRequest = null,
+  onSessionOpenRequestConsumed,
   composerPrefillRequest = null,
   onComposerPrefillConsumed,
   onActiveSessionIdChange,
+  onOpenInbox,
+  inboxUnreadCount = 0,
+  onRequestCreateSession,
 }: ChatPaneProps) {
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const authSessionState = useDesktopAuthSession();
@@ -1676,6 +1821,14 @@ export function ChatPane({
   const [memoryProposalDrafts, setMemoryProposalDrafts] = useState<
     Record<string, string>
   >({});
+  const [availableSessions, setAvailableSessions] = useState<ChatSessionOption[]>(
+    [],
+  );
+  const [isLoadingAvailableSessions, setIsLoadingAvailableSessions] =
+    useState(false);
+  const [availableSessionsError, setAvailableSessionsError] = useState("");
+  const [localSessionOpenRequest, setLocalSessionOpenRequest] =
+    useState<ChatPaneSessionOpenRequest | null>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesContentRef = useRef<HTMLDivElement>(null);
   const chatScrollbarThumbRef = useRef<HTMLDivElement>(null);
@@ -1708,6 +1861,8 @@ export function ChatPane({
   const liveTraceStepsRef = useRef<ChatTraceStep[]>([]);
   const historyViewportGenerationRef = useRef(0);
   const [activeSessionId, setActiveSessionId] = useState("");
+  const effectiveSessionOpenRequest =
+    sessionOpenRequest ?? localSessionOpenRequest;
 
   function appendStreamTelemetry(
     entry: Omit<StreamTelemetryEntry, "id" | "at">,
@@ -2632,11 +2787,12 @@ export function ChatPane({
   ]);
 
   useEffect(() => {
-    const requestedSessionId = (sessionOpenRequest?.sessionId || "").trim();
-    const requestKey = sessionOpenRequest?.requestKey ?? 0;
-    const requestMode = sessionOpenRequest?.mode ?? "session";
+    const requestedSessionId =
+      (effectiveSessionOpenRequest?.sessionId || "").trim();
+    const requestKey = effectiveSessionOpenRequest?.requestKey ?? 0;
+    const requestMode = effectiveSessionOpenRequest?.mode ?? "session";
     const requestedParentSessionId =
-      sessionOpenRequest?.parentSessionId?.trim() || null;
+      effectiveSessionOpenRequest?.parentSessionId?.trim() || null;
     if (
       !selectedWorkspaceId ||
       requestKey <= 0 ||
@@ -2649,6 +2805,9 @@ export function ChatPane({
 
     async function openRequestedSession() {
       lastHandledSessionOpenRequestKeyRef.current = requestKey;
+      if ((sessionOpenRequest?.requestKey ?? 0) === requestKey) {
+        onSessionOpenRequestConsumed?.(requestKey);
+      }
 
       let historyLoaded = false;
       beginHistoryViewportRestore();
@@ -2721,16 +2880,118 @@ export function ChatPane({
       cancelled = true;
     };
   }, [
+    onSessionOpenRequestConsumed,
     selectedWorkspaceId,
+    effectiveSessionOpenRequest?.requestKey,
+    effectiveSessionOpenRequest?.sessionId,
+    effectiveSessionOpenRequest?.mode,
+    effectiveSessionOpenRequest?.parentSessionId,
     sessionOpenRequest?.requestKey,
-    sessionOpenRequest?.sessionId,
-    sessionOpenRequest?.mode,
-    sessionOpenRequest?.parentSessionId,
   ]);
 
   useEffect(() => {
     setTodoPanelExpanded(false);
   }, [activeSessionId]);
+
+  useEffect(() => {
+    if (isOnboardingVariant) {
+      setAvailableSessions([]);
+      setAvailableSessionsError("");
+      setIsLoadingAvailableSessions(false);
+      return;
+    }
+    if (!selectedWorkspaceId) {
+      setAvailableSessions([]);
+      setAvailableSessionsError("");
+      setIsLoadingAvailableSessions(false);
+      return;
+    }
+
+    let cancelled = false;
+    let requestInFlight = false;
+
+    const loadAvailableSessions = async (options?: { showLoading?: boolean }) => {
+      if (requestInFlight) {
+        return;
+      }
+      requestInFlight = true;
+      if (options?.showLoading) {
+        setIsLoadingAvailableSessions(true);
+      }
+
+      try {
+        const [runtimeStates, sessionsResponse] = await Promise.all([
+          window.electronAPI.workspace.listRuntimeStates(selectedWorkspaceId),
+          window.electronAPI.workspace.listAgentSessions(selectedWorkspaceId),
+        ]);
+        if (cancelled) {
+          return;
+        }
+
+        const runtimeStateBySessionId = new Map(
+          runtimeStates.items.map((item) => [item.session_id, item]),
+        );
+        const nextOptions = sessionsResponse.items
+          .map((session) => {
+            const sessionId = session.session_id.trim();
+            if (!sessionId) {
+              return null;
+            }
+            const runtimeState = runtimeStateBySessionId.get(sessionId);
+            const title =
+              session.title?.trim() ||
+              defaultWorkspaceSessionTitle(session.kind, sessionId);
+            const updatedAt =
+              runtimeState?.updated_at?.trim() ||
+              session.updated_at?.trim() ||
+              "";
+            return {
+              sessionId,
+              title,
+              statusLabel: chatSessionStatusLabel(runtimeState),
+              updatedAt,
+              updatedLabel: formatSessionUpdatedLabel(updatedAt),
+              searchText: `${title} ${session.kind || ""} ${sessionId}`.trim(),
+            } satisfies ChatSessionOption;
+          })
+          .filter((item): item is ChatSessionOption => Boolean(item))
+          .sort(compareChatSessionOptions);
+
+        setAvailableSessions(nextOptions);
+        setAvailableSessionsError("");
+      } catch (error) {
+        if (!cancelled) {
+          setAvailableSessionsError(normalizeErrorMessage(error));
+        }
+      } finally {
+        requestInFlight = false;
+        if (!cancelled && options?.showLoading) {
+          setIsLoadingAvailableSessions(false);
+        }
+      }
+    };
+
+    const refreshVisibleSessions = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      void loadAvailableSessions();
+    };
+
+    void loadAvailableSessions({ showLoading: true });
+    const intervalId = window.setInterval(() => {
+      refreshVisibleSessions();
+    }, 4000);
+    window.addEventListener("focus", refreshVisibleSessions);
+    document.addEventListener("visibilitychange", refreshVisibleSessions);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshVisibleSessions);
+      document.removeEventListener("visibilitychange", refreshVisibleSessions);
+    };
+  }, [activeSessionId, isOnboardingVariant, selectedWorkspaceId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -3666,6 +3927,22 @@ export function ChatPane({
       })),
     [pendingAttachments],
   );
+  const activeSessionOption = useMemo(
+    () =>
+      availableSessions.find((session) => session.sessionId === activeSessionId) ??
+      null,
+    [activeSessionId, availableSessions],
+  );
+  const activeSessionTitle =
+    activeSessionOption?.title ||
+    (activeSessionId
+      ? defaultWorkspaceSessionTitle("workspace_session", activeSessionId)
+      : "New session");
+  const activeSessionDetail = activeSessionOption
+    ? `${activeSessionOption.statusLabel} · ${activeSessionOption.updatedLabel}`
+    : activeSessionId
+      ? "Current session"
+      : "Draft conversation";
   const readinessMessage =
     !selectedWorkspace || isOnboardingVariant || workspaceAppsReady
       ? ""
@@ -3972,6 +4249,30 @@ export function ChatPane({
     };
   }, [hasMessages]);
 
+  const openSessionFromPicker = (sessionId: string) => {
+    const normalizedSessionId = sessionId.trim();
+    if (!normalizedSessionId || normalizedSessionId === activeSessionIdRef.current) {
+      return;
+    }
+    setLocalSessionOpenRequest({
+      sessionId: normalizedSessionId,
+      requestKey: Date.now(),
+    });
+  };
+
+  const requestDraftSessionFromPicker = () => {
+    if (onRequestCreateSession) {
+      onRequestCreateSession();
+      return;
+    }
+    setLocalSessionOpenRequest({
+      sessionId: "",
+      mode: "draft",
+      parentSessionId: null,
+      requestKey: Date.now(),
+    });
+  };
+
   return (
     <PaneCard
       className={
@@ -4007,6 +4308,23 @@ export function ChatPane({
                 </div>
               </div>
             </div>
+          </div>
+        ) : null}
+
+        {!isOnboardingVariant ? (
+          <div className="shrink-0 border-b border-border/45 px-4 py-2.5 sm:px-5">
+            <SessionSelector
+              activeSessionId={activeSessionId}
+              activeTitle={activeSessionTitle}
+              activeDetail={activeSessionDetail}
+              sessions={availableSessions}
+              isLoading={isLoadingAvailableSessions}
+              errorMessage={availableSessionsError}
+              onSelectSession={openSessionFromPicker}
+              onOpenInbox={onOpenInbox}
+              inboxUnreadCount={inboxUnreadCount}
+              onCreateSession={requestDraftSessionFromPicker}
+            />
           </div>
         ) : null}
 
@@ -4420,6 +4738,205 @@ export function ChatPane({
         </div>
       </div>
     </PaneCard>
+  );
+}
+
+interface SessionSelectorProps {
+  activeSessionId: string;
+  activeTitle: string;
+  activeDetail: string;
+  sessions: ChatSessionOption[];
+  isLoading: boolean;
+  errorMessage: string;
+  onSelectSession: (sessionId: string) => void;
+  onOpenInbox?: () => void;
+  inboxUnreadCount: number;
+  onCreateSession: () => void;
+}
+
+function SessionSelector({
+  activeSessionId,
+  activeTitle,
+  activeDetail,
+  sessions,
+  isLoading,
+  errorMessage,
+  onSelectSession,
+  onOpenInbox,
+  inboxUnreadCount,
+  onCreateSession,
+}: SessionSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const activeSession =
+    sessions.find((session) => session.sessionId === activeSessionId) ?? null;
+  const activeIndicator = activeSession
+    ? sessionStatusIndicator(activeSession.statusLabel)
+    : {
+        className: "text-muted-foreground",
+        icon: <PencilLine size={12} />,
+      };
+  const filteredSessions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return sessions;
+    }
+    return sessions.filter((session) =>
+      session.searchText.toLowerCase().includes(normalizedQuery),
+    );
+  }, [query, sessions]);
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) {
+            setQuery("");
+          }
+        }}
+      >
+        <div className="min-w-0 flex-1">
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-xl px-2 py-1.5 text-left transition-colors"
+                aria-label="Select agent session"
+                title={`${activeTitle} · ${activeDetail}`}
+              >
+                <span
+                  className={`grid size-5 shrink-0 place-items-center ${activeIndicator.className}`}
+                >
+                  {activeIndicator.icon}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[15px] font-semibold tracking-[-0.02em] text-foreground">
+                  {activeTitle}
+                </span>
+                <ChevronDown
+                  size={13}
+                  className={`shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
+                    open
+                      ? "rotate-180 group-hover:-translate-y-0.5 group-hover:scale-125"
+                      : "rotate-0 group-hover:translate-y-0.5 group-hover:scale-125"
+                  } motion-reduce:transform-none`}
+                />
+              </button>
+            }
+          />
+        </div>
+        <PopoverContent align="start" className="w-[300px] p-0">
+          <div className="border-b border-border/40 p-2">
+            <div className="relative flex items-center rounded-[10px] border border-border/40 bg-muted/35 px-2.5 transition-colors focus-within:border-border/55 focus-within:bg-background/70">
+              <Search
+                size={13}
+                className="shrink-0 text-muted-foreground"
+              />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search sessions..."
+                className="embedded-input h-8 w-full bg-transparent pl-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/60"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <div className="max-h-[320px] overflow-y-auto p-1.5">
+            {isLoading ? (
+              <div className="px-3 py-3 text-[12px] text-muted-foreground">
+                Loading sessions...
+              </div>
+            ) : errorMessage ? (
+              <div className="px-3 py-3 text-[12px] text-destructive">
+                {errorMessage}
+              </div>
+            ) : filteredSessions.length === 0 ? (
+              <div className="px-3 py-3 text-[12px] text-muted-foreground">
+                {query.trim() ? "No matching sessions." : "No saved sessions yet."}
+              </div>
+            ) : (
+              filteredSessions.map((session) => {
+                const isActive = session.sessionId === activeSessionId;
+                const indicator = sessionStatusIndicator(session.statusLabel);
+                return (
+                  <button
+                    key={session.sessionId}
+                    type="button"
+                    onClick={() => {
+                      onSelectSession(session.sessionId);
+                      setOpen(false);
+                      setQuery("");
+                    }}
+                    className={`flex w-full items-center gap-2 rounded-[12px] px-3 py-2 text-left transition ${
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent/50"
+                    }`}
+                    title={`${session.title} · ${session.statusLabel} · ${session.updatedLabel}`}
+                  >
+                    <span
+                      className={`grid size-4 shrink-0 place-items-center ${indicator.className}`}
+                    >
+                      {indicator.icon}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px] font-medium text-current">
+                        {session.title}
+                      </div>
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {session.statusLabel}
+                      </div>
+                    </div>
+                    {isActive ? (
+                      <Check size={13} className="shrink-0 text-primary" />
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <div className="flex shrink-0 items-center gap-1">
+        {onOpenInbox ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => {
+              setOpen(false);
+              setQuery("");
+              onOpenInbox();
+            }}
+            aria-label="Show inbox"
+            className="relative rounded-lg text-muted-foreground hover:text-foreground"
+          >
+            <Inbox size={15} />
+            {inboxUnreadCount > 0 ? (
+              <span className="absolute right-1.5 top-1.5 size-2 rounded-full border border-card bg-destructive" />
+            ) : null}
+          </Button>
+        ) : null}
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => {
+            setOpen(false);
+            setQuery("");
+            onCreateSession();
+          }}
+          aria-label="Create new session"
+          className="rounded-lg text-muted-foreground hover:text-foreground"
+        >
+          <Plus size={15} />
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -36,15 +36,31 @@ test("file explorer polls the current directory to surface live file changes", a
   assert.match(source, /\}, \[currentPath, selectedWorkspaceId\]\);/);
 });
 
-test("file explorer opens folders on double click instead of single click", async () => {
+test("file explorer switches folders to inline tree expansion and keeps explorer-only file opening", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /onClick=\{\(\) => \{\s*setSelectedPath\(entry\.absolutePath\);\s*closeContextMenu\(\);\s*\}\}/);
   assert.match(
     source,
-    /onDoubleClick=\{\(\) => \{\s*if \(entry\.isDirectory\) \{\s*void openPath\(entry\.absolutePath\);\s*return;\s*\}\s*void openFilePreview\(entry\.absolutePath\);\s*\}\}/
+    /type FileExplorerVisibleRow =/,
   );
-  assert.match(source, /double-click to open folder/);
+  assert.match(
+    source,
+    /function buildVisibleExplorerRows\(/,
+  );
+  assert.match(
+    source,
+    /const toggleDirectoryExpansion = useCallback\(\s*async \(entry: LocalFileEntry\) => \{/,
+  );
+  assert.match(
+    source,
+    /onClick=\{\(\) => \{\s*setSelectedPath\(entry\.absolutePath\);\s*closeContextMenu\(\);\s*if \(entry\.isDirectory\) \{\s*void toggleDirectoryExpansion\(entry\);\s*return;\s*\}\s*if \(!previewInPane\) \{\s*void openFileTarget\(entry\.absolutePath\);\s*\}\s*\}\}/,
+  );
+  assert.match(
+    source,
+    /onDoubleClick=\{\(\) => \{\s*if \(!entry\.isDirectory && previewInPane\) \{\s*void openFilePreview\(entry\.absolutePath\);\s*\}\s*\}\}/,
+  );
+  assert.match(source, /click to \$\{isExpanded \? "collapse" : "expand"\} folder/);
+  assert.match(source, /click to open file, drag into chat to attach/);
 });
 
 test("file explorer keeps drag-to-attach without using a grab cursor", async () => {
@@ -59,56 +75,33 @@ test("file explorer keeps drag-to-attach without using a grab cursor", async () 
   assert.doesNotMatch(source, /cursor-grabbing/);
 });
 
-test("file explorer home opens the selected workspace root when available", async () => {
+test("file explorer keeps a minimal tree header without showing the workspace root row", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /const openHomeDirectory = async \(\) => \{/);
-  assert.match(source, /const workspaceRoot = await window\.electronAPI\.workspace\.getWorkspaceRoot\(selectedWorkspaceId\);/);
-  assert.match(source, /await loadDirectory\(workspaceRoot, true\);/);
-  assert.match(source, /await loadDirectory\(null, true\);/);
-  assert.match(source, /onClick=\{\(\) => \{\s*void openHomeDirectory\(\);\s*\}\}/);
-});
-
-test("file explorer uses breadcrumbs and home instead of a separate up button", async () => {
-  const source = await readFile(sourcePath, "utf8");
-
-  assert.match(source, /const \[workspaceRootPath, setWorkspaceRootPath\] = useState<string \| null>\(null\);/);
-  assert.match(
-    source,
-    /const isAtWorkspaceRoot = workspaceRootPath[\s\S]*normalizeComparablePath\(currentPath\) === normalizeComparablePath\(workspaceRootPath\)/
-  );
-  assert.doesNotMatch(source, /label="Up"/);
-  assert.doesNotMatch(source, /ArrowUp/);
-  assert.match(source, /label="Home"[\s\S]*disabled=\{isAtWorkspaceRoot\}/);
-});
-
-test("file explorer renders clickable breadcrumbs scoped to the current path", async () => {
-  const source = await readFile(sourcePath, "utf8");
-
-  assert.match(source, /type FileExplorerBreadcrumb = \{/);
-  assert.match(source, /function buildPathBreadcrumbs\(/);
-  assert.match(
-    source,
-    /const breadcrumbs = useMemo\(\s*\(\) => buildPathBreadcrumbs\(currentPath, workspaceRootPath\),\s*\[currentPath, workspaceRootPath\],\s*\);/,
-  );
-  assert.match(source, /chat-scrollbar-hidden mt-1\.5 flex items-center gap-1 overflow-x-auto/);
-  assert.match(source, /breadcrumbs\.map\(\(breadcrumb\) => \(/);
-  assert.match(source, /<ChevronRight size=\{10\}/);
-  assert.match(
-    source,
-    /onClick=\{\(\) => \{\s*void openPath\(breadcrumb\.absolutePath\);\s*\}\}/,
-  );
+  assert.match(source, /text-\[11px\] font-medium uppercase tracking-\[0\.14em\] text-muted-foreground\/72">\s*Files\s*</);
+  assert.doesNotMatch(source, /const rootFolderLabel = currentPath \? getFolderName\(currentPath\) : "Workspace";/);
+  assert.doesNotMatch(source, /const isRootExpanded = normalizedQuery\.length > 0 \|\| expandedDirectoryPaths\[currentPath\] !== false;/);
+  assert.doesNotMatch(source, /setExpandedDirectoryPaths\(\(current\) => \(\{\s*\.\.\.current,\s*\[currentPath\]: !isRootExpanded,\s*\}\)\);/);
+  assert.doesNotMatch(source, /label="Back"/);
+  assert.doesNotMatch(source, /label="Forward"/);
+  assert.doesNotMatch(source, /label="Home"/);
+  assert.doesNotMatch(source, /buildPathBreadcrumbs/);
+  assert.doesNotMatch(source, /const \[history, setHistory\]/);
 });
 
 test("file explorer accepts one-shot focus requests for artifact files", async () => {
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(source, /export type FileExplorerFocusRequest = \{\s*path: string;\s*requestKey: number;\s*\};/);
-  assert.match(source, /interface FileExplorerPaneProps \{\s*focusRequest\?: FileExplorerFocusRequest \| null;\s*onFocusRequestConsumed\?: \(requestKey: number\) => void;\s*\}/);
+  assert.match(
+    source,
+    /interface FileExplorerPaneProps \{\s*focusRequest\?: FileExplorerFocusRequest \| null;\s*onFocusRequestConsumed\?: \(requestKey: number\) => void;\s*previewInPane\?: boolean;\s*onFileOpen\?: \(path: string\) => void;\s*embedded\?: boolean;\s*\}/,
+  );
   assert.match(source, /const request = focusRequest;\s*if \(lastProcessedFocusRequestKeyRef\.current === request\.requestKey\) \{\s*return;\s*\}/);
   assert.match(source, /const workspaceRoot =\s*workspaceRootPath \?\?\s*\(await window\.electronAPI\.workspace\.getWorkspaceRoot\(selectedWorkspaceId\)\);/);
   assert.match(source, /targetPath = resolveWorkspaceTargetPath\(workspaceRoot, targetPath\);/);
-  assert.match(source, /await openFilePreview\(targetPath, \{ syncDirectory: true \}\);/);
+  assert.match(source, /const revealPathInTree = useCallback\(/);
+  assert.match(source, /await openFileTarget\(targetPath, \{ syncDirectory: true \}\);/);
   assert.match(source, /onFocusRequestConsumed\?\.\(request\.requestKey\);/);
 });
 
@@ -120,7 +113,9 @@ test("file explorer adds a markdown preview mode while keeping text editing inli
   assert.match(source, /type TextPreviewMode = "edit" \| "preview";/);
   assert.match(source, /const \[textPreviewMode, setTextPreviewMode\] = useState<TextPreviewMode>\("edit"\);/);
   assert.match(source, /setTextPreviewMode\(isMarkdownPreviewPayload\(payload\) \? "preview" : "edit"\);/);
-  assert.match(source, /title=\{preview \|\| previewLoading \|\| previewError \? "File" : ""\}/);
+  assert.match(source, /const showInlinePreview = previewInPane && Boolean\(preview \|\| previewLoading \|\| previewError\);/);
+  assert.match(source, /const explorerPane = embedded \? \(\s*content\s*\) : \(/);
+  assert.match(source, /title=\{showInlinePreview \? "File" : ""\}/);
   assert.match(source, /preview\?\.kind === "text" \? \(/);
   assert.match(source, /isMarkdownPreview && textPreviewMode === "preview"/);
   assert.match(source, /<SimpleMarkdown[\s\S]*className="chat-markdown text-sm text-foreground"[\s\S]*onLinkClick=\{openPreviewLink\}[\s\S]*\{previewDraft\}[\s\S]*<\/SimpleMarkdown>/);
@@ -138,6 +133,15 @@ test("file explorer adds a markdown preview mode while keeping text editing inli
     /window\.electronAPI\.fs\.writeTextFile\(\s*preview\.absolutePath,\s*previewDraft,\s*selectedWorkspaceId \?\? null,\s*\)/,
   );
   assert.match(source, /Save/);
+});
+
+test("file explorer preview metadata omits the absolute file path", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(
+    source,
+    /\{preview\?\.absolutePath \? <span>\{preview\.absolutePath\}<\/span> : null\}/,
+  );
 });
 
 test("file explorer warns users to save before leaving an unsaved file", async () => {
@@ -191,6 +195,8 @@ test("file explorer exposes right-click rename and delete actions for entries", 
     source,
     /window\.electronAPI\.fs\.renamePath\(\s*renamingEntry\.absolutePath,\s*nextName,\s*selectedWorkspaceId \?\? null,\s*\)/,
   );
+  assert.match(source, /const refreshDirectoryEntries = useCallback\(/);
+  assert.match(source, /const parentPath =\s*getParentFolderPath\(renamingEntry\.absolutePath\) \?\? currentPathRef\.current;/);
   assert.match(
     source,
     /window\.electronAPI\.fs\.deletePath\(\s*entry\.absolutePath,\s*selectedWorkspaceId \?\? null,\s*\)/,
@@ -202,8 +208,14 @@ test("file explorer exposes right-click rename and delete actions for entries", 
 test("file explorer does not expose a pane-level close action", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /interface FileExplorerPaneProps \{\s*focusRequest\?: FileExplorerFocusRequest \| null;\s*onFocusRequestConsumed\?: \(requestKey: number\) => void;\s*\}/);
-  assert.match(source, /export function FileExplorerPane\(\{\s*focusRequest = null,\s*onFocusRequestConsumed,\s*}: FileExplorerPaneProps\)/);
+  assert.match(
+    source,
+    /interface FileExplorerPaneProps \{\s*focusRequest\?: FileExplorerFocusRequest \| null;\s*onFocusRequestConsumed\?: \(requestKey: number\) => void;\s*previewInPane\?: boolean;\s*onFileOpen\?: \(path: string\) => void;\s*embedded\?: boolean;\s*\}/,
+  );
+  assert.match(
+    source,
+    /export function FileExplorerPane\(\{\s*focusRequest = null,\s*onFocusRequestConsumed,\s*previewInPane = true,\s*onFileOpen,\s*embedded = false,\s*}: FileExplorerPaneProps\)/,
+  );
   assert.doesNotMatch(source, /label="Close file explorer"/);
   assert.doesNotMatch(source, /icon=\{<X size=\{1[23]\} \/>/);
 });

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -14,14 +14,11 @@ import {
   FileText,
   FileVideoCamera,
   Folder,
-  Forward,
-  Home,
   Save,
   Search,
   Shield,
   Star,
   type LucideIcon,
-  Undo2
 } from "lucide-react";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { IconButton } from "@/components/ui/IconButton";
@@ -41,6 +38,9 @@ export type FileExplorerFocusRequest = {
 interface FileExplorerPaneProps {
   focusRequest?: FileExplorerFocusRequest | null;
   onFocusRequestConsumed?: (requestKey: number) => void;
+  previewInPane?: boolean;
+  onFileOpen?: (path: string) => void;
+  embedded?: boolean;
 }
 
 const SPREADSHEET_EXTENSIONS = new Set([
@@ -153,12 +153,6 @@ type ExplorerIconDescriptor = {
   className: string;
 };
 
-type FileExplorerBreadcrumb = {
-  label: string;
-  absolutePath: string;
-  isCurrent: boolean;
-};
-
 type FileExplorerContextMenuState = {
   entry: LocalFileEntry;
   x: number;
@@ -172,6 +166,23 @@ type FileExplorerContextMenuState = {
     height: number;
   };
 };
+
+type FileExplorerVisibleRow =
+  | {
+      type: "entry";
+      entry: LocalFileEntry;
+      depth: number;
+      isExpanded: boolean;
+      isLoadingChildren: boolean;
+      childError: string;
+    }
+  | {
+      type: "feedback";
+      id: string;
+      depth: number;
+      tone: "loading" | "error";
+      message: string;
+    };
 
 function getComparableFileName(targetName: string) {
   const normalized = targetName.trim().toLowerCase().replace(/[\\/]+$/, "");
@@ -332,6 +343,18 @@ function normalizeComparablePath(targetPath: string) {
   return normalized;
 }
 
+function isPathWithin(parentPath: string, targetPath: string) {
+  const normalizedParent = normalizeComparablePath(parentPath);
+  const normalizedTarget = normalizeComparablePath(targetPath);
+  if (!normalizedParent || !normalizedTarget) {
+    return false;
+  }
+  return (
+    normalizedTarget === normalizedParent ||
+    normalizedTarget.startsWith(`${normalizedParent}/`)
+  );
+}
+
 function isAbsolutePath(targetPath: string) {
   return /^(?:[a-zA-Z]:[\\/]|\/)/.test(targetPath.trim());
 }
@@ -351,53 +374,123 @@ function resolveWorkspaceTargetPath(workspaceRoot: string, targetPath: string) {
   return `${normalizedRoot}${separator}${normalizedTarget}`;
 }
 
-function buildPathBreadcrumbs(
-  currentPath: string,
-  workspaceRootPath: string | null,
-): FileExplorerBreadcrumb[] {
-  const trimmedCurrentPath = currentPath.trim();
-  if (!trimmedCurrentPath) {
-    return [];
+function findLoadedEntry(
+  entries: LocalFileEntry[],
+  targetPath: string,
+  directoryEntriesByPath: Record<string, LocalFileEntry[]>,
+): LocalFileEntry | null {
+  const normalizedTargetPath = normalizeComparablePath(targetPath);
+  if (!normalizedTargetPath) {
+    return null;
   }
 
-  const normalizedWorkspaceRoot = workspaceRootPath
-    ? normalizeComparablePath(workspaceRootPath)
-    : "";
-  const breadcrumbs: FileExplorerBreadcrumb[] = [];
-  const seenPaths = new Set<string>();
-  let cursor: string | null = trimmedCurrentPath;
-
-  while (cursor) {
-    const normalizedCursor = normalizeComparablePath(cursor);
-    if (!normalizedCursor || seenPaths.has(normalizedCursor)) {
-      break;
+  const stack = [...entries];
+  while (stack.length > 0) {
+    const entry = stack.shift();
+    if (!entry) {
+      continue;
     }
-    seenPaths.add(normalizedCursor);
-    breadcrumbs.unshift({
-      label: getFolderName(cursor),
-      absolutePath: cursor,
-      isCurrent: false,
+
+    if (normalizeComparablePath(entry.absolutePath) === normalizedTargetPath) {
+      return entry;
+    }
+
+    if (!entry.isDirectory) {
+      continue;
+    }
+
+    const childEntries = directoryEntriesByPath[entry.absolutePath];
+    if (childEntries?.length) {
+      stack.unshift(...childEntries);
+    }
+  }
+
+  return null;
+}
+
+function buildVisibleExplorerRows(
+  entries: LocalFileEntry[],
+  directoryEntriesByPath: Record<string, LocalFileEntry[]>,
+  expandedDirectoryPaths: Record<string, boolean>,
+  directoryLoadingByPath: Record<string, boolean>,
+  directoryErrorByPath: Record<string, string>,
+  query: string,
+  depth = 0,
+): FileExplorerVisibleRow[] {
+  const rows: FileExplorerVisibleRow[] = [];
+
+  for (const entry of entries) {
+    const isExpanded = Boolean(expandedDirectoryPaths[entry.absolutePath]);
+    const isLoadingChildren = Boolean(directoryLoadingByPath[entry.absolutePath]);
+    const childError = directoryErrorByPath[entry.absolutePath] ?? "";
+    const shouldSearchChildren =
+      entry.isDirectory && (isExpanded || query.length > 0);
+    const childEntries = shouldSearchChildren
+      ? directoryEntriesByPath[entry.absolutePath] ?? []
+      : [];
+    const childRows = shouldSearchChildren
+      ? buildVisibleExplorerRows(
+          childEntries,
+          directoryEntriesByPath,
+          expandedDirectoryPaths,
+          directoryLoadingByPath,
+          directoryErrorByPath,
+          query,
+          depth + 1,
+        )
+      : [];
+    const matchesSelf =
+      query.length === 0 || entry.name.toLowerCase().includes(query);
+    const hasMatchingDescendants = childRows.length > 0;
+
+    if (query.length > 0 && !matchesSelf && !hasMatchingDescendants) {
+      continue;
+    }
+
+    rows.push({
+      type: "entry",
+      entry,
+      depth,
+      isExpanded,
+      isLoadingChildren,
+      childError,
     });
-    if (
-      normalizedWorkspaceRoot &&
-      normalizedCursor === normalizedWorkspaceRoot
-    ) {
-      break;
+
+    const shouldShowChildren = entry.isDirectory
+      ? query.length > 0
+        ? hasMatchingDescendants
+        : isExpanded
+      : false;
+    if (!shouldShowChildren) {
+      continue;
     }
-    const parentPath = getParentFolderPath(cursor);
-    if (
-      !parentPath ||
-      normalizeComparablePath(parentPath) === normalizedCursor
-    ) {
-      break;
+
+    if (isLoadingChildren) {
+      rows.push({
+        type: "feedback",
+        id: `loading:${entry.absolutePath}`,
+        depth: depth + 1,
+        tone: "loading",
+        message: "Loading folder...",
+      });
+      continue;
     }
-    cursor = parentPath;
+
+    if (childError) {
+      rows.push({
+        type: "feedback",
+        id: `error:${entry.absolutePath}`,
+        depth: depth + 1,
+        tone: "error",
+        message: childError,
+      });
+      continue;
+    }
+
+    rows.push(...childRows);
   }
 
-  return breadcrumbs.map((breadcrumb, index) => ({
-    ...breadcrumb,
-    isCurrent: index === breadcrumbs.length - 1,
-  }));
+  return rows;
 }
 
 function formatFileSize(size: number) {
@@ -485,6 +578,9 @@ function createAttachmentDragPreview(entry: LocalFileEntry) {
 export function FileExplorerPane({
   focusRequest = null,
   onFocusRequestConsumed,
+  previewInPane = true,
+  onFileOpen,
+  embedded = false,
 }: FileExplorerPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const contextMenuRef = useRef<HTMLDivElement | null>(null);
@@ -493,12 +589,23 @@ export function FileExplorerPane({
   const dragPreviewRef = useRef<HTMLDivElement | null>(null);
   const lastSyncedWorkspaceRootRef = useRef<{ workspaceId: string; rootPath: string } | null>(null);
   const lastProcessedFocusRequestKeyRef = useRef<number | null>(null);
+  const currentPathRef = useRef("");
   const [currentPath, setCurrentPath] = useState<string>("");
   const [entries, setEntries] = useState<LocalFileEntry[]>([]);
+  const [directoryEntriesByPath, setDirectoryEntriesByPath] = useState<
+    Record<string, LocalFileEntry[]>
+  >({});
+  const [expandedDirectoryPaths, setExpandedDirectoryPaths] = useState<
+    Record<string, boolean>
+  >({});
+  const [directoryLoadingByPath, setDirectoryLoadingByPath] = useState<
+    Record<string, boolean>
+  >({});
+  const [directoryErrorByPath, setDirectoryErrorByPath] = useState<
+    Record<string, string>
+  >({});
   const [selectedPath, setSelectedPath] = useState<string>("");
   const [workspaceRootPath, setWorkspaceRootPath] = useState<string | null>(null);
-  const [history, setHistory] = useState<string[]>([]);
-  const [historyIndex, setHistoryIndex] = useState(-1);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
@@ -515,9 +622,9 @@ export function FileExplorerPane({
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [renameSaving, setRenameSaving] = useState(false);
-  const historyRef = useRef<string[]>([]);
-  const historyIndexRef = useRef(-1);
   const { selectedWorkspaceId } = useWorkspaceSelection();
+
+  currentPathRef.current = currentPath;
 
   const loadDirectory = useCallback(async (targetPath?: string | null, pushHistory = true) => {
     setLoading(true);
@@ -528,31 +635,31 @@ export function FileExplorerPane({
         targetPath ?? null,
         selectedWorkspaceId ?? null,
       );
+      const previousCurrentPath = currentPathRef.current;
+      const shouldResetTree =
+        pushHistory ||
+        normalizeComparablePath(previousCurrentPath) !==
+          normalizeComparablePath(payload.currentPath);
       setCurrentPath(payload.currentPath);
+      currentPathRef.current = payload.currentPath;
       setEntries(payload.entries);
-
-      if (pushHistory) {
-        const currentHistory = historyRef.current;
-        const currentIndex = historyIndexRef.current;
-        const base = currentIndex >= 0 ? currentHistory.slice(0, currentIndex + 1) : currentHistory;
-        const last = base[base.length - 1];
-
-        if (last === payload.currentPath) {
-          historyRef.current = base;
-          historyIndexRef.current = base.length - 1;
-          setHistory(base);
-          setHistoryIndex(base.length - 1);
-        } else {
-          const next = [...base, payload.currentPath];
-          historyRef.current = next;
-          historyIndexRef.current = next.length - 1;
-          setHistory(next);
-          setHistoryIndex(next.length - 1);
-        }
+      setDirectoryEntriesByPath((current) =>
+        shouldResetTree
+          ? { [payload.currentPath]: payload.entries }
+          : { ...current, [payload.currentPath]: payload.entries },
+      );
+      if (shouldResetTree) {
+        setExpandedDirectoryPaths({});
+        setDirectoryLoadingByPath({});
+        setDirectoryErrorByPath({});
       }
 
       setSelectedPath((prev) =>
-        !prev || !payload.entries.some((entry) => entry.absolutePath === prev) ? (payload.entries[0]?.absolutePath ?? "") : prev
+        !prev ||
+        (!payload.entries.some((entry) => entry.absolutePath === prev) &&
+          !isPathWithin(payload.currentPath, prev))
+          ? (payload.entries[0]?.absolutePath ?? "")
+          : prev
       );
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : "Failed to open directory.";
@@ -630,8 +737,16 @@ export function FileExplorerPane({
           return;
         }
         setEntries(payload.entries);
+        setDirectoryEntriesByPath((current) => ({
+          ...current,
+          [payload.currentPath]: payload.entries,
+        }));
         setSelectedPath((prev) =>
-          !prev || !payload.entries.some((entry) => entry.absolutePath === prev) ? (payload.entries[0]?.absolutePath ?? "") : prev
+          !prev ||
+          (!payload.entries.some((entry) => entry.absolutePath === prev) &&
+            !isPathWithin(payload.currentPath, prev))
+            ? (payload.entries[0]?.absolutePath ?? "")
+            : prev
         );
       } catch {
         // Best-effort background refresh; keep current listing on transient failures.
@@ -733,25 +848,31 @@ export function FileExplorerPane({
     };
   }, [contextMenu]);
 
-  const canGoBack = historyIndex > 0;
-  const canGoForward = historyIndex >= 0 && historyIndex < history.length - 1;
-  const isAtWorkspaceRoot = workspaceRootPath
-    ? normalizeComparablePath(currentPath) === normalizeComparablePath(workspaceRootPath)
-    : false;
-  const breadcrumbs = useMemo(
-    () => buildPathBreadcrumbs(currentPath, workspaceRootPath),
-    [currentPath, workspaceRootPath],
-  );
-
   const filteredEntries = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) return entries;
-    return entries.filter((entry) => entry.name.toLowerCase().includes(normalizedQuery));
-  }, [entries, query]);
+    return buildVisibleExplorerRows(
+      entries,
+      directoryEntriesByPath,
+      expandedDirectoryPaths,
+      directoryLoadingByPath,
+      directoryErrorByPath,
+      normalizedQuery,
+    );
+  }, [
+    directoryEntriesByPath,
+    directoryErrorByPath,
+    directoryLoadingByPath,
+    entries,
+    expandedDirectoryPaths,
+    query,
+  ]);
 
-  const selectedEntry = entries.find((entry) => entry.absolutePath === selectedPath);
+  const selectedEntry = useMemo(
+    () => findLoadedEntry(entries, selectedPath, directoryEntriesByPath),
+    [directoryEntriesByPath, entries, selectedPath],
+  );
   const renamingEntry = renamingPath
-    ? entries.find((entry) => entry.absolutePath === renamingPath) ?? null
+    ? findLoadedEntry(entries, renamingPath, directoryEntriesByPath)
     : null;
   const isDirty = preview?.isEditable ? previewDraft !== (preview.content ?? "") : false;
   const isMarkdownPreview = isMarkdownPreviewPayload(preview);
@@ -759,6 +880,170 @@ export function FileExplorerPane({
   const openPreviewLink = useCallback((url: string) => {
     void window.electronAPI.ui.openExternalUrl(url);
   }, []);
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenu(null);
+  }, []);
+
+  const ensureDirectoryEntriesLoaded = useCallback(
+    async (targetPath: string) => {
+      const normalizedTargetPath = targetPath.trim();
+      if (!normalizedTargetPath) {
+        return null;
+      }
+
+      if (directoryEntriesByPath[normalizedTargetPath]) {
+        return directoryEntriesByPath[normalizedTargetPath];
+      }
+
+      setDirectoryLoadingByPath((current) => ({
+        ...current,
+        [normalizedTargetPath]: true,
+      }));
+      setDirectoryErrorByPath((current) => {
+        if (!current[normalizedTargetPath]) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[normalizedTargetPath];
+        return next;
+      });
+
+      try {
+        const payload = await window.electronAPI.fs.listDirectory(
+          normalizedTargetPath,
+          selectedWorkspaceId ?? null,
+        );
+        setDirectoryEntriesByPath((current) => ({
+          ...current,
+          [payload.currentPath]: payload.entries,
+        }));
+        return payload.entries;
+      } catch (cause) {
+        const message =
+          cause instanceof Error ? cause.message : "Failed to open directory.";
+        setDirectoryErrorByPath((current) => ({
+          ...current,
+          [normalizedTargetPath]: message,
+        }));
+        return null;
+      } finally {
+        setDirectoryLoadingByPath((current) => {
+          if (!current[normalizedTargetPath]) {
+            return current;
+          }
+          const next = { ...current };
+          delete next[normalizedTargetPath];
+          return next;
+        });
+      }
+    },
+    [directoryEntriesByPath, selectedWorkspaceId],
+  );
+
+  const refreshDirectoryEntries = useCallback(
+    async (targetPath: string) => {
+      const normalizedTargetPath = targetPath.trim();
+      if (!normalizedTargetPath) {
+        return;
+      }
+
+      if (
+        normalizeComparablePath(normalizedTargetPath) ===
+        normalizeComparablePath(currentPathRef.current)
+      ) {
+        await loadDirectory(currentPathRef.current, false);
+        return;
+      }
+
+      const payload = await window.electronAPI.fs.listDirectory(
+        normalizedTargetPath,
+        selectedWorkspaceId ?? null,
+      );
+      setDirectoryEntriesByPath((current) => ({
+        ...current,
+        [payload.currentPath]: payload.entries,
+      }));
+      setDirectoryErrorByPath((current) => {
+        if (!current[payload.currentPath]) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[payload.currentPath];
+        return next;
+      });
+    },
+    [loadDirectory, selectedWorkspaceId],
+  );
+
+  const revealPathInTree = useCallback(
+    async (targetPath: string) => {
+      const parentFolderPath = getParentFolderPath(targetPath);
+      if (!parentFolderPath) {
+        return;
+      }
+
+      const treeRootPath = currentPathRef.current;
+      if (!treeRootPath || !isPathWithin(treeRootPath, parentFolderPath)) {
+        await loadDirectory(parentFolderPath, true);
+        return;
+      }
+
+      const ancestorPaths: string[] = [];
+      const normalizedTreeRoot = normalizeComparablePath(treeRootPath);
+      let cursor: string | null = parentFolderPath;
+
+      while (cursor && normalizeComparablePath(cursor) !== normalizedTreeRoot) {
+        ancestorPaths.unshift(cursor);
+        const nextParent = getParentFolderPath(cursor);
+        if (
+          !nextParent ||
+          normalizeComparablePath(nextParent) === normalizeComparablePath(cursor)
+        ) {
+          break;
+        }
+        cursor = nextParent;
+      }
+
+      for (const ancestorPath of ancestorPaths) {
+        const childEntries = await ensureDirectoryEntriesLoaded(ancestorPath);
+        if (childEntries === null) {
+          return;
+        }
+        setExpandedDirectoryPaths((current) => ({
+          ...current,
+          [ancestorPath]: true,
+        }));
+      }
+    },
+    [ensureDirectoryEntriesLoaded, loadDirectory],
+  );
+
+  const toggleDirectoryExpansion = useCallback(
+    async (entry: LocalFileEntry) => {
+      setSelectedPath(entry.absolutePath);
+      closeContextMenu();
+
+      if (expandedDirectoryPaths[entry.absolutePath]) {
+        setExpandedDirectoryPaths((current) => ({
+          ...current,
+          [entry.absolutePath]: false,
+        }));
+        return;
+      }
+
+      const childEntries = await ensureDirectoryEntriesLoaded(entry.absolutePath);
+      if (childEntries === null) {
+        return;
+      }
+
+      setExpandedDirectoryPaths((current) => ({
+        ...current,
+        [entry.absolutePath]: true,
+      }));
+    },
+    [closeContextMenu, ensureDirectoryEntriesLoaded, expandedDirectoryPaths],
+  );
 
   const confirmDiscardIfDirty = useCallback(() => {
     if (!isDirty) {
@@ -795,29 +1080,6 @@ export function FileExplorerPane({
     input.setSelectionRange(0, selectionEnd);
   }, [renamingEntry]);
 
-  const openPath = async (targetPath: string) => {
-    if (!confirmDiscardIfDirty()) {
-      return;
-    }
-
-    setPreview(null);
-    setPreviewDraft("");
-    setTextPreviewMode("edit");
-    setPreviewError("");
-    await loadDirectory(targetPath, true);
-  };
-
-  const openSelectedDirectory = async () => {
-    const targetEntry = entries.find((entry) => entry.absolutePath === selectedPath);
-    if (targetEntry?.isDirectory) {
-      await openPath(targetEntry.absolutePath);
-    }
-  };
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenu(null);
-  }, []);
-
   const stopRenamingEntry = useCallback(() => {
     setRenamingPath(null);
     setRenameDraft("");
@@ -832,33 +1094,6 @@ export function FileExplorerPane({
     setRenameDraft(entry.name);
   }, [closeContextMenu]);
 
-  const openHomeDirectory = async () => {
-    if (!confirmDiscardIfDirty()) {
-      return;
-    }
-
-    if (selectedWorkspaceId) {
-      try {
-        const workspaceRoot = await window.electronAPI.workspace.getWorkspaceRoot(selectedWorkspaceId);
-        if (workspaceRoot) {
-          setPreview(null);
-          setPreviewDraft("");
-          setTextPreviewMode("edit");
-          setPreviewError("");
-          await loadDirectory(workspaceRoot, true);
-          return;
-        }
-      } catch {
-        // Fall through to default home root.
-      }
-    }
-
-    setPreview(null);
-    setPreviewDraft("");
-    setTextPreviewMode("edit");
-    setPreviewError("");
-    await loadDirectory(null, true);
-  };
 
   const openFilePreview = async (targetPath: string, options?: { skipConfirm?: boolean; syncDirectory?: boolean }) => {
     const skipConfirm = options?.skipConfirm ?? false;
@@ -867,10 +1102,7 @@ export function FileExplorerPane({
     }
 
     if (options?.syncDirectory) {
-      const parentFolderPath = getParentFolderPath(targetPath);
-      if (parentFolderPath && parentFolderPath !== currentPath) {
-        await loadDirectory(parentFolderPath, true);
-      }
+      await revealPathInTree(targetPath);
     }
 
     setSelectedPath(targetPath);
@@ -895,6 +1127,44 @@ export function FileExplorerPane({
       setPreviewLoading(false);
     }
   };
+
+  const openFileTarget = useCallback(
+    async (
+      targetPath: string,
+      options?: { skipConfirm?: boolean; syncDirectory?: boolean },
+    ) => {
+      if (previewInPane || !onFileOpen) {
+        await openFilePreview(targetPath, options);
+        return;
+      }
+
+      const skipConfirm = options?.skipConfirm ?? false;
+      if (!skipConfirm && !confirmDiscardIfDirty()) {
+        return;
+      }
+
+      if (options?.syncDirectory) {
+        await revealPathInTree(targetPath);
+      }
+
+      setSelectedPath(targetPath);
+      setPreview(null);
+      setPreviewDraft("");
+      setTextPreviewMode("edit");
+      setActiveTableSheetIndex(0);
+      setPreviewError("");
+      setPreviewLoading(false);
+      setSaving(false);
+      onFileOpen(targetPath);
+    },
+    [
+      confirmDiscardIfDirty,
+      onFileOpen,
+      openFilePreview,
+      previewInPane,
+      revealPathInTree,
+    ],
+  );
 
   const closePreview = () => {
     if (!confirmDiscardIfDirty()) {
@@ -934,36 +1204,6 @@ export function FileExplorerPane({
     }
   };
 
-  const onBack = async () => {
-    if (!canGoBack || !confirmDiscardIfDirty()) return;
-    const targetIndex = historyIndex - 1;
-    const targetPath = history[targetIndex];
-    if (!targetPath) return;
-
-    historyIndexRef.current = targetIndex;
-    setHistoryIndex(targetIndex);
-    setPreview(null);
-    setPreviewDraft("");
-    setTextPreviewMode("edit");
-    setPreviewError("");
-    await loadDirectory(targetPath, false);
-  };
-
-  const onForward = async () => {
-    if (!canGoForward || !confirmDiscardIfDirty()) return;
-    const targetIndex = historyIndex + 1;
-    const targetPath = history[targetIndex];
-    if (!targetPath) return;
-
-    historyIndexRef.current = targetIndex;
-    setHistoryIndex(targetIndex);
-    setPreview(null);
-    setPreviewDraft("");
-    setTextPreviewMode("edit");
-    setPreviewError("");
-    await loadDirectory(targetPath, false);
-  };
-
   const previewTableSheets =
     preview?.kind === "table" && Array.isArray(preview.tableSheets)
       ? preview.tableSheets
@@ -972,12 +1212,20 @@ export function FileExplorerPane({
     previewTableSheets.length > 0
       ? previewTableSheets[Math.min(activeTableSheetIndex, previewTableSheets.length - 1)]
       : null;
-  const bookmarkTargetPath = preview?.absolutePath ?? currentPath;
-  const bookmarkTargetLabel = preview?.name ?? getFolderName(currentPath);
+  const showInlinePreview = previewInPane && Boolean(preview || previewLoading || previewError);
+  const selectedFileEntry =
+    !previewInPane && selectedEntry && !selectedEntry.isDirectory
+      ? selectedEntry
+      : null;
+  const bookmarkTargetPath =
+    preview?.absolutePath ?? selectedFileEntry?.absolutePath ?? currentPath;
+  const bookmarkTargetLabel =
+    preview?.name ?? selectedFileEntry?.name ?? getFolderName(currentPath);
   const activeBookmark = fileBookmarks.find((bookmark) => bookmark.targetPath === bookmarkTargetPath);
-  const activeBookmarkId = preview?.absolutePath ?? currentPath;
+  const activeBookmarkId =
+    preview?.absolutePath ?? selectedFileEntry?.absolutePath ?? currentPath;
   const isCompact = containerWidth > 0 && containerWidth < 420;
-  const isVeryCompact = containerWidth > 0 && containerWidth < 320;
+  const normalizedQuery = query.trim().toLowerCase();
 
   const toggleBookmark = async () => {
     if (!bookmarkTargetPath) {
@@ -998,11 +1246,29 @@ export function FileExplorerPane({
 
   const openBookmarkedTarget = async (bookmark: FileBookmarkPayload) => {
     if (bookmark.isDirectory) {
-      await openPath(bookmark.targetPath);
+      setSelectedPath(bookmark.targetPath);
+      if (
+        !currentPathRef.current ||
+        !isPathWithin(currentPathRef.current, bookmark.targetPath)
+      ) {
+        await loadDirectory(bookmark.targetPath, true);
+        return;
+      }
+
+      await revealPathInTree(
+        `${bookmark.targetPath}${bookmark.targetPath.includes("\\") ? "\\" : "/"}.__bookmark__`,
+      );
+      const childEntries = await ensureDirectoryEntriesLoaded(bookmark.targetPath);
+      if (childEntries !== null) {
+        setExpandedDirectoryPaths((current) => ({
+          ...current,
+          [bookmark.targetPath]: true,
+        }));
+      }
       return;
     }
 
-    await openFilePreview(bookmark.targetPath, { skipConfirm: false, syncDirectory: true });
+    await openFileTarget(bookmark.targetPath, { skipConfirm: false, syncDirectory: true });
   };
 
   useEffect(() => {
@@ -1037,7 +1303,7 @@ export function FileExplorerPane({
       }
 
       try {
-        await openFilePreview(targetPath, { syncDirectory: true });
+        await openFileTarget(targetPath, { syncDirectory: true });
       } finally {
         if (!cancelled) {
           onFocusRequestConsumed?.(request.requestKey);
@@ -1052,7 +1318,7 @@ export function FileExplorerPane({
   }, [
     focusRequest,
     onFocusRequestConsumed,
-    openFilePreview,
+    openFileTarget,
     selectedWorkspaceId,
     workspaceRootPath,
   ]);
@@ -1060,11 +1326,11 @@ export function FileExplorerPane({
   const openEntryFromContextMenu = useCallback(async (entry: LocalFileEntry) => {
     closeContextMenu();
     if (entry.isDirectory) {
-      await openPath(entry.absolutePath);
+      await toggleDirectoryExpansion(entry);
       return;
     }
-    await openFilePreview(entry.absolutePath);
-  }, [closeContextMenu, openFilePreview]);
+    await openFileTarget(entry.absolutePath);
+  }, [closeContextMenu, openFileTarget, toggleDirectoryExpansion]);
 
   const submitRenameEntry = useCallback(async () => {
     if (!renamingEntry || renameInFlightRef.current) {
@@ -1086,7 +1352,9 @@ export function FileExplorerPane({
         nextName,
         selectedWorkspaceId ?? null,
       );
-      await loadDirectory(currentPath, false);
+      const parentPath =
+        getParentFolderPath(renamingEntry.absolutePath) ?? currentPathRef.current;
+      await refreshDirectoryEntries(parentPath);
       setSelectedPath(payload.absolutePath);
       stopRenamingEntry();
     } catch (cause) {
@@ -1101,10 +1369,9 @@ export function FileExplorerPane({
       setRenameSaving(false);
     }
   }, [
-    currentPath,
-    loadDirectory,
     renameDraft,
     renamingEntry,
+    refreshDirectoryEntries,
     selectedWorkspaceId,
     stopRenamingEntry,
   ]);
@@ -1137,13 +1404,15 @@ export function FileExplorerPane({
         entry.absolutePath,
         selectedWorkspaceId ?? null,
       );
-      await loadDirectory(currentPath, false);
+      const parentPath =
+        getParentFolderPath(entry.absolutePath) ?? currentPathRef.current;
+      await refreshDirectoryEntries(parentPath);
       setSelectedPath("");
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : "Failed to delete file.";
       setError(message);
     }
-  }, [closeContextMenu, currentPath, loadDirectory, selectedWorkspaceId]);
+  }, [closeContextMenu, refreshDirectoryEntries, selectedWorkspaceId]);
 
   const contextMenuPosition = useMemo(() => {
     if (!contextMenu) {
@@ -1164,491 +1433,490 @@ export function FileExplorerPane({
     };
   }, [contextMenu]);
 
-  return (
-    <>
-      <PaneCard
-        title={preview || previewLoading || previewError ? "File" : ""}
-        actions={
-          preview || previewLoading || previewError ? (
-            <>
-              <button
-                type="button"
-                onClick={closePreview}
-                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-              >
-                <ArrowLeft size={12} />
-                Files
-              </button>
-              <IconButton
-                icon={<Star size={12} className={activeBookmark ? "fill-current" : ""} />}
-                label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
-                active={Boolean(activeBookmark)}
-                onClick={() => void toggleBookmark()}
-                disabled={!bookmarkTargetPath}
-              />
-              {isMarkdownPreview ? (
-                <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
-                  <button
-                    type="button"
-                    onClick={() => setTextPreviewMode("preview")}
-                    className={`rounded px-2 py-1 text-xs transition-colors ${
-                      textPreviewMode === "preview"
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                    }`}
-                  >
-                    Preview
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setTextPreviewMode("edit")}
-                    className={`rounded px-2 py-1 text-xs transition-colors ${
-                      textPreviewMode === "edit"
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                    }`}
-                  >
-                    Edit
-                  </button>
-                </div>
-              ) : null}
-              {preview?.isEditable ? (
-                <button
-                  type="button"
-                  onClick={() => void savePreview()}
-                  disabled={!isDirty || saving}
-                  className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  <Save size={12} />
-                  {saving ? "Saving" : "Save"}
-                </button>
-              ) : null}
-            </>
-          ) : undefined
-        }
-      >
-        {preview || previewLoading || previewError ? (
-          <div className="flex h-full min-h-0 flex-col">
-          <div className="shrink-0 border-b border-border px-4 py-2.5">
-            <div className="truncate text-sm font-semibold text-foreground">
-              {preview?.name || selectedEntry?.name || "Preview"}
-              {isDirty ? <span className="ml-2 text-xs text-primary">unsaved</span> : null}
-            </div>
-            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
-              {preview?.absolutePath ? <span>{preview.absolutePath}</span> : null}
-              {preview?.size != null ? <span>{formatFileSize(preview.size)}</span> : null}
-              {preview?.modifiedAt ? <span>{formatModified(preview.modifiedAt)}</span> : null}
-            </div>
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-hidden p-2.5">
-            {previewLoading ? (
-              <div className="grid h-full place-items-center rounded-lg border border-border bg-muted text-sm text-muted-foreground">
-                Loading file...
-              </div>
-            ) : previewError ? (
-              <div className="grid h-full place-items-center rounded-lg border border-destructive/30 bg-destructive/5 px-4 text-center text-sm text-destructive">
-                {previewError}
-              </div>
-            ) : preview?.kind === "text" ? (
-              isMarkdownPreview && textPreviewMode === "preview" ? (
-                <div className="h-full overflow-auto rounded-lg border border-border bg-muted/55 p-4">
-                  {previewDraft.trim() ? (
-                    <SimpleMarkdown
-                      className="chat-markdown text-sm text-foreground"
-                      onLinkClick={openPreviewLink}
-                    >
-                      {previewDraft}
-                    </SimpleMarkdown>
-                  ) : (
-                    <div className="grid h-full min-h-[120px] place-items-center text-sm text-muted-foreground">
-                      Nothing to preview yet.
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <textarea
-                  value={previewDraft}
-                  onChange={(event) => setPreviewDraft(event.target.value)}
-                  readOnly={!preview.isEditable}
-                  spellCheck={false}
-                  className={`h-full w-full resize-none rounded-lg border border-border bg-muted p-4 font-mono text-xs leading-6 text-foreground outline-none transition-colors ${
-                    preview.isEditable
-                      ? "embedded-input focus:border-border/70"
-                      : "cursor-default opacity-90"
-                  }`}
-                />
-              )
-            ) : preview?.kind === "image" && preview.dataUrl ? (
-              <div className="flex h-full items-center justify-center overflow-auto rounded-lg border border-border bg-muted p-3">
-                <img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-md object-contain" />
-              </div>
-            ) : preview?.kind === "pdf" && preview.dataUrl ? (
-              <div className="h-full overflow-hidden rounded-lg border border-border bg-white">
-                <iframe src={preview.dataUrl} title={preview.name} className="h-full w-full border-0" />
-              </div>
-            ) : preview?.kind === "table" && activeTableSheet ? (
-              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-muted">
-                {previewTableSheets.length > 1 ? (
-                  <div className="chat-scrollbar-hidden flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border p-2">
-                    {previewTableSheets.map((sheet, index) => {
-                      const isActive = index === activeTableSheetIndex;
-                      return (
-                        <button
-                          key={`${sheet.name}-${sheet.index}`}
-                          type="button"
-                          onClick={() => setActiveTableSheetIndex(index)}
-                          className={`rounded-md border px-2 py-1 text-[11px] transition-colors ${
-                            isActive
-                              ? "border-primary/35 bg-primary/12 text-primary"
-                              : "border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                          }`}
-                        >
-                          {sheet.name}
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : null}
-                <div className="min-h-0 flex-1 overflow-auto">
-                  <table className="w-max min-w-full border-collapse text-xs text-foreground">
-                    <thead className="sticky top-0 z-[1] bg-muted">
-                      <tr>
-                        <th className="border-b border-r border-border bg-muted px-2 py-1.5 text-left text-[11px] text-muted-foreground">
-                          #
-                        </th>
-                        {activeTableSheet.columns.map((column, columnIndex) => (
-                          <th
-                            key={`${column}-${columnIndex}`}
-                            className="border-b border-r border-border bg-muted px-2 py-1.5 text-left text-[11px] text-muted-foreground"
-                          >
-                            {column}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {activeTableSheet.rows.length === 0 ? (
-                        <tr>
-                          <td
-                            colSpan={activeTableSheet.columns.length + 1}
-                            className="px-3 py-4 text-center text-xs text-muted-foreground"
-                          >
-                            No rows in this sheet.
-                          </td>
-                        </tr>
-                      ) : (
-                        activeTableSheet.rows.map((row, rowIndex) => (
-                          <tr key={`row-${rowIndex}`} className="odd:bg-background/20 even:bg-transparent">
-                            <td className="border-b border-r border-border px-2 py-1.5 align-top text-[11px] text-muted-foreground">
-                              {rowIndex + 1}
-                            </td>
-                            {row.map((value, columnIndex) => (
-                              <td
-                                key={`cell-${rowIndex}-${columnIndex}`}
-                                className="max-w-[320px] border-b border-r border-border px-2 py-1.5 align-top"
-                              >
-                                <div className="break-words whitespace-pre-wrap">{value || "\u00a0"}</div>
-                              </td>
-                            ))}
-                          </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                </div>
-                {activeTableSheet.truncated ? (
-                  <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
-                    Showing {activeTableSheet.rows.length} of {activeTableSheet.totalRows} rows and{" "}
-                    {Math.min(activeTableSheet.columns.length, activeTableSheet.totalColumns)} of{" "}
-                    {Math.max(activeTableSheet.totalColumns, activeTableSheet.columns.length)} columns.
-                  </div>
-                ) : null}
-              </div>
-            ) : (
-              <div className="flex h-full flex-col items-center justify-center rounded-lg border border-border bg-muted px-5 text-center">
-                <FileText size={22} className="mb-3 text-muted-foreground" />
-                <div className="text-sm font-medium text-foreground">Preview unavailable</div>
-                <div className="mt-2 max-w-xs text-xs leading-6 text-muted-foreground">
-                  {preview?.unsupportedReason || "This file type is not supported for inline preview yet."}
-                </div>
-              </div>
-            )}
-          </div>
+  const content = showInlinePreview ? (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 border-b border-border px-4 py-2.5">
+        <div className="truncate text-sm font-semibold text-foreground">
+          {preview?.name || selectedEntry?.name || "Preview"}
+          {isDirty ? <span className="ml-2 text-xs text-primary">unsaved</span> : null}
         </div>
-      ) : (
-          <div ref={containerRef} className="flex h-full min-h-0">
-          {fileBookmarks.length > 0 ? (
-            <aside className="flex w-11 flex-col items-center gap-1.5 border-r border-border py-2.5">
-              <div className="chat-scrollbar-hidden flex min-h-0 flex-1 flex-col items-center gap-1 overflow-x-hidden overflow-y-auto px-1">
-                {fileBookmarks.map((bookmark) => {
-                  const isActive = activeBookmarkId === bookmark.targetPath;
-                  const { Icon, className } = getExplorerIconDescriptor(
-                    bookmark.targetPath,
-                    bookmark.isDirectory
-                  );
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+          {preview?.size != null ? <span>{formatFileSize(preview.size)}</span> : null}
+          {preview?.modifiedAt ? <span>{formatModified(preview.modifiedAt)}</span> : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden p-2.5">
+        {previewLoading ? (
+          <div className="grid h-full place-items-center rounded-lg border border-border bg-muted text-sm text-muted-foreground">
+            Loading file...
+          </div>
+        ) : previewError ? (
+          <div className="grid h-full place-items-center rounded-lg border border-destructive/30 bg-destructive/5 px-4 text-center text-sm text-destructive">
+            {previewError}
+          </div>
+        ) : preview?.kind === "text" ? (
+          isMarkdownPreview && textPreviewMode === "preview" ? (
+            <div className="h-full overflow-auto rounded-lg border border-border bg-muted/55 p-4">
+              {previewDraft.trim() ? (
+                <SimpleMarkdown
+                  className="chat-markdown text-sm text-foreground"
+                  onLinkClick={openPreviewLink}
+                >
+                  {previewDraft}
+                </SimpleMarkdown>
+              ) : (
+                <div className="grid h-full min-h-[120px] place-items-center text-sm text-muted-foreground">
+                  Nothing to preview yet.
+                </div>
+              )}
+            </div>
+          ) : (
+            <textarea
+              value={previewDraft}
+              onChange={(event) => setPreviewDraft(event.target.value)}
+              readOnly={!preview.isEditable}
+              spellCheck={false}
+              className={`h-full w-full resize-none rounded-lg border border-border bg-muted p-4 font-mono text-xs leading-6 text-foreground outline-none transition-colors ${
+                preview.isEditable
+                  ? "embedded-input focus:border-border/70"
+                  : "cursor-default opacity-90"
+              }`}
+            />
+          )
+        ) : preview?.kind === "image" && preview.dataUrl ? (
+          <div className="flex h-full items-center justify-center overflow-auto rounded-lg border border-border bg-muted p-3">
+            <img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-md object-contain" />
+          </div>
+        ) : preview?.kind === "pdf" && preview.dataUrl ? (
+          <div className="h-full overflow-hidden rounded-lg border border-border bg-white">
+            <iframe src={preview.dataUrl} title={preview.name} className="h-full w-full border-0" />
+          </div>
+        ) : preview?.kind === "table" && activeTableSheet ? (
+          <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-muted">
+            {previewTableSheets.length > 1 ? (
+              <div className="chat-scrollbar-hidden flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border p-2">
+                {previewTableSheets.map((sheet, index) => {
+                  const isActive = index === activeTableSheetIndex;
                   return (
                     <button
-                      key={bookmark.id}
+                      key={`${sheet.name}-${sheet.index}`}
                       type="button"
-                      onClick={() => void openBookmarkedTarget(bookmark)}
-                      title={bookmark.label}
-                      className={`grid size-7 shrink-0 place-items-center rounded-md transition-colors ${
+                      onClick={() => setActiveTableSheetIndex(index)}
+                      className={`rounded-md border px-2 py-1 text-[11px] transition-colors ${
                         isActive
-                          ? "bg-primary/12 text-primary"
-                          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                          ? "border-primary/35 bg-primary/12 text-primary"
+                          : "border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                       }`}
                     >
-                      <Icon size={14} className={className} />
+                      {sheet.name}
                     </button>
                   );
                 })}
               </div>
-            </aside>
-          ) : null}
-
-          <div className="flex min-w-0 flex-1 flex-col">
-            <div className="shrink-0 border-b border-border px-3 py-2">
-              <div className="mb-2 flex min-w-0 items-center gap-0.5">
-                <IconButton icon={<Undo2 size={13} />} label="Back" onClick={() => void onBack()} disabled={!canGoBack} />
-                <IconButton icon={<Forward size={13} />} label="Forward" onClick={() => void onForward()} disabled={!canGoForward} />
-                {!isVeryCompact ? (
-                  <IconButton
-                    icon={<Home size={13} />}
-                    label="Home"
-                    onClick={() => {
-                      void openHomeDirectory();
-                    }}
-                    disabled={isAtWorkspaceRoot}
-                  />
-                ) : null}
-                <div className="min-w-0 flex-1" />
-                <IconButton
-                  icon={<Star size={13} className={activeBookmark ? "fill-current" : ""} />}
-                  label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
-                  active={Boolean(activeBookmark)}
-                  onClick={() => void toggleBookmark()}
-                  disabled={!bookmarkTargetPath}
-                />
-              </div>
-              <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1.5 text-xs transition-colors focus-within:border-ring">
-                <Search size={13} className="shrink-0 text-muted-foreground" />
-                <input
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  className="embedded-input w-full bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/50"
-                  placeholder="Search files"
-                />
-              </div>
-              <div className="chat-scrollbar-hidden mt-1.5 flex items-center gap-1 overflow-x-auto text-[10px] uppercase tracking-widest text-muted-foreground/60">
-                {breadcrumbs.length > 0 ? (
-                  breadcrumbs.map((breadcrumb) => (
-                    <div
-                      key={breadcrumb.absolutePath}
-                      className="flex shrink-0 items-center gap-1"
-                    >
-                      {breadcrumb !== breadcrumbs[0] ? (
-                        <ChevronRight size={10} className="text-muted-foreground/45" />
-                      ) : null}
-                      {breadcrumb.isCurrent ? (
-                        <span className="truncate text-foreground/78">
-                          {breadcrumb.label}
-                        </span>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void openPath(breadcrumb.absolutePath);
-                          }}
-                          className="truncate transition-colors hover:text-foreground"
-                        >
-                          {breadcrumb.label}
-                        </button>
-                      )}
-                    </div>
-                  ))
-                ) : (
-                  <span>{isCompact ? getFolderName(currentPath) : currentPath}</span>
-                )}
-              </div>
+            ) : null}
+            <div className="min-h-0 flex-1 overflow-auto">
+              <table className="w-max min-w-full border-collapse text-xs text-foreground">
+                <thead className="sticky top-0 z-[1] bg-muted">
+                  <tr>
+                    <th className="border-b border-r border-border bg-muted px-2 py-1.5 text-left text-[11px] text-muted-foreground">
+                      #
+                    </th>
+                    {activeTableSheet.columns.map((column, columnIndex) => (
+                      <th
+                        key={`${column}-${columnIndex}`}
+                        className="border-b border-r border-border bg-muted px-2 py-1.5 text-left text-[11px] text-muted-foreground"
+                      >
+                        {column}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeTableSheet.rows.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={activeTableSheet.columns.length + 1}
+                        className="px-3 py-4 text-center text-xs text-muted-foreground"
+                      >
+                        No rows in this sheet.
+                      </td>
+                    </tr>
+                  ) : (
+                    activeTableSheet.rows.map((row, rowIndex) => (
+                      <tr key={`row-${rowIndex}`} className="odd:bg-background/20 even:bg-transparent">
+                        <td className="border-b border-r border-border px-2 py-1.5 align-top text-[11px] text-muted-foreground">
+                          {rowIndex + 1}
+                        </td>
+                        {row.map((value, columnIndex) => (
+                          <td
+                            key={`cell-${rowIndex}-${columnIndex}`}
+                            className="max-w-[320px] border-b border-r border-border px-2 py-1.5 align-top"
+                          >
+                            <div className="break-words whitespace-pre-wrap">{value || "\u00a0"}</div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
             </div>
-
-            {!isCompact ? (
-              <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_110px] border-b border-border px-3 py-1.5 text-[10px] uppercase tracking-widest text-muted-foreground/60 lg:grid-cols-[minmax(0,1fr)_140px_90px]">
-                <span>Name</span>
-                <span>Modified</span>
-                <span className="hidden lg:block">Size</span>
+            {activeTableSheet.truncated ? (
+              <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+                Showing {activeTableSheet.rows.length} of {activeTableSheet.totalRows} rows and{" "}
+                {Math.min(activeTableSheet.columns.length, activeTableSheet.totalColumns)} of{" "}
+                {Math.max(activeTableSheet.totalColumns, activeTableSheet.columns.length)} columns.
               </div>
             ) : null}
-
-            <div className="chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1">
-              {loading ? <div className="px-2 py-4 text-xs text-muted-foreground">Loading directory...</div> : null}
-
-              {error ? <div className="px-2 py-3 text-xs text-destructive">{error}</div> : null}
-
-              {!loading && !error && filteredEntries.length === 0 ? (
-                <div className="px-2 py-4 text-xs text-muted-foreground">No files matched your search.</div>
-              ) : null}
-
-              {!loading && !error
-                ? filteredEntries.map((entry) => {
-                    const { Icon, className } = getExplorerIconDescriptor(
-                      entry.name,
-                      entry.isDirectory
-                    );
-                    const selected = selectedPath === entry.absolutePath;
-                    const isRenaming = renamingPath === entry.absolutePath;
-                    const rowClassName = `group mb-0.5 w-full rounded-md px-2 py-1.5 text-left transition-colors ${
-                      selected
-                        ? "bg-primary/10 text-primary"
-                        : "text-foreground/80 hover:bg-accent hover:text-accent-foreground"
-                    } ${isRenaming ? "cursor-default" : "cursor-pointer"}`;
-                    const nameField = isRenaming ? (
-                      <input
-                        ref={renameInputRef}
-                        value={renameDraft}
-                        onChange={(event) => setRenameDraft(event.target.value)}
-                        onBlur={() => {
-                          void submitRenameEntry();
-                        }}
-                        onClick={(event) => event.stopPropagation()}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter") {
-                            event.preventDefault();
-                            void submitRenameEntry();
-                            return;
-                          }
-                          if (event.key === "Escape") {
-                            event.preventDefault();
-                            cancelRenameEntry();
-                          }
-                        }}
-                        disabled={renameSaving}
-                        className="embedded-input h-6 min-w-0 flex-1 rounded-sm border border-border/70 bg-background px-1.5 text-xs font-medium text-foreground outline-none focus:border-ring disabled:opacity-60"
-                      />
-                    ) : (
-                      <span className="truncate text-xs font-medium">{entry.name}</span>
-                    );
-                    const rowContent = isCompact ? (
-                      <span className="flex min-w-0 flex-col gap-0.5">
-                        <span className="flex min-w-0 items-center gap-2">
-                          <Icon size={14} className={`shrink-0 ${className}`} />
-                          {nameField}
-                        </span>
-                        <span className="flex min-w-0 items-center gap-2 pl-6 text-[11px] text-muted-foreground">
-                          <span className="truncate">{formatModified(entry.modifiedAt)}</span>
-                          {!entry.isDirectory ? <span className="shrink-0">{formatFileSize(entry.size)}</span> : null}
-                        </span>
-                      </span>
-                    ) : (
-                      <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_110px] items-center lg:grid-cols-[minmax(0,1fr)_140px_90px]">
-                        <span className="flex min-w-0 items-center gap-2">
-                          <Icon size={14} className={className} />
-                          {nameField}
-                        </span>
-                        <span className="truncate text-[11px] text-muted-foreground">
-                          {formatModified(entry.modifiedAt)}
-                        </span>
-                        <span className="hidden text-[11px] text-muted-foreground lg:block">
-                          {entry.isDirectory ? "-" : formatFileSize(entry.size)}
-                        </span>
-                      </span>
-                    );
-                    return (
-                    <div
-                      key={entry.absolutePath}
-                      className={rowClassName}
-                      title={
-                        entry.isDirectory
-                          ? `${entry.name} — double-click to open folder`
-                          : `${entry.name} — drag into chat to attach`
-                      }
-                    >
-                      {isRenaming ? (
-                        <div className="w-full">
-                          {rowContent}
-                        </div>
-                      ) : (
-                        <button
-                          type="button"
-                          draggable={!entry.isDirectory}
-                          onClick={() => {
-                            setSelectedPath(entry.absolutePath);
-                            closeContextMenu();
-                          }}
-                          onContextMenu={(event) => {
-                            event.preventDefault();
-                            const paneRect = containerRef.current?.getBoundingClientRect();
-                            if (!paneRect) {
-                              return;
-                            }
-                            setSelectedPath(entry.absolutePath);
-                            setContextMenu({
-                              entry,
-                              x: event.clientX,
-                              y: event.clientY,
-                              paneBounds: {
-                                left: paneRect.left,
-                                top: paneRect.top,
-                                right: paneRect.right,
-                                bottom: paneRect.bottom,
-                                width: paneRect.width,
-                                height: paneRect.height,
-                              },
-                            });
-                          }}
-                          onDoubleClick={() => {
-                            if (entry.isDirectory) {
-                              void openPath(entry.absolutePath);
-                              return;
-                            }
-                            void openFilePreview(entry.absolutePath);
-                          }}
-                          onDragStart={(event) => {
-                            if (entry.isDirectory) {
-                              event.preventDefault();
-                              return;
-                            }
-
-                            event.dataTransfer.effectAllowed = "copy";
-                            event.dataTransfer.setData(
-                              EXPLORER_ATTACHMENT_DRAG_TYPE,
-                              serializeExplorerAttachmentDragPayload({
-                                absolutePath: entry.absolutePath,
-                                name: entry.name,
-                                size: entry.size,
-                              })
-                            );
-                            event.dataTransfer.setData("text/plain", entry.name);
-                            const preview = createAttachmentDragPreview(entry);
-                            dragPreviewRef.current?.remove();
-                            dragPreviewRef.current = preview;
-                            event.dataTransfer.setDragImage(preview, 18, 18);
-                          }}
-                          onDragEnd={() => {
-                            dragPreviewRef.current?.remove();
-                            dragPreviewRef.current = null;
-                          }}
-                          className="w-full cursor-pointer text-left"
-                          title={
-                            entry.isDirectory
-                              ? `${entry.name} — double-click to open folder`
-                              : `${entry.name} — drag into chat to attach`
-                          }
-                        >
-                          {rowContent}
-                        </button>
-                      )}
-                    </div>
-                    );
-                  })
-                : null}
-            </div>
-
           </div>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center rounded-lg border border-border bg-muted px-5 text-center">
+            <FileText size={22} className="mb-3 text-muted-foreground" />
+            <div className="text-sm font-medium text-foreground">Preview unavailable</div>
+            <div className="mt-2 max-w-xs text-xs leading-6 text-muted-foreground">
+              {preview?.unsupportedReason || "This file type is not supported for inline preview yet."}
+            </div>
           </div>
         )}
-      </PaneCard>
+      </div>
+    </div>
+  ) : (
+    <div ref={containerRef} className="flex h-full min-h-0">
+      {fileBookmarks.length > 0 ? (
+        <aside className="flex w-11 flex-col items-center gap-1.5 border-r border-border py-2.5">
+          <div className="chat-scrollbar-hidden flex min-h-0 flex-1 flex-col items-center gap-1 overflow-x-hidden overflow-y-auto px-1">
+            {fileBookmarks.map((bookmark) => {
+              const isActive = activeBookmarkId === bookmark.targetPath;
+              const { Icon, className } = getExplorerIconDescriptor(
+                bookmark.targetPath,
+                bookmark.isDirectory
+              );
+              return (
+                <button
+                  key={bookmark.id}
+                  type="button"
+                  onClick={() => void openBookmarkedTarget(bookmark)}
+                  title={bookmark.label}
+                  className={`grid size-7 shrink-0 place-items-center rounded-md transition-colors ${
+                    isActive
+                      ? "bg-primary/12 text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                >
+                  <Icon size={14} className={className} />
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+      ) : null}
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="shrink-0 border-b border-border px-3 py-2">
+          <div className="mb-2 flex min-w-0 items-center gap-2">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground/72">
+                Files
+              </div>
+            </div>
+            <IconButton
+              icon={<Star size={13} className={activeBookmark ? "fill-current" : ""} />}
+              label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
+              active={Boolean(activeBookmark)}
+              onClick={() => void toggleBookmark()}
+              disabled={!bookmarkTargetPath}
+            />
+          </div>
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1.5 text-xs transition-colors focus-within:border-ring">
+            <Search size={13} className="shrink-0 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="embedded-input w-full bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/50"
+              placeholder="Search files"
+            />
+          </div>
+        </div>
+
+        <div className="chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1">
+          {loading ? <div className="px-2 py-4 text-xs text-muted-foreground">Loading directory...</div> : null}
+
+          {error ? <div className="px-2 py-3 text-xs text-destructive">{error}</div> : null}
+
+          {!loading && !error && filteredEntries.length === 0 ? (
+            <div className="px-2 py-4 text-xs text-muted-foreground">No files matched your search.</div>
+          ) : null}
+
+          {!loading && !error
+            ? filteredEntries.map((row) => {
+                if (row.type === "feedback") {
+                  return (
+                    <div
+                      key={row.id}
+                      className={`mb-0.5 rounded-md px-2 py-1.5 text-[11px] ${
+                        row.tone === "error"
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
+                      style={{ paddingLeft: `${8 + row.depth * 16}px` }}
+                    >
+                      {row.message}
+                    </div>
+                  );
+                }
+
+                const { entry, depth, isExpanded, isLoadingChildren } = row;
+                const { Icon, className } = getExplorerIconDescriptor(
+                  entry.name,
+                  entry.isDirectory
+                );
+                const selected = selectedPath === entry.absolutePath;
+                const isRenaming = renamingPath === entry.absolutePath;
+                const rowClassName = `group mb-0.5 w-full rounded-md px-2 py-1.5 text-left transition-colors ${
+                  selected
+                    ? "bg-primary/10 text-primary"
+                    : "text-foreground/80 hover:bg-accent hover:text-accent-foreground"
+                } ${isRenaming ? "cursor-default" : "cursor-pointer"}`;
+                const nameField = isRenaming ? (
+                  <input
+                    ref={renameInputRef}
+                    value={renameDraft}
+                    onChange={(event) => setRenameDraft(event.target.value)}
+                    onBlur={() => {
+                      void submitRenameEntry();
+                    }}
+                    onClick={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void submitRenameEntry();
+                        return;
+                      }
+                      if (event.key === "Escape") {
+                        event.preventDefault();
+                        cancelRenameEntry();
+                      }
+                    }}
+                    disabled={renameSaving}
+                    className="embedded-input h-6 min-w-0 flex-1 rounded-sm border border-border/70 bg-background px-1.5 text-xs font-medium text-foreground outline-none focus:border-ring disabled:opacity-60"
+                  />
+                ) : (
+                  <span className="truncate text-xs font-medium">{entry.name}</span>
+                );
+                const disclosureControl = entry.isDirectory ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      void toggleDirectoryExpansion(entry);
+                    }}
+                    className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
+                  >
+                    <ChevronRight
+                      size={12}
+                      className={`transition-transform duration-200 ${
+                        isExpanded ? "rotate-90" : ""
+                      } ${isLoadingChildren ? "opacity-60" : ""}`}
+                    />
+                  </button>
+                ) : (
+                  <span className="size-4 shrink-0" />
+                );
+                const rowContent = (
+                  <span className="flex min-w-0 flex-col gap-0.5">
+                    <span
+                      className="flex min-w-0 items-center gap-2"
+                      style={{ paddingLeft: `${depth * 16}px` }}
+                    >
+                      {disclosureControl}
+                      <Icon size={14} className={`shrink-0 ${className}`} />
+                      {nameField}
+                    </span>
+                    <span
+                      className="flex min-w-0 items-center gap-2 pl-6 text-[11px] text-muted-foreground"
+                      style={{ paddingLeft: `${depth * 16 + 24}px` }}
+                    >
+                      <span className="truncate">{formatModified(entry.modifiedAt)}</span>
+                      {!entry.isDirectory ? <span className="shrink-0">{formatFileSize(entry.size)}</span> : null}
+                    </span>
+                  </span>
+                );
+                return (
+                <div
+                  key={entry.absolutePath}
+                  className={rowClassName}
+                  title={
+                    entry.isDirectory
+                      ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
+                      : previewInPane
+                        ? `${entry.name} — drag into chat to attach`
+                        : `${entry.name} — click to open file, drag into chat to attach`
+                  }
+                >
+                  {isRenaming ? (
+                    <div className="w-full">
+                      {rowContent}
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      draggable={!entry.isDirectory}
+                      onClick={() => {
+                        setSelectedPath(entry.absolutePath);
+                        closeContextMenu();
+                        if (entry.isDirectory) {
+                          void toggleDirectoryExpansion(entry);
+                          return;
+                        }
+                        if (!previewInPane) {
+                          void openFileTarget(entry.absolutePath);
+                        }
+                      }}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        const paneRect = containerRef.current?.getBoundingClientRect();
+                        if (!paneRect) {
+                          return;
+                        }
+                        setSelectedPath(entry.absolutePath);
+                        setContextMenu({
+                          entry,
+                          x: event.clientX,
+                          y: event.clientY,
+                          paneBounds: {
+                            left: paneRect.left,
+                            top: paneRect.top,
+                            right: paneRect.right,
+                            bottom: paneRect.bottom,
+                            width: paneRect.width,
+                            height: paneRect.height,
+                          },
+                        });
+                      }}
+                      onDoubleClick={() => {
+                        if (!entry.isDirectory && previewInPane) {
+                          void openFilePreview(entry.absolutePath);
+                        }
+                      }}
+                      onDragStart={(event) => {
+                        if (entry.isDirectory) {
+                          event.preventDefault();
+                          return;
+                        }
+
+                        event.dataTransfer.effectAllowed = "copy";
+                        event.dataTransfer.setData(
+                          EXPLORER_ATTACHMENT_DRAG_TYPE,
+                          serializeExplorerAttachmentDragPayload({
+                            absolutePath: entry.absolutePath,
+                            name: entry.name,
+                            size: entry.size,
+                          })
+                        );
+                        event.dataTransfer.setData("text/plain", entry.name);
+                        const preview = createAttachmentDragPreview(entry);
+                        dragPreviewRef.current?.remove();
+                        dragPreviewRef.current = preview;
+                        event.dataTransfer.setDragImage(preview, 18, 18);
+                      }}
+                      onDragEnd={() => {
+                        dragPreviewRef.current?.remove();
+                        dragPreviewRef.current = null;
+                      }}
+                      className="w-full cursor-pointer text-left"
+                      title={
+                        entry.isDirectory
+                          ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
+                          : previewInPane
+                            ? `${entry.name} — drag into chat to attach`
+                            : `${entry.name} — click to open file, drag into chat to attach`
+                      }
+                    >
+                      {rowContent}
+                    </button>
+                  )}
+                </div>
+                );
+              })
+            : null}
+        </div>
+      </div>
+    </div>
+  );
+
+  const explorerPane = embedded ? (
+    content
+  ) : (
+    <PaneCard
+      title={showInlinePreview ? "File" : ""}
+      actions={
+        showInlinePreview ? (
+          <>
+            <button
+              type="button"
+              onClick={closePreview}
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <ArrowLeft size={12} />
+              Files
+            </button>
+            <IconButton
+              icon={<Star size={12} className={activeBookmark ? "fill-current" : ""} />}
+              label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
+              active={Boolean(activeBookmark)}
+              onClick={() => void toggleBookmark()}
+              disabled={!bookmarkTargetPath}
+            />
+            {isMarkdownPreview ? (
+              <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setTextPreviewMode("preview")}
+                  className={`rounded px-2 py-1 text-xs transition-colors ${
+                    textPreviewMode === "preview"
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                >
+                  Preview
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setTextPreviewMode("edit")}
+                  className={`rounded px-2 py-1 text-xs transition-colors ${
+                    textPreviewMode === "edit"
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                >
+                  Edit
+                </button>
+              </div>
+            ) : null}
+            {preview?.isEditable ? (
+              <button
+                type="button"
+                onClick={() => void savePreview()}
+                disabled={!isDirty || saving}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Save size={12} />
+                {saving ? "Saving" : "Save"}
+              </button>
+            ) : null}
+          </>
+        ) : undefined
+      }
+    >
+      {content}
+    </PaneCard>
+  );
+
+  return (
+    <>
+      {explorerPane}
       {contextMenu && contextMenuPosition
         ? createPortal(
             <div
@@ -1663,7 +1931,11 @@ export function FileExplorerPane({
                 }}
                 className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
               >
-                {contextMenu.entry.isDirectory ? "Open folder" : "Open file"}
+                {contextMenu.entry.isDirectory
+                  ? expandedDirectoryPaths[contextMenu.entry.absolutePath]
+                    ? "Collapse folder"
+                    : "Expand folder"
+                  : "Open file"}
               </button>
               <button
                 type="button"

--- a/desktop/src/components/panes/InternalSurfacePane.test.mjs
+++ b/desktop/src/components/panes/InternalSurfacePane.test.mjs
@@ -13,7 +13,39 @@ test("internal surface renders markdown files with the shared markdown renderer"
   assert.match(source, /import \{ SimpleMarkdown \} from "@\/components\/marketplace\/SimpleMarkdown";/);
   assert.match(source, /const MARKDOWN_PREVIEW_EXTENSIONS = new Set\(\[\s*"\.md",\s*"\.mdx",\s*"\.markdown",\s*\]\);/);
   assert.match(source, /function isMarkdownPreviewPayload\(/);
-  assert.match(source, /if \(preview\.kind === "text"\) \{[\s\S]*if \(isMarkdownPreviewPayload\(preview\)\) \{/);
-  assert.match(source, /<SimpleMarkdown[\s\S]*className="chat-markdown text-sm text-foreground\/90"[\s\S]*onLinkClick=\{openPreviewLink\}[\s\S]*\{preview\.content\}[\s\S]*<\/SimpleMarkdown>/);
+  assert.match(source, /const \[textPreviewMode, setTextPreviewMode\] =\s*useState<TextPreviewMode>\("edit"\);/);
+  assert.match(source, /setTextPreviewMode\("edit"\);/);
+  assert.match(source, /if \(preview\.kind === "text"\) \{[\s\S]*\{isMarkdownPreview && textPreviewMode === "preview" \? \(/);
+  assert.match(source, /<SimpleMarkdown[\s\S]*className="chat-markdown text-sm text-foreground\/90"[\s\S]*onLinkClick=\{openPreviewLink\}[\s\S]*\{previewDraft\}[\s\S]*<\/SimpleMarkdown>/);
   assert.match(source, /window\.electronAPI\.ui\.openExternalUrl\(url\)/);
+});
+
+test("internal surface preview omits absolute path metadata", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(
+    source,
+    /MetadataRow label="Path" value=\{preview\.absolutePath\}/,
+  );
+  assert.doesNotMatch(
+    source,
+    /MetadataRow label="Target" value=\{resourceId\}/,
+  );
+});
+
+test("internal surface enables editing and saving for file displays", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const savePreview = useCallback\(async \(\) => \{[\s\S]*window\.electronAPI\.fs\.writeTextFile\(\s*preview\.absolutePath,\s*previewDraft,\s*selectedWorkspaceId \?\? null,\s*\)/,
+  );
+  assert.match(
+    source,
+    /<textarea[\s\S]*value=\{previewDraft\}[\s\S]*onChange=\{\(event\) => setPreviewDraft\(event\.target\.value\)\}[\s\S]*readOnly=\{!preview\.isEditable\}/,
+  );
+  assert.match(
+    source,
+    /{preview\.isEditable \? \(\s*<button[\s\S]*onClick=\{\(\) => void savePreview\(\)\}[\s\S]*\{isSaving \? "Saving" : "Save"\}/,
+  );
 });

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { FileText, FileWarning, Loader2 } from "lucide-react";
+import { FileText, FileWarning, Loader2, Save } from "lucide-react";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -16,8 +16,12 @@ const MARKDOWN_PREVIEW_EXTENSIONS = new Set([
   ".mdx",
   ".markdown",
 ]);
+type TextPreviewMode = "edit" | "preview";
 
-function resolveWorkspaceTargetPath(workspaceRoot: string, resourceId: string): string {
+function resolveWorkspaceTargetPath(
+  workspaceRoot: string,
+  resourceId: string,
+): string {
   const trimmedRoot = workspaceRoot.trim();
   const trimmedResource = resourceId.trim();
   if (!trimmedRoot) {
@@ -38,14 +42,24 @@ function isMarkdownPreviewPayload(
   if (!preview || preview.kind !== "text") {
     return false;
   }
-  return MARKDOWN_PREVIEW_EXTENSIONS.has(preview.extension.trim().toLowerCase());
+  return MARKDOWN_PREVIEW_EXTENSIONS.has(
+    preview.extension.trim().toLowerCase(),
+  );
 }
 
-export function InternalSurfacePane({ surface, resourceId, htmlContent }: InternalSurfacePaneProps) {
+export function InternalSurfacePane({
+  surface,
+  resourceId,
+  htmlContent,
+}: InternalSurfacePaneProps) {
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const [preview, setPreview] = useState<FilePreviewPayload | null>(null);
+  const [previewDraft, setPreviewDraft] = useState("");
+  const [textPreviewMode, setTextPreviewMode] =
+    useState<TextPreviewMode>("edit");
   const [activeTableSheetIndex, setActiveTableSheetIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const openPreviewLink = useCallback((url: string) => {
     void window.electronAPI.ui.openExternalUrl(url);
@@ -54,9 +68,12 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
   useEffect(() => {
     if (typeof resourceId !== "string" || !resourceId || (surface !== "document" && surface !== "file")) {
       setPreview(null);
+      setPreviewDraft("");
+      setTextPreviewMode("edit");
       setActiveTableSheetIndex(0);
       setErrorMessage("");
       setIsLoading(false);
+      setIsSaving(false);
       return;
     }
 
@@ -79,13 +96,19 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
         const nextPreview = await window.electronAPI.fs.readFilePreview(targetPath, selectedWorkspaceId ?? null);
         if (!cancelled) {
           setPreview(nextPreview);
+          setPreviewDraft(nextPreview.content ?? "");
+          setTextPreviewMode("edit");
           setActiveTableSheetIndex(0);
+          setIsSaving(false);
         }
       } catch (error) {
         if (!cancelled) {
           setPreview(null);
+          setPreviewDraft("");
+          setTextPreviewMode("edit");
           setActiveTableSheetIndex(0);
           setErrorMessage(error instanceof Error ? error.message : "Failed to load output preview.");
+          setIsSaving(false);
         }
       } finally {
         if (!cancelled) {
@@ -100,6 +123,40 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
     };
   }, [resourceId, selectedWorkspaceId, surface]);
 
+  const isMarkdownPreview = isMarkdownPreviewPayload(preview);
+  const isDirty =
+    preview?.kind === "text" && preview.isEditable
+      ? previewDraft !== (preview.content ?? "")
+      : false;
+
+  const savePreview = useCallback(async () => {
+    if (!preview || preview.kind !== "text" || !preview.isEditable) {
+      return;
+    }
+
+    setIsSaving(true);
+    setErrorMessage("");
+
+    try {
+      const nextPreview = await window.electronAPI.fs.writeTextFile(
+        preview.absolutePath,
+        previewDraft,
+        selectedWorkspaceId ?? null,
+      );
+      setPreview(nextPreview);
+      setPreviewDraft(nextPreview.content ?? "");
+      setTextPreviewMode(
+        isMarkdownPreviewPayload(nextPreview) ? textPreviewMode : "edit",
+      );
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to save file.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }, [preview, previewDraft, selectedWorkspaceId, textPreviewMode]);
+
   const body = useMemo(() => {
     if (surface === "event") {
       return <EmptyState title="Event detail" detail="This output remains inside Holaboss and does not resolve to a file-backed preview." />;
@@ -109,7 +166,6 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
       if (htmlContent && htmlContent.trim()) {
         return (
           <div className="grid min-h-0 gap-3">
-            {resourceId ? <MetadataRow label="Target" value={resourceId} /> : null}
             <iframe
               title="Output preview"
               sandbox=""
@@ -146,18 +202,61 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
     }
 
     if (preview.kind === "text") {
-      if (isMarkdownPreviewPayload(preview)) {
-        return (
-          <div className="grid min-h-0 gap-3">
-            <MetadataRow label="Path" value={preview.absolutePath} />
-            <MetadataRow label="Modified" value={new Date(preview.modifiedAt).toLocaleString()} />
+      return (
+        <div className="grid min-h-0 gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <MetadataRow
+              label="Modified"
+              value={new Date(preview.modifiedAt).toLocaleString()}
+            />
+            <div className="flex shrink-0 items-center gap-2">
+              {isMarkdownPreview ? (
+                <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
+                  <button
+                    type="button"
+                    onClick={() => setTextPreviewMode("preview")}
+                    className={`rounded px-2 py-1 text-xs transition-colors ${
+                      textPreviewMode === "preview"
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                    }`}
+                  >
+                    Preview
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTextPreviewMode("edit")}
+                    className={`rounded px-2 py-1 text-xs transition-colors ${
+                      textPreviewMode === "edit"
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                    }`}
+                  >
+                    Edit
+                  </button>
+                </div>
+              ) : null}
+              {preview.isEditable ? (
+                <button
+                  type="button"
+                  onClick={() => void savePreview()}
+                  disabled={!isDirty || isSaving}
+                  className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Save size={12} />
+                  {isSaving ? "Saving" : "Save"}
+                </button>
+              ) : null}
+            </div>
+          </div>
+          {isMarkdownPreview && textPreviewMode === "preview" ? (
             <div className="min-h-0 overflow-auto rounded-[18px] border border-border/35 bg-black/10 p-4">
-              {preview.content?.trim() ? (
+              {previewDraft.trim() ? (
                 <SimpleMarkdown
                   className="chat-markdown text-sm text-foreground/90"
                   onLinkClick={openPreviewLink}
                 >
-                  {preview.content}
+                  {previewDraft}
                 </SimpleMarkdown>
               ) : (
                 <div className="grid min-h-[160px] place-items-center text-[12px] text-muted-foreground">
@@ -165,16 +264,19 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
                 </div>
               )}
             </div>
-          </div>
-        );
-      }
-      return (
-        <div className="grid min-h-0 gap-3">
-          <MetadataRow label="Path" value={preview.absolutePath} />
-          <MetadataRow label="Modified" value={new Date(preview.modifiedAt).toLocaleString()} />
-          <pre className="min-h-0 overflow-auto rounded-[18px] border border-border/35 bg-black/20 p-4 text-[12px] leading-6 text-foreground/88">
-            {preview.content || ""}
-          </pre>
+          ) : (
+            <textarea
+              value={previewDraft}
+              onChange={(event) => setPreviewDraft(event.target.value)}
+              readOnly={!preview.isEditable}
+              spellCheck={false}
+              className={`min-h-[60vh] w-full resize-none rounded-[18px] border border-border/35 p-4 font-mono text-[12px] leading-6 text-foreground/88 outline-none transition-colors ${
+                preview.isEditable
+                  ? "embedded-input bg-black/20 focus:border-border/70"
+                  : "cursor-default bg-black/20 opacity-90"
+              }`}
+            />
+          )}
         </div>
       );
     }
@@ -182,7 +284,6 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
     if (preview.kind === "image" && preview.dataUrl) {
       return (
         <div className="grid min-h-0 gap-3">
-          <MetadataRow label="Path" value={preview.absolutePath} />
           <div className="overflow-auto rounded-[18px] border border-border/35 bg-black/20 p-4">
             <img src={preview.dataUrl} alt={preview.name} className="mx-auto max-h-[60vh] max-w-full rounded-[12px]" />
           </div>
@@ -193,7 +294,6 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
     if (preview.kind === "pdf" && preview.dataUrl) {
       return (
         <div className="grid min-h-0 gap-3">
-          <MetadataRow label="Path" value={preview.absolutePath} />
           <iframe title={preview.name} src={preview.dataUrl} className="min-h-[60vh] w-full rounded-[18px] border border-border/35 bg-white" />
         </div>
       );
@@ -204,7 +304,6 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
       if (activeSheet) {
         return (
           <div className="grid min-h-0 gap-3">
-            <MetadataRow label="Path" value={preview.absolutePath} />
             <div className="flex min-h-0 flex-col overflow-hidden rounded-[18px] border border-border/35 bg-black/10">
               {preview.tableSheets.length > 1 ? (
                 <div className="flex items-center gap-1 overflow-x-auto border-b border-border/35 p-2">
@@ -281,7 +380,22 @@ export function InternalSurfacePane({ surface, resourceId, htmlContent }: Intern
         detail={preview.unsupportedReason || "This file type is not yet previewable in the desktop output viewer."}
       />
     );
-  }, [activeTableSheetIndex, errorMessage, htmlContent, isLoading, openPreviewLink, preview, resourceId, surface]);
+  }, [
+    activeTableSheetIndex,
+    errorMessage,
+    htmlContent,
+    isLoading,
+    isDirty,
+    isMarkdownPreview,
+    isSaving,
+    openPreviewLink,
+    preview,
+    previewDraft,
+    resourceId,
+    savePreview,
+    surface,
+    textPreviewMode,
+  ]);
 
   return (
     <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-[var(--radius-xl)] shadow-lg">

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -1,0 +1,239 @@
+import {
+  FormEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { ChevronLeft, ChevronRight, Globe, Loader2, RefreshCcw, Star } from "lucide-react";
+import { IconButton } from "@/components/ui/IconButton";
+import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
+
+const HOME_URL = "https://www.google.com";
+const EXPLICIT_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+const LOCALHOST_PATTERN = /^localhost(?::\d+)?(?:[/?#]|$)/i;
+const IPV4_HOST_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?:[/?#]|$)/;
+const IPV6_HOST_PATTERN = /^\[[0-9a-fA-F:]+\](?::\d+)?(?:[/?#]|$)/;
+
+function normalizeUrl(rawInput: string) {
+  const trimmed = rawInput.trim();
+  if (!trimmed) {
+    return HOME_URL;
+  }
+
+  if (EXPLICIT_SCHEME_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("//")) {
+    return `https:${trimmed}`;
+  }
+  if (
+    LOCALHOST_PATTERN.test(trimmed) ||
+    IPV4_HOST_PATTERN.test(trimmed) ||
+    IPV6_HOST_PATTERN.test(trimmed)
+  ) {
+    return `http://${trimmed}`;
+  }
+  if (trimmed.includes(".")) {
+    return `https://${trimmed}`;
+  }
+  return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
+}
+
+interface SpaceBrowserDisplayPaneProps {
+  browserSpace: BrowserSpaceId;
+  suspendNativeView?: boolean;
+  layoutSyncKey?: string;
+  embedded?: boolean;
+}
+
+export function SpaceBrowserDisplayPane({
+  browserSpace,
+  suspendNativeView = false,
+  layoutSyncKey = "",
+  embedded = false,
+}: SpaceBrowserDisplayPaneProps) {
+  const [inputValue, setInputValue] = useState("");
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const { activeTab, activeBookmark, isBookmarked } = useWorkspaceBrowser(
+    browserSpace,
+  );
+
+  useEffect(() => {
+    setInputValue(activeTab.url || "");
+  }, [activeTab.id, activeTab.url]);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    if (suspendNativeView) {
+      void window.electronAPI.browser.setBounds({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      });
+      return;
+    }
+
+    let rafId = 0;
+
+    const syncBounds = () => {
+      const rect = viewport.getBoundingClientRect();
+      void window.electronAPI.browser.setBounds({
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    const queueSync = () => {
+      window.cancelAnimationFrame(rafId);
+      rafId = window.requestAnimationFrame(syncBounds);
+    };
+
+    queueSync();
+    const observer = new ResizeObserver(queueSync);
+    observer.observe(viewport);
+    window.addEventListener("resize", queueSync);
+    window.setTimeout(queueSync, 100);
+    window.setTimeout(queueSync, 400);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", queueSync);
+      window.cancelAnimationFrame(rafId);
+      void window.electronAPI.browser.setBounds({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      });
+    };
+  }, [layoutSyncKey, suspendNativeView]);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void window.electronAPI.browser.navigate(normalizeUrl(inputValue));
+  };
+
+  const onToggleBookmark = () => {
+    if (!activeTab.url) {
+      return;
+    }
+
+    if (activeBookmark) {
+      void window.electronAPI.browser.removeBookmark(activeBookmark.id);
+      return;
+    }
+
+    void window.electronAPI.browser.addBookmark({
+      url: activeTab.url,
+      title: activeTab.title || activeTab.url,
+    });
+  };
+
+  return (
+    <section
+      className={`relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden ${
+        embedded
+          ? "bg-transparent"
+          : "rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm"
+      }`}
+    >
+      <div className="shrink-0 border-b border-border/45 px-4 py-3">
+        <div className="flex items-center gap-1.5">
+          <IconButton
+            icon={<ChevronLeft size={13} />}
+            label="Back"
+            onClick={() => void window.electronAPI.browser.back()}
+            disabled={!activeTab.canGoBack}
+            className="size-8"
+          />
+          <IconButton
+            icon={<ChevronRight size={13} />}
+            label="Forward"
+            onClick={() => void window.electronAPI.browser.forward()}
+            disabled={!activeTab.canGoForward}
+            className="size-8"
+          />
+          <IconButton
+            icon={<RefreshCcw size={13} />}
+            label="Refresh"
+            onClick={() => void window.electronAPI.browser.reload()}
+            disabled={!activeTab.initialized}
+            className="size-8"
+          />
+
+          <form onSubmit={onSubmit} className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 transition-colors focus-within:border-ring">
+              <Globe size={13} className="shrink-0 text-muted-foreground" />
+              <input
+                value={inputValue}
+                onChange={(event) => setInputValue(event.target.value)}
+                className="embedded-input w-full min-w-0 bg-transparent text-[12px] text-foreground outline-none placeholder:text-muted-foreground/55"
+                placeholder="Enter URL or search"
+              />
+            </div>
+          </form>
+
+          <button
+            type="button"
+            onClick={onToggleBookmark}
+            disabled={!activeTab.url}
+            className={`grid size-8 shrink-0 place-items-center rounded-full border transition ${
+              isBookmarked
+                ? "border-primary/50 bg-primary/10 text-primary"
+                : "border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            }`}
+            aria-label={isBookmarked ? "Remove bookmark" : "Add bookmark"}
+          >
+            <Star size={13} fill={isBookmarked ? "currentColor" : "none"} />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden p-3">
+        <div
+          ref={viewportRef}
+          className="relative h-full min-h-0 overflow-hidden rounded-xl border border-border bg-card"
+        >
+          {!activeTab.initialized ? (
+            <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
+              <div className="pointer-events-none w-full max-w-[360px] rounded-[24px] border border-border bg-card/92 px-6 py-6 shadow-lg backdrop-blur-sm">
+                <div className="mx-auto flex size-12 items-center justify-center rounded-[18px] border border-primary/25 bg-primary/10 text-primary">
+                  <Loader2 size={18} className="animate-spin" />
+                </div>
+                <div className="mt-4 text-[15px] font-medium tracking-[-0.02em] text-foreground">
+                  Starting {browserSpace === "agent" ? "agent" : "user"} browser
+                </div>
+                <div className="mt-1.5 text-[12px] leading-6 text-muted-foreground">
+                  Opening the embedded {browserSpace === "agent" ? "agent" : "user"} browser for this workspace.
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {activeTab.initialized && activeTab.loading ? (
+            <div className="pointer-events-none absolute inset-x-4 top-4 z-10">
+              <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card/92 px-3 py-1.5 text-[11px] text-muted-foreground shadow-md backdrop-blur-sm">
+                <Loader2 size={12} className="animate-spin text-primary" />
+                <span>Loading page</span>
+              </div>
+            </div>
+          ) : null}
+
+          {activeTab.error ? (
+            <div className="absolute inset-x-4 bottom-4 rounded-xl border border-amber-300/40 bg-black/70 px-3 py-2 text-xs text-amber-100/85">
+              {activeTab.error}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -1,0 +1,198 @@
+import { Bot, Globe, Plus, Star, X } from "lucide-react";
+import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
+
+interface SpaceBrowserExplorerPaneProps {
+  browserSpace: BrowserSpaceId;
+  onBrowserSpaceChange: (space: BrowserSpaceId) => void;
+  onActivateDisplay: () => void;
+}
+
+export function SpaceBrowserExplorerPane({
+  browserSpace,
+  onBrowserSpaceChange,
+  onActivateDisplay,
+}: SpaceBrowserExplorerPaneProps) {
+  const { selectedWorkspaceId, browserState, activeTab, bookmarks } =
+    useWorkspaceBrowser(browserSpace);
+
+  const openBrowserSpace = (space: BrowserSpaceId) => {
+    if (!selectedWorkspaceId || space === browserSpace) {
+      return;
+    }
+    onBrowserSpaceChange(space);
+    onActivateDisplay();
+  };
+
+  const openBookmark = (bookmark: BrowserBookmarkPayload) => {
+    onActivateDisplay();
+    void window.electronAPI.browser.navigate(bookmark.url);
+  };
+
+  const openNewTab = () => {
+    onActivateDisplay();
+    void window.electronAPI.browser.newTab();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-transparent">
+      <div className="border-b border-border/45 px-3 py-3">
+        <div className="flex items-center gap-2">
+          <div className="inline-flex min-w-0 flex-1 items-center rounded-md border border-border bg-muted/50 p-0.5">
+            <button
+              type="button"
+              onClick={() => openBrowserSpace("user")}
+              className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-[11px] font-medium transition ${
+                browserSpace === "user"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              }`}
+            >
+              <Globe size={12} />
+              <span>User</span>
+              <span className="rounded-full bg-foreground/8 px-1.5 py-0.5 text-[10px] text-current/80">
+                {browserState.tabCounts.user}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => openBrowserSpace("agent")}
+              className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-[11px] font-medium transition ${
+                browserSpace === "agent"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              }`}
+            >
+              <Bot size={12} />
+              <span>Agent</span>
+              <span className="rounded-full bg-foreground/8 px-1.5 py-0.5 text-[10px] text-current/80">
+                {browserState.tabCounts.agent}
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+        <div className="space-y-1">
+          {bookmarks.length === 0 ? (
+            <div className="px-1 py-1 text-[12px] leading-6 text-muted-foreground/72">
+              Saved bookmarks will appear here.
+            </div>
+          ) : (
+            bookmarks.map((bookmark) => (
+              <button
+                key={bookmark.id}
+                type="button"
+                onClick={() => openBookmark(bookmark)}
+                className="flex w-full items-center gap-2 rounded-md border border-transparent px-3 py-2 text-left transition hover:bg-accent hover:text-accent-foreground"
+              >
+                {bookmark.faviconUrl ? (
+                  <img
+                    src={bookmark.faviconUrl}
+                    alt=""
+                    className="size-4 shrink-0 rounded-sm"
+                  />
+                ) : (
+                  <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-primary/12 text-primary">
+                    <Star size={10} />
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <div className="truncate text-[12px] font-medium text-foreground/88">
+                    {bookmark.title}
+                  </div>
+                  <div className="truncate text-[11px] text-muted-foreground/72">
+                    {bookmark.url}
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="mt-4 border-t border-border/40 pt-4">
+          <div className="mb-2 flex items-center justify-between gap-2 px-1">
+            <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+              Tabs
+            </div>
+            <button
+              type="button"
+              onClick={openNewTab}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-card/80 px-2 py-1 text-[11px] font-medium text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+              aria-label="Open new tab"
+            >
+              <Plus size={12} />
+              <span>New Tab</span>
+            </button>
+          </div>
+          <div className="space-y-1">
+          {browserState.tabs.length === 0 ? (
+            <div className="rounded-[16px] border border-dashed border-border/50 px-3 py-3 text-[12px] leading-6 text-muted-foreground/72">
+              No open tabs in the {browserSpace} browser.
+            </div>
+          ) : (
+            browserState.tabs.map((tab) => {
+              const isActive = tab.id === activeTab.id;
+              return (
+                <div
+                  key={tab.id}
+                  className={`group flex items-center gap-2 rounded-md border border-transparent px-3 py-2 transition ${
+                    isActive
+                      ? "border-primary/35 bg-primary/10 text-primary"
+                      : "hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onActivateDisplay();
+                      void window.electronAPI.browser.setActiveTab(tab.id);
+                    }}
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    title={tab.title || tab.url}
+                  >
+                    {tab.faviconUrl ? (
+                      <img
+                        src={tab.faviconUrl}
+                        alt=""
+                        className="size-4 shrink-0 rounded-sm"
+                      />
+                    ) : (
+                      <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-foreground/8 text-muted-foreground">
+                        {browserSpace === "agent" ? (
+                          <Bot size={10} />
+                        ) : (
+                          <Globe size={10} />
+                        )}
+                      </div>
+                    )}
+                    <div className="min-w-0">
+                      <div className="truncate text-[12px] font-medium text-current">
+                        {tab.title || "New Tab"}
+                      </div>
+                      <div className="truncate text-[11px] text-current/70">
+                        {tab.url || "about:blank"}
+                      </div>
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onActivateDisplay();
+                      void window.electronAPI.browser.closeTab(tab.id);
+                    }}
+                    className="grid size-6 shrink-0 place-items-center rounded-full text-muted-foreground/75 transition hover:bg-accent hover:text-accent-foreground"
+                    aria-label={`Close ${tab.title || "tab"}`}
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              );
+            })
+          )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/panes/useWorkspaceBrowser.ts
+++ b/desktop/src/components/panes/useWorkspaceBrowser.ts
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react";
+import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+
+const EMPTY_BROWSER_STATE: BrowserStatePayload = {
+  id: "",
+  url: "",
+  title: "New Tab",
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  initialized: false,
+  error: "",
+};
+
+function initialBrowserState(space: BrowserSpaceId): BrowserTabListPayload {
+  return {
+    space,
+    activeTabId: "",
+    tabs: [],
+    tabCounts: {
+      user: 0,
+      agent: 0,
+    },
+  };
+}
+
+interface UseWorkspaceBrowserOptions {
+  includeDownloads?: boolean;
+  includeHistory?: boolean;
+}
+
+export function useWorkspaceBrowser(
+  browserSpace: BrowserSpaceId,
+  options?: UseWorkspaceBrowserOptions,
+) {
+  const { selectedWorkspaceId } = useWorkspaceSelection();
+  const [browserState, setBrowserState] = useState<BrowserTabListPayload>(
+    () => initialBrowserState(browserSpace),
+  );
+  const [bookmarks, setBookmarks] = useState<BrowserBookmarkPayload[]>([]);
+  const [downloads, setDownloads] = useState<BrowserDownloadPayload[]>([]);
+  const [historyEntries, setHistoryEntries] = useState<
+    BrowserHistoryEntryPayload[]
+  >([]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const applyState = (state: BrowserTabListPayload) => {
+      if (!mounted || state.space !== browserSpace) {
+        return;
+      }
+      setBrowserState(state);
+    };
+
+    if (!selectedWorkspaceId) {
+      setBrowserState(initialBrowserState(browserSpace));
+      return () => {
+        mounted = false;
+      };
+    }
+
+    void window.electronAPI.browser
+      .setActiveWorkspace(selectedWorkspaceId, browserSpace)
+      .then((state) => {
+        if (mounted) {
+          applyState(state);
+        }
+      });
+    const unsubscribe = window.electronAPI.browser.onStateChange(applyState);
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, [browserSpace, selectedWorkspaceId]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const applyBookmarks = (nextBookmarks: BrowserBookmarkPayload[]) => {
+      if (mounted) {
+        setBookmarks(nextBookmarks);
+      }
+    };
+    const applyDownloads = (nextDownloads: BrowserDownloadPayload[]) => {
+      if (mounted) {
+        setDownloads(nextDownloads);
+      }
+    };
+    const applyHistory = (nextHistory: BrowserHistoryEntryPayload[]) => {
+      if (mounted) {
+        setHistoryEntries(nextHistory);
+      }
+    };
+
+    if (!selectedWorkspaceId) {
+      setBookmarks([]);
+      setDownloads([]);
+      setHistoryEntries([]);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    void window.electronAPI.browser.getBookmarks().then(applyBookmarks);
+    const unsubscribeBookmarks =
+      window.electronAPI.browser.onBookmarksChange(applyBookmarks);
+
+    let unsubscribeDownloads: () => void = () => {};
+    if (options?.includeDownloads) {
+      void window.electronAPI.browser.getDownloads().then(applyDownloads);
+      unsubscribeDownloads =
+        window.electronAPI.browser.onDownloadsChange(applyDownloads);
+    } else {
+      setDownloads([]);
+    }
+
+    let unsubscribeHistory: () => void = () => {};
+    if (options?.includeHistory) {
+      void window.electronAPI.browser.getHistory().then(applyHistory);
+      unsubscribeHistory =
+        window.electronAPI.browser.onHistoryChange(applyHistory);
+    } else {
+      setHistoryEntries([]);
+    }
+
+    return () => {
+      mounted = false;
+      unsubscribeBookmarks();
+      unsubscribeDownloads();
+      unsubscribeHistory();
+    };
+  }, [options?.includeDownloads, options?.includeHistory, selectedWorkspaceId]);
+
+  const activeTab = useMemo(
+    () =>
+      browserState.tabs.find((tab) => tab.id === browserState.activeTabId) ??
+      browserState.tabs[0] ??
+      EMPTY_BROWSER_STATE,
+    [browserState],
+  );
+
+  const activeBookmark = useMemo(
+    () => bookmarks.find((bookmark) => bookmark.url === activeTab.url) ?? null,
+    [activeTab.url, bookmarks],
+  );
+
+  return {
+    selectedWorkspaceId,
+    browserState,
+    activeTab,
+    bookmarks,
+    downloads,
+    historyEntries,
+    activeBookmark,
+    isBookmarked: Boolean(activeBookmark),
+  };
+}


### PR DESCRIPTION
## Summary
- reshape desktop space mode around a shared explorer and universal display surface
- move inbox and session switching into the right pane while preserving workspace display context
- update the file tree, browser explorer, left-rail behavior, and chat header interactions for the new navigation model
- follow up with a more exaggerated hover animation for the session selector chevron

## Validation
- ./node_modules/.bin/tsc --noEmit
- node --test src/components/layout/AppShell.test.mjs src/components/layout/OperationsDrawer.test.mjs src/components/panes/ChatPane.test.mjs src/components/panes/FileExplorerPane.test.mjs src/components/panes/InternalSurfacePane.test.mjs src/components/panes/BrowserPane.test.mjs
- node --test src/components/panes/ChatPane.test.mjs