### PR TITLE
fix: improve desktop notification and workspace error feedback

### DIFF
--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -97,6 +97,9 @@ test("app shell polls runtime notifications and renders the toast stack", async 
   assert.doesNotMatch(source, /className=\{anchoredToastStackClassName\}/);
   assert.doesNotMatch(source, /style=\{anchoredToastStackStyle\}/);
   assert.match(source, /const runtimeNotificationById = useMemo\(/);
+  assert.doesNotMatch(source, /notificationToastTimeoutsRef/);
+  assert.doesNotMatch(source, /notificationToastDurationMs/);
+  assert.doesNotMatch(source, /window\.setTimeout\(\(\) => \{\s*dismissNotificationToast\(item\.id\);/);
 });
 
 test("app shell keeps desktop updates separate from runtime notification state", async () => {

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -97,8 +97,6 @@ const SPACE_EXPLORER_COLLAPSED_WIDTH = 68;
 const UTILITY_PANE_RESIZER_WIDTH = 16;
 const APP_UPDATE_CHANGELOG_BASE_URL =
   "https://github.com/holaboss-ai/holaboss-ai/releases/tag";
-const DEFAULT_NOTIFICATION_TOAST_DURATION_MS = 7_000;
-const CRITICAL_NOTIFICATION_TOAST_DURATION_MS = 12_000;
 const DEFAULT_PROACTIVE_HEARTBEAT_CRON = "0 9 * * *";
 const MAX_SEEN_TASK_PROPOSAL_IDS_PER_WORKSPACE = 200;
 
@@ -230,14 +228,6 @@ function utilityPaneMinWidth(paneId: UtilityPaneId): number {
   return paneId === "files"
     ? MIN_FILES_PANE_WIDTH
     : MIN_BROWSER_PANE_WIDTH;
-}
-
-function notificationToastDurationMs(
-  notification: RuntimeNotificationRecordPayload,
-): number {
-  return notification.priority === "critical"
-    ? CRITICAL_NOTIFICATION_TOAST_DURATION_MS
-    : DEFAULT_NOTIFICATION_TOAST_DURATION_MS;
 }
 
 function isDevNotificationToastPreviewId(notificationId: string): boolean {
@@ -940,7 +930,6 @@ function AppShellContent() {
   const spaceVisibilityRef = useRef(spaceVisibility);
   const notificationsHydratedRef = useRef(false);
   const seenNotificationIdsRef = useRef(new Set<string>());
-  const notificationToastTimeoutsRef = useRef(new Map<string, number>());
   const lastRestorableSpaceDisplayViewByWorkspaceRef = useRef<
     Record<string, RestorableSpaceDisplayView>
   >({});
@@ -1432,11 +1421,6 @@ function AppShellContent() {
   }, [theme]);
 
   const dismissNotificationToast = useCallback((notificationId: string) => {
-    const timeoutId = notificationToastTimeoutsRef.current.get(notificationId);
-    if (timeoutId !== undefined) {
-      window.clearTimeout(timeoutId);
-      notificationToastTimeoutsRef.current.delete(notificationId);
-    }
     setToastNotifications((current) =>
       current.filter((item) => item.id !== notificationId),
     );
@@ -1473,17 +1457,11 @@ function AppShellContent() {
           }
           return [item, ...current].slice(0, 4);
         });
-        if (!notificationToastTimeoutsRef.current.has(item.id)) {
-          const timeoutId = window.setTimeout(() => {
-            dismissNotificationToast(item.id);
-          }, notificationToastDurationMs(item));
-          notificationToastTimeoutsRef.current.set(item.id, timeoutId);
-        }
       }
     } catch {
       // Notification polling should stay silent when the runtime is restarting.
     }
-  }, [dismissNotificationToast]);
+  }, []);
 
   useEffect(() => {
     const activeNotificationIds = new Set(
@@ -1493,13 +1471,6 @@ function AppShellContent() {
       const next = current.filter((item) => activeNotificationIds.has(item.id));
       return next.length === current.length ? current : next;
     });
-    for (const [notificationId, timeoutId] of notificationToastTimeoutsRef.current.entries()) {
-      if (activeNotificationIds.has(notificationId)) {
-        continue;
-      }
-      window.clearTimeout(timeoutId);
-      notificationToastTimeoutsRef.current.delete(notificationId);
-    }
   }, [notifications]);
 
   const handleActivateNotification = useCallback(
@@ -1625,10 +1596,6 @@ function AppShellContent() {
     }, 3000);
     return () => {
       window.clearInterval(intervalId);
-      for (const timeoutId of notificationToastTimeoutsRef.current.values()) {
-        window.clearTimeout(timeoutId);
-      }
-      notificationToastTimeoutsRef.current.clear();
     };
   }, [refreshNotifications]);
 

--- a/desktop/src/lib/workspaceDesktop.test.mjs
+++ b/desktop/src/lib/workspaceDesktop.test.mjs
@@ -18,3 +18,22 @@ test("deleting the selected workspace clears selection before the local delete r
   assert.match(source, /setWorkspaceBlockingReasonState\(""\);/);
   assert.match(source, /await window\.electronAPI\.workspace\.deleteWorkspace\(trimmedWorkspaceId\);/);
 });
+
+test("workspace desktop error normalization unwraps Electron IPC errors before mapping", async () => {
+  const source = await readFile(WORKSPACE_DESKTOP_PATH, "utf8");
+
+  assert.match(
+    source,
+    /const ipcMatch = message\.match\(\s*\/\^Error invoking remote method '\[\^'\]\+': Error: \(\.\+\)\$\/s,/,
+  );
+  assert.match(
+    source,
+    /const unwrappedMessage = ipcMatch \? ipcMatch\[1\]\.trim\(\) : message\.trim\(\);/,
+  );
+  assert.match(source, /const normalized = unwrappedMessage\.toLowerCase\(\);/);
+  assert.match(
+    source,
+    /if \(rawNormalized\.includes\("error invoking remote method"\) && !ipcMatch\) \{/,
+  );
+  assert.match(source, /return unwrappedMessage;/);
+});

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -130,7 +130,12 @@ function normalizeWorkspaceHarness(value: string | null | undefined): WorkspaceH
 
 function normalizeErrorMessage(error: unknown) {
   const message = error instanceof Error ? error.message : "Request failed.";
-  const normalized = message.trim().toLowerCase();
+  const ipcMatch = message.match(
+    /^Error invoking remote method '[^']+': Error: (.+)$/s,
+  );
+  const unwrappedMessage = ipcMatch ? ipcMatch[1].trim() : message.trim();
+  const normalized = unwrappedMessage.toLowerCase();
+  const rawNormalized = message.trim().toLowerCase();
 
   if (normalized.includes("workspace:listworkspaces")) {
     return "Couldn't load workspace state right now. The local runtime may still be starting.";
@@ -140,11 +145,11 @@ function normalizeErrorMessage(error: unknown) {
     return "The local runtime hit an internal error. Try again in a moment.";
   }
 
-  if (normalized.includes("error invoking remote method")) {
+  if (rawNormalized.includes("error invoking remote method") && !ipcMatch) {
     return "The desktop app couldn't complete that request. Try again in a moment.";
   }
 
-  return message;
+  return unwrappedMessage;
 }
 
 function normalizedOnboardingStatus(workspace: WorkspaceRecordPayload | null): string {


### PR DESCRIPTION
## Summary
- keep runtime notification toasts visible until the user dismisses or activates them instead of auto-expiring in the shell
- unwrap Electron IPC wrapper errors before workspace error normalization so onboarding surfaces the underlying failure message
- add regression coverage for persistent notification toasts and IPC error unwrapping in desktop shell tests

## Context
- the shell was auto-hiding notification toasts after a fixed timeout even though the underlying notification remained active
- desktop workspace creation errors coming through Electron IPC were being collapsed into a generic banner instead of exposing the actionable underlying failure

## Validation
- `node --test desktop/src/components/layout/AppShell.test.mjs`
- `node --test desktop/src/lib/workspaceDesktop.test.mjs`
- `node --test desktop/electron/workspace-create-transition.test.mjs`
