### PR TITLE
refactor(desktop): UI consistency — shadcn components, semantic tokens, density polish

### DIFF
--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -5,6 +5,7 @@ import {
   RefreshCw,
   ShieldCheck,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import anthropicLogoMarkup from "@/assets/providers/anthropic.svg?raw";
 import geminiLogoMarkup from "@/assets/providers/gemini.svg?raw";
 import minimaxLogoMarkup from "@/assets/providers/minimax.svg?raw";
@@ -1840,7 +1841,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     );
   }
 
-  function renderProviderCard(providerId: KnownProviderId) {
+  function renderProviderRow(providerId: KnownProviderId, isLast: boolean) {
     const template = KNOWN_PROVIDER_TEMPLATES[providerId];
     const isHolabossProvider = providerId === "holaboss";
     const isConnected = providerConnected(providerId);
@@ -1849,120 +1850,95 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     const hasPendingConnection = !isConnected && draftEnabled;
     const isExpandable = isHolabossProvider ? isConnected : draftEnabled || isConnected;
     const isExpanded = isExpandable && expandedProviderId === providerId;
-    const statusText = isHolabossProvider
-      ? runtimeBindingReady
-        ? "Managed and ready on this desktop."
-        : isSignedIn
-          ? "Signed in. Refresh runtime binding to finish setup."
-          : "Sign in to enable the managed provider."
-      : isDisconnecting
-        ? "Disconnecting now."
-        : hasPendingConnection
-          ? "Enter an API key and save to connect."
-          : isConnected
-            ? "Connected. Expand to edit settings."
-            : "Not connected.";
-    const actionButtonClassName =
-      "inline-flex h-9 min-w-[128px] shrink-0 items-center justify-center rounded-[10px] px-3 text-sm transition disabled:cursor-not-allowed disabled:opacity-50";
-    const actionBadgeClassName =
-      "inline-flex h-9 min-w-[128px] shrink-0 items-center justify-center rounded-full border px-3 text-xs uppercase tracking-[0.14em]";
 
     return (
       <div
         key={providerId}
-        className={`theme-control-surface overflow-hidden rounded-[14px] border transition ${
-          isExpanded
-            ? "border-primary/35 bg-card/96 shadow-[0_0_0_1px_rgb(var(--color-primary)/0.08)]"
-            : "border-border/55 bg-card/92 hover:border-border/75"
-        }`}
+        className={isLast ? "" : "border-b border-border/30"}
       >
-        <div className="flex flex-col gap-3 px-4 py-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex min-w-0 flex-1 items-start gap-3">
-            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[14px] border border-border/55 bg-background/80 text-foreground">
-              <ProviderBrandIcon providerId={providerId} />
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold text-foreground">{template.label}</div>
-              <div className="mt-1 text-sm leading-6 text-foreground/82">{template.description}</div>
-              <div className="mt-1 text-sm leading-6 text-muted-foreground/95">{statusText}</div>
-            </div>
+        <div className="flex items-center gap-3 py-3">
+          <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-border/55 bg-background/80 text-foreground">
+            <ProviderBrandIcon providerId={providerId} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-foreground">{template.label}</div>
           </div>
 
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 md:flex-col md:items-end md:justify-center">
+          <div className="flex shrink-0 items-center gap-2">
             {isHolabossProvider ? (
               isConnected ? (
-                <div className={`${actionBadgeClassName} border-primary/30 bg-primary/10 text-primary`}>
+                <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary">
                   Enabled
-                </div>
+                </Badge>
               ) : (
-                <button
-                  type="button"
+                <Button
+                  variant="outline"
+                  size="sm"
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
-                  className={`${actionButtonClassName} border border-success/30 bg-success/10 text-success hover:bg-success/16`}
                 >
                   {isStartingSignIn ? "Opening..." : "Sign in"}
-                </button>
+                </Button>
               )
             ) : isConnected ? (
               <>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
                   disabled={isSavingRuntimeConfigDocument}
-                  className={`${actionButtonClassName} border border-border/45 text-foreground hover:border-primary/35`}
                 >
                   {isExpanded ? "Hide" : "Edit"}
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => void handleDisconnectRuntimeProvider(providerId)}
                   disabled={isSavingRuntimeConfigDocument}
-                  className={`${actionButtonClassName} border border-border/45 text-foreground hover:border-destructive/40 hover:text-destructive`}
                 >
                   {isDisconnecting ? "Disconnecting..." : "Disconnect"}
-                </button>
+                </Button>
               </>
             ) : hasPendingConnection ? (
               <>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
                   disabled={isSavingRuntimeConfigDocument}
-                  className={`${actionButtonClassName} border border-border/45 text-foreground hover:border-primary/35`}
                 >
                   {isExpanded ? "Hide" : "Edit"}
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => {
                     updateProviderDraft(providerId, { enabled: false });
                     setExpandedProviderId((current) => (current === providerId ? null : current));
                   }}
                   disabled={isSavingRuntimeConfigDocument}
-                  className={`${actionButtonClassName} border border-border/45 text-foreground hover:border-destructive/40 hover:text-destructive`}
                 >
                   Cancel
-                </button>
+                </Button>
               </>
             ) : (
-              <button
-                type="button"
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => {
                   updateProviderDraft(providerId, { enabled: true });
                   setExpandedProviderId(providerId);
                 }}
                 disabled={isSavingRuntimeConfigDocument}
-                className={`${actionButtonClassName} border border-border/55 text-foreground hover:border-success/30 hover:text-success`}
               >
                 Connect
-              </button>
+              </Button>
             )}
           </div>
         </div>
 
         {isExpanded && isExpandable && (
-          <div className="border-t border-border/35 px-4 pb-4 pt-3">
+          <div className="pb-3 pl-11">
             {renderProviderDrawerContent(providerId)}
           </div>
         )}
@@ -1970,12 +1946,21 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     );
   }
 
+  const allProviderIds = [...connectedProviderIds, ...availableProviderIds];
+
   const runtimeProviderSettings = (
     <div className="mt-3 grid gap-4">
-      <div className="rounded-[18px] border border-border/40 bg-card/80 p-4">
-        <div className="grid gap-3">
-        <div className="text-sm font-medium text-foreground">Connected providers</div>
-        <div className="rounded-[14px] border border-border/35 bg-muted/25 p-3">
+      <div>
+        {allProviderIds.map((providerId, index) =>
+          renderProviderRow(providerId, index === allProviderIds.length - 1)
+        )}
+      </div>
+
+      <div className="mt-5 border-t border-border/30 pt-5">
+        <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Task Configuration
+        </div>
+        <div className="mt-4 rounded-[14px] border border-border/35 bg-muted/25 p-3">
           <div className="text-sm font-medium text-foreground">Background tasks</div>
           <div className="mt-1 text-sm text-muted-foreground">
             Used for memory recall and post-run tasks.
@@ -2077,7 +2062,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             ) : null}
           </div>
         </div>
-        <div className="rounded-[14px] border border-border/35 bg-muted/25 p-3">
+        <div className="mt-3 rounded-[14px] border border-border/35 bg-muted/25 p-3">
           <div className="text-sm font-medium text-foreground">Image generation</div>
           <div className="mt-1 text-sm text-muted-foreground">
             Used when the agent generates new images into the workspace.
@@ -2179,27 +2164,6 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             ) : null}
           </div>
         </div>
-        {connectedProviderIds.length === 0 ? (
-          <div className="rounded-[12px] border border-border/35 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-            No connected providers.
-          </div>
-        ) : (
-          connectedProviderIds.map((providerId) => renderProviderCard(providerId))
-        )}
-        </div>
-      </div>
-
-      <div className="rounded-[18px] border border-border/40 bg-card/80 p-4">
-        <div className="text-sm font-medium text-foreground">Available providers</div>
-        <div className="mt-3 grid gap-2">
-          {availableProviderIds.length === 0 ? (
-            <div className="rounded-[12px] border border-border/35 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-              All providers are connected.
-            </div>
-          ) : (
-            availableProviderIds.map((providerId) => renderProviderCard(providerId))
-          )}
-        </div>
       </div>
 
     </div>
@@ -2218,28 +2182,32 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
       <section className="grid w-full max-w-[1080px] gap-5">
         <div className="grid gap-4">
           <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-            <div className="flex min-w-0 items-center gap-4">
-              <div className="grid h-16 w-16 shrink-0 place-items-center rounded-full border border-border/30 bg-muted/70 text-2xl font-semibold text-foreground">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full border border-border/30 bg-muted/70 text-sm font-semibold text-foreground">
                 {sessionInitials(session)}
               </div>
               <div className="min-w-0">
-                <div className="truncate text-[28px] font-semibold tracking-[-0.04em] text-foreground">
+                <div className="truncate text-sm font-semibold text-foreground">
                   {isSignedIn
                     ? sessionDisplayName(session) || "Your account"
                     : "Your account"}
                 </div>
-                <div className="mt-1 truncate text-base text-muted-foreground">
-                  {isSignedIn ? sessionEmail(session) || "Signed in" : "Not connected"}
-                </div>
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  <div
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium ${badgeClassName}`}
-                  >
+                {isSignedIn && sessionEmail(session) ? (
+                  <div className="truncate text-sm text-muted-foreground">
+                    {sessionEmail(session)}
+                  </div>
+                ) : !isSignedIn ? (
+                  <div className="truncate text-sm text-muted-foreground">
+                    Not connected
+                  </div>
+                ) : null}
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className={badgeClassName}>
                     <ShieldCheck size={12} />
                     <span>{statusBadgeLabel}</span>
-                  </div>
-                  <div className="inline-flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-1 text-[11px] font-medium text-muted-foreground">
-                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary/70" />
+                  </Badge>
+                  <Badge variant="outline" className="border-border/40 bg-muted/40 text-muted-foreground">
+                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${runtimeBindingReady ? "bg-success" : isSignedIn ? "bg-warning" : "bg-muted-foreground"}`} />
                     <span>
                       {runtimeBindingReady
                         ? "Runtime ready on this desktop"
@@ -2247,7 +2215,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                           ? "Runtime setup in progress"
                           : "Runtime unavailable"}
                     </span>
-                  </div>
+                  </Badge>
                 </div>
               </div>
             </div>
@@ -2256,30 +2224,31 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
               {isSignedIn ? (
                 <>
                   <Button
-                    variant="outline"
-                    size="icon-lg"
+                    variant="ghost"
+                    size="icon-sm"
                     aria-label="Refresh session"
                     onClick={() => void handleRefreshSession()}
                     disabled={sessionState.isPending}
                   >
                     {sessionState.isPending ? (
-                      <Loader2 size={16} className="animate-spin" />
+                      <Loader2 size={14} className="animate-spin" />
                     ) : (
-                      <RefreshCw size={16} />
+                      <RefreshCw size={14} />
                     )}
                   </Button>
                   <Button
-                    variant="destructive"
-                    size="icon-lg"
+                    variant="ghost"
+                    size="icon-sm"
                     aria-label="Sign out"
                     onClick={() => void handleSignOut()}
                     disabled={!isSignedIn}
                   >
-                    <LogOut size={16} />
+                    <LogOut size={14} />
                   </Button>
                 </>
               ) : (
                 <Button
+                  size="sm"
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
                 >

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -12,6 +12,8 @@ import ollamaLogoMarkup from "@/assets/providers/ollama.svg?raw";
 import openaiLogoMarkup from "@/assets/providers/openai.svg?raw";
 import openrouterLogoMarkup from "@/assets/providers/openrouter.svg?raw";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -1165,11 +1167,11 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
 
   const badgeClassName =
     statusTone === "error"
-      ? "border-rose-400/35 bg-rose-500/10 text-rose-400"
+      ? "border-destructive/30 bg-destructive/10 text-destructive"
       : statusTone === "ready"
-        ? "border-neon-green/35 bg-neon-green/10 text-neon-green"
+        ? "border-success/30 bg-success/10 text-success"
         : statusTone === "syncing"
-          ? "border-amber-300/35 bg-amber-400/10 text-amber-300"
+          ? "border-warning/30 bg-warning/10 text-warning"
           : "border-border/45 bg-muted/40 text-muted-foreground";
 
   useEffect(() => {
@@ -1199,7 +1201,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
         <Loader2 size={18} className="animate-spin" />
       </div>
       <div className="text-base font-medium text-foreground">
-        {isExchangingRuntimeBinding ? "Refreshing desktop connection..." : "Connecting your Holaboss account..."}
+        {isExchangingRuntimeBinding ? "Refreshing desktop connection..." : "Connecting your account..."}
       </div>
       <div className="max-w-[520px] text-sm leading-6 text-muted-foreground">
         Finalizing your desktop session and runtime binding. This should only take a moment.
@@ -1789,8 +1791,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
       <div className="grid gap-2">
         <label className="grid gap-1">
           <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Base URL</span>
-          <input
-            className="auth-settings-control theme-control-surface h-9 rounded-[10px] border border-border/45 px-2.5 text-sm text-foreground outline-none transition"
+          <Input
             value={draft.baseUrl}
             onChange={(event) => updateProviderDraft(providerId, { baseUrl: event.target.value })}
             placeholder={template.defaultBaseUrl}
@@ -1799,8 +1800,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
         </label>
         <label className="grid gap-1">
           <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">API Key</span>
-          <input
-            className="auth-settings-control theme-control-surface h-9 rounded-[10px] border border-border/45 px-2.5 text-sm text-foreground outline-none transition"
+          <Input
             type="password"
             value={draft.apiKey}
             onChange={(event) => updateProviderDraft(providerId, { apiKey: event.target.value })}
@@ -1819,22 +1819,22 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
           />
         </label>
         <div className="flex flex-wrap gap-2 pt-1">
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            size="sm"
             onClick={() => void handleSaveRuntimeSettings(providerId)}
             disabled={isSavingRuntimeConfigDocument}
-            className="theme-control-surface rounded-[10px] border border-primary/30 bg-primary/8 px-3 py-2 text-sm text-foreground transition hover:border-primary/45 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSavingRuntimeConfigDocument ? "Saving..." : "Save"}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => handleCancelProviderEditing(providerId)}
             disabled={isSavingRuntimeConfigDocument}
-            className="theme-control-surface rounded-[10px] border border-border/45 px-3 py-2 text-sm text-foreground transition hover:border-border/70 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Cancel
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -1899,7 +1899,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                   type="button"
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
-                  className={`${actionButtonClassName} border border-neon-green/40 bg-neon-green/10 text-neon-green hover:bg-neon-green/16`}
+                  className={`${actionButtonClassName} border border-success/30 bg-success/10 text-success hover:bg-success/16`}
                 >
                   {isStartingSignIn ? "Opening..." : "Sign in"}
                 </button>
@@ -1953,7 +1953,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                   setExpandedProviderId(providerId);
                 }}
                 disabled={isSavingRuntimeConfigDocument}
-                className={`${actionButtonClassName} border border-border/55 text-foreground hover:border-neon-green/35 hover:text-neon-green`}
+                className={`${actionButtonClassName} border border-border/55 text-foreground hover:border-success/30 hover:text-success`}
               >
                 Connect
               </button>
@@ -2039,8 +2039,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 </Select>
               ) : (
                 <>
-                  <input
-                    className="auth-settings-control theme-control-surface h-9 rounded-[10px] border border-border/45 px-2.5 text-sm text-foreground outline-none transition"
+                  <Input
                     value={backgroundTasksDraft.model}
                     onChange={(event) => updateBackgroundTasksDraft({ model: event.target.value })}
                     placeholder={backgroundTaskModelPlaceholder(
@@ -2142,8 +2141,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 </Select>
               ) : (
                 <>
-                  <input
-                    className="auth-settings-control theme-control-surface h-9 rounded-[10px] border border-border/45 px-2.5 text-sm text-foreground outline-none transition"
+                  <Input
                     value={imageGenerationDraft.model}
                     onChange={(event) => updateImageGenerationDraft({ model: event.target.value })}
                     placeholder={imageGenerationModelPlaceholder(
@@ -2227,8 +2225,8 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
               <div className="min-w-0">
                 <div className="truncate text-[28px] font-semibold tracking-[-0.04em] text-foreground">
                   {isSignedIn
-                    ? sessionDisplayName(session) || "Holaboss account"
-                    : "Holaboss account"}
+                    ? sessionDisplayName(session) || "Your account"
+                    : "Your account"}
                 </div>
                 <div className="mt-1 truncate text-base text-muted-foreground">
                   {isSignedIn ? sessionEmail(session) || "Signed in" : "Not connected"}
@@ -2257,38 +2255,36 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             <div className="flex shrink-0 items-center gap-2 self-start md:self-auto">
               {isSignedIn ? (
                 <>
-                  <button
-                    type="button"
+                  <Button
+                    variant="outline"
+                    size="icon-lg"
                     aria-label="Refresh session"
                     onClick={() => void handleRefreshSession()}
                     disabled={sessionState.isPending}
-                    className="grid h-11 w-11 place-items-center rounded-[16px] border border-border/45 bg-background text-muted-foreground transition hover:border-primary/35 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {sessionState.isPending ? (
                       <Loader2 size={16} className="animate-spin" />
                     ) : (
                       <RefreshCw size={16} />
                     )}
-                  </button>
-                  <button
-                    type="button"
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="icon-lg"
                     aria-label="Sign out"
                     onClick={() => void handleSignOut()}
                     disabled={!isSignedIn}
-                    className="grid h-11 w-11 place-items-center rounded-[16px] border border-destructive/20 bg-destructive/5 text-destructive transition hover:border-destructive/35 hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <LogOut size={16} />
-                  </button>
+                  </Button>
                 </>
               ) : (
-                <button
-                  className="inline-flex h-10 items-center justify-center rounded-full border border-primary/35 bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                  type="button"
+                <Button
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
                 >
                   {isStartingSignIn ? "Opening sign-in..." : "Sign in"}
-                </button>
+                </Button>
               )}
             </div>
           </div>
@@ -2297,8 +2293,8 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             <div
               className={`mt-4 rounded-[20px] border px-4 py-3 text-sm ${
                 authError
-                  ? "border-rose-400/25 bg-rose-500/8 text-rose-400"
-                  : "border-neon-green/25 bg-neon-green/8 text-neon-green"
+                  ? "border-destructive/30 bg-destructive/10 text-destructive"
+                  : "border-success/30 bg-success/10 text-success"
               }`}
             >
               {authError || authMessage}
@@ -2326,7 +2322,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             className={`mt-3 rounded-[16px] border px-4 py-3 text-sm ${
               authError
                 ? "border-rose-400/35 bg-rose-500/8 text-rose-400"
-                : "border-neon-green/35 bg-neon-green/8 text-neon-green"
+                : "border-success/30 bg-success/10 text-success"
             }`}
           >
             {authError || authMessage}
@@ -2358,7 +2354,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 </div>
                 <div className="min-w-0">
                   <div className="text-base font-medium text-foreground">
-                    {isSignedIn ? sessionDisplayName(session) || "Holaboss account" : "Holaboss account"}
+                    {isSignedIn ? sessionDisplayName(session) || "Your account" : "Your account"}
                   </div>
                   <div className="mt-0.5 truncate text-sm text-muted-foreground">
                     {isSignedIn ? sessionEmail(session) || "Signed in" : "Not connected"}
@@ -2384,33 +2380,29 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
 
             <div className="mt-4 flex flex-wrap gap-2">
               {!isSignedIn && (
-                <button
-                  className="inline-flex h-10 items-center justify-center rounded-[16px] border border-primary/40 bg-primary/10 px-4 text-sm text-primary transition hover:bg-primary/16 disabled:cursor-not-allowed disabled:opacity-50"
-                  type="button"
+                <Button
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
                 >
                   {isStartingSignIn ? "Opening sign-in..." : "Sign in with browser"}
-                </button>
+                </Button>
               )}
 
-              <button
-                className="theme-control-surface inline-flex h-10 items-center justify-center rounded-[16px] border border-border/45 px-4 text-sm text-foreground transition hover:border-primary/35 disabled:cursor-not-allowed disabled:opacity-50"
-                type="button"
+              <Button
+                variant="outline"
                 onClick={() => void handleRefreshSession()}
                 disabled={sessionState.isPending}
               >
                 Refresh session
-              </button>
+              </Button>
 
-              <button
-                className="inline-flex h-10 items-center justify-center rounded-[16px] border border-destructive/30 bg-destructive/10 px-4 text-sm text-destructive transition hover:border-destructive/45 hover:bg-destructive/15 disabled:cursor-not-allowed disabled:opacity-50"
-                type="button"
+              <Button
+                variant="destructive"
                 onClick={() => void handleSignOut()}
                 disabled={!isSignedIn}
               >
                 Sign out
-              </button>
+              </Button>
             </div>
 
             {(authMessage || authError) && (
@@ -2418,7 +2410,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 className={`mt-3 rounded-[16px] border px-4 py-3 text-sm ${
                   authError
                     ? "border-rose-400/35 bg-rose-500/8 text-rose-400"
-                    : "border-neon-green/35 bg-neon-green/8 text-neon-green"
+                    : "border-success/30 bg-success/10 text-success"
                 }`}
               >
                 {authError || authMessage}
@@ -2436,7 +2428,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
               className={`mt-3 rounded-[16px] border px-4 py-3 text-sm ${
                 authError
                   ? "border-rose-400/35 bg-rose-500/8 text-rose-400"
-                  : "border-neon-green/35 bg-neon-green/8 text-neon-green"
+                  : "border-success/30 bg-success/10 text-success"
               }`}
             >
               {authError || authMessage}

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
 import { Button } from "@/components/ui/button";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
@@ -34,46 +34,21 @@ export function BillingSettingsPanel() {
 
   return (
     <div className="grid max-w-[760px] gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <div className="text-xl font-semibold text-foreground">Billing</div>
-          <div className="text-sm text-muted-foreground">
-            Hosted credits and managed usage for this desktop account.
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            void refresh();
-          }}
-          disabled={isLoading}
-        >
-          {isLoading ? (
-            <Loader2 size={14} className="animate-spin" />
-          ) : (
-            <RefreshCw size={14} />
-          )}
-          {isLoading ? "Refreshing..." : "Refresh"}
-        </Button>
-      </div>
-
       {showExpirationBanner ? (
-        <div className="flex items-center justify-between gap-3 rounded-[16px] border border-amber-400/25 bg-amber-400/10 px-4 py-3">
-          <div className="flex min-w-0 items-center gap-2 text-sm text-amber-200">
+        <div className="flex items-center justify-between gap-3 rounded-[16px] border border-warning/30 bg-warning/10 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2 text-sm text-warning">
             <AlertCircle size={16} className="shrink-0" />
             <span className="truncate">
               {overview?.planName || "Plan"} expires on {overview?.expiresAt ? formatBillingDate(overview.expiresAt) : ""}
             </span>
           </div>
-          <button
-            type="button"
+          <Button
+            variant="link"
+            size="sm"
             onClick={() => openBillingLink(links?.billingPageUrl)}
-            className="shrink-0 text-sm font-medium text-primary transition hover:text-primary/80"
           >
             Reactivate
-          </button>
+          </Button>
         </div>
       ) : null}
 
@@ -83,6 +58,7 @@ export function BillingSettingsPanel() {
         links={links}
         isLoading={isLoading}
         error={error}
+        onRefresh={() => void refresh()}
       />
       <section className="grid gap-3 rounded-[24px] border border-border/40 bg-card/40 px-4 py-4">
         <div className="text-xl font-semibold text-foreground">Usage record</div>

--- a/desktop/src/components/billing/BillingSummaryCard.tsx
+++ b/desktop/src/components/billing/BillingSummaryCard.tsx
@@ -70,86 +70,84 @@ export function BillingSummaryCard({
   const timelineLabel = billingTimelineLabel(overview);
 
   return (
-    <section className="rounded-[24px] border border-border/40 bg-card/80 px-5 py-5">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2.5">
-            <span className="text-2xl font-semibold text-foreground">
-              {isLoading ? "Loading..." : overview?.planName || "Free"}
-            </span>
-            {!isLoading && timelineLabel !== "Billing managed on web" ? (
-              <Badge variant="secondary">{timelineLabel}</Badge>
-            ) : null}
-          </div>
-          <div className="mt-1 text-sm text-muted-foreground">
-            {isLoading ? "Checking hosted billing..." : "Billing managed on web"}
-          </div>
+    <section className="rounded-xl border border-border/40 px-4 py-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-semibold text-foreground">
+            {isLoading ? "Loading..." : overview?.planName || "Free"}
+          </span>
+          {!isLoading && timelineLabel !== "Billing managed on web" ? (
+            <Badge variant="outline" className="shrink-0 text-muted-foreground">
+              {timelineLabel}
+            </Badge>
+          ) : null}
         </div>
 
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-1">
           {onRefresh ? (
             <Button
               variant="ghost"
-              size="icon"
+              size="icon-sm"
               aria-label="Refresh billing"
               onClick={onRefresh}
               disabled={isLoading}
             >
-              {isLoading ? (
-                <Loader2 size={16} className="animate-spin" />
-              ) : (
-                <RefreshCw size={16} />
-              )}
+              <RefreshCw size={13} className={isLoading ? "animate-spin" : ""} />
             </Button>
           ) : null}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => openBillingLink(links?.billingPageUrl)}
-          >
-            Manage on web
-          </Button>
-          <Button
-            size="sm"
-            onClick={() => openBillingLink(links?.addCreditsUrl)}
-          >
-            Add credits
-          </Button>
+          {!isLoading ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openBillingLink(links?.billingPageUrl)}
+              >
+                Manage
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => openBillingLink(links?.addCreditsUrl)}
+              >
+                Add credits
+              </Button>
+            </>
+          ) : null}
         </div>
       </div>
 
       {error ? (
-        <div className="mt-4 rounded-[16px] border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+        <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
           {error.message}
         </div>
       ) : null}
 
       {!isLoading && !hasOverview && !error ? (
-        <div className="mt-4 rounded-[16px] border border-border/35 bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
-          Sign in to view billing.
+        <div className="mt-3 rounded-md border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+          Sign in to view billing details.
         </div>
       ) : null}
 
-      <div className="mt-5 border-t border-dashed border-border/50 pt-5">
-        <div className="grid gap-5">
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3">
-            <div>
-              <div className="text-xl font-semibold tracking-[-0.03em] text-foreground tabular-nums">
-                {creditsValue}
-              </div>
-              <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                <span>Credits</span>
-                <Popover>
-                  <PopoverTrigger
-                    render={
-                      <button
-                        type="button"
-                        aria-label="About credits"
-                        className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition hover:bg-accent hover:text-foreground"
-                      />
-                    }
-                  >
-                    <CircleHelp size={14} />
+      <div className="mt-4 border-t border-border/40 pt-4">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+          <div>
+            <div className="text-lg font-semibold tabular-nums text-foreground">
+              {creditsValue}
+            </div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <span>Credits</span>
+              <Popover>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label="About credits"
+                      className="size-4 rounded-full text-muted-foreground"
+                    />
+                  }
+                >
+                  <CircleHelp size={12} />
                   </PopoverTrigger>
                   <PopoverContent align="start" className="w-80">
                     <PopoverHeader>
@@ -164,36 +162,35 @@ export function BillingSummaryCard({
                 </Popover>
               </div>
             </div>
-            <div className="text-right">
-              <div className="text-xl font-semibold tracking-[-0.03em] text-foreground tabular-nums">
-                {overview?.monthlyCreditsIncluded?.toLocaleString() ?? "—"}
-              </div>
-              <div className="mt-1 text-sm text-muted-foreground">Monthly credits</div>
+          <div className="text-right">
+            <div className="text-lg font-semibold tabular-nums text-foreground">
+              {overview?.monthlyCreditsIncluded?.toLocaleString() ?? "—"}
             </div>
+            <div className="text-xs text-muted-foreground">Monthly</div>
           </div>
+        </div>
 
-          <div className="grid gap-3 text-sm text-muted-foreground">
-            <div className="flex items-center justify-between gap-3">
-              <span>Total allocated</span>
-              <span className="tabular-nums text-foreground">
-                {overview?.totalAllocated?.toLocaleString() ?? "—"}
-              </span>
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <span>Total used</span>
-              <span className="tabular-nums text-foreground">
-                {overview?.totalUsed?.toLocaleString() ?? "—"}
-              </span>
-            </div>
-            {overview?.dailyRefreshCredits ? (
-              <div className="flex items-center justify-between gap-3">
-                <span>Daily refresh</span>
-                <span className="tabular-nums text-foreground">
-                  {overview.dailyRefreshCredits.toLocaleString()}
-                </span>
-              </div>
-            ) : null}
+        <div className="mt-3 grid gap-1.5 border-t border-border/30 pt-3 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between">
+            <span>Total allocated</span>
+            <span className="tabular-nums text-foreground">
+              {overview?.totalAllocated?.toLocaleString() ?? "—"}
+            </span>
           </div>
+          <div className="flex items-center justify-between">
+            <span>Total used</span>
+            <span className="tabular-nums text-foreground">
+              {overview?.totalUsed?.toLocaleString() ?? "—"}
+            </span>
+          </div>
+          {overview?.dailyRefreshCredits ? (
+            <div className="flex items-center justify-between">
+              <span>Daily refresh</span>
+              <span className="tabular-nums text-foreground">
+                {overview.dailyRefreshCredits.toLocaleString()}
+              </span>
+            </div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/desktop/src/components/billing/BillingSummaryCard.tsx
+++ b/desktop/src/components/billing/BillingSummaryCard.tsx
@@ -1,4 +1,6 @@
-import { CircleHelp } from "lucide-react";
+import { CircleHelp, Loader2, RefreshCw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
@@ -13,6 +15,7 @@ interface BillingSummaryCardProps {
   links: DesktopBillingLinksPayload | null;
   isLoading?: boolean;
   error?: Error | null;
+  onRefresh?: () => void;
 }
 
 const CREDITS_HELP_ITEMS = [
@@ -55,6 +58,7 @@ export function BillingSummaryCard({
   links,
   isLoading = false,
   error = null,
+  onRefresh,
 }: BillingSummaryCardProps) {
   const hasOverview = Boolean(overview);
   const creditsValue = isLoading
@@ -63,41 +67,59 @@ export function BillingSummaryCard({
       ? (overview?.creditsBalance ?? 0).toLocaleString()
       : "—";
 
+  const timelineLabel = billingTimelineLabel(overview);
+
   return (
-    <section
-      className="rounded-[24px] border border-border/40 px-5 py-5"
-      style={{ backgroundColor: "rgb(243, 243, 244)" }}
-    >
+    <section className="rounded-[24px] border border-border/40 bg-card/80 px-5 py-5">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <div className="text-2xl font-semibold text-foreground">
-            {isLoading ? "Loading..." : overview?.planName || "Holaboss"}
+          <div className="flex items-center gap-2.5">
+            <span className="text-2xl font-semibold text-foreground">
+              {isLoading ? "Loading..." : overview?.planName || "Free"}
+            </span>
+            {!isLoading && timelineLabel !== "Billing managed on web" ? (
+              <Badge variant="secondary">{timelineLabel}</Badge>
+            ) : null}
           </div>
           <div className="mt-1 text-sm text-muted-foreground">
-            {isLoading ? "Checking hosted billing..." : billingTimelineLabel(overview)}
+            {isLoading ? "Checking hosted billing..." : "Billing managed on web"}
           </div>
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          <button
-            type="button"
+          {onRefresh ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Refresh billing"
+              onClick={onRefresh}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <RefreshCw size={16} />
+              )}
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
             onClick={() => openBillingLink(links?.billingPageUrl)}
-            className="theme-control-surface inline-flex h-10 items-center justify-center rounded-full border border-border/45 px-4 text-sm font-medium text-foreground transition hover:border-primary/35"
           >
             Manage on web
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            size="sm"
             onClick={() => openBillingLink(links?.addCreditsUrl)}
-            className="inline-flex h-10 items-center justify-center rounded-full border border-primary/35 bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           >
             Add credits
-          </button>
+          </Button>
         </div>
       </div>
 
       {error ? (
-        <div className="mt-4 rounded-[16px] border border-rose-400/35 bg-rose-500/8 px-4 py-3 text-sm text-rose-400">
+        <div className="mt-4 rounded-[16px] border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {error.message}
         </div>
       ) : null}

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -27,6 +27,7 @@ import { SpaceBrowserDisplayPane } from "@/components/panes/SpaceBrowserDisplayP
 import { SpaceBrowserExplorerPane } from "@/components/panes/SpaceBrowserExplorerPane";
 import { SkillsPane } from "@/components/panes/SkillsPane";
 import { PublishDialog } from "@/components/publish/PublishDialog";
+import { Button } from "@/components/ui/button";
 import { UpdateReminder } from "@/components/ui/UpdateReminder";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
 import { getWorkspaceAppDefinition } from "@/lib/workspaceApps";
@@ -2554,14 +2555,14 @@ function AppShellContent() {
                 <Inbox size={14} className="shrink-0 text-muted-foreground" />
                 <span className="truncate">Inbox</span>
               </div>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon-sm"
                 onClick={handleReturnToChatPane}
                 aria-label="Return to chat"
-                className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
               >
                 <ArrowLeft size={15} />
-              </button>
+              </Button>
             </div>
           </div>
           <div className="min-h-0 flex-1 overflow-hidden">
@@ -3232,14 +3233,14 @@ function AppShellContent() {
                                         <span>Browser</span>
                                       </button>
                                     </div>
-                                    <button
-                                      type="button"
+                                    <Button
+                                      variant="outline"
+                                      size="icon"
                                       onClick={() => setSpaceExplorerCollapsed(true)}
                                       aria-label="Collapse explorer"
-                                      className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-card/80 text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
                                     >
                                       <PanelLeftClose size={14} />
-                                    </button>
+                                    </Button>
                                   </div>
                                 </div>
 
@@ -3311,14 +3312,14 @@ function AppShellContent() {
                                   <Globe size={16} />
                                 </button>
                                 <div className="min-h-0 flex-1" />
-                                <button
-                                  type="button"
+                                <Button
+                                  variant="outline"
+                                  size="icon-lg"
                                   onClick={() => setSpaceExplorerCollapsed(false)}
                                   aria-label="Expand explorer"
-                                  className="inline-flex size-11 items-center justify-center rounded-[16px] border border-border bg-card/80 text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
                                 >
                                   <PanelLeftOpen size={16} />
-                                </button>
+                                </Button>
                               </div>
                             )}
                           </div>

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -86,7 +86,7 @@ const THEMES = [
   "bubblegum-dark",
   "bubblegum-light",
 ] as const;
-const MIN_FILES_PANE_WIDTH = 220;
+const MIN_FILES_PANE_WIDTH = 260;
 const MIN_BROWSER_PANE_WIDTH = 120;
 const MAX_UTILITY_PANE_WIDTH = 720;
 const DEFAULT_FILES_PANE_WIDTH = MIN_FILES_PANE_WIDTH;
@@ -3215,11 +3215,11 @@ function AppShellContent() {
                                     className="min-w-0 flex-1"
                                   >
                                     <TabsList className="w-full">
-                                      <TabsTrigger value="files" className="flex-1 gap-1.5">
+                                      <TabsTrigger value="files" className="min-w-0 flex-1 basis-0 gap-1.5">
                                         <Folder size={13} />
                                         Files
                                       </TabsTrigger>
-                                      <TabsTrigger value="browser" className="flex-1 gap-1.5">
+                                      <TabsTrigger value="browser" className="min-w-0 flex-1 basis-0 gap-1.5">
                                         <Globe size={13} />
                                         Browser
                                       </TabsTrigger>

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -28,6 +28,7 @@ import { SpaceBrowserExplorerPane } from "@/components/panes/SpaceBrowserExplore
 import { SkillsPane } from "@/components/panes/SkillsPane";
 import { PublishDialog } from "@/components/publish/PublishDialog";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UpdateReminder } from "@/components/ui/UpdateReminder";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
 import { getWorkspaceAppDefinition } from "@/lib/workspaceApps";
@@ -3199,49 +3200,39 @@ function AppShellContent() {
                           <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
                             {showSpaceExplorer ? (
                               <>
-                                <div className="shrink-0 border-b border-border/45 px-3 py-3">
-                                  <div className="flex items-center gap-2">
-                                    <div className="inline-flex min-w-0 flex-1 items-center rounded-md border border-border bg-muted/50 p-0.5">
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          setSpaceExplorerMode("files");
-                                          restoreLastSpaceDisplayView();
-                                        }}
-                                        className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-3 py-2 text-[12px] font-medium transition ${
-                                          spaceExplorerMode === "files"
-                                            ? "bg-background text-foreground shadow-sm"
-                                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                                        }`}
-                                      >
+                                <div className="flex shrink-0 items-center gap-2 border-b border-border/45 px-3 py-2.5">
+                                  <Tabs
+                                    value={spaceExplorerMode}
+                                    onValueChange={(value) => {
+                                      const mode = value as SpaceExplorerMode;
+                                      setSpaceExplorerMode(mode);
+                                      if (mode === "browser") {
+                                        setSpaceDisplayView({ type: "browser" });
+                                      } else {
+                                        restoreLastSpaceDisplayView();
+                                      }
+                                    }}
+                                    className="min-w-0 flex-1"
+                                  >
+                                    <TabsList className="w-full">
+                                      <TabsTrigger value="files" className="flex-1 gap-1.5">
                                         <Folder size={13} />
-                                        <span>Files</span>
-                                      </button>
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          setSpaceExplorerMode("browser");
-                                          setSpaceDisplayView({ type: "browser" });
-                                        }}
-                                        className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-3 py-2 text-[12px] font-medium transition ${
-                                          spaceExplorerMode === "browser"
-                                            ? "bg-background text-foreground shadow-sm"
-                                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                                        }`}
-                                      >
+                                        Files
+                                      </TabsTrigger>
+                                      <TabsTrigger value="browser" className="flex-1 gap-1.5">
                                         <Globe size={13} />
-                                        <span>Browser</span>
-                                      </button>
-                                    </div>
-                                    <Button
-                                      variant="outline"
-                                      size="icon"
-                                      onClick={() => setSpaceExplorerCollapsed(true)}
-                                      aria-label="Collapse explorer"
-                                    >
-                                      <PanelLeftClose size={14} />
-                                    </Button>
-                                  </div>
+                                        Browser
+                                      </TabsTrigger>
+                                    </TabsList>
+                                  </Tabs>
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    onClick={() => setSpaceExplorerCollapsed(true)}
+                                    aria-label="Collapse explorer"
+                                  >
+                                    <PanelLeftClose size={14} />
+                                  </Button>
                                 </div>
 
                                 <div className="min-h-0 flex-1 overflow-hidden">
@@ -3279,38 +3270,32 @@ function AppShellContent() {
                               </>
                             ) : (
                               <div className="flex h-full min-h-0 flex-col items-center gap-2 px-2 py-3">
-                                <button
-                                  type="button"
+                                <Button
+                                  variant={spaceExplorerMode === "files" ? "outline" : "ghost"}
+                                  size="icon"
                                   onClick={() => {
                                     setSpaceExplorerMode("files");
                                     restoreLastSpaceDisplayView();
                                     setSpaceExplorerCollapsed(false);
                                   }}
                                   aria-label="Open file explorer"
-                                  className={`inline-flex size-11 items-center justify-center rounded-[16px] border transition ${
-                                    spaceExplorerMode === "files"
-                                      ? "border-primary/45 bg-primary/12 text-primary"
-                                      : "border-border bg-card/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                                  }`}
+                                  className={spaceExplorerMode === "files" ? "border-primary/40 bg-primary/10 text-primary" : "text-muted-foreground"}
                                 >
-                                  <Folder size={16} />
-                                </button>
-                                <button
-                                  type="button"
+                                  <Folder size={15} />
+                                </Button>
+                                <Button
+                                  variant={spaceExplorerMode === "browser" ? "outline" : "ghost"}
+                                  size="icon"
                                   onClick={() => {
                                     setSpaceExplorerMode("browser");
                                     setSpaceDisplayView({ type: "browser" });
                                     setSpaceExplorerCollapsed(false);
                                   }}
                                   aria-label="Open browser explorer"
-                                  className={`inline-flex size-11 items-center justify-center rounded-[16px] border transition ${
-                                    spaceExplorerMode === "browser"
-                                      ? "border-primary/45 bg-primary/12 text-primary"
-                                      : "border-border bg-card/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                                  }`}
+                                  className={spaceExplorerMode === "browser" ? "border-primary/40 bg-primary/10 text-primary" : "text-muted-foreground"}
                                 >
-                                  <Globe size={16} />
-                                </button>
+                                  <Globe size={15} />
+                                </Button>
                                 <div className="min-h-0 flex-1" />
                                 <Button
                                   variant="outline"

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1,15 +1,15 @@
+import { appShellMainGridClassName } from "@/components/layout/appShellLayout";
 import {
-    LeftNavigationRail,
-    type LeftRailItem,
+  LeftNavigationRail,
+  type LeftRailItem,
 } from "@/components/layout/LeftNavigationRail";
 import { NotificationToastStack } from "@/components/layout/NotificationToastStack";
 import {
-    OperationsInboxPane,
-    type OperationsDrawerTab,
+  OperationsInboxPane,
+  type OperationsDrawerTab,
 } from "@/components/layout/OperationsDrawer";
 import { SettingsDialog } from "@/components/layout/SettingsDialog";
 import { TopTabsBar } from "@/components/layout/TopTabsBar";
-import { appShellMainGridClassName } from "@/components/layout/appShellLayout";
 import { FirstWorkspacePane } from "@/components/onboarding";
 import { AppSurfacePane } from "@/components/panes/AppSurfacePane";
 import { resolveAppSurfacePath } from "@/components/panes/appSurfaceRoute";
@@ -17,15 +17,15 @@ import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { BrowserPane } from "@/components/panes/BrowserPane";
 import { ChatPane } from "@/components/panes/ChatPane";
 import {
-    FileExplorerPane,
-    type FileExplorerFocusRequest,
+  FileExplorerPane,
+  type FileExplorerFocusRequest,
 } from "@/components/panes/FileExplorerPane";
 import { InternalSurfacePane } from "@/components/panes/InternalSurfacePane";
 import { MarketplacePane } from "@/components/panes/MarketplacePane";
 import { OnboardingPane } from "@/components/panes/OnboardingPane";
+import { SkillsPane } from "@/components/panes/SkillsPane";
 import { SpaceBrowserDisplayPane } from "@/components/panes/SpaceBrowserDisplayPane";
 import { SpaceBrowserExplorerPane } from "@/components/panes/SpaceBrowserExplorerPane";
-import { SkillsPane } from "@/components/panes/SkillsPane";
 import { PublishDialog } from "@/components/publish/PublishDialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -33,32 +33,32 @@ import { UpdateReminder } from "@/components/ui/UpdateReminder";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
 import { getWorkspaceAppDefinition } from "@/lib/workspaceApps";
 import {
-    useWorkspaceDesktop,
-    WorkspaceDesktopProvider,
+  useWorkspaceDesktop,
+  WorkspaceDesktopProvider,
 } from "@/lib/workspaceDesktop";
 import {
-    useWorkspaceSelection,
-    WorkspaceSelectionProvider,
+  useWorkspaceSelection,
+  WorkspaceSelectionProvider,
 } from "@/lib/workspaceSelection";
 import {
-    ArrowLeft,
-    CircleCheck,
-    Folder,
-    Globe,
-    Inbox,
-    Loader2,
-    PanelLeftClose,
-    PanelLeftOpen,
-    TriangleAlert,
-    XCircle,
+  ArrowLeft,
+  CircleCheck,
+  Folder,
+  Globe,
+  Inbox,
+  Loader2,
+  PanelLeftClose,
+  PanelLeftOpen,
+  TriangleAlert,
+  XCircle,
 } from "lucide-react";
 import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 
 const THEME_STORAGE_KEY = "holaboss-theme-v1";
@@ -227,9 +227,7 @@ type WorkspaceOutputNavigationTarget =
     };
 
 function utilityPaneMinWidth(paneId: UtilityPaneId): number {
-  return paneId === "files"
-    ? MIN_FILES_PANE_WIDTH
-    : MIN_BROWSER_PANE_WIDTH;
+  return paneId === "files" ? MIN_FILES_PANE_WIDTH : MIN_BROWSER_PANE_WIDTH;
 }
 
 function isDevNotificationToastPreviewId(notificationId: string): boolean {
@@ -249,7 +247,8 @@ function buildDevNotificationToastPreviewNotifications(
       source_type: "dev_preview",
       source_label: "Preview",
       title: "Task proposal ready",
-      message: "This is a collapsed preview stack. Hover it to fan the toasts out.",
+      message:
+        "This is a collapsed preview stack. Hover it to fan the toasts out.",
       level: "info",
       priority: "normal",
       state: "unread",
@@ -266,7 +265,8 @@ function buildDevNotificationToastPreviewNotifications(
       source_type: "dev_preview",
       source_label: "Preview",
       title: "Build completed",
-      message: "A success toast helps show the stacked depth and color treatment.",
+      message:
+        "A success toast helps show the stacked depth and color treatment.",
       level: "success",
       priority: "low",
       state: "unread",
@@ -283,7 +283,8 @@ function buildDevNotificationToastPreviewNotifications(
       source_type: "dev_preview",
       source_label: "Preview",
       title: "Workflow waiting on input",
-      message: "Use this preview hook whenever you want to inspect the stacked toast layout.",
+      message:
+        "Use this preview hook whenever you want to inspect the stacked toast layout.",
       level: "warning",
       priority: "high",
       state: "unread",
@@ -300,7 +301,8 @@ function buildDevNotificationToastPreviewNotifications(
       source_type: "dev_preview",
       source_label: "Preview",
       title: "Run failed",
-      message: "The fourth toast makes the overlap obvious without needing real notification traffic.",
+      message:
+        "The fourth toast makes the overlap obvious without needing real notification traffic.",
       level: "error",
       priority: "critical",
       state: "unread",
@@ -313,9 +315,7 @@ function buildDevNotificationToastPreviewNotifications(
   ];
 }
 
-function appUpdateChangelogUrl(
-  status: AppUpdateStatusPayload,
-): string | null {
+function appUpdateChangelogUrl(status: AppUpdateStatusPayload): string | null {
   const version = status.latestVersion?.trim();
   if (!version) {
     return null;
@@ -741,7 +741,7 @@ function FocusPlaceholder({
   description: string;
 }) {
   return (
-    <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden rounded-[var(--radius-xl)] shadow-lg">
+    <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden rounded-xl shadow-lg">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(87,255,173,0.08),transparent_45%)]" />
       <div className="relative max-w-[520px] px-8 text-center">
         <div className="text-[10px] uppercase tracking-[0.18em] text-primary/78">
@@ -760,7 +760,7 @@ function FocusPlaceholder({
 
 function WorkspaceStartupErrorPane({ message }: { message: string }) {
   return (
-    <section className="theme-shell relative flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden rounded-[var(--radius-xl)] shadow-lg">
+    <section className="theme-shell relative flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden rounded-xl shadow-lg">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(247,90,84,0.12),transparent_32%),radial-gradient(circle_at_bottom,rgba(247,170,126,0.08),transparent_36%)]" />
       <div className="relative w-full max-w-[720px] px-6 py-8">
         <div className="theme-subtle-surface rounded-[30px] border border-[rgba(247,90,84,0.24)] p-6 shadow-lg sm:p-8">
@@ -804,7 +804,8 @@ function WorkspaceOnboardingTakeover({
 }
 
 function AppShellContent() {
-  const { selectedWorkspaceId, setSelectedWorkspaceId } = useWorkspaceSelection();
+  const { selectedWorkspaceId, setSelectedWorkspaceId } =
+    useWorkspaceSelection();
   const {
     runtimeConfig,
     workspaces,
@@ -904,10 +905,14 @@ function AppShellContent() {
     useState("");
   const [proactiveHeartbeatConfig, setProactiveHeartbeatConfig] =
     useState<ProactiveHeartbeatConfigPayload | null>(null);
-  const [isLoadingProactiveHeartbeatConfig, setIsLoadingProactiveHeartbeatConfig] =
-    useState(false);
-  const [isUpdatingProactiveHeartbeatConfig, setIsUpdatingProactiveHeartbeatConfig] =
-    useState(false);
+  const [
+    isLoadingProactiveHeartbeatConfig,
+    setIsLoadingProactiveHeartbeatConfig,
+  ] = useState(false);
+  const [
+    isUpdatingProactiveHeartbeatConfig,
+    setIsUpdatingProactiveHeartbeatConfig,
+  ] = useState(false);
   const [proactiveHeartbeatError, setProactiveHeartbeatError] = useState("");
   const [proactiveStatus, setProactiveStatus] =
     useState<ProactiveAgentStatusPayload | null>(null);
@@ -963,9 +968,9 @@ function AppShellContent() {
     () =>
       Boolean(
         selectedWorkspaceId &&
-          proactiveTaskProposalsEnabled &&
-          (proactiveHeartbeatConfig?.enabled ?? false) &&
-          (currentProactiveHeartbeatWorkspace?.enabled ?? true),
+        proactiveTaskProposalsEnabled &&
+        (proactiveHeartbeatConfig?.enabled ?? false) &&
+        (currentProactiveHeartbeatWorkspace?.enabled ?? true),
       ),
     [
       currentProactiveHeartbeatWorkspace,
@@ -975,8 +980,7 @@ function AppShellContent() {
     ],
   );
   const isLoadingProactiveWorkspaceEnabled =
-    isLoadingProactiveTaskProposalsEnabled ||
-    isLoadingProactiveHeartbeatConfig;
+    isLoadingProactiveTaskProposalsEnabled || isLoadingProactiveHeartbeatConfig;
   const isUpdatingProactiveWorkspaceEnabled =
     isUpdatingProactiveTaskProposalsEnabled ||
     isUpdatingProactiveHeartbeatConfig;
@@ -997,7 +1001,10 @@ function AppShellContent() {
     [devNotificationToastPreview, toastNotifications],
   );
   const runtimeNotificationById = useMemo(
-    () => new Map(notifications.map((notification) => [notification.id, notification])),
+    () =>
+      new Map(
+        notifications.map((notification) => [notification.id, notification]),
+      ),
     [notifications],
   );
   const unreadTaskProposalCount = useMemo(() => {
@@ -1185,10 +1192,7 @@ function AppShellContent() {
       const combinedWidth = Math.min(leftWidth + rightWidth, maxCombinedWidth);
       const nextLeftWidth = Math.max(
         utilityPaneMinWidth(leftPaneId),
-        Math.min(
-          leftWidth,
-          combinedWidth - utilityPaneMinWidth(rightPaneId),
-        ),
+        Math.min(leftWidth, combinedWidth - utilityPaneMinWidth(rightPaneId)),
       );
       return {
         leftWidth: nextLeftWidth,
@@ -1328,8 +1332,7 @@ function AppShellContent() {
           return;
         }
 
-        const targetBrowserSpace =
-          payload.space === "agent" ? "agent" : "user";
+        const targetBrowserSpace = payload.space === "agent" ? "agent" : "user";
         const openBrowserPane = () => {
           setActiveLeftRailItem("space");
           setSpaceExplorerMode("browser");
@@ -1434,7 +1437,8 @@ function AppShellContent() {
     }
 
     try {
-      const response = await window.electronAPI.workspace.listNotifications(null);
+      const response =
+        await window.electronAPI.workspace.listNotifications(null);
       setNotifications(response.items);
 
       if (!notificationsHydratedRef.current) {
@@ -1558,11 +1562,7 @@ function AppShellContent() {
         // Ignore transient notification update failures in the shell.
       }
     },
-    [
-      dismissNotificationToast,
-      runtimeNotificationById,
-      refreshNotifications,
-    ],
+    [dismissNotificationToast, runtimeNotificationById, refreshNotifications],
   );
 
   const handleActivateDisplayedNotification = useCallback(
@@ -1874,12 +1874,11 @@ function AppShellContent() {
     setProactiveHeartbeatError("");
     setIsUpdatingProactiveHeartbeatConfig(true);
     try {
-      const config = await window.electronAPI.workspace.setProactiveHeartbeatConfig(
-        {
+      const config =
+        await window.electronAPI.workspace.setProactiveHeartbeatConfig({
           cron: normalizedCron,
           enabled: proactiveHeartbeatConfig?.enabled ?? false,
-        },
-      );
+        });
       setProactiveHeartbeatConfig(config);
     } catch (error) {
       setProactiveHeartbeatError(normalizeErrorMessage(error));
@@ -2318,11 +2317,14 @@ function AppShellContent() {
     setChatFocusRequestKey((current) => current + 1);
   }, []);
 
-  const handleChatComposerPrefillConsumed = useCallback((requestKey: number) => {
-    setChatComposerPrefillRequest((current) =>
-      current?.requestKey === requestKey ? null : current,
-    );
-  }, []);
+  const handleChatComposerPrefillConsumed = useCallback(
+    (requestKey: number) => {
+      setChatComposerPrefillRequest((current) =>
+        current?.requestKey === requestKey ? null : current,
+      );
+    },
+    [],
+  );
 
   const handleChatSessionOpenRequestConsumed = useCallback(
     (requestKey: number) => {
@@ -2352,9 +2354,7 @@ function AppShellContent() {
     }
 
     const lastDisplayView =
-      lastRestorableSpaceDisplayViewByWorkspaceRef.current[
-        selectedWorkspaceId
-      ];
+      lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId];
     setSpaceDisplayView(lastDisplayView ?? { type: "browser" });
   }, [selectedWorkspaceId]);
 
@@ -2366,9 +2366,7 @@ function AppShellContent() {
     }
 
     const nextDisplayView =
-      lastRestorableSpaceDisplayViewByWorkspaceRef.current[
-        selectedWorkspaceId
-      ];
+      lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId];
     if (!nextDisplayView) {
       setSpaceExplorerMode("browser");
       setSpaceDisplayView({ type: "browser" });
@@ -2491,8 +2489,7 @@ function AppShellContent() {
   const showOperationsDrawer = false;
   const showSpaceExplorer = !spaceExplorerCollapsed;
   const shouldShowAppUpdateReminder = Boolean(
-    effectiveAppUpdateStatus &&
-      effectiveAppUpdateStatus.downloaded,
+    effectiveAppUpdateStatus && effectiveAppUpdateStatus.downloaded,
   );
   const appVersionLabel =
     effectiveAppUpdateStatus?.currentVersion?.trim() || "";
@@ -2598,7 +2595,9 @@ function AppShellContent() {
               onProactiveWorkspaceEnabledChange={
                 handleProactiveWorkspaceEnabledChange
               }
-              onProactiveHeartbeatCronChange={handleProactiveHeartbeatCronChange}
+              onProactiveHeartbeatCronChange={
+                handleProactiveHeartbeatCronChange
+              }
               onAcceptProposal={acceptTaskProposal}
               onDismissProposal={dismissTaskProposal}
               hasWorkspace={hasSelectedWorkspace}
@@ -2723,7 +2722,10 @@ function AppShellContent() {
             app={
               activeAppId === spaceDisplayView.appId
                 ? activeApp
-                : getWorkspaceAppDefinition(spaceDisplayView.appId, installedApps)
+                : getWorkspaceAppDefinition(
+                    spaceDisplayView.appId,
+                    installedApps,
+                  )
             }
             resourceId={spaceDisplayView.resourceId}
             view={spaceDisplayView.view}
@@ -2809,27 +2811,30 @@ function AppShellContent() {
     ],
   );
 
-  const clampSpaceAgentPaneWidth = useCallback((width: number) => {
-    const hostWidth =
-      utilityPaneHostRef.current?.getBoundingClientRect().width ?? 0;
-    const explorerWidth = spaceExplorerCollapsed
-      ? SPACE_EXPLORER_COLLAPSED_WIDTH
-      : filesPaneWidth;
-    const maxWidth =
-      hostWidth > 0
-        ? Math.min(
-            MAX_UTILITY_PANE_WIDTH,
-            Math.max(
-              MIN_AGENT_CONTENT_WIDTH,
-              hostWidth -
-                explorerWidth -
-                SPACE_DISPLAY_MIN_WIDTH -
-                UTILITY_PANE_RESIZER_WIDTH,
-            ),
-          )
-        : MAX_UTILITY_PANE_WIDTH;
-    return Math.max(MIN_AGENT_CONTENT_WIDTH, Math.min(width, maxWidth));
-  }, [filesPaneWidth, spaceExplorerCollapsed]);
+  const clampSpaceAgentPaneWidth = useCallback(
+    (width: number) => {
+      const hostWidth =
+        utilityPaneHostRef.current?.getBoundingClientRect().width ?? 0;
+      const explorerWidth = spaceExplorerCollapsed
+        ? SPACE_EXPLORER_COLLAPSED_WIDTH
+        : filesPaneWidth;
+      const maxWidth =
+        hostWidth > 0
+          ? Math.min(
+              MAX_UTILITY_PANE_WIDTH,
+              Math.max(
+                MIN_AGENT_CONTENT_WIDTH,
+                hostWidth -
+                  explorerWidth -
+                  SPACE_DISPLAY_MIN_WIDTH -
+                  UTILITY_PANE_RESIZER_WIDTH,
+              ),
+            )
+          : MAX_UTILITY_PANE_WIDTH;
+      return Math.max(MIN_AGENT_CONTENT_WIDTH, Math.min(width, maxWidth));
+    },
+    [filesPaneWidth, spaceExplorerCollapsed],
+  );
 
   useEffect(() => {
     if (!spaceMode) {
@@ -2999,11 +3004,7 @@ function AppShellContent() {
       observer?.disconnect();
       window.removeEventListener("resize", syncUtilityPaneWidths);
     };
-  }, [
-    showOperationsDrawer,
-    syncUtilityPaneWidths,
-    visibleSpacePaneIds.length,
-  ]);
+  }, [showOperationsDrawer, syncUtilityPaneWidths, visibleSpacePaneIds.length]);
 
   useEffect(() => {
     const handlePointerMove = (event: PointerEvent) => {
@@ -3154,9 +3155,7 @@ function AppShellContent() {
                 />
                 <div
                   className={`absolute inset-y-0 left-0 z-40 hidden transition-transform duration-200 ease-out lg:block ${
-                    spaceLeftRailVisible
-                      ? "translate-x-0"
-                      : "-translate-x-full"
+                    spaceLeftRailVisible ? "translate-x-0" : "-translate-x-full"
                   }`}
                   onMouseEnter={() => setSpaceLeftRailVisible(true)}
                   onMouseLeave={() => setSpaceLeftRailVisible(false)}
@@ -3207,7 +3206,9 @@ function AppShellContent() {
                                       const mode = value as SpaceExplorerMode;
                                       setSpaceExplorerMode(mode);
                                       if (mode === "browser") {
-                                        setSpaceDisplayView({ type: "browser" });
+                                        setSpaceDisplayView({
+                                          type: "browser",
+                                        });
                                       } else {
                                         restoreLastSpaceDisplayView();
                                       }
@@ -3215,23 +3216,31 @@ function AppShellContent() {
                                     className="min-w-0 flex-1"
                                   >
                                     <TabsList className="w-full">
-                                      <TabsTrigger value="files" className="min-w-0 flex-1 basis-0 gap-1.5">
-                                        <Folder size={13} />
+                                      <TabsTrigger
+                                        value="files"
+                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                      >
+                                        <Folder />
                                         Files
                                       </TabsTrigger>
-                                      <TabsTrigger value="browser" className="min-w-0 flex-1 basis-0 gap-1.5">
-                                        <Globe size={13} />
+                                      <TabsTrigger
+                                        value="browser"
+                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                      >
+                                        <Globe />
                                         Browser
                                       </TabsTrigger>
                                     </TabsList>
                                   </Tabs>
                                   <Button
-                                    variant="outline"
-                                    size="icon"
-                                    onClick={() => setSpaceExplorerCollapsed(true)}
+                                    variant="ghost"
+                                    size="icon-sm"
+                                    onClick={() =>
+                                      setSpaceExplorerCollapsed(true)
+                                    }
                                     aria-label="Collapse explorer"
                                   >
-                                    <PanelLeftClose size={14} />
+                                    <PanelLeftClose />
                                   </Button>
                                 </div>
 
@@ -3240,8 +3249,11 @@ function AppShellContent() {
                                     <FileExplorerPane
                                       focusRequest={fileExplorerFocusRequest}
                                       onFocusRequestConsumed={(requestKey) => {
-                                        setFileExplorerFocusRequest((current) =>
-                                          current?.requestKey === requestKey ? null : current,
+                                        setFileExplorerFocusRequest(
+                                          (current) =>
+                                            current?.requestKey === requestKey
+                                              ? null
+                                              : current,
                                         );
                                       }}
                                       previewInPane={false}
@@ -3259,7 +3271,9 @@ function AppShellContent() {
                                       browserSpace={spaceBrowserSpace}
                                       onBrowserSpaceChange={(space) => {
                                         setSpaceBrowserSpace(space);
-                                        setSpaceDisplayView({ type: "browser" });
+                                        setSpaceDisplayView({
+                                          type: "browser",
+                                        });
                                       }}
                                       onActivateDisplay={() =>
                                         setSpaceDisplayView({ type: "browser" })
@@ -3271,7 +3285,11 @@ function AppShellContent() {
                             ) : (
                               <div className="flex h-full min-h-0 flex-col items-center gap-2 px-2 py-3">
                                 <Button
-                                  variant={spaceExplorerMode === "files" ? "outline" : "ghost"}
+                                  variant={
+                                    spaceExplorerMode === "files"
+                                      ? "outline"
+                                      : "ghost"
+                                  }
                                   size="icon"
                                   onClick={() => {
                                     setSpaceExplorerMode("files");
@@ -3279,12 +3297,20 @@ function AppShellContent() {
                                     setSpaceExplorerCollapsed(false);
                                   }}
                                   aria-label="Open file explorer"
-                                  className={spaceExplorerMode === "files" ? "border-primary/40 bg-primary/10 text-primary" : "text-muted-foreground"}
+                                  className={
+                                    spaceExplorerMode === "files"
+                                      ? "border-primary/40 bg-primary/10 text-primary"
+                                      : "text-muted-foreground"
+                                  }
                                 >
-                                  <Folder size={15} />
+                                  <Folder />
                                 </Button>
                                 <Button
-                                  variant={spaceExplorerMode === "browser" ? "outline" : "ghost"}
+                                  variant={
+                                    spaceExplorerMode === "browser"
+                                      ? "outline"
+                                      : "ghost"
+                                  }
                                   size="icon"
                                   onClick={() => {
                                     setSpaceExplorerMode("browser");
@@ -3292,18 +3318,24 @@ function AppShellContent() {
                                     setSpaceExplorerCollapsed(false);
                                   }}
                                   aria-label="Open browser explorer"
-                                  className={spaceExplorerMode === "browser" ? "border-primary/40 bg-primary/10 text-primary" : "text-muted-foreground"}
+                                  className={
+                                    spaceExplorerMode === "browser"
+                                      ? "border-primary/40 bg-primary/10 text-primary"
+                                      : "text-muted-foreground"
+                                  }
                                 >
-                                  <Globe size={15} />
+                                  <Globe />
                                 </Button>
                                 <div className="min-h-0 flex-1" />
                                 <Button
                                   variant="outline"
-                                  size="icon-lg"
-                                  onClick={() => setSpaceExplorerCollapsed(false)}
+                                  size="icon"
+                                  onClick={() =>
+                                    setSpaceExplorerCollapsed(false)
+                                  }
                                   aria-label="Expand explorer"
                                 >
-                                  <PanelLeftOpen size={16} />
+                                  <PanelLeftOpen />
                                 </Button>
                               </div>
                             )}
@@ -3325,12 +3357,12 @@ function AppShellContent() {
                         onPointerDown={startSpaceDisplayResize}
                         className="group relative z-10 flex w-4 shrink-0 cursor-col-resize touch-none items-center justify-center"
                       >
-                        <div className="pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-border/55 transition-all duration-150 group-hover:w-[2px] group-hover:bg-[rgba(247,90,84,0.5)]" />
+                        <div className="pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-border/55 transition-all duration-150 group-hover:w-0.5 group-hover:bg-[rgba(247,90,84,0.5)]" />
                         <div className="pointer-events-none absolute left-1/2 top-1/2 h-14 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[rgba(247,90,84,0.08)] opacity-0 transition duration-150 group-hover:opacity-100" />
                       </div>
 
                       <div
-                        className="min-h-0 shrink-0 overflow-hidden rounded-[var(--radius-xl)]"
+                        className="min-h-0 shrink-0 overflow-hidden rounded-xl"
                         style={{
                           width: `${spaceAgentPaneWidth}px`,
                           minWidth: `${MIN_AGENT_CONTENT_WIDTH}px`,
@@ -3341,7 +3373,7 @@ function AppShellContent() {
                     </div>
                   </div>
                 ) : activeLeftRailItem === "app" ? (
-                  <div className="h-full min-h-0 overflow-hidden rounded-[var(--radius-xl)]">
+                  <div className="h-full min-h-0 overflow-hidden rounded-xl">
                     {agentView.type === "app" ? (
                       <AppSurfacePane
                         appId={agentView.appId}
@@ -3357,7 +3389,7 @@ function AppShellContent() {
                         view={agentView.view}
                       />
                     ) : (
-                      <section className="theme-shell flex h-full min-h-0 items-center justify-center rounded-[var(--radius-xl)] border border-border/45 shadow-lg">
+                      <section className="theme-shell flex h-full min-h-0 items-center justify-center rounded-xl border border-border/45 shadow-lg">
                         <div className="max-w-[360px] px-6 text-center">
                           <div className="text-[22px] font-medium tracking-[-0.03em] text-foreground">
                             Choose an app
@@ -3371,24 +3403,23 @@ function AppShellContent() {
                     )}
                   </div>
                 ) : activeLeftRailItem === "automations" ? (
-                  <div className="h-full min-h-0 overflow-hidden rounded-[var(--radius-xl)]">
+                  <div className="h-full min-h-0 overflow-hidden rounded-xl">
                     <AutomationsPane
                       onOpenRunSession={handleOpenAutomationRunSession}
                       onCreateSchedule={handleCreateScheduleInChat}
                     />
                   </div>
                 ) : activeLeftRailItem === "marketplace" ? (
-                  <div className="h-full min-h-0 overflow-hidden rounded-[var(--radius-xl)]">
+                  <div className="h-full min-h-0 overflow-hidden rounded-xl">
                     <MarketplacePane />
                   </div>
                 ) : (
-                  <div className="h-full min-h-0 overflow-hidden rounded-[var(--radius-xl)]">
+                  <div className="h-full min-h-0 overflow-hidden rounded-xl">
                     <SkillsPane />
                   </div>
                 )}
               </div>
             </div>
-
           </div>
         )}
       </div>

--- a/desktop/src/components/layout/NotificationToastStack.tsx
+++ b/desktop/src/components/layout/NotificationToastStack.tsx
@@ -26,13 +26,13 @@ const EXPANDED_TOAST_GAP_PX = 12;
 
 function toastAccentClassName(level: RuntimeNotificationLevel): string {
   if (level === "success") {
-    return "bg-emerald-500/15 text-emerald-300 ring-emerald-400/30";
+    return "bg-success/10 text-success ring-success/30";
   }
   if (level === "warning") {
-    return "bg-amber-400/15 text-amber-200 ring-amber-300/30";
+    return "bg-warning/10 text-warning ring-warning/30";
   }
   if (level === "error") {
-    return "bg-rose-500/15 text-rose-200 ring-rose-400/30";
+    return "bg-destructive/10 text-destructive ring-destructive/30";
   }
   return "bg-sky-500/15 text-sky-200 ring-sky-400/30";
 }

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -553,13 +553,13 @@ function runningSessionStatusIndicator(
       };
     case "WAITING":
       return {
-        className: "text-amber-600",
+        className: "text-warning",
         icon: <Clock size={14} />,
         label: "Waiting for input",
       };
     case "PAUSED":
       return {
-        className: "text-orange-600",
+        className: "text-warning",
         icon: <Pause size={14} />,
         label: "Paused",
       };
@@ -571,7 +571,7 @@ function runningSessionStatusIndicator(
       };
     case "COMPLETED":
       return {
-        className: "text-emerald-600",
+        className: "text-success",
         icon: <Check size={14} />,
         label: "Completed",
       };
@@ -840,14 +840,14 @@ function SignedOutInboxNotice({
   isAuthPending: boolean;
 }) {
   return (
-    <div className="rounded-[22px] border border-amber-500/20 bg-amber-500/10 px-4 py-5">
+    <div className="rounded-[22px] border border-warning/20 bg-warning/10 px-4 py-5">
       <div className="flex flex-col gap-4">
         <div className="space-y-1">
           <div className="text-sm font-semibold text-foreground">
             Sign in to review task proposals
           </div>
           <div className="text-sm leading-6 text-muted-foreground">
-            Sign in to connect this desktop to your Holaboss account and review
+            Sign in to connect this desktop to your account and review
             Inbox proposals.
           </div>
         </div>

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -241,7 +241,7 @@ export function OperationsDrawer({
   }, [activeTab, selectedWorkspaceId]);
 
   return (
-    <aside className="theme-shell neon-border relative flex h-full min-h-0 min-w-[296px] max-w-[336px] flex-col overflow-hidden rounded-[var(--radius-xl)] shadow-lg">
+    <aside className="theme-shell neon-border relative flex h-full min-h-0 min-w-[296px] max-w-[336px] flex-col overflow-hidden rounded-xl shadow-lg">
       <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3 py-2">
         <div className="flex items-center gap-1.5">
           <DrawerTabButton
@@ -293,9 +293,7 @@ export function OperationsDrawer({
             onProactiveWorkspaceEnabledChange={
               onProactiveWorkspaceEnabledChange
             }
-            onProactiveHeartbeatCronChange={
-              onProactiveHeartbeatCronChange
-            }
+            onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
             onAcceptProposal={onAcceptProposal}
             onDismissProposal={onDismissProposal}
           />
@@ -370,9 +368,7 @@ export function OperationsInboxPane({
       selectedWorkspaceName={selectedWorkspaceName}
       proactiveWorkspaceEnabled={proactiveWorkspaceEnabled}
       isLoadingProactiveWorkspaceEnabled={isLoadingProactiveWorkspaceEnabled}
-      isUpdatingProactiveWorkspaceEnabled={
-        isUpdatingProactiveWorkspaceEnabled
-      }
+      isUpdatingProactiveWorkspaceEnabled={isUpdatingProactiveWorkspaceEnabled}
       proactiveHeartbeatCron={proactiveHeartbeatCron}
       isLoadingProactiveHeartbeatConfig={isLoadingProactiveHeartbeatConfig}
       isUpdatingProactiveHeartbeatConfig={isUpdatingProactiveHeartbeatConfig}
@@ -463,13 +459,11 @@ function runningSessionState(entry: {
   return "IDLE";
 }
 
-function runningSessionStateTimestamp(
-  entry: {
-    status: string;
-    updated_at: string;
-    last_turn_completed_at: string | null;
-  },
-): string {
+function runningSessionStateTimestamp(entry: {
+  status: string;
+  updated_at: string;
+  last_turn_completed_at: string | null;
+}): string {
   if (
     entry.status === "BUSY" ||
     entry.status === "QUEUED" ||
@@ -535,9 +529,11 @@ function compareRunningSessionEntries(
   return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
 }
 
-function runningSessionStatusIndicator(
-  status: string,
-): { className: string; icon: ReactNode; label: string } {
+function runningSessionStatusIndicator(status: string): {
+  className: string;
+  icon: ReactNode;
+  label: string;
+} {
   switch (status) {
     case "RUNNING":
       return {
@@ -724,9 +720,7 @@ function InboxPanel({
               onProactiveWorkspaceEnabledChange={
                 onProactiveWorkspaceEnabledChange
               }
-              onProactiveHeartbeatCronChange={
-                onProactiveHeartbeatCronChange
-              }
+              onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
               compact
             />
           </div>
@@ -847,8 +841,8 @@ function SignedOutInboxNotice({
             Sign in to review task proposals
           </div>
           <div className="text-sm leading-6 text-muted-foreground">
-            Sign in to connect this desktop to your account and review
-            Inbox proposals.
+            Sign in to connect this desktop to your account and review Inbox
+            proposals.
           </div>
         </div>
         <div>
@@ -954,7 +948,8 @@ function RunningPanel({
                         {session.title}
                       </div>
                       <div className="mt-1 text-xs text-muted-foreground">
-                        {session.stateDetail} {relativeTime(session.stateTimestamp)}
+                        {session.stateDetail}{" "}
+                        {relativeTime(session.stateTimestamp)}
                       </div>
                       {session.lastError ? (
                         <div className="mt-1.5 truncate text-xs text-destructive">

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -256,14 +256,14 @@ function ProactiveScheduleEditor({
   };
 
   return (
-    <div className="px-3 py-2">
+    <div>
       <Button
         type="button"
         variant="ghost"
         size="sm"
         onClick={() => setDrawerOpen((current) => !current)}
         aria-expanded={drawerOpen}
-        className="w-full justify-between gap-2 text-left"
+        className="w-full justify-between gap-2 px-0 text-left hover:bg-transparent"
       >
         <span className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>Schedule</span>

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { ChevronDown, Loader2, Sparkles } from "lucide-react";
 import {
   Select,
@@ -73,16 +74,6 @@ function proactiveStateClasses(state: string): string {
     return "border-border/45 bg-background/70 text-muted-foreground";
   }
   return "border-border/45 bg-background/70 text-foreground/72";
-}
-
-function proactiveToggleClasses(enabled: boolean): string {
-  return enabled
-    ? "border-border/45 bg-background/90 text-foreground/88 hover:border-primary/35 hover:text-foreground"
-    : "border-border/45 bg-background/90 text-muted-foreground hover:border-primary/35 hover:text-foreground";
-}
-
-function proactiveToggleDotClasses(enabled: boolean): string {
-  return enabled ? "bg-success" : "bg-warning";
 }
 
 type ProactiveScheduleUnit = "minute" | "hour" | "day";
@@ -264,124 +255,106 @@ function ProactiveScheduleEditor({
   };
 
   return (
-    <div className="border-t border-border/40 px-3 py-3">
-      <button
+    <div className="px-3 py-2">
+      <Button
         type="button"
-        aria-expanded={drawerOpen}
+        variant="ghost"
+        size="sm"
         onClick={() => setDrawerOpen((current) => !current)}
-        className="flex w-full items-center justify-between gap-3 rounded-[16px] px-1 py-1 text-left transition-colors hover:bg-muted/35"
+        aria-expanded={drawerOpen}
+        className="w-full justify-between gap-2 text-left"
       >
-        <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-            Schedule
-          </div>
-          <div className="mt-1 text-[11px] leading-5 text-muted-foreground/82">
-            {scheduleSummaryLabel(currentSchedule)}
-          </div>
-        </div>
+        <span className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Schedule</span>
+          <span className="text-foreground/72">{scheduleSummaryLabel(currentSchedule)}</span>
+        </span>
         <ChevronDown
           size={14}
           className={`shrink-0 text-muted-foreground transition-transform ${
             drawerOpen ? "rotate-180" : ""
           }`}
         />
-      </button>
+      </Button>
       {drawerOpen ? (
-        <div className="mt-3 rounded-[18px] border border-border/35 bg-background/55 px-3 py-3">
-          <div className="text-[11px] leading-5 text-muted-foreground/82">
-            Server schedule for this desktop instance.
-          </div>
-          <div className={compact ? "mt-2 grid gap-2" : "mt-2 flex flex-wrap items-center gap-2"}>
-            <div className="flex min-w-0 items-center gap-2">
-              <span className="shrink-0 text-[11px] font-medium text-muted-foreground/88">
-                Every
-              </span>
-              <Input
-                type="number"
-                min={1}
-                max={
-                  scheduleDraft.unit === "minute"
-                    ? 59
-                    : scheduleDraft.unit === "hour"
-                      ? 23
-                      : 31
+        <div className="mt-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="shrink-0 text-xs text-muted-foreground">
+              Every
+            </span>
+            <Input
+              type="number"
+              min={1}
+              max={
+                scheduleDraft.unit === "minute"
+                  ? 59
+                  : scheduleDraft.unit === "hour"
+                    ? 23
+                    : 31
+              }
+              step={1}
+              value={String(scheduleDraft.interval)}
+              onChange={(event) => {
+                const nextValue = Number.parseInt(event.target.value, 10);
+                setScheduleDraft((current) => ({
+                  ...current,
+                  interval: Number.isFinite(nextValue)
+                    ? clampScheduleInterval(nextValue, current.unit)
+                    : 1,
+                }));
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") {
+                  return;
                 }
-                step={1}
-                value={String(scheduleDraft.interval)}
-                onChange={(event) => {
-                  const nextValue = Number.parseInt(event.target.value, 10);
-                  setScheduleDraft((current) => ({
-                    ...current,
-                    interval: Number.isFinite(nextValue)
-                      ? clampScheduleInterval(nextValue, current.unit)
-                      : 1,
-                  }));
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter") {
-                    return;
-                  }
-                  event.preventDefault();
-                  handleSave();
-                }}
-                inputMode="numeric"
-                disabled={
-                  !hasWorkspace ||
-                  isLoadingProactiveHeartbeatConfig ||
-                  isUpdatingProactiveHeartbeatConfig
+                event.preventDefault();
+                handleSave();
+              }}
+              inputMode="numeric"
+              disabled={
+                !hasWorkspace ||
+                isLoadingProactiveHeartbeatConfig ||
+                isUpdatingProactiveHeartbeatConfig
+              }
+              className="h-7 w-14 text-xs"
+            />
+            <Select
+              value={scheduleDraft.unit}
+              onValueChange={(value) => {
+                if (!value) {
+                  return;
                 }
-                className={`h-8 rounded-full bg-background/90 px-3 text-center text-[11px] ${
-                  compact ? "w-[72px]" : "w-20"
-                }`}
-              />
-              <div className={compact ? "min-w-0 flex-1" : ""}>
-                <Select
-                  value={scheduleDraft.unit}
-                  onValueChange={(value) => {
-                    if (!value) {
-                      return;
-                    }
-                    const nextUnit = value as ProactiveScheduleUnit;
-                    setScheduleDraft((current) => ({
-                      ...current,
-                      unit: nextUnit,
-                      interval: clampScheduleInterval(current.interval, nextUnit),
-                    }));
-                  }}
-                  disabled={
-                    !hasWorkspace ||
-                    isLoadingProactiveHeartbeatConfig ||
-                    isUpdatingProactiveHeartbeatConfig
-                  }
-                >
-                  <SelectTrigger
-                    className={`h-8 rounded-full bg-background/90 px-3 text-[11px] ${
-                      compact ? "w-full min-w-0" : "min-w-[120px]"
-                    }`}
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="minute">
-                      {scheduleUnitLabel("minute", scheduleDraft.interval)}
-                    </SelectItem>
-                    <SelectItem value="hour">
-                      {scheduleUnitLabel("hour", scheduleDraft.interval)}
-                    </SelectItem>
-                    <SelectItem value="day">
-                      {scheduleUnitLabel("day", scheduleDraft.interval)}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
+                const nextUnit = value as ProactiveScheduleUnit;
+                setScheduleDraft((current) => ({
+                  ...current,
+                  unit: nextUnit,
+                  interval: clampScheduleInterval(current.interval, nextUnit),
+                }));
+              }}
+              disabled={
+                !hasWorkspace ||
+                isLoadingProactiveHeartbeatConfig ||
+                isUpdatingProactiveHeartbeatConfig
+              }
+            >
+              <SelectTrigger className="h-7 w-24 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="minute">
+                  {scheduleUnitLabel("minute", scheduleDraft.interval)}
+                </SelectItem>
+                <SelectItem value="hour">
+                  {scheduleUnitLabel("hour", scheduleDraft.interval)}
+                </SelectItem>
+                <SelectItem value="day">
+                  {scheduleUnitLabel("day", scheduleDraft.interval)}
+                </SelectItem>
+              </SelectContent>
+            </Select>
             <Button
               type="button"
-              size="sm"
+              size="xs"
               variant="outline"
-              className={`h-8 rounded-full px-3 text-[11px] font-medium ${
-                compact ? "w-full" : ""
-              }`}
               onClick={handleSave}
               disabled={!canSave}
             >
@@ -472,39 +445,15 @@ export function ProactiveLifecyclePanel({
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
             {onProactiveWorkspaceEnabledChange ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className={`h-8 rounded-full px-3 text-[11px] font-medium ${proactiveToggleClasses(
-                  proactiveWorkspaceEnabled,
-                )}`}
-                onClick={() =>
-                  !isUpdatingProactiveWorkspaceEnabled &&
-                  onProactiveWorkspaceEnabledChange(
-                    !proactiveWorkspaceEnabled,
-                  )
-                }
-                disabled={
-                  isUpdatingProactiveWorkspaceEnabled ||
-                  !hasWorkspace
-                }
-              >
-                {isUpdatingProactiveWorkspaceEnabled ? (
-                  <Loader2 size={12} className="animate-spin" />
-                ) : (
-                  <span
-                    className={`inline-block size-1.5 rounded-full ${
-                      proactiveToggleDotClasses(
-                        proactiveWorkspaceEnabled,
-                      )
-                    }`}
-                  />
-                )}
-                <span>
-                  {proactiveWorkspaceEnabled ? "Enabled" : "Disabled"}
-                </span>
-              </Button>
+              isUpdatingProactiveWorkspaceEnabled ? (
+                <Loader2 size={12} className="animate-spin text-muted-foreground" />
+              ) : (
+                <Switch
+                  checked={proactiveWorkspaceEnabled}
+                  onCheckedChange={(checked) => onProactiveWorkspaceEnabledChange(checked)}
+                  disabled={isUpdatingProactiveWorkspaceEnabled || !hasWorkspace}
+                />
+              )
             ) : null}
             {onTriggerProposal ? (
               <Tooltip>
@@ -572,36 +521,15 @@ export function ProactiveLifecyclePanel({
             </div>
             <div className="flex items-center gap-1.5">
               {onProactiveWorkspaceEnabledChange ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className={`h-8 rounded-full px-3 text-[11px] font-medium ${proactiveToggleClasses(
-                    proactiveWorkspaceEnabled,
-                  )}`}
-                  onClick={() =>
-                    !isUpdatingProactiveWorkspaceEnabled &&
-                    onProactiveWorkspaceEnabledChange(
-                      !proactiveWorkspaceEnabled,
-                    )
-                  }
-                  disabled={
-                    isUpdatingProactiveWorkspaceEnabled || !hasWorkspace
-                  }
-                >
-                  {isUpdatingProactiveWorkspaceEnabled ? (
-                    <Loader2 size={12} className="animate-spin" />
-                  ) : (
-                    <span
-                      className={`inline-block size-1.5 rounded-full ${proactiveToggleDotClasses(
-                        proactiveWorkspaceEnabled,
-                      )}`}
-                    />
-                  )}
-                  <span>
-                    {proactiveWorkspaceEnabled ? "Enabled" : "Disabled"}
-                  </span>
-                </Button>
+                isUpdatingProactiveWorkspaceEnabled ? (
+                  <Loader2 size={12} className="animate-spin text-muted-foreground" />
+                ) : (
+                  <Switch
+                    checked={proactiveWorkspaceEnabled}
+                    onCheckedChange={(checked) => onProactiveWorkspaceEnabledChange(checked)}
+                    disabled={isUpdatingProactiveWorkspaceEnabled || !hasWorkspace}
+                  />
+                )
               ) : null}
               {onTriggerProposal ? (
                 <Tooltip>

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -434,15 +435,11 @@ export function ProactiveLifecyclePanel({
 
   if (compact) {
     return (
-      <section className="w-full overflow-hidden rounded-[20px] border border-border/40 bg-card">
-        <div className="flex items-center justify-between gap-3 px-3 py-3">
-          <div
-            className={`inline-flex items-center rounded-full border px-3 py-1 text-[10px] font-medium tracking-[0.14em] ${proactiveStateClasses(
-              state,
-            )}`}
-          >
+      <section className="w-full space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <Badge variant="outline" className={proactiveStateClasses(state)}>
             {proactiveStateLabel(state)}
-          </div>
+          </Badge>
           <div className="flex shrink-0 items-center gap-1.5">
             {onProactiveWorkspaceEnabledChange ? (
               isUpdatingProactiveWorkspaceEnabled ? (
@@ -462,11 +459,11 @@ export function ProactiveLifecyclePanel({
                     <Button
                       type="button"
                       size="icon-xs"
-                      variant="outline"
-                      aria-label="Run proactive analysis"
+                      variant="ghost"
+                      aria-label="Run analysis"
                       onClick={onTriggerProposal}
                       disabled={!hasWorkspace || isTriggeringProposal}
-                      className="rounded-full border-border/45 bg-background/90 text-muted-foreground hover:border-primary/35 hover:bg-background hover:text-primary"
+                      className="text-muted-foreground hover:text-primary"
                     />
                   }
                 >
@@ -484,12 +481,8 @@ export function ProactiveLifecyclePanel({
         <ProactiveScheduleEditor
           hasWorkspace={hasWorkspace}
           proactiveHeartbeatCron={proactiveHeartbeatCron}
-          isLoadingProactiveHeartbeatConfig={
-            isLoadingProactiveHeartbeatConfig
-          }
-          isUpdatingProactiveHeartbeatConfig={
-            isUpdatingProactiveHeartbeatConfig
-          }
+          isLoadingProactiveHeartbeatConfig={isLoadingProactiveHeartbeatConfig}
+          isUpdatingProactiveHeartbeatConfig={isUpdatingProactiveHeartbeatConfig}
           onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
           compact
         />
@@ -498,7 +491,7 @@ export function ProactiveLifecyclePanel({
   }
 
   return (
-    <section className="w-full overflow-hidden rounded-[20px] border border-border/40 bg-card shadow-sm">
+    <section className="w-full overflow-hidden rounded-xl border border-border/40 bg-card shadow-sm">
       <div className="px-4 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
@@ -512,13 +505,9 @@ export function ProactiveLifecyclePanel({
             ) : null}
           </div>
           <div className="flex shrink-0 flex-col items-end gap-1.5">
-            <div
-              className={`inline-flex items-center rounded-full border px-3 py-1 text-[10px] font-medium tracking-[0.14em] ${proactiveStateClasses(
-                state,
-              )}`}
-            >
+            <Badge variant="outline" className={proactiveStateClasses(state)}>
               {proactiveStateLabel(state)}
-            </div>
+            </Badge>
             <div className="flex items-center gap-1.5">
               {onProactiveWorkspaceEnabledChange ? (
                 isUpdatingProactiveWorkspaceEnabled ? (

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -173,8 +173,7 @@ function scheduleDraftFromCron(cron: string): ProactiveScheduleDraft {
     ...fallback,
     anchorMinute:
       minuteValue !== null ? Math.min(Math.max(minuteValue, 0), 59) : 0,
-    anchorHour:
-      hourValue !== null ? Math.min(Math.max(hourValue, 0), 23) : 9,
+    anchorHour: hourValue !== null ? Math.min(Math.max(hourValue, 0), 23) : 9,
   };
 }
 
@@ -240,12 +239,12 @@ function ProactiveScheduleEditor({
   const generatedCron = buildCronFromScheduleDraft(scheduleDraft);
   const canSave = Boolean(
     hasWorkspace &&
-      onProactiveHeartbeatCronChange &&
-      !isLoadingProactiveHeartbeatConfig &&
-      !isUpdatingProactiveHeartbeatConfig &&
-      (scheduleDraft.interval !== currentSchedule.interval ||
-        scheduleDraft.unit !== currentSchedule.unit) &&
-      generatedCron.trim(),
+    onProactiveHeartbeatCronChange &&
+    !isLoadingProactiveHeartbeatConfig &&
+    !isUpdatingProactiveHeartbeatConfig &&
+    (scheduleDraft.interval !== currentSchedule.interval ||
+      scheduleDraft.unit !== currentSchedule.unit) &&
+    generatedCron.trim(),
   );
 
   const handleSave = () => {
@@ -261,13 +260,15 @@ function ProactiveScheduleEditor({
         type="button"
         variant="ghost"
         size="sm"
+        className="w-full justify-between"
         onClick={() => setDrawerOpen((current) => !current)}
         aria-expanded={drawerOpen}
-        className="w-full justify-between gap-2 px-0 text-left hover:bg-transparent"
       >
         <span className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>Schedule</span>
-          <span className="text-foreground/72">{scheduleSummaryLabel(currentSchedule)}</span>
+          <span className="text-foreground/72">
+            {scheduleSummaryLabel(currentSchedule)}
+          </span>
         </span>
         <ChevronDown
           size={14}
@@ -368,7 +369,8 @@ function ProactiveScheduleEditor({
           </div>
           {currentSchedule.customCronDetected ? (
             <div className="mt-2 text-[11px] leading-5 text-muted-foreground/72">
-              Saving here replaces the current custom cron with this simpler cadence.
+              Saving here replaces the current custom cron with this simpler
+              cadence.
             </div>
           ) : null}
         </div>
@@ -443,12 +445,19 @@ export function ProactiveLifecyclePanel({
           <div className="flex shrink-0 items-center gap-1.5">
             {onProactiveWorkspaceEnabledChange ? (
               isUpdatingProactiveWorkspaceEnabled ? (
-                <Loader2 size={12} className="animate-spin text-muted-foreground" />
+                <Loader2
+                  size={12}
+                  className="animate-spin text-muted-foreground"
+                />
               ) : (
                 <Switch
                   checked={proactiveWorkspaceEnabled}
-                  onCheckedChange={(checked) => onProactiveWorkspaceEnabledChange(checked)}
-                  disabled={isUpdatingProactiveWorkspaceEnabled || !hasWorkspace}
+                  onCheckedChange={(checked) =>
+                    onProactiveWorkspaceEnabledChange(checked)
+                  }
+                  disabled={
+                    isUpdatingProactiveWorkspaceEnabled || !hasWorkspace
+                  }
                 />
               )
             ) : null}
@@ -482,7 +491,9 @@ export function ProactiveLifecyclePanel({
           hasWorkspace={hasWorkspace}
           proactiveHeartbeatCron={proactiveHeartbeatCron}
           isLoadingProactiveHeartbeatConfig={isLoadingProactiveHeartbeatConfig}
-          isUpdatingProactiveHeartbeatConfig={isUpdatingProactiveHeartbeatConfig}
+          isUpdatingProactiveHeartbeatConfig={
+            isUpdatingProactiveHeartbeatConfig
+          }
           onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
           compact
         />
@@ -511,12 +522,19 @@ export function ProactiveLifecyclePanel({
             <div className="flex items-center gap-1.5">
               {onProactiveWorkspaceEnabledChange ? (
                 isUpdatingProactiveWorkspaceEnabled ? (
-                  <Loader2 size={12} className="animate-spin text-muted-foreground" />
+                  <Loader2
+                    size={12}
+                    className="animate-spin text-muted-foreground"
+                  />
                 ) : (
                   <Switch
                     checked={proactiveWorkspaceEnabled}
-                    onCheckedChange={(checked) => onProactiveWorkspaceEnabledChange(checked)}
-                    disabled={isUpdatingProactiveWorkspaceEnabled || !hasWorkspace}
+                    onCheckedChange={(checked) =>
+                      onProactiveWorkspaceEnabledChange(checked)
+                    }
+                    disabled={
+                      isUpdatingProactiveWorkspaceEnabled || !hasWorkspace
+                    }
                   />
                 )
               ) : null}
@@ -552,9 +570,7 @@ export function ProactiveLifecyclePanel({
         hasWorkspace={hasWorkspace}
         proactiveHeartbeatCron={proactiveHeartbeatCron}
         isLoadingProactiveHeartbeatConfig={isLoadingProactiveHeartbeatConfig}
-        isUpdatingProactiveHeartbeatConfig={
-          isUpdatingProactiveHeartbeatConfig
-        }
+        isUpdatingProactiveHeartbeatConfig={isUpdatingProactiveHeartbeatConfig}
         onProactiveHeartbeatCronChange={onProactiveHeartbeatCronChange}
       />
     </section>

--- a/desktop/src/components/layout/ProactiveStatusCard.tsx
+++ b/desktop/src/components/layout/ProactiveStatusCard.tsx
@@ -64,7 +64,7 @@ function proactiveStateClasses(state: string): string {
     return "border-indigo-500/25 bg-indigo-500/10 text-indigo-700 dark:text-indigo-300";
   }
   if (state === "analyzing") {
-    return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    return "border-warning/30 bg-warning/10 text-warning";
   }
   if (state === "error" || state === "unavailable") {
     return "border-destructive/30 bg-destructive/10 text-destructive";
@@ -82,7 +82,7 @@ function proactiveToggleClasses(enabled: boolean): string {
 }
 
 function proactiveToggleDotClasses(enabled: boolean): string {
-  return enabled ? "bg-emerald-500" : "bg-amber-500";
+  return enabled ? "bg-success" : "bg-warning";
 }
 
 type ProactiveScheduleUnit = "minute" | "hour" | "day";

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -18,6 +18,7 @@ import { AuthPanel } from "@/components/auth/AuthPanel";
 import { BillingSettingsPanel } from "@/components/billing/BillingSettingsPanel";
 import { IntegrationsPane } from "@/components/panes/IntegrationsPane";
 import { SubmissionsPanel } from "@/components/settings/SubmissionsPanel";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 const THEME_SWATCHES: Record<string, [string, string, string]> = {
@@ -266,13 +267,13 @@ export function SettingsDialog({
             ) : null}
 
             {activeSection === "settings" ? (
-              <div className="grid gap-6">
-                <section className="theme-subtle-surface rounded-[24px] border border-border/40 p-5">
-                  <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+              <div className="grid gap-5">
+                <section>
+                  <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
                     Appearance
                   </div>
 
-                  <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                     {themes.map((themeOption) => {
                       const selected = themeOption === theme;
                       const swatches = THEME_SWATCHES[themeOption] ?? [
@@ -282,54 +283,51 @@ export function SettingsDialog({
                       ];
 
                       return (
-                        <button
+                        <Button
                           key={themeOption}
-                          type="button"
+                          variant="ghost"
                           onClick={() => onThemeChange(themeOption)}
-                          className={`rounded-xl border p-3 text-left transition-colors ${
+                          className={`h-auto flex-col items-stretch rounded-xl border p-2.5 text-left ${
                             selected
-                              ? "border-primary/45 bg-primary/10 shadow-sm"
-                              : "border-border/40 bg-card/80 hover:border-primary/28 hover:bg-accent"
+                              ? "border-primary/40 bg-primary/6"
+                              : "border-border/40 hover:border-border hover:bg-accent"
                           }`}
                         >
-                          <div className="rounded-[16px] border border-border/30 bg-card/80 p-3">
-                            <div className="grid grid-cols-[1.2fr_0.9fr] gap-2">
+                          <div className="grid grid-cols-[1.2fr_0.9fr] gap-2">
+                            <div
+                              className="h-14 rounded-lg border border-white/10"
+                              style={{
+                                background: `linear-gradient(160deg, ${swatches[0]}, ${swatches[2]})`,
+                              }}
+                            />
+                            <div className="grid gap-2">
                               <div
-                                className="h-16 rounded-[14px] border border-white/10"
+                                className="h-6 rounded-md border border-white/10"
+                                style={{ background: swatches[1] }}
+                              />
+                              <div
+                                className="h-6 rounded-md border border-white/10"
                                 style={{
-                                  background: `linear-gradient(160deg, ${swatches[0]}, ${swatches[2]})`,
+                                  background: `color-mix(in srgb, ${swatches[1]} 42%, ${swatches[0]} 58%)`,
                                 }}
                               />
-                              <div className="grid gap-2">
-                                <div
-                                  className="h-7 rounded-[10px] border border-white/10"
-                                  style={{ background: swatches[1] }}
-                                />
-                                <div
-                                  className="h-7 rounded-[10px] border border-white/10"
-                                  style={{
-                                    background: `color-mix(in srgb, ${swatches[1]} 42%, ${swatches[0]} 58%)`,
-                                  }}
-                                />
-                              </div>
                             </div>
                           </div>
 
-                          <div className="mt-3 flex items-center justify-between gap-3">
-                            <span className="text-sm font-medium text-foreground">
+                          <div className="mt-2.5 flex items-center justify-between gap-2">
+                            <span className="text-[13px] font-medium text-foreground">
                               {prettifyThemeLabel(themeOption)}
                             </span>
-                            <span
-                              className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-[0.14em] ${
-                                selected
-                                  ? "border-primary/40 bg-primary/12 text-primary"
-                                  : "border-border/35 text-muted-foreground/68"
-                              }`}
-                            >
-                              {selected ? "Active" : "Preview"}
-                            </span>
+                            {selected ? (
+                              <Badge
+                                variant="outline"
+                                className="border-primary/40 bg-primary/10 text-primary"
+                              >
+                                Active
+                              </Badge>
+                            ) : null}
                           </div>
-                        </button>
+                        </Button>
                       );
                     })}
                   </div>

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -198,10 +198,10 @@ export function SettingsDialog({
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
-        className="pointer-events-auto relative z-10 grid h-[min(780px,calc(100vh-32px))] w-[min(1080px,calc(100vw-24px))] min-w-0 overflow-hidden rounded-[28px] border border-border bg-background shadow-lg grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[248px_minmax(0,1fr)] lg:grid-rows-1"
+        className="pointer-events-auto relative z-10 grid h-[min(680px,calc(100vh-32px))] w-[min(880px,calc(100vw-24px))] min-w-0 overflow-hidden rounded-2xl border border-border bg-background shadow-lg grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[220px_minmax(0,1fr)] lg:grid-rows-1"
       >
         <aside className="border-b border-sidebar-border bg-sidebar p-4 text-sidebar-foreground lg:border-b-0 lg:border-r">
-          <nav className="mt-6 grid gap-1.5">
+          <nav className="mt-6 grid gap-1">
             {SETTINGS_SECTIONS.map(({ id, label, icon: Icon }) => {
               const active = id === activeSection;
 
@@ -210,22 +210,14 @@ export function SettingsDialog({
                   key={id}
                   type="button"
                   onClick={() => onSectionChange(id)}
-                  className={`flex items-center gap-3 rounded-lg px-2.5 py-2 text-left transition ${
+                  className={`flex h-8 items-center gap-2.5 rounded-lg px-2.5 text-left text-[13px] transition-colors ${
                     active
                       ? "bg-sidebar-accent text-sidebar-accent-foreground"
                       : "text-sidebar-foreground/72 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                   }`}
                 >
-                  <span
-                    className={`grid h-8 w-8 shrink-0 place-items-center rounded-[10px] ${
-                      active
-                        ? "bg-sidebar-primary/12 text-sidebar-primary"
-                        : "text-sidebar-foreground/60"
-                    }`}
-                  >
-                    <Icon className="size-4" />
-                  </span>
-                  <span className="min-w-0 text-sm font-medium">{label}</span>
+                  <Icon className="size-4 shrink-0" />
+                  <span className="min-w-0 font-medium">{label}</span>
                 </button>
               );
             })}
@@ -233,22 +225,22 @@ export function SettingsDialog({
         </aside>
 
         <section className="flex min-h-0 min-w-0 flex-col overflow-hidden">
-          <header className="flex items-center justify-between gap-4 border-b border-border/35 px-6 py-5">
-            <div className="text-xl font-semibold text-foreground">
+          <header className="flex items-center justify-between gap-4 border-b border-border/35 px-6 py-4">
+            <div className="text-base font-semibold text-foreground">
               {titleForSection(activeSection)}
             </div>
 
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="icon"
               onClick={onClose}
               aria-label="Close settings"
-              className="grid h-10 w-10 shrink-0 place-items-center rounded-[14px] border border-border/45 text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
             >
               <X size={16} />
-            </button>
+            </Button>
           </header>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 [scrollbar-gutter:stable]">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5 [scrollbar-gutter:stable]">
             {activeSection === "account" ? (
               <div className="w-full">
                 <AuthPanel view="account" />
@@ -294,7 +286,7 @@ export function SettingsDialog({
                           key={themeOption}
                           type="button"
                           onClick={() => onThemeChange(themeOption)}
-                          className={`rounded-[20px] border p-3 text-left transition ${
+                          className={`rounded-xl border p-3 text-left transition-colors ${
                             selected
                               ? "border-primary/45 bg-primary/10 shadow-sm"
                               : "border-border/40 bg-card/80 hover:border-primary/28 hover:bg-accent"
@@ -346,7 +338,7 @@ export function SettingsDialog({
             ) : null}
 
             {activeSection === "about" ? (
-              <div className="grid max-w-[720px] gap-4">
+              <div className="grid max-w-[720px] gap-8">
                 <section className="theme-subtle-surface rounded-[24px] border border-border/40 p-5">
                   <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                     Links

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -382,6 +382,7 @@ export function SettingsDialog({
                     <Button
                       type="button"
                       variant="outline"
+                      size="sm"
                       onClick={() => void handleExportDiagnosticsBundle()}
                       disabled={diagnosticsExportState.status === "exporting"}
                     >
@@ -392,9 +393,6 @@ export function SettingsDialog({
                       )}
                       Export Diagnostics Bundle
                     </Button>
-                    <span className="text-xs text-muted-foreground/80">
-                      Saved to Downloads as a zip file.
-                    </span>
                   </div>
                   {diagnosticsExportState.message ? (
                     <div

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -384,38 +384,22 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon-lg" />}
+              render={<Button variant="outline" size="icon-lg" className="relative" />}
             >
               <User2 />
+              <span
+                className={`absolute -right-0.5 -top-0.5 size-2 rounded-full ring-2 ring-background ${
+                  runtimeStatus?.status === "running"
+                    ? "bg-success"
+                    : runtimeStatus?.status === "starting"
+                      ? "animate-pulse bg-warning"
+                      : runtimeStatus?.status === "error"
+                        ? "bg-destructive"
+                        : "bg-muted-foreground/40"
+                }`}
+              />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" sideOffset={8} className="w-56">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="px-3 py-3">
-                  <div className="flex items-center gap-2.5">
-                    <span
-                      className={`size-2.5 shrink-0 rounded-full ${
-                        runtimeStatus?.status === "running"
-                          ? "bg-success"
-                          : runtimeStatus?.status === "starting"
-                            ? "animate-pulse bg-warning"
-                            : runtimeStatus?.status === "error"
-                              ? "bg-destructive"
-                              : "bg-muted-foreground/50"
-                      }`}
-                    />
-                    <span className="text-sm font-medium text-foreground">
-                      {runtimeStatus?.status === "running"
-                        ? "Runtime active"
-                        : runtimeStatus?.status === "starting"
-                          ? "Runtime starting"
-                          : runtimeStatus?.status === "error"
-                            ? "Runtime error"
-                            : "Runtime offline"}
-                    </span>
-                  </div>
-                </DropdownMenuLabel>
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
+            <DropdownMenuContent align="end" sideOffset={8} className="w-52">
               <DropdownMenuGroup>
                 <DropdownMenuItem onClick={() => onOpenAccount?.()}>
                   <User2 />

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -395,9 +395,9 @@ export function TopTabsBar({
                     <span
                       className={`size-2.5 shrink-0 rounded-full ${
                         runtimeStatus?.status === "running"
-                          ? "bg-emerald-500"
+                          ? "bg-success"
                           : runtimeStatus?.status === "starting"
-                            ? "animate-pulse bg-amber-400"
+                            ? "animate-pulse bg-warning"
                             : runtimeStatus?.status === "error"
                               ? "bg-destructive"
                               : "bg-muted-foreground/50"

--- a/desktop/src/components/onboarding/CreatingView.tsx
+++ b/desktop/src/components/onboarding/CreatingView.tsx
@@ -51,7 +51,7 @@ export function CreatingView({
         className={`w-full ${panelVariant ? "h-full max-w-[1020px]" : "max-w-[540px]"}`}
       >
         <div
-          className={`theme-shell mx-auto flex w-full flex-col items-center rounded-[var(--radius-xl)] border border-border/45 shadow-lg ${
+          className={`theme-shell mx-auto flex w-full flex-col items-center rounded-xl border border-border/45 shadow-lg ${
             panelVariant
               ? "h-full max-w-[1020px] justify-center px-6 py-6 sm:px-8 sm:py-7 lg:px-10 lg:py-8"
               : "max-w-[540px] px-6 py-8 sm:px-8"

--- a/desktop/src/components/panes/AppSurfacePane.tsx
+++ b/desktop/src/components/panes/AppSurfacePane.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Activity, LoaderCircle, Plug, RefreshCw, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import { getWorkspaceAppDefinition, type WorkspaceAppDefinition, type WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
@@ -173,15 +174,16 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
             <div className="text-xs leading-5 text-foreground">{error}</div>
           </div>
           <div className="mt-3">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="default"
               onClick={() => void handleRemove()}
               disabled={isRemoving}
-              className="inline-flex h-8 items-center gap-2 rounded-md border border-border px-3 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
             >
               {isRemoving ? <LoaderCircle size={13} className="animate-spin" /> : <Trash2 size={13} />}
               Remove
-            </button>
+            </Button>
           </div>
           {actionError ? (
             <div className="mt-2 rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-xs text-destructive">
@@ -262,41 +264,49 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
         {/* Actions pinned to bottom */}
         <div className="border-t border-border p-3">
           <div className="flex flex-col gap-1.5">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="default"
               onClick={() => setReloadKey((k) => k + 1)}
-              className="flex h-8 items-center justify-center gap-2 rounded-md border border-border text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              className="w-full justify-center"
             >
               <RefreshCw size={12} />
               Reload
-            </button>
+            </Button>
             {confirmRemove ? (
               <div className="flex items-center gap-1.5">
-                <button
+                <Button
                   type="button"
+                  variant="destructive"
+                  size="default"
                   onClick={() => void handleRemove()}
                   disabled={isRemoving}
-                  className="flex h-8 flex-1 items-center justify-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 text-xs text-destructive transition-colors hover:bg-destructive/15 disabled:opacity-50"
+                  className="flex-1 justify-center"
                 >
                   {isRemoving ? "Removing..." : "Confirm"}
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="outline"
+                  size="default"
                   onClick={() => setConfirmRemove(false)}
-                  className="flex h-8 flex-1 items-center justify-center rounded-md border border-border text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className="flex-1 justify-center"
                 >
                   Cancel
-                </button>
+                </Button>
               </div>
             ) : (
-              <button
+              <Button
                 type="button"
+                variant="outline"
+                size="default"
                 onClick={() => setConfirmRemove(true)}
-                className="flex h-8 items-center justify-center gap-2 rounded-md border border-border text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="w-full justify-center"
               >
                 <Trash2 size={12} />
                 Remove app
-              </button>
+              </Button>
             )}
           </div>
 
@@ -336,14 +346,16 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
               <div className="max-w-sm rounded-lg border border-destructive/25 bg-destructive/5 p-4 text-center">
                 <div className="text-sm font-medium text-foreground">App preview unavailable</div>
                 <div className="mt-2 text-xs leading-5 text-muted-foreground">{frameError}</div>
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="default"
                   onClick={() => setReloadKey((k) => k + 1)}
-                  className="mt-3 inline-flex h-8 items-center gap-2 rounded-md border border-border px-3 text-xs text-foreground transition-colors hover:bg-accent"
+                  className="mt-3"
                 >
                   <RefreshCw size={12} />
                   Retry
-                </button>
+                </Button>
               </div>
             </div>
           ) : null}

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Clock3, Loader2, MoreHorizontal, Play, Plus, Trash2 } from "lucide-react";
-import { PaneCard } from "@/components/ui/PaneCard";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PaneCard } from "@/components/ui/PaneCard";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -378,28 +379,24 @@ export function AutomationsPane({
 
           <div className="theme-subtle-surface mt-5 inline-flex items-center rounded-xl border border-border/45 p-1">
             <div className="inline-flex items-center gap-1">
-              <button
+              <Button
                 type="button"
+                variant={activeTab === "scheduled" ? "secondary" : "ghost"}
+                size="default"
                 onClick={() => setActiveTab("scheduled")}
-                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
-                  activeTab === "scheduled"
-                    ? "bg-card text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+                className={activeTab === "scheduled" ? "shadow-sm" : ""}
               >
                 Scheduled
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant={activeTab === "completed" ? "secondary" : "ghost"}
+                size="default"
                 onClick={() => setActiveTab("completed")}
-                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
-                  activeTab === "completed"
-                    ? "bg-card text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+                className={activeTab === "completed" ? "shadow-sm" : ""}
               >
                 Completed
-              </button>
+              </Button>
             </div>
           </div>
 
@@ -444,11 +441,12 @@ export function AutomationsPane({
                               {jobTitle(job)}
                             </div>
                             <div className="mt-1">
-                              <span
-                                className={`inline-flex h-5 items-center rounded-full border px-2 text-[10px] font-medium uppercase tracking-[0.12em] ${jobKindClassName(job)}`}
+                              <Badge
+                                variant="outline"
+                                className={`uppercase tracking-[0.12em] ${jobKindClassName(job)}`}
                               >
                                 {jobKindLabel(job)}
-                              </span>
+                              </Badge>
                             </div>
                           </div>
 
@@ -564,11 +562,12 @@ export function AutomationsPane({
                       </div>
 
                       <div>
-                        <span
-                          className={`inline-flex h-6 items-center rounded-full border px-2 text-[11px] font-medium ${completedStatusClassName(run.status)}`}
+                        <Badge
+                          variant="outline"
+                          className={completedStatusClassName(run.status)}
                         >
                           {completedStatusLabel(run.status)}
-                        </span>
+                        </Badge>
                       </div>
                     </button>
                   ))}

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -19,6 +19,7 @@ import {
   Star,
   X,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/IconButton";
 import { PaneCard } from "@/components/ui/PaneCard";
@@ -526,7 +527,7 @@ export function BrowserPane({
                 <div
                   key={tab.id}
                   className={[
-                    "group flex min-w-0 max-w-[200px] items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors",
+                    "group flex min-w-0 max-w-[200px] items-center gap-1.5 rounded-lg border px-2.5 py-1 transition-colors",
                     isActive
                       ? "border-primary/50 bg-primary/12 text-primary"
                       : "bg-muted border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground",
@@ -542,7 +543,7 @@ export function BrowserPane({
                   >
                     <Globe size={12} className="shrink-0" />
                     {!isNarrowPane ? (
-                      <span className="truncate text-[10px] font-semibold tracking-wide">
+                      <span className="truncate text-xs font-semibold tracking-wide">
                         {tab.title || "New Tab"}
                       </span>
                     ) : null}
@@ -550,14 +551,15 @@ export function BrowserPane({
                       <Loader2 size={11} className="shrink-0 animate-spin" />
                     ) : null}
                   </button>
-                  <button
-                    type="button"
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
                     onClick={() => onCloseTab(tab.id)}
-                    className="grid size-4.5 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-current"
+                    className="size-4.5 shrink-0 text-muted-foreground"
                     aria-label={`Close ${tab.title || "tab"}`}
                   >
                     <X size={11} />
-                  </button>
+                  </Button>
                 </div>
               );
             })}
@@ -567,7 +569,7 @@ export function BrowserPane({
               variant="outline"
               size="icon-sm"
               onClick={onNewTab}
-              className="shrink-0 rounded-full"
+              className="shrink-0"
               aria-label="New tab"
             >
               <Plus size={12} />
@@ -607,7 +609,7 @@ export function BrowserPane({
                   variant="outline"
                   size="sm"
                   onClick={() => onSelectBrowserSpace(alternateBrowserSpace)}
-                  className="shrink-0 rounded-full bg-background/80 text-[11px]"
+                  className="shrink-0 bg-background/80 text-xs"
                   aria-label={`Switch to ${alternateBrowserLabel} browser`}
                   title={`Switch to ${alternateBrowserLabel} browser`}
                 >
@@ -645,9 +647,9 @@ export function BrowserPane({
                 >
                   <MoreHorizontal size={14} />
                   {activeDownloadCount > 0 ? (
-                    <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full border border-primary/55 bg-primary/90 px-1 text-[9px] font-bold leading-4 text-black">
+                    <Badge className="absolute -right-1 -top-1 h-4 min-w-4 px-1 text-xs font-bold leading-none">
                       {activeDownloadCount}
-                    </span>
+                    </Badge>
                   ) : null}
                 </Button>
               </div>
@@ -675,21 +677,21 @@ export function BrowserPane({
                       window.setTimeout(() => setAddressFocused(false), 120)
                     }
                     onKeyDown={onAddressKeyDown}
-                    className="embedded-input w-full min-w-0 bg-transparent text-[11px] text-foreground outline-none placeholder:text-muted-foreground"
+                    className="embedded-input w-full min-w-0 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
                     placeholder={
                       isNarrowPane ? "Search" : "Enter URL or search"
                     }
                   />
                   {!isNarrowPane ? (
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
                       onClick={onToggleBookmark}
-                      className={[
-                        "grid size-6 shrink-0 place-items-center rounded-full border transition-colors",
+                      className={
                         isBookmarked
                           ? "border-primary/60 bg-primary/18 text-primary"
-                          : "border-transparent bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                      ].join(" ")}
+                          : "text-muted-foreground"
+                      }
                       aria-label={
                         isBookmarked ? "Remove bookmark" : "Add bookmark"
                       }
@@ -702,7 +704,7 @@ export function BrowserPane({
                         size={13}
                         fill={isBookmarked ? "currentColor" : "none"}
                       />
-                    </button>
+                    </Button>
                   ) : null}
                 </div>
               </div>
@@ -712,11 +714,12 @@ export function BrowserPane({
           {showBookmarkStrip ? (
             <div className="flex min-h-6 items-center gap-0.5 overflow-x-auto px-1.5 py-0.5">
               {bookmarks.slice(0, 12).map((bookmark) => (
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="xs"
                   key={bookmark.id}
                   onClick={() => navigateTo(bookmark.url)}
-                  className="shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground/80"
+                  className="shrink-0 px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
                 >
                   <span className="flex items-center gap-1.5">
                     {bookmark.faviconUrl ? (
@@ -734,7 +737,7 @@ export function BrowserPane({
                       {bookmark.title}
                     </span>
                   </span>
-                </button>
+                </Button>
               ))}
             </div>
           ) : null}
@@ -766,7 +769,7 @@ export function BrowserPane({
 
             {activeTab.initialized && activeTab.loading ? (
               <div className="pointer-events-none absolute inset-x-3 top-3 z-10">
-                <div className="inline-flex items-center gap-2 rounded-full border border-border/50 bg-card px-3 py-1.5 text-[11px] text-muted-foreground shadow-lg backdrop-blur">
+                <div className="inline-flex items-center gap-2 rounded-lg border border-border/50 bg-card px-3 py-1.5 text-xs text-muted-foreground shadow-lg backdrop-blur">
                   <Loader2
                     size={12}
                     className="animate-spin text-primary"

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -19,6 +19,7 @@ import {
   Star,
   X,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/IconButton";
 import { PaneCard } from "@/components/ui/PaneCard";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
@@ -561,14 +562,16 @@ export function BrowserPane({
               );
             })}
 
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="icon-sm"
               onClick={onNewTab}
-              className="bg-muted grid size-7 shrink-0 place-items-center rounded-full border border-border text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+              className="shrink-0 rounded-full"
               aria-label="New tab"
             >
               <Plus size={12} />
-            </button>
+            </Button>
           </div>
 
           <div
@@ -599,10 +602,12 @@ export function BrowserPane({
                   disabled={!activeTab.initialized}
                   className="size-7"
                 />
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="sm"
                   onClick={() => onSelectBrowserSpace(alternateBrowserSpace)}
-                  className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-muted-foreground transition hover:border-primary/28 hover:text-foreground"
+                  className="shrink-0 rounded-full bg-background/80 text-[11px]"
                   aria-label={`Switch to ${alternateBrowserLabel} browser`}
                   title={`Switch to ${alternateBrowserLabel} browser`}
                 >
@@ -615,19 +620,18 @@ export function BrowserPane({
                     }
                   />
                   {!isNarrowPane ? <span>{visibleBrowserLabel}</span> : null}
-                </button>
+                </Button>
               </div>
 
               <div
                 className={`relative flex shrink-0 items-center gap-1 ${isCompactPane ? "" : "ml-auto"}`}
               >
-                <button
+                <Button
                   ref={moreButtonRef}
                   type="button"
-                  className={[
-                    "bg-muted relative grid size-7 place-items-center rounded-md border transition-colors",
-                    "border-border/60 text-muted-foreground hover:border-primary/45 hover:text-primary",
-                  ].join(" ")}
+                  variant="outline"
+                  size="icon-sm"
+                  className="relative"
                   aria-label="More browser options"
                   title="More"
                   onClick={() => {
@@ -645,7 +649,7 @@ export function BrowserPane({
                       {activeDownloadCount}
                     </span>
                   ) : null}
-                </button>
+                </Button>
               </div>
             </div>
 

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -21,7 +21,6 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { IconButton } from "@/components/ui/IconButton";
 import { PaneCard } from "@/components/ui/PaneCard";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -582,28 +581,34 @@ export function BrowserPane({
             <div
               className={`flex min-w-0 ${isCompactPane ? "w-full items-center justify-between gap-1" : "items-center gap-1"}`}
             >
-              <div className="flex min-w-0 items-center gap-1">
-                <IconButton
-                  icon={<ChevronLeft size={13} />}
-                  label="Back"
+              <div className="flex min-w-0 items-center gap-0.5">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Back"
                   onClick={() => void window.electronAPI.browser.back()}
                   disabled={!activeTab.canGoBack}
-                  className="size-7"
-                />
-                <IconButton
-                  icon={<ChevronRight size={13} />}
-                  label="Forward"
+                >
+                  <ChevronLeft size={14} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Forward"
                   onClick={() => void window.electronAPI.browser.forward()}
                   disabled={!activeTab.canGoForward}
-                  className="size-7"
-                />
-                <IconButton
-                  icon={<RefreshCcw size={13} />}
-                  label="Refresh"
+                >
+                  <ChevronRight size={14} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Refresh"
                   onClick={() => void window.electronAPI.browser.reload()}
                   disabled={!activeTab.initialized}
-                  className="size-7"
-                />
+                >
+                  <RefreshCcw size={13} />
+                </Button>
                 <Button
                   type="button"
                   variant="outline"

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -5618,85 +5618,80 @@ function ArtifactBrowserModal({
   );
 
   return (
-    <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/45 px-4 py-6 backdrop-blur-[2px]">
-      <div className="bg-background flex h-full max-h-[720px] w-full max-w-[760px] flex-col rounded-[28px] border border-border/50 shadow-2xl">
-        <div className="flex items-center justify-between gap-4 border-b border-border/35 px-5 py-4">
+    <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/40 px-6 py-8 backdrop-blur-[2px]">
+      <div className="flex max-h-full w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border/50 bg-background shadow-xl">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/30 px-4 py-3">
           <div>
-            <div className="text-[24px] font-semibold tracking-[-0.03em] text-foreground">
-              All artifacts in this session
+            <div className="text-sm font-semibold text-foreground">
+              Artifacts
             </div>
-            <div className="mt-1 text-[12px] text-muted-foreground">
-              {outputs.length} artifact{outputs.length === 1 ? "" : "s"}
+            <div className="text-xs text-muted-foreground">
+              {outputs.length} item{outputs.length === 1 ? "" : "s"} in this session
             </div>
           </div>
           <Button
             type="button"
-            variant="outline"
-            size="icon"
+            variant="ghost"
+            size="icon-sm"
             onClick={onClose}
-            className="rounded-full"
-            aria-label="Close artifacts browser"
+            aria-label="Close"
           >
-            <X size={16} />
+            <X size={14} />
           </Button>
         </div>
 
-        <div className="flex flex-wrap gap-2 px-5 py-4">
+        <div className="flex shrink-0 flex-wrap gap-1.5 border-b border-border/20 px-4 py-2.5">
           {filterLabels.map((item) => {
             const active = filter === item.id;
             return (
-              <button
+              <Button
                 key={item.id}
-                type="button"
+                variant={active ? "secondary" : "ghost"}
+                size="xs"
                 onClick={() => onFilterChange(item.id)}
-                className={`rounded-full border px-3 py-1.5 text-[12px] transition ${
-                  active
-                    ? "border-foreground bg-foreground text-background"
-                    : "border-border/45 text-muted-foreground hover:border-border/70 hover:text-foreground"
-                }`}
               >
                 {item.label}
-              </button>
+              </Button>
             );
           })}
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
           {filteredOutputs.length === 0 ? (
-            <div className="flex h-full items-center justify-center rounded-[24px] border border-dashed border-border/45 text-[13px] text-muted-foreground">
+            <div className="py-10 text-center text-xs text-muted-foreground">
               No artifacts match this filter.
             </div>
           ) : (
-            <div className="grid gap-2">
+            <div className="grid gap-1">
               {filteredOutputs.map((output) => (
-                <button
+                <Button
                   key={output.id}
-                  type="button"
+                  variant="ghost"
                   onClick={() => {
                     onClose();
                     onOpenOutput?.(output);
                   }}
                   disabled={!onOpenOutput}
-                  className="flex items-center gap-3 rounded-[18px] border border-border/35 px-4 py-3 text-left transition hover:border-border/60 hover:bg-muted/45 disabled:cursor-default disabled:hover:border-border/35 disabled:hover:bg-transparent"
+                  className="h-auto w-full justify-start gap-3 px-3 py-2.5 text-left"
                 >
                   <OutputArtifactIcon output={output} />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-[14px] font-medium text-foreground">
+                    <div className="truncate text-sm font-medium text-foreground">
                       {output.title || "Untitled artifact"}
                     </div>
-                    <div className="truncate text-[12px] text-muted-foreground">
+                    <div className="truncate text-xs text-muted-foreground">
                       {outputSecondaryLabel(output)}
                     </div>
                   </div>
                   {outputChangeLabel(output) ? (
                     <Badge
                       variant="outline"
-                      className="uppercase tracking-[0.12em]"
+                      className="shrink-0 uppercase tracking-[0.12em]"
                     >
                       {outputChangeLabel(output)}
                     </Badge>
                   ) : null}
-                </button>
+                </Button>
               ))}
             </div>
           )}

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -35,6 +35,7 @@ import {
   Waypoints,
   X,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PaneCard } from "@/components/ui/PaneCard";
@@ -4342,23 +4343,27 @@ export function ChatPane({
                 </div>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2">
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="sm"
                   onClick={() => openExternalUrl(billingLinks?.addCreditsUrl)}
-                  className="inline-flex items-center rounded-full border border-primary/35 bg-primary/10 px-3 py-1.5 text-[12px] font-medium text-primary transition hover:bg-primary/16"
+                  className="rounded-full border-primary/35 bg-primary/10 text-primary hover:bg-primary/16"
                 >
                   Add credits
-                </button>
+                </Button>
                 {showOutOfCreditsWarning ? (
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
+                    size="sm"
                     onClick={() =>
                       openExternalUrl(billingLinks?.billingPageUrl)
                     }
-                    className="inline-flex items-center rounded-full border border-border/60 bg-background px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-primary/35 hover:text-primary"
+                    className="rounded-full"
                   >
                     Manage on web
-                  </button>
+                  </Button>
                 ) : null}
               </div>
             </div>
@@ -4379,13 +4384,15 @@ export function ChatPane({
                   <div className="text-[10px] tracking-[0.12em] text-muted-foreground">
                     Stream telemetry ({streamTelemetry.length})
                   </div>
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
+                    size="xs"
                     onClick={() => setStreamTelemetry([])}
-                    className="rounded border border-border/50 px-2 py-1 text-[10px] text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
+                    className="text-[10px]"
                   >
                     Clear
-                  </button>
+                  </Button>
                 </div>
                 <div className="bg-muted max-h-36 overflow-y-auto rounded border border-border/35 p-2 font-mono text-[10px] text-muted-foreground">
                   {streamTelemetryTail.length === 0 ? (
@@ -5494,29 +5501,33 @@ function AssistantTurnMemoryProposals({
               </div>
 
               <div className="flex shrink-0 items-start gap-2">
-                <div className="rounded-full border border-border/45 px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                <Badge variant="outline" className="uppercase tracking-[0.14em]">
                   {memoryProposalStateLabel(proposal.state)}
-                </div>
+                </Badge>
                 {isPending ? (
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
+                    size="icon"
                     onClick={() => onEditProposal(proposal.proposal_id)}
-                    className="grid h-9 w-9 place-items-center rounded-[14px] border border-border/45 text-muted-foreground transition hover:border-border/70 hover:text-foreground"
+                    className="rounded-[14px]"
                     aria-label="Edit memory proposal"
                   >
                     <PencilLine size={14} />
-                  </button>
+                  </Button>
                 ) : null}
               </div>
             </div>
 
             {isPending ? (
               <div className="mt-4 flex flex-wrap gap-2">
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="lg"
                   onClick={() => onDismissProposal(proposal)}
                   disabled={isActing}
-                  className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/45 px-3 text-sm text-muted-foreground transition hover:border-primary/28 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-2xl"
                 >
                   {isActing && proposalAction?.action === "dismiss" ? (
                     <Loader2 size={12} className="animate-spin" />
@@ -5524,12 +5535,14 @@ function AssistantTurnMemoryProposals({
                     <X size={12} />
                   )}
                   <span>Dismiss</span>
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="outline"
+                  size="lg"
                   onClick={() => onAcceptProposal(proposal)}
                   disabled={isActing}
-                  className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-primary/40 bg-primary/10 px-3 text-sm text-primary transition hover:bg-primary/14 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-2xl border-primary/40 bg-primary/10 text-primary hover:bg-primary/14"
                 >
                   {isActing && proposalAction?.action === "accept" ? (
                     <Loader2 size={12} className="animate-spin" />
@@ -5537,7 +5550,7 @@ function AssistantTurnMemoryProposals({
                     <Check size={12} />
                   )}
                   <span>Accept</span>
-                </button>
+                </Button>
               </div>
             ) : null}
           </article>
@@ -5594,14 +5607,16 @@ function ArtifactBrowserModal({
               {outputs.length} artifact{outputs.length === 1 ? "" : "s"}
             </div>
           </div>
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="icon"
             onClick={onClose}
-            className="grid h-9 w-9 place-items-center rounded-full border border-border/45 text-muted-foreground transition hover:border-border/70 hover:text-foreground"
+            className="rounded-full"
             aria-label="Close artifacts browser"
           >
             <X size={16} />
-          </button>
+          </Button>
         </div>
 
         <div className="flex flex-wrap gap-2 px-5 py-4">
@@ -5652,9 +5667,9 @@ function ArtifactBrowserModal({
                     </div>
                   </div>
                   {outputChangeLabel(output) ? (
-                    <div className="rounded-full border border-border/45 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                    <Badge variant="outline" className="uppercase tracking-[0.12em]">
                       {outputChangeLabel(output)}
-                    </div>
+                    </Badge>
                   ) : null}
                 </button>
               ))}
@@ -6310,10 +6325,12 @@ function Composer({
           >
             {noAvailableModels ? (
               <>
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="lg"
                   onClick={onOpenModelProviders}
-                  className="bg-card flex h-9 shrink-0 items-center justify-between gap-2 rounded-[11px] border border-border/28 px-3 text-left text-[12px] font-semibold text-foreground transition hover:border-primary/35 hover:bg-card/92"
+                  className="shrink-0 justify-between rounded-[11px] bg-card text-[12px] font-semibold hover:border-primary/35 hover:bg-card/92"
                   aria-label="Configure model providers"
                 >
                   <span className="flex min-w-0 items-center gap-2">
@@ -6327,7 +6344,7 @@ function Composer({
                     size={14}
                     className="shrink-0 text-muted-foreground"
                   />
-                </button>
+                </Button>
                 <div className="min-w-0 text-[10px] leading-5 text-muted-foreground">
                   Open provider settings to connect a model.
                 </div>

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -3890,7 +3890,7 @@ export function ChatPane({
     composerIsComposingRef.current = false;
   };
 
-  const assistantLabel = "Holaboss";
+  const assistantLabel = selectedWorkspace?.name || "Assistant";
   const assistantMode = isOnboardingVariant
     ? "workspace setup"
     : assistantMetaLabel(
@@ -4112,7 +4112,7 @@ export function ChatPane({
     availableChatModelOptions.length > 0
       ? ""
       : hasPendingConfiguredProviderCatalog
-        ? "Holaboss models are finishing setup. Refresh runtime binding or use another provider."
+        ? "Managed models are finishing setup. Refresh runtime binding or use another provider."
       : "No models available. Configure a provider to start chatting.";
   const composerBaseDisabledReason =
     baseComposerDisabledReason ||

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -263,7 +263,10 @@ function isDeprecatedChatModel(model: string) {
 }
 
 function normalizeRuntimeModelCapability(value: string) {
-  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
   if (!normalized) {
     return "";
   }
@@ -465,7 +468,10 @@ function outputMetadataNumber(
 function outputBrowserFilterForOutput(
   output: WorkspaceOutputRecordPayload,
 ): ArtifactBrowserFilter {
-  if (outputMetadataString(output, "origin_type") === "app" || output.module_id) {
+  if (
+    outputMetadataString(output, "origin_type") === "app" ||
+    output.module_id
+  ) {
     return "apps";
   }
   const category = outputMetadataString(output, "category");
@@ -482,7 +488,10 @@ function outputBrowserFilterForOutput(
 }
 
 function outputKindLabel(output: WorkspaceOutputRecordPayload) {
-  if (outputMetadataString(output, "origin_type") === "app" || output.module_id) {
+  if (
+    outputMetadataString(output, "origin_type") === "app" ||
+    output.module_id
+  ) {
     const artifactType = outputMetadataString(output, "artifact_type");
     if (artifactType) {
       return artifactType.charAt(0).toUpperCase() + artifactType.slice(1);
@@ -683,8 +692,10 @@ function compareChatSessionOptions(
       return normalizedRight - normalizedLeft;
     }
   }
-  return right.updatedAt.localeCompare(left.updatedAt) ||
-    left.title.localeCompare(right.title);
+  return (
+    right.updatedAt.localeCompare(left.updatedAt) ||
+    left.title.localeCompare(right.title)
+  );
 }
 
 function sessionStatusIndicator(statusLabel: string) {
@@ -824,7 +835,10 @@ function summarizeUnknown(value: unknown, maxLength = 140): string {
 function normalizeChatTodoStatus(value: unknown): ChatTodoStatus | null {
   const normalized =
     typeof value === "string"
-      ? value.trim().toLowerCase().replace(/[\s-]+/g, "_")
+      ? value
+          .trim()
+          .toLowerCase()
+          .replace(/[\s-]+/g, "_")
       : "";
   switch (normalized) {
     case "pending":
@@ -849,8 +863,7 @@ function normalizeChatTodoTask(value: unknown): ChatTodoTask | null {
     return null;
   }
   const notes = typeof value.notes === "string" ? value.notes.trim() : "";
-  const details =
-    typeof value.details === "string" ? value.details.trim() : "";
+  const details = typeof value.details === "string" ? value.details.trim() : "";
   return {
     id,
     content,
@@ -1122,7 +1135,9 @@ function runFailedDetail(payload: Record<string, unknown>): string {
   if (!detail) {
     return `${contextLabel} failed.`;
   }
-  return detail.startsWith(contextLabel) ? detail : `${contextLabel}: ${detail}`;
+  return detail.startsWith(contextLabel)
+    ? detail
+    : `${contextLabel}: ${detail}`;
 }
 
 function assistantMetaLabel(
@@ -1524,7 +1539,9 @@ function phaseTraceStepFromEvent(
         kind: "phase",
         title: "Run paused",
         status: "waiting",
-        details: ["The run was paused before completion and can be continued in a later turn."],
+        details: [
+          "The run was paused before completion and can be continued in a later turn.",
+        ],
         order,
       };
     }
@@ -1795,8 +1812,10 @@ export function ChatPane({
   );
   const [isHistoryViewportPending, setIsHistoryViewportPending] =
     useState(false);
-  const [historyViewportRestoreGeneration, setHistoryViewportRestoreGeneration] =
-    useState(0);
+  const [
+    historyViewportRestoreGeneration,
+    setHistoryViewportRestoreGeneration,
+  ] = useState(0);
   const [chatScrollMetrics, setChatScrollMetrics] = useState({
     scrollTop: 0,
     scrollHeight: 0,
@@ -1822,9 +1841,9 @@ export function ChatPane({
   const [memoryProposalDrafts, setMemoryProposalDrafts] = useState<
     Record<string, string>
   >({});
-  const [availableSessions, setAvailableSessions] = useState<ChatSessionOption[]>(
-    [],
-  );
+  const [availableSessions, setAvailableSessions] = useState<
+    ChatSessionOption[]
+  >([]);
   const [isLoadingAvailableSessions, setIsLoadingAvailableSessions] =
     useState(false);
   const [availableSessionsError, setAvailableSessionsError] = useState("");
@@ -1839,9 +1858,7 @@ export function ChatPane({
   const composerIsComposingRef = useRef(false);
   const shouldAutoScrollRef = useRef(true);
   const lastChatScrollTopRef = useRef(0);
-  const chatScrollbarDragStateRef = useRef<ChatScrollbarDragState | null>(
-    null,
-  );
+  const chatScrollbarDragStateRef = useRef<ChatScrollbarDragState | null>(null);
   const chatScrollbarBodyUserSelectRef = useRef<string | null>(null);
   const chatScrollbarBodyCursorRef = useRef<string | null>(null);
   const activeSessionIdRef = useRef<string | null>(null);
@@ -2432,8 +2449,7 @@ export function ChatPane({
     }
 
     const railRect = railElement.getBoundingClientRect();
-    const unclampedThumbOffset =
-      clientY - railRect.top - thumbPointerOffset;
+    const unclampedThumbOffset = clientY - railRect.top - thumbPointerOffset;
     const nextThumbOffset = Math.min(
       Math.max(0, unclampedThumbOffset),
       chatScrollbarThumbTravel,
@@ -2544,8 +2560,7 @@ export function ChatPane({
 
     container.scrollTo({
       top: container.scrollHeight,
-      behavior:
-        isResponding || isHistoryViewportPending ? "auto" : "smooth",
+      behavior: isResponding || isHistoryViewportPending ? "auto" : "smooth",
     });
   }, [
     isHistoryViewportPending,
@@ -2788,8 +2803,9 @@ export function ChatPane({
   ]);
 
   useEffect(() => {
-    const requestedSessionId =
-      (effectiveSessionOpenRequest?.sessionId || "").trim();
+    const requestedSessionId = (
+      effectiveSessionOpenRequest?.sessionId || ""
+    ).trim();
     const requestKey = effectiveSessionOpenRequest?.requestKey ?? 0;
     const requestMode = effectiveSessionOpenRequest?.mode ?? "session";
     const requestedParentSessionId =
@@ -2911,7 +2927,9 @@ export function ChatPane({
     let cancelled = false;
     let requestInFlight = false;
 
-    const loadAvailableSessions = async (options?: { showLoading?: boolean }) => {
+    const loadAvailableSessions = async (options?: {
+      showLoading?: boolean;
+    }) => {
       if (requestInFlight) {
         return;
       }
@@ -3930,8 +3948,9 @@ export function ChatPane({
   );
   const activeSessionOption = useMemo(
     () =>
-      availableSessions.find((session) => session.sessionId === activeSessionId) ??
-      null,
+      availableSessions.find(
+        (session) => session.sessionId === activeSessionId,
+      ) ?? null,
     [activeSessionId, availableSessions],
   );
   const activeSessionTitle =
@@ -4113,7 +4132,7 @@ export function ChatPane({
       ? ""
       : hasPendingConfiguredProviderCatalog
         ? "Managed models are finishing setup. Refresh runtime binding or use another provider."
-      : "No models available. Configure a provider to start chatting.";
+        : "No models available. Configure a provider to start chatting.";
   const composerBaseDisabledReason =
     baseComposerDisabledReason ||
     (usesHostedManagedCredits && isOutOfCredits
@@ -4143,8 +4162,7 @@ export function ChatPane({
   const textareaPlaceholder = isOnboardingVariant
     ? "Answer the onboarding prompt or share setup details"
     : "Ask anything";
-  const showHistoryRestoreScreen =
-    isLoadingHistory || isHistoryViewportPending;
+  const showHistoryRestoreScreen = isLoadingHistory || isHistoryViewportPending;
   const chatScrollRange = Math.max(
     0,
     chatScrollMetrics.scrollHeight - chatScrollMetrics.clientHeight,
@@ -4252,7 +4270,10 @@ export function ChatPane({
 
   const openSessionFromPicker = (sessionId: string) => {
     const normalizedSessionId = sessionId.trim();
-    if (!normalizedSessionId || normalizedSessionId === activeSessionIdRef.current) {
+    if (
+      !normalizedSessionId ||
+      normalizedSessionId === activeSessionIdRef.current
+    ) {
       return;
     }
     setLocalSessionOpenRequest({
@@ -4683,9 +4704,7 @@ export function ChatPane({
                     <CurrentTodoPanel
                       todoPlan={currentTodoPlan}
                       expanded={todoPanelExpanded}
-                      onToggle={() =>
-                        setTodoPanelExpanded((value) => !value)
-                      }
+                      onToggle={() => setTodoPanelExpanded((value) => !value)}
                     />
                   ) : null}
                   <Composer
@@ -4807,39 +4826,34 @@ function SessionSelector({
         <div className="min-w-0 flex-1">
           <PopoverTrigger
             render={
-              <button
-                type="button"
-                className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-xl px-2 py-1.5 text-left transition-colors"
+              <Button
+                variant="outline"
+                className="w-full min-w-0 justify-start"
                 aria-label="Select agent session"
                 title={`${activeTitle} · ${activeDetail}`}
-              >
-                <span
-                  className={`grid size-5 shrink-0 place-items-center ${activeIndicator.className}`}
-                >
-                  {activeIndicator.icon}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-[15px] font-semibold tracking-[-0.02em] text-foreground">
-                  {activeTitle}
-                </span>
-                <ChevronDown
-                  size={13}
-                  className={`shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
-                    open
-                      ? "rotate-180 group-hover:-translate-y-1 group-hover:scale-150"
-                      : "rotate-0 group-hover:translate-y-1 group-hover:scale-150"
-                  } motion-reduce:transform-none`}
-                />
-              </button>
+              />
             }
-          />
+          >
+            <span
+              className={`grid size-4 shrink-0 place-items-center ${activeIndicator.className}`}
+            >
+              {activeIndicator.icon}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-xs text-start font-medium text-foreground">
+              {activeTitle}
+            </span>
+            <ChevronDown
+              size={12}
+              className={`shrink-0 text-muted-foreground transition-transform ${
+                open ? "rotate-180" : ""
+              }`}
+            />
+          </PopoverTrigger>
         </div>
         <PopoverContent align="start" className="w-[300px] p-0">
           <div className="border-b border-border/40 p-2">
             <div className="relative flex items-center rounded-[10px] border border-border/40 bg-muted/35 px-2.5 transition-colors focus-within:border-border/55 focus-within:bg-background/70">
-              <Search
-                size={13}
-                className="shrink-0 text-muted-foreground"
-              />
+              <Search size={13} className="shrink-0 text-muted-foreground" />
               <input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
@@ -4861,7 +4875,9 @@ function SessionSelector({
               </div>
             ) : filteredSessions.length === 0 ? (
               <div className="px-3 py-3 text-[12px] text-muted-foreground">
-                {query.trim() ? "No matching sessions." : "No saved sessions yet."}
+                {query.trim()
+                  ? "No matching sessions."
+                  : "No saved sessions yet."}
               </div>
             ) : (
               filteredSessions.map((session) => {
@@ -4876,7 +4892,7 @@ function SessionSelector({
                       setOpen(false);
                       setQuery("");
                     }}
-                    className={`flex w-full items-center gap-2 rounded-[12px] px-3 py-2 text-left transition ${
+                    className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors ${
                       isActive
                         ? "bg-accent text-accent-foreground"
                         : "hover:bg-accent/50"
@@ -5402,7 +5418,8 @@ function CurrentTodoPanel({
                   <div className="mt-3 space-y-2">
                     {phase.tasks.map((task) => {
                       const isActiveTask = activeEntry?.task.id === task.id;
-                      const hasVisibleDetails = isActiveTask && Boolean(task.details);
+                      const hasVisibleDetails =
+                        isActiveTask && Boolean(task.details);
                       return (
                         <div
                           key={task.id}
@@ -5410,7 +5427,9 @@ function CurrentTodoPanel({
                         >
                           <TodoStatusIcon status={task.status} />
                           <div className="min-w-0 flex-1">
-                            <div className="text-foreground">{task.content}</div>
+                            <div className="text-foreground">
+                              {task.content}
+                            </div>
                             {hasVisibleDetails ? (
                               <div className="mt-1 whitespace-pre-wrap text-[11px] text-muted-foreground">
                                 {task.details}
@@ -5501,7 +5520,10 @@ function AssistantTurnMemoryProposals({
               </div>
 
               <div className="flex shrink-0 items-start gap-2">
-                <Badge variant="outline" className="uppercase tracking-[0.14em]">
+                <Badge
+                  variant="outline"
+                  className="uppercase tracking-[0.14em]"
+                >
                   {memoryProposalStateLabel(proposal.state)}
                 </Badge>
                 {isPending ? (
@@ -5667,7 +5689,10 @@ function ArtifactBrowserModal({
                     </div>
                   </div>
                   {outputChangeLabel(output) ? (
-                    <Badge variant="outline" className="uppercase tracking-[0.12em]">
+                    <Badge
+                      variant="outline"
+                      className="uppercase tracking-[0.12em]"
+                    >
                       {outputChangeLabel(output)}
                     </Badge>
                   ) : null}
@@ -5763,9 +5788,8 @@ function TraceStepGroup({
   const activeStep =
     [...steps]
       .reverse()
-      .find(
-        (step) => step.status === "running" || step.status === "waiting",
-      ) ?? null;
+      .find((step) => step.status === "running" || step.status === "waiting") ??
+    null;
   const latestStep = steps.length > 0 ? steps[steps.length - 1] : null;
   const summaryStep = activeStep ?? (groupIsLive ? latestStep : null);
   const summarySuffix = groupHasTerminalError
@@ -5796,8 +5820,8 @@ function TraceStepGroup({
             : groupIsLive
               ? `Working through ${stepLabel}...`
               : runningCount > 0
-              ? `Running ${stepLabel}...`
-              : `Used ${stepLabel}`}
+                ? `Running ${stepLabel}...`
+                : `Used ${stepLabel}`}
           {summarySuffix}
         </span>
         <ChevronDown
@@ -6072,7 +6096,7 @@ function ModelCombobox({
             ? "bg-accent text-accent-foreground"
             : optionDisabled
               ? "cursor-not-allowed text-muted-foreground/70"
-            : "text-foreground hover:bg-accent/50"
+              : "text-foreground hover:bg-accent/50"
         }`}
       >
         <span className="truncate">{option.label}</span>
@@ -6194,11 +6218,14 @@ function Composer({
     modelOptions.length === 0 &&
     modelOptionGroups.length === 0;
   const inputDisabled = disabled || isResponding;
-  const visibleModelOptions = modelOptionGroups.flatMap((group) => group.options);
+  const visibleModelOptions = modelOptionGroups.flatMap(
+    (group) => group.options,
+  );
   const selectedModelOptionLabel =
     visibleModelOptions.find((option) => option.value === selectedModel)
       ?.selectedLabel ??
-    visibleModelOptions.find((option) => option.value === selectedModel)?.label ??
+    visibleModelOptions.find((option) => option.value === selectedModel)
+      ?.label ??
     modelOptions.find((option) => option.value === selectedModel)
       ?.selectedLabel ??
     modelOptions.find((option) => option.value === selectedModel)?.label ??
@@ -6398,9 +6425,7 @@ function Composer({
           ) : (
             <Button
               size="icon"
-              disabled={
-                (!input.trim() && attachments.length === 0) || disabled
-              }
+              disabled={(!input.trim() && attachments.length === 0) || disabled}
               render={<button type="submit" />}
               className="rounded-full"
             >

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -5520,10 +5520,7 @@ function AssistantTurnMemoryProposals({
               </div>
 
               <div className="flex shrink-0 items-start gap-2">
-                <Badge
-                  variant="outline"
-                  className="uppercase tracking-[0.14em]"
-                >
+                <Badge variant="outline" className="uppercase">
                   {memoryProposalStateLabel(proposal.state)}
                 </Badge>
                 {isPending ? (
@@ -5626,7 +5623,8 @@ function ArtifactBrowserModal({
               Artifacts
             </div>
             <div className="text-xs text-muted-foreground">
-              {outputs.length} item{outputs.length === 1 ? "" : "s"} in this session
+              {outputs.length} item{outputs.length === 1 ? "" : "s"} in this
+              session
             </div>
           </div>
           <Button
@@ -5672,7 +5670,7 @@ function ArtifactBrowserModal({
                     onOpenOutput?.(output);
                   }}
                   disabled={!onOpenOutput}
-                  className="h-auto w-full justify-start gap-3 px-3 py-2.5 text-left"
+                  className="h-auto w-full min-w-0 justify-start gap-3 overflow-hidden px-3 py-2.5 text-left"
                 >
                   <OutputArtifactIcon output={output} />
                   <div className="min-w-0 flex-1">
@@ -5684,10 +5682,7 @@ function ArtifactBrowserModal({
                     </div>
                   </div>
                   {outputChangeLabel(output) ? (
-                    <Badge
-                      variant="outline"
-                      className="shrink-0 uppercase tracking-[0.12em]"
-                    >
+                    <Badge variant="outline" className="shrink-0 uppercase">
                       {outputChangeLabel(output)}
                     </Badge>
                   ) : null}

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -22,12 +22,11 @@ import {
 } from "lucide-react";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { Button } from "@/components/ui/button";
-import { IconButton } from "@/components/ui/IconButton";
 import { PaneCard } from "@/components/ui/PaneCard";
 import {
   EXPLORER_ATTACHMENT_DRAG_TYPE,
   inferDraggedAttachmentKind,
-  serializeExplorerAttachmentDragPayload
+  serializeExplorerAttachmentDragPayload,
 } from "@/lib/attachmentDrag";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -50,7 +49,7 @@ const SPREADSHEET_EXTENSIONS = new Set([
   ".xls",
   ".xlsx",
   ".xlsm",
-  ".ods"
+  ".ods",
 ]);
 
 const IMAGE_EXTENSIONS = new Set([
@@ -63,7 +62,7 @@ const IMAGE_EXTENSIONS = new Set([
   ".bmp",
   ".ico",
   ".avif",
-  ".heic"
+  ".heic",
 ]);
 
 const ARCHIVE_EXTENSIONS = new Set([
@@ -74,7 +73,7 @@ const ARCHIVE_EXTENSIONS = new Set([
   ".bz2",
   ".xz",
   ".7z",
-  ".rar"
+  ".rar",
 ]);
 
 const AUDIO_EXTENSIONS = new Set([
@@ -83,7 +82,7 @@ const AUDIO_EXTENSIONS = new Set([
   ".m4a",
   ".aac",
   ".ogg",
-  ".flac"
+  ".flac",
 ]);
 
 const VIDEO_EXTENSIONS = new Set([
@@ -92,13 +91,10 @@ const VIDEO_EXTENSIONS = new Set([
   ".avi",
   ".mkv",
   ".webm",
-  ".m4v"
+  ".m4v",
 ]);
 
-const JSON_EXTENSIONS = new Set([
-  ".json",
-  ".jsonl"
-]);
+const JSON_EXTENSIONS = new Set([".json", ".jsonl"]);
 
 const CODE_EXTENSIONS = new Set([
   ".js",
@@ -122,30 +118,16 @@ const CODE_EXTENSIONS = new Set([
   ".cc",
   ".cpp",
   ".h",
-  ".hpp"
+  ".hpp",
 ]);
 
-const CONFIG_EXTENSIONS = new Set([
-  ".yml",
-  ".yaml",
-  ".toml",
-  ".ini"
-]);
+const CONFIG_EXTENSIONS = new Set([".yml", ".yaml", ".toml", ".ini"]);
 
-const SPECIAL_CODE_FILENAMES = new Set([
-  "dockerfile",
-  "makefile"
-]);
+const SPECIAL_CODE_FILENAMES = new Set(["dockerfile", "makefile"]);
 
-const SPECIAL_POLICY_FILENAMES = new Set([
-  "agents.md"
-]);
+const SPECIAL_POLICY_FILENAMES = new Set(["agents.md"]);
 
-const MARKDOWN_PREVIEW_EXTENSIONS = new Set([
-  ".md",
-  ".mdx",
-  ".markdown"
-]);
+const MARKDOWN_PREVIEW_EXTENSIONS = new Set([".md", ".mdx", ".markdown"]);
 
 type TextPreviewMode = "edit" | "preview";
 
@@ -186,7 +168,10 @@ type FileExplorerVisibleRow =
     };
 
 function getComparableFileName(targetName: string) {
-  const normalized = targetName.trim().toLowerCase().replace(/[\\/]+$/, "");
+  const normalized = targetName
+    .trim()
+    .toLowerCase()
+    .replace(/[\\/]+$/, "");
   const parts = normalized.split(/[\\/]/).filter(Boolean);
   return parts[parts.length - 1] || normalized;
 }
@@ -200,11 +185,14 @@ function getFileExtension(fileName: string) {
   return normalized.slice(lastDotIndex);
 }
 
-function getExplorerIconDescriptor(targetName: string, isDirectory: boolean): ExplorerIconDescriptor {
+function getExplorerIconDescriptor(
+  targetName: string,
+  isDirectory: boolean,
+): ExplorerIconDescriptor {
   if (isDirectory) {
     return {
       Icon: Folder,
-      className: "text-primary"
+      className: "text-primary",
     };
   }
 
@@ -214,56 +202,56 @@ function getExplorerIconDescriptor(targetName: string, isDirectory: boolean): Ex
   if (SPECIAL_POLICY_FILENAMES.has(normalizedFileName)) {
     return {
       Icon: Shield,
-      className: "text-cyan-700 dark:text-cyan-300"
+      className: "text-cyan-700 dark:text-cyan-300",
     };
   }
 
   if (SPREADSHEET_EXTENSIONS.has(extension)) {
     return {
       Icon: FileSpreadsheet,
-      className: "text-emerald-600 dark:text-emerald-400"
+      className: "text-emerald-600 dark:text-emerald-400",
     };
   }
 
   if (extension === ".pdf") {
     return {
       Icon: FileBadge2,
-      className: "text-rose-600 dark:text-rose-400"
+      className: "text-rose-600 dark:text-rose-400",
     };
   }
 
   if (IMAGE_EXTENSIONS.has(extension)) {
     return {
       Icon: FileImage,
-      className: "text-sky-600 dark:text-sky-400"
+      className: "text-sky-600 dark:text-sky-400",
     };
   }
 
   if (ARCHIVE_EXTENSIONS.has(extension)) {
     return {
       Icon: FileArchive,
-      className: "text-amber-600 dark:text-amber-400"
+      className: "text-amber-600 dark:text-amber-400",
     };
   }
 
   if (AUDIO_EXTENSIONS.has(extension)) {
     return {
       Icon: FileAudio2,
-      className: "text-teal-600 dark:text-teal-400"
+      className: "text-teal-600 dark:text-teal-400",
     };
   }
 
   if (VIDEO_EXTENSIONS.has(extension)) {
     return {
       Icon: FileVideoCamera,
-      className: "text-orange-600 dark:text-orange-400"
+      className: "text-orange-600 dark:text-orange-400",
     };
   }
 
   if (JSON_EXTENSIONS.has(extension)) {
     return {
       Icon: FileJson,
-      className: "text-amber-700 dark:text-amber-300"
+      className: "text-amber-700 dark:text-amber-300",
     };
   }
 
@@ -273,30 +261,35 @@ function getExplorerIconDescriptor(targetName: string, isDirectory: boolean): Ex
   ) {
     return {
       Icon: FileCode2,
-      className: "text-sky-700 dark:text-sky-300"
+      className: "text-sky-700 dark:text-sky-300",
     };
   }
 
-  if (CONFIG_EXTENSIONS.has(extension) || normalizedFileName.startsWith(".env")) {
+  if (
+    CONFIG_EXTENSIONS.has(extension) ||
+    normalizedFileName.startsWith(".env")
+  ) {
     return {
       Icon: FileCog,
-      className: "text-slate-600 dark:text-slate-400"
+      className: "text-slate-600 dark:text-slate-400",
     };
   }
 
   return {
     Icon: FileText,
-    className: "text-muted-foreground"
+    className: "text-muted-foreground",
   };
 }
 
 function isMarkdownPreviewPayload(
-  preview: Pick<FilePreviewPayload, "kind" | "extension"> | null | undefined
+  preview: Pick<FilePreviewPayload, "kind" | "extension"> | null | undefined,
 ): boolean {
   if (!preview || preview.kind !== "text") {
     return false;
   }
-  return MARKDOWN_PREVIEW_EXTENSIONS.has(preview.extension.trim().toLowerCase());
+  return MARKDOWN_PREVIEW_EXTENSIONS.has(
+    preview.extension.trim().toLowerCase(),
+  );
 }
 
 function getFolderName(targetPath: string) {
@@ -320,7 +313,10 @@ function getParentFolderPath(targetPath: string) {
     return null;
   }
 
-  const lastSeparatorIndex = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+  const lastSeparatorIndex = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  );
   if (lastSeparatorIndex <= 0) {
     return normalized.includes("\\") ? normalized.slice(0, 3) : "/";
   }
@@ -422,12 +418,14 @@ function buildVisibleExplorerRows(
 
   for (const entry of entries) {
     const isExpanded = Boolean(expandedDirectoryPaths[entry.absolutePath]);
-    const isLoadingChildren = Boolean(directoryLoadingByPath[entry.absolutePath]);
+    const isLoadingChildren = Boolean(
+      directoryLoadingByPath[entry.absolutePath],
+    );
     const childError = directoryErrorByPath[entry.absolutePath] ?? "";
     const shouldSearchChildren =
       entry.isDirectory && (isExpanded || query.length > 0);
     const childEntries = shouldSearchChildren
-      ? directoryEntriesByPath[entry.absolutePath] ?? []
+      ? (directoryEntriesByPath[entry.absolutePath] ?? [])
       : [];
     const childRows = shouldSearchChildren
       ? buildVisibleExplorerRows(
@@ -514,7 +512,7 @@ function formatModified(ts: string) {
     month: "short",
     day: "2-digit",
     hour: "2-digit",
-    minute: "2-digit"
+    minute: "2-digit",
   }).format(date);
 }
 
@@ -545,12 +543,14 @@ function createAttachmentDragPreview(entry: LocalFileEntry) {
   preview.style.boxShadow = "0 12px 30px rgba(45, 18, 16, 0.16)";
   preview.style.backdropFilter = "blur(10px)";
   preview.style.color = "rgba(49, 32, 29, 0.96)";
-  preview.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  preview.style.fontFamily =
+    "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   preview.style.pointerEvents = "none";
   preview.style.zIndex = "2147483647";
 
   const badge = document.createElement("span");
-  badge.textContent = inferDraggedAttachmentKind(entry.name) === "image" ? "IMG" : "FILE";
+  badge.textContent =
+    inferDraggedAttachmentKind(entry.name) === "image" ? "IMG" : "FILE";
   badge.style.display = "inline-flex";
   badge.style.alignItems = "center";
   badge.style.justifyContent = "center";
@@ -564,7 +564,8 @@ function createAttachmentDragPreview(entry: LocalFileEntry) {
   badge.style.letterSpacing = "0.12em";
 
   const label = document.createElement("span");
-  label.textContent = `${entry.name} ${entry.isDirectory ? "" : `(${formatFileSize(entry.size)})`}`.trim();
+  label.textContent =
+    `${entry.name} ${entry.isDirectory ? "" : `(${formatFileSize(entry.size)})`}`.trim();
   label.style.overflow = "hidden";
   label.style.textOverflow = "ellipsis";
   label.style.whiteSpace = "nowrap";
@@ -588,7 +589,10 @@ export function FileExplorerPane({
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameInFlightRef = useRef(false);
   const dragPreviewRef = useRef<HTMLDivElement | null>(null);
-  const lastSyncedWorkspaceRootRef = useRef<{ workspaceId: string; rootPath: string } | null>(null);
+  const lastSyncedWorkspaceRootRef = useRef<{
+    workspaceId: string;
+    rootPath: string;
+  } | null>(null);
   const lastProcessedFocusRequestKeyRef = useRef<number | null>(null);
   const currentPathRef = useRef("");
   const [currentPath, setCurrentPath] = useState<string>("");
@@ -606,20 +610,24 @@ export function FileExplorerPane({
     Record<string, string>
   >({});
   const [selectedPath, setSelectedPath] = useState<string>("");
-  const [workspaceRootPath, setWorkspaceRootPath] = useState<string | null>(null);
+  const [workspaceRootPath, setWorkspaceRootPath] = useState<string | null>(
+    null,
+  );
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
   const [preview, setPreview] = useState<FilePreviewPayload | null>(null);
   const [previewDraft, setPreviewDraft] = useState("");
-  const [textPreviewMode, setTextPreviewMode] = useState<TextPreviewMode>("edit");
+  const [textPreviewMode, setTextPreviewMode] =
+    useState<TextPreviewMode>("edit");
   const [activeTableSheetIndex, setActiveTableSheetIndex] = useState(0);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState("");
   const [saving, setSaving] = useState(false);
   const [fileBookmarks, setFileBookmarks] = useState<FileBookmarkPayload[]>([]);
   const [containerWidth, setContainerWidth] = useState(0);
-  const [contextMenu, setContextMenu] = useState<FileExplorerContextMenuState | null>(null);
+  const [contextMenu, setContextMenu] =
+    useState<FileExplorerContextMenuState | null>(null);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [renameSaving, setRenameSaving] = useState(false);
@@ -627,48 +635,52 @@ export function FileExplorerPane({
 
   currentPathRef.current = currentPath;
 
-  const loadDirectory = useCallback(async (targetPath?: string | null, pushHistory = true) => {
-    setLoading(true);
-    setError("");
+  const loadDirectory = useCallback(
+    async (targetPath?: string | null, pushHistory = true) => {
+      setLoading(true);
+      setError("");
 
-    try {
-      const payload = await window.electronAPI.fs.listDirectory(
-        targetPath ?? null,
-        selectedWorkspaceId ?? null,
-      );
-      const previousCurrentPath = currentPathRef.current;
-      const shouldResetTree =
-        pushHistory ||
-        normalizeComparablePath(previousCurrentPath) !==
-          normalizeComparablePath(payload.currentPath);
-      setCurrentPath(payload.currentPath);
-      currentPathRef.current = payload.currentPath;
-      setEntries(payload.entries);
-      setDirectoryEntriesByPath((current) =>
-        shouldResetTree
-          ? { [payload.currentPath]: payload.entries }
-          : { ...current, [payload.currentPath]: payload.entries },
-      );
-      if (shouldResetTree) {
-        setExpandedDirectoryPaths({});
-        setDirectoryLoadingByPath({});
-        setDirectoryErrorByPath({});
+      try {
+        const payload = await window.electronAPI.fs.listDirectory(
+          targetPath ?? null,
+          selectedWorkspaceId ?? null,
+        );
+        const previousCurrentPath = currentPathRef.current;
+        const shouldResetTree =
+          pushHistory ||
+          normalizeComparablePath(previousCurrentPath) !==
+            normalizeComparablePath(payload.currentPath);
+        setCurrentPath(payload.currentPath);
+        currentPathRef.current = payload.currentPath;
+        setEntries(payload.entries);
+        setDirectoryEntriesByPath((current) =>
+          shouldResetTree
+            ? { [payload.currentPath]: payload.entries }
+            : { ...current, [payload.currentPath]: payload.entries },
+        );
+        if (shouldResetTree) {
+          setExpandedDirectoryPaths({});
+          setDirectoryLoadingByPath({});
+          setDirectoryErrorByPath({});
+        }
+
+        setSelectedPath((prev) =>
+          !prev ||
+          (!payload.entries.some((entry) => entry.absolutePath === prev) &&
+            !isPathWithin(payload.currentPath, prev))
+            ? (payload.entries[0]?.absolutePath ?? "")
+            : prev,
+        );
+      } catch (cause) {
+        const message =
+          cause instanceof Error ? cause.message : "Failed to open directory.";
+        setError(message);
+      } finally {
+        setLoading(false);
       }
-
-      setSelectedPath((prev) =>
-        !prev ||
-        (!payload.entries.some((entry) => entry.absolutePath === prev) &&
-          !isPathWithin(payload.currentPath, prev))
-          ? (payload.entries[0]?.absolutePath ?? "")
-          : prev
-      );
-    } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to open directory.";
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedWorkspaceId]);
+    },
+    [selectedWorkspaceId],
+  );
 
   useEffect(() => {
     void loadDirectory(null, true);
@@ -686,7 +698,10 @@ export function FileExplorerPane({
 
     async function loadWorkspaceDirectory() {
       try {
-        const workspaceRoot = await window.electronAPI.workspace.getWorkspaceRoot(selectedWorkspaceId);
+        const workspaceRoot =
+          await window.electronAPI.workspace.getWorkspaceRoot(
+            selectedWorkspaceId,
+          );
         if (workspaceRoot) {
           setWorkspaceRootPath(workspaceRoot);
         }
@@ -701,7 +716,7 @@ export function FileExplorerPane({
         }
         lastSyncedWorkspaceRootRef.current = {
           workspaceId: selectedWorkspaceId,
-          rootPath: workspaceRoot
+          rootPath: workspaceRoot,
         };
         await loadDirectory(workspaceRoot, true);
       } catch {
@@ -747,7 +762,7 @@ export function FileExplorerPane({
           (!payload.entries.some((entry) => entry.absolutePath === prev) &&
             !isPathWithin(payload.currentPath, prev))
             ? (payload.entries[0]?.absolutePath ?? "")
-            : prev
+            : prev,
         );
       } catch {
         // Best-effort background refresh; keep current listing on transient failures.
@@ -769,11 +784,13 @@ export function FileExplorerPane({
   useEffect(() => {
     let mounted = true;
 
-    void window.electronAPI.fs.getBookmarks(selectedWorkspaceId ?? null).then((bookmarks) => {
-      if (mounted) {
-        setFileBookmarks(bookmarks);
-      }
-    });
+    void window.electronAPI.fs
+      .getBookmarks(selectedWorkspaceId ?? null)
+      .then((bookmarks) => {
+        if (mounted) {
+          setFileBookmarks(bookmarks);
+        }
+      });
 
     const unsubscribe = window.electronAPI.fs.onBookmarksChange((bookmarks) => {
       setFileBookmarks(bookmarks);
@@ -875,7 +892,9 @@ export function FileExplorerPane({
   const renamingEntry = renamingPath
     ? findLoadedEntry(entries, renamingPath, directoryEntriesByPath)
     : null;
-  const isDirty = preview?.isEditable ? previewDraft !== (preview.content ?? "") : false;
+  const isDirty = preview?.isEditable
+    ? previewDraft !== (preview.content ?? "")
+    : false;
   const isMarkdownPreview = isMarkdownPreviewPayload(preview);
 
   const openPreviewLink = useCallback((url: string) => {
@@ -999,7 +1018,8 @@ export function FileExplorerPane({
         const nextParent = getParentFolderPath(cursor);
         if (
           !nextParent ||
-          normalizeComparablePath(nextParent) === normalizeComparablePath(cursor)
+          normalizeComparablePath(nextParent) ===
+            normalizeComparablePath(cursor)
         ) {
           break;
         }
@@ -1033,7 +1053,9 @@ export function FileExplorerPane({
         return;
       }
 
-      const childEntries = await ensureDirectoryEntriesLoaded(entry.absolutePath);
+      const childEntries = await ensureDirectoryEntriesLoaded(
+        entry.absolutePath,
+      );
       if (childEntries === null) {
         return;
       }
@@ -1076,7 +1098,10 @@ export function FileExplorerPane({
     }
 
     const input = renameInputRef.current;
-    const selectionEnd = renameSelectionEnd(renamingEntry.name, renamingEntry.isDirectory);
+    const selectionEnd = renameSelectionEnd(
+      renamingEntry.name,
+      renamingEntry.isDirectory,
+    );
     input.focus();
     input.setSelectionRange(0, selectionEnd);
   }, [renamingEntry]);
@@ -1087,16 +1112,21 @@ export function FileExplorerPane({
     setRenameSaving(false);
   }, []);
 
-  const startRenamingEntry = useCallback((entry: LocalFileEntry) => {
-    closeContextMenu();
-    setError("");
-    setSelectedPath(entry.absolutePath);
-    setRenamingPath(entry.absolutePath);
-    setRenameDraft(entry.name);
-  }, [closeContextMenu]);
+  const startRenamingEntry = useCallback(
+    (entry: LocalFileEntry) => {
+      closeContextMenu();
+      setError("");
+      setSelectedPath(entry.absolutePath);
+      setRenamingPath(entry.absolutePath);
+      setRenameDraft(entry.name);
+    },
+    [closeContextMenu],
+  );
 
-
-  const openFilePreview = async (targetPath: string, options?: { skipConfirm?: boolean; syncDirectory?: boolean }) => {
+  const openFilePreview = async (
+    targetPath: string,
+    options?: { skipConfirm?: boolean; syncDirectory?: boolean },
+  ) => {
     const skipConfirm = options?.skipConfirm ?? false;
     if (!skipConfirm && !confirmDiscardIfDirty()) {
       return;
@@ -1118,9 +1148,12 @@ export function FileExplorerPane({
       );
       setPreview(payload);
       setPreviewDraft(payload.content ?? "");
-      setTextPreviewMode(isMarkdownPreviewPayload(payload) ? "preview" : "edit");
+      setTextPreviewMode(
+        isMarkdownPreviewPayload(payload) ? "preview" : "edit",
+      );
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to open file.";
+      const message =
+        cause instanceof Error ? cause.message : "Failed to open file.";
       setPreview(null);
       setTextPreviewMode("edit");
       setPreviewError(message);
@@ -1198,7 +1231,8 @@ export function FileExplorerPane({
       setPreviewDraft(nextPreview.content ?? "");
       await loadDirectory(currentPath, false);
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to save file.";
+      const message =
+        cause instanceof Error ? cause.message : "Failed to save file.";
       setPreviewError(message);
     } finally {
       setSaving(false);
@@ -1211,9 +1245,12 @@ export function FileExplorerPane({
       : [];
   const activeTableSheet =
     previewTableSheets.length > 0
-      ? previewTableSheets[Math.min(activeTableSheetIndex, previewTableSheets.length - 1)]
+      ? previewTableSheets[
+          Math.min(activeTableSheetIndex, previewTableSheets.length - 1)
+        ]
       : null;
-  const showInlinePreview = previewInPane && Boolean(preview || previewLoading || previewError);
+  const showInlinePreview =
+    previewInPane && Boolean(preview || previewLoading || previewError);
   const selectedFileEntry =
     !previewInPane && selectedEntry && !selectedEntry.isDirectory
       ? selectedEntry
@@ -1222,7 +1259,9 @@ export function FileExplorerPane({
     preview?.absolutePath ?? selectedFileEntry?.absolutePath ?? currentPath;
   const bookmarkTargetLabel =
     preview?.name ?? selectedFileEntry?.name ?? getFolderName(currentPath);
-  const activeBookmark = fileBookmarks.find((bookmark) => bookmark.targetPath === bookmarkTargetPath);
+  const activeBookmark = fileBookmarks.find(
+    (bookmark) => bookmark.targetPath === bookmarkTargetPath,
+  );
   const activeBookmarkId =
     preview?.absolutePath ?? selectedFileEntry?.absolutePath ?? currentPath;
   const isCompact = containerWidth > 0 && containerWidth < 420;
@@ -1259,7 +1298,9 @@ export function FileExplorerPane({
       await revealPathInTree(
         `${bookmark.targetPath}${bookmark.targetPath.includes("\\") ? "\\" : "/"}.__bookmark__`,
       );
-      const childEntries = await ensureDirectoryEntriesLoaded(bookmark.targetPath);
+      const childEntries = await ensureDirectoryEntriesLoaded(
+        bookmark.targetPath,
+      );
       if (childEntries !== null) {
         setExpandedDirectoryPaths((current) => ({
           ...current,
@@ -1269,7 +1310,10 @@ export function FileExplorerPane({
       return;
     }
 
-    await openFileTarget(bookmark.targetPath, { skipConfirm: false, syncDirectory: true });
+    await openFileTarget(bookmark.targetPath, {
+      skipConfirm: false,
+      syncDirectory: true,
+    });
   };
 
   useEffect(() => {
@@ -1289,7 +1333,9 @@ export function FileExplorerPane({
       if (!isAbsolutePath(targetPath) && selectedWorkspaceId) {
         const workspaceRoot =
           workspaceRootPath ??
-          (await window.electronAPI.workspace.getWorkspaceRoot(selectedWorkspaceId));
+          (await window.electronAPI.workspace.getWorkspaceRoot(
+            selectedWorkspaceId,
+          ));
         if (cancelled) {
           return;
         }
@@ -1324,14 +1370,17 @@ export function FileExplorerPane({
     workspaceRootPath,
   ]);
 
-  const openEntryFromContextMenu = useCallback(async (entry: LocalFileEntry) => {
-    closeContextMenu();
-    if (entry.isDirectory) {
-      await toggleDirectoryExpansion(entry);
-      return;
-    }
-    await openFileTarget(entry.absolutePath);
-  }, [closeContextMenu, openFileTarget, toggleDirectoryExpansion]);
+  const openEntryFromContextMenu = useCallback(
+    async (entry: LocalFileEntry) => {
+      closeContextMenu();
+      if (entry.isDirectory) {
+        await toggleDirectoryExpansion(entry);
+        return;
+      }
+      await openFileTarget(entry.absolutePath);
+    },
+    [closeContextMenu, openFileTarget, toggleDirectoryExpansion],
+  );
 
   const submitRenameEntry = useCallback(async () => {
     if (!renamingEntry || renameInFlightRef.current) {
@@ -1354,12 +1403,14 @@ export function FileExplorerPane({
         selectedWorkspaceId ?? null,
       );
       const parentPath =
-        getParentFolderPath(renamingEntry.absolutePath) ?? currentPathRef.current;
+        getParentFolderPath(renamingEntry.absolutePath) ??
+        currentPathRef.current;
       await refreshDirectoryEntries(parentPath);
       setSelectedPath(payload.absolutePath);
       stopRenamingEntry();
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to rename item.";
+      const message =
+        cause instanceof Error ? cause.message : "Failed to rename item.";
       setError(message);
       window.setTimeout(() => {
         renameInputRef.current?.focus();
@@ -1377,9 +1428,12 @@ export function FileExplorerPane({
     stopRenamingEntry,
   ]);
 
-  const renameEntryFromContextMenu = useCallback((entry: LocalFileEntry) => {
-    startRenamingEntry(entry);
-  }, [startRenamingEntry]);
+  const renameEntryFromContextMenu = useCallback(
+    (entry: LocalFileEntry) => {
+      startRenamingEntry(entry);
+    },
+    [startRenamingEntry],
+  );
 
   const cancelRenameEntry = useCallback(() => {
     if (renameInFlightRef.current) {
@@ -1388,38 +1442,45 @@ export function FileExplorerPane({
     stopRenamingEntry();
   }, [stopRenamingEntry]);
 
-  const deleteEntryFromContextMenu = useCallback(async (entry: LocalFileEntry) => {
-    closeContextMenu();
-    const confirmed = window.confirm(
-      entry.isDirectory
-        ? `Delete folder "${entry.name}" and all of its contents? This cannot be undone.`
-        : `Delete file "${entry.name}"? This cannot be undone.`,
-    );
-    if (!confirmed) {
-      return;
-    }
-
-    setError("");
-    try {
-      await window.electronAPI.fs.deletePath(
-        entry.absolutePath,
-        selectedWorkspaceId ?? null,
+  const deleteEntryFromContextMenu = useCallback(
+    async (entry: LocalFileEntry) => {
+      closeContextMenu();
+      const confirmed = window.confirm(
+        entry.isDirectory
+          ? `Delete folder "${entry.name}" and all of its contents? This cannot be undone.`
+          : `Delete file "${entry.name}"? This cannot be undone.`,
       );
-      const parentPath =
-        getParentFolderPath(entry.absolutePath) ?? currentPathRef.current;
-      await refreshDirectoryEntries(parentPath);
-      setSelectedPath("");
-    } catch (cause) {
-      const message = cause instanceof Error ? cause.message : "Failed to delete file.";
-      setError(message);
-    }
-  }, [closeContextMenu, refreshDirectoryEntries, selectedWorkspaceId]);
+      if (!confirmed) {
+        return;
+      }
+
+      setError("");
+      try {
+        await window.electronAPI.fs.deletePath(
+          entry.absolutePath,
+          selectedWorkspaceId ?? null,
+        );
+        const parentPath =
+          getParentFolderPath(entry.absolutePath) ?? currentPathRef.current;
+        await refreshDirectoryEntries(parentPath);
+        setSelectedPath("");
+      } catch (cause) {
+        const message =
+          cause instanceof Error ? cause.message : "Failed to delete file.";
+        setError(message);
+      }
+    },
+    [closeContextMenu, refreshDirectoryEntries, selectedWorkspaceId],
+  );
 
   const contextMenuPosition = useMemo(() => {
     if (!contextMenu) {
       return null;
     }
-    const menuWidth = Math.min(196, Math.max(160, contextMenu.paneBounds.width - 16));
+    const menuWidth = Math.min(
+      196,
+      Math.max(160, contextMenu.paneBounds.width - 16),
+    );
     const menuHeight = 124;
     return {
       left: Math.max(
@@ -1439,11 +1500,17 @@ export function FileExplorerPane({
       <div className="shrink-0 border-b border-border px-4 py-2.5">
         <div className="truncate text-sm font-semibold text-foreground">
           {preview?.name || selectedEntry?.name || "Preview"}
-          {isDirty ? <span className="ml-2 text-xs text-primary">unsaved</span> : null}
+          {isDirty ? (
+            <span className="ml-2 text-xs text-primary">unsaved</span>
+          ) : null}
         </div>
         <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
-          {preview?.size != null ? <span>{formatFileSize(preview.size)}</span> : null}
-          {preview?.modifiedAt ? <span>{formatModified(preview.modifiedAt)}</span> : null}
+          {preview?.size != null ? (
+            <span>{formatFileSize(preview.size)}</span>
+          ) : null}
+          {preview?.modifiedAt ? (
+            <span>{formatModified(preview.modifiedAt)}</span>
+          ) : null}
         </div>
       </div>
 
@@ -1487,11 +1554,19 @@ export function FileExplorerPane({
           )
         ) : preview?.kind === "image" && preview.dataUrl ? (
           <div className="flex h-full items-center justify-center overflow-auto rounded-lg border border-border bg-muted p-3">
-            <img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-md object-contain" />
+            <img
+              src={preview.dataUrl}
+              alt={preview.name}
+              className="max-h-full max-w-full rounded-md object-contain"
+            />
           </div>
         ) : preview?.kind === "pdf" && preview.dataUrl ? (
           <div className="h-full overflow-hidden rounded-lg border border-border bg-white">
-            <iframe src={preview.dataUrl} title={preview.name} className="h-full w-full border-0" />
+            <iframe
+              src={preview.dataUrl}
+              title={preview.name}
+              className="h-full w-full border-0"
+            />
           </div>
         ) : preview?.kind === "table" && activeTableSheet ? (
           <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-muted">
@@ -1545,7 +1620,10 @@ export function FileExplorerPane({
                     </tr>
                   ) : (
                     activeTableSheet.rows.map((row, rowIndex) => (
-                      <tr key={`row-${rowIndex}`} className="odd:bg-background/20 even:bg-transparent">
+                      <tr
+                        key={`row-${rowIndex}`}
+                        className="odd:bg-background/20 even:bg-transparent"
+                      >
                         <td className="border-b border-r border-border px-2 py-1.5 align-top text-[11px] text-muted-foreground">
                           {rowIndex + 1}
                         </td>
@@ -1554,7 +1632,9 @@ export function FileExplorerPane({
                             key={`cell-${rowIndex}-${columnIndex}`}
                             className="max-w-[320px] border-b border-r border-border px-2 py-1.5 align-top"
                           >
-                            <div className="break-words whitespace-pre-wrap">{value || "\u00a0"}</div>
+                            <div className="break-words whitespace-pre-wrap">
+                              {value || "\u00a0"}
+                            </div>
                           </td>
                         ))}
                       </tr>
@@ -1565,18 +1645,30 @@ export function FileExplorerPane({
             </div>
             {activeTableSheet.truncated ? (
               <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
-                Showing {activeTableSheet.rows.length} of {activeTableSheet.totalRows} rows and{" "}
-                {Math.min(activeTableSheet.columns.length, activeTableSheet.totalColumns)} of{" "}
-                {Math.max(activeTableSheet.totalColumns, activeTableSheet.columns.length)} columns.
+                Showing {activeTableSheet.rows.length} of{" "}
+                {activeTableSheet.totalRows} rows and{" "}
+                {Math.min(
+                  activeTableSheet.columns.length,
+                  activeTableSheet.totalColumns,
+                )}{" "}
+                of{" "}
+                {Math.max(
+                  activeTableSheet.totalColumns,
+                  activeTableSheet.columns.length,
+                )}{" "}
+                columns.
               </div>
             ) : null}
           </div>
         ) : (
           <div className="flex h-full flex-col items-center justify-center rounded-lg border border-border bg-muted px-5 text-center">
             <FileText size={22} className="mb-3 text-muted-foreground" />
-            <div className="text-sm font-medium text-foreground">Preview unavailable</div>
+            <div className="text-sm font-medium text-foreground">
+              Preview unavailable
+            </div>
             <div className="mt-2 max-w-xs text-xs leading-6 text-muted-foreground">
-              {preview?.unsupportedReason || "This file type is not supported for inline preview yet."}
+              {preview?.unsupportedReason ||
+                "This file type is not supported for inline preview yet."}
             </div>
           </div>
         )}
@@ -1591,7 +1683,7 @@ export function FileExplorerPane({
               const isActive = activeBookmarkId === bookmark.targetPath;
               const { Icon, className } = getExplorerIconDescriptor(
                 bookmark.targetPath,
-                bookmark.isDirectory
+                bookmark.isDirectory,
               );
               return (
                 <button
@@ -1621,13 +1713,23 @@ export function FileExplorerPane({
                 Files
               </div>
             </div>
-            <IconButton
-              icon={<Star size={13} className={activeBookmark ? "fill-current" : ""} />}
-              label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
-              active={Boolean(activeBookmark)}
+            <Button
+              variant={activeBookmark ? "outline" : "ghost"}
+              size="icon-sm"
+              aria-label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
               onClick={() => void toggleBookmark()}
               disabled={!bookmarkTargetPath}
-            />
+              className={
+                activeBookmark
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "text-muted-foreground"
+              }
+            >
+              <Star
+                size={13}
+                className={activeBookmark ? "fill-current" : ""}
+              />
+            </Button>
           </div>
           <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1.5 text-xs transition-colors focus-within:border-ring">
             <Search size={13} className="shrink-0 text-muted-foreground" />
@@ -1641,12 +1743,20 @@ export function FileExplorerPane({
         </div>
 
         <div className="chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1">
-          {loading ? <div className="px-2 py-4 text-xs text-muted-foreground">Loading directory...</div> : null}
+          {loading ? (
+            <div className="px-2 py-4 text-xs text-muted-foreground">
+              Loading directory...
+            </div>
+          ) : null}
 
-          {error ? <div className="px-2 py-3 text-xs text-destructive">{error}</div> : null}
+          {error ? (
+            <div className="px-2 py-3 text-xs text-destructive">{error}</div>
+          ) : null}
 
           {!loading && !error && filteredEntries.length === 0 ? (
-            <div className="px-2 py-4 text-xs text-muted-foreground">No files matched your search.</div>
+            <div className="px-2 py-4 text-xs text-muted-foreground">
+              No files matched your search.
+            </div>
           ) : null}
 
           {!loading && !error
@@ -1670,7 +1780,7 @@ export function FileExplorerPane({
                 const { entry, depth, isExpanded, isLoadingChildren } = row;
                 const { Icon, className } = getExplorerIconDescriptor(
                   entry.name,
-                  entry.isDirectory
+                  entry.isDirectory,
                 );
                 const selected = selectedPath === entry.absolutePath;
                 const isRenaming = renamingPath === entry.absolutePath;
@@ -1703,7 +1813,9 @@ export function FileExplorerPane({
                     className="embedded-input h-6 min-w-0 flex-1 rounded-sm border border-border/70 bg-background px-1.5 text-xs font-medium text-foreground outline-none focus:border-ring disabled:opacity-60"
                   />
                 ) : (
-                  <span className="truncate text-xs font-medium">{entry.name}</span>
+                  <span className="truncate text-xs font-medium">
+                    {entry.name}
+                  </span>
                 );
                 const disclosureControl = entry.isDirectory ? (
                   <button
@@ -1713,7 +1825,9 @@ export function FileExplorerPane({
                       void toggleDirectoryExpansion(entry);
                     }}
                     className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
+                    aria-label={
+                      isExpanded ? "Collapse folder" : "Expand folder"
+                    }
                   >
                     <ChevronRight
                       size={12}
@@ -1739,106 +1853,111 @@ export function FileExplorerPane({
                       className="flex min-w-0 items-center gap-2 pl-6 text-[11px] text-muted-foreground"
                       style={{ paddingLeft: `${depth * 16 + 24}px` }}
                     >
-                      <span className="truncate">{formatModified(entry.modifiedAt)}</span>
-                      {!entry.isDirectory ? <span className="shrink-0">{formatFileSize(entry.size)}</span> : null}
+                      <span className="truncate">
+                        {formatModified(entry.modifiedAt)}
+                      </span>
+                      {!entry.isDirectory ? (
+                        <span className="shrink-0">
+                          {formatFileSize(entry.size)}
+                        </span>
+                      ) : null}
                     </span>
                   </span>
                 );
                 return (
-                <div
-                  key={entry.absolutePath}
-                  className={rowClassName}
-                  title={
-                    entry.isDirectory
-                      ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
-                      : previewInPane
-                        ? `${entry.name} — drag into chat to attach`
-                        : `${entry.name} — click to open file, drag into chat to attach`
-                  }
-                >
-                  {isRenaming ? (
-                    <div className="w-full">
-                      {rowContent}
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      draggable={!entry.isDirectory}
-                      onClick={() => {
-                        setSelectedPath(entry.absolutePath);
-                        closeContextMenu();
-                        if (entry.isDirectory) {
-                          void toggleDirectoryExpansion(entry);
-                          return;
-                        }
-                        if (!previewInPane) {
-                          void openFileTarget(entry.absolutePath);
-                        }
-                      }}
-                      onContextMenu={(event) => {
-                        event.preventDefault();
-                        const paneRect = containerRef.current?.getBoundingClientRect();
-                        if (!paneRect) {
-                          return;
-                        }
-                        setSelectedPath(entry.absolutePath);
-                        setContextMenu({
-                          entry,
-                          x: event.clientX,
-                          y: event.clientY,
-                          paneBounds: {
-                            left: paneRect.left,
-                            top: paneRect.top,
-                            right: paneRect.right,
-                            bottom: paneRect.bottom,
-                            width: paneRect.width,
-                            height: paneRect.height,
-                          },
-                        });
-                      }}
-                      onDoubleClick={() => {
-                        if (!entry.isDirectory && previewInPane) {
-                          void openFilePreview(entry.absolutePath);
-                        }
-                      }}
-                      onDragStart={(event) => {
-                        if (entry.isDirectory) {
+                  <div
+                    key={entry.absolutePath}
+                    className={rowClassName}
+                    title={
+                      entry.isDirectory
+                        ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
+                        : previewInPane
+                          ? `${entry.name} — drag into chat to attach`
+                          : `${entry.name} — click to open file, drag into chat to attach`
+                    }
+                  >
+                    {isRenaming ? (
+                      <div className="w-full">{rowContent}</div>
+                    ) : (
+                      <button
+                        type="button"
+                        draggable={!entry.isDirectory}
+                        onClick={() => {
+                          setSelectedPath(entry.absolutePath);
+                          closeContextMenu();
+                          if (entry.isDirectory) {
+                            void toggleDirectoryExpansion(entry);
+                            return;
+                          }
+                          if (!previewInPane) {
+                            void openFileTarget(entry.absolutePath);
+                          }
+                        }}
+                        onContextMenu={(event) => {
                           event.preventDefault();
-                          return;
-                        }
+                          const paneRect =
+                            containerRef.current?.getBoundingClientRect();
+                          if (!paneRect) {
+                            return;
+                          }
+                          setSelectedPath(entry.absolutePath);
+                          setContextMenu({
+                            entry,
+                            x: event.clientX,
+                            y: event.clientY,
+                            paneBounds: {
+                              left: paneRect.left,
+                              top: paneRect.top,
+                              right: paneRect.right,
+                              bottom: paneRect.bottom,
+                              width: paneRect.width,
+                              height: paneRect.height,
+                            },
+                          });
+                        }}
+                        onDoubleClick={() => {
+                          if (!entry.isDirectory && previewInPane) {
+                            void openFilePreview(entry.absolutePath);
+                          }
+                        }}
+                        onDragStart={(event) => {
+                          if (entry.isDirectory) {
+                            event.preventDefault();
+                            return;
+                          }
 
-                        event.dataTransfer.effectAllowed = "copy";
-                        event.dataTransfer.setData(
-                          EXPLORER_ATTACHMENT_DRAG_TYPE,
-                          serializeExplorerAttachmentDragPayload({
-                            absolutePath: entry.absolutePath,
-                            name: entry.name,
-                            size: entry.size,
-                          })
-                        );
-                        event.dataTransfer.setData("text/plain", entry.name);
-                        const preview = createAttachmentDragPreview(entry);
-                        dragPreviewRef.current?.remove();
-                        dragPreviewRef.current = preview;
-                        event.dataTransfer.setDragImage(preview, 18, 18);
-                      }}
-                      onDragEnd={() => {
-                        dragPreviewRef.current?.remove();
-                        dragPreviewRef.current = null;
-                      }}
-                      className="w-full cursor-pointer text-left"
-                      title={
-                        entry.isDirectory
-                          ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
-                          : previewInPane
-                            ? `${entry.name} — drag into chat to attach`
-                            : `${entry.name} — click to open file, drag into chat to attach`
-                      }
-                    >
-                      {rowContent}
-                    </button>
-                  )}
-                </div>
+                          event.dataTransfer.effectAllowed = "copy";
+                          event.dataTransfer.setData(
+                            EXPLORER_ATTACHMENT_DRAG_TYPE,
+                            serializeExplorerAttachmentDragPayload({
+                              absolutePath: entry.absolutePath,
+                              name: entry.name,
+                              size: entry.size,
+                            }),
+                          );
+                          event.dataTransfer.setData("text/plain", entry.name);
+                          const preview = createAttachmentDragPreview(entry);
+                          dragPreviewRef.current?.remove();
+                          dragPreviewRef.current = preview;
+                          event.dataTransfer.setDragImage(preview, 18, 18);
+                        }}
+                        onDragEnd={() => {
+                          dragPreviewRef.current?.remove();
+                          dragPreviewRef.current = null;
+                        }}
+                        className="w-full cursor-pointer text-left"
+                        title={
+                          entry.isDirectory
+                            ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder`
+                            : previewInPane
+                              ? `${entry.name} — drag into chat to attach`
+                              : `${entry.name} — click to open file, drag into chat to attach`
+                        }
+                      >
+                        {rowContent}
+                      </button>
+                    )}
+                  </div>
                 );
               })
             : null}
@@ -1864,18 +1983,30 @@ export function FileExplorerPane({
               <ArrowLeft size={12} />
               Files
             </Button>
-            <IconButton
-              icon={<Star size={12} className={activeBookmark ? "fill-current" : ""} />}
-              label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
-              active={Boolean(activeBookmark)}
+            <Button
+              variant={activeBookmark ? "outline" : "ghost"}
+              size="icon-sm"
+              aria-label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
               onClick={() => void toggleBookmark()}
               disabled={!bookmarkTargetPath}
-            />
+              className={
+                activeBookmark
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "text-muted-foreground"
+              }
+            >
+              <Star
+                size={12}
+                className={activeBookmark ? "fill-current" : ""}
+              />
+            </Button>
             {isMarkdownPreview ? (
               <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
                 <Button
                   type="button"
-                  variant={textPreviewMode === "preview" ? "secondary" : "ghost"}
+                  variant={
+                    textPreviewMode === "preview" ? "secondary" : "ghost"
+                  }
                   size="xs"
                   onClick={() => setTextPreviewMode("preview")}
                   className={textPreviewMode === "preview" ? "shadow-sm" : ""}

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -21,6 +21,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
+import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/IconButton";
 import { PaneCard } from "@/components/ui/PaneCard";
 import {
@@ -1854,14 +1855,15 @@ export function FileExplorerPane({
       actions={
         showInlinePreview ? (
           <>
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               onClick={closePreview}
-              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
               <ArrowLeft size={12} />
               Files
-            </button>
+            </Button>
             <IconButton
               icon={<Star size={12} className={activeBookmark ? "fill-current" : ""} />}
               label={activeBookmark ? "Remove bookmark" : "Add bookmark"}
@@ -1871,40 +1873,37 @@ export function FileExplorerPane({
             />
             {isMarkdownPreview ? (
               <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
-                <button
+                <Button
                   type="button"
+                  variant={textPreviewMode === "preview" ? "secondary" : "ghost"}
+                  size="xs"
                   onClick={() => setTextPreviewMode("preview")}
-                  className={`rounded px-2 py-1 text-xs transition-colors ${
-                    textPreviewMode === "preview"
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                  }`}
+                  className={textPreviewMode === "preview" ? "shadow-sm" : ""}
                 >
                   Preview
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant={textPreviewMode === "edit" ? "secondary" : "ghost"}
+                  size="xs"
                   onClick={() => setTextPreviewMode("edit")}
-                  className={`rounded px-2 py-1 text-xs transition-colors ${
-                    textPreviewMode === "edit"
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                  }`}
+                  className={textPreviewMode === "edit" ? "shadow-sm" : ""}
                 >
                   Edit
-                </button>
+                </Button>
               </div>
             ) : null}
             {preview?.isEditable ? (
-              <button
+              <Button
                 type="button"
+                variant="outline"
+                size="sm"
                 onClick={() => void savePreview()}
                 disabled={!isDirty || saving}
-                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <Save size={12} />
                 {saving ? "Saving" : "Save"}
-              </button>
+              </Button>
             ) : null}
           </>
         ) : undefined
@@ -1924,37 +1923,43 @@ export function FileExplorerPane({
               style={contextMenuPosition}
               className="fixed z-[80] rounded-xl border border-border/70 bg-popover/92 p-1.5 text-popover-foreground shadow-xl ring-1 ring-foreground/10 backdrop-blur-xl"
             >
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="default"
                 onClick={() => {
                   void openEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="w-full justify-start"
               >
                 {contextMenu.entry.isDirectory
                   ? expandedDirectoryPaths[contextMenu.entry.absolutePath]
                     ? "Collapse folder"
                     : "Expand folder"
                   : "Open file"}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost"
+                size="default"
                 onClick={() => {
                   void renameEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="w-full justify-start"
               >
                 Rename…
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost"
+                size="default"
                 onClick={() => {
                   void deleteEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 hover:text-destructive"
+                className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
               >
                 Delete…
-              </button>
+              </Button>
             </div>,
             document.body,
           )

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   FileVideoCamera,
   Folder,
+  Loader2,
   Save,
   Search,
   Shield,
@@ -21,6 +22,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PaneCard } from "@/components/ui/PaneCard";
 import {
@@ -1495,73 +1497,106 @@ export function FileExplorerPane({
     };
   }, [contextMenu]);
 
+  const previewFileName = preview?.name || selectedEntry?.name || "Untitled";
+  const previewFileIcon = selectedEntry
+    ? getExplorerIconDescriptor(previewFileName, selectedEntry.isDirectory)
+    : getExplorerIconDescriptor(previewFileName, false);
+  const PreviewFileIcon = previewFileIcon.Icon;
+
   const content = showInlinePreview ? (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 border-b border-border px-4 py-2.5">
-        <div className="truncate text-sm font-semibold text-foreground">
-          {preview?.name || selectedEntry?.name || "Preview"}
-          {isDirty ? (
-            <span className="ml-2 text-xs text-primary">unsaved</span>
-          ) : null}
-        </div>
-        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
-          {preview?.size != null ? (
-            <span>{formatFileSize(preview.size)}</span>
-          ) : null}
-          {preview?.modifiedAt ? (
-            <span>{formatModified(preview.modifiedAt)}</span>
-          ) : null}
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      {/* File identity header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-border/30 px-4 py-2.5">
+        <span className={`grid size-7 shrink-0 place-items-center rounded-lg border border-border/40 bg-muted/30 ${previewFileIcon.className}`}>
+          <PreviewFileIcon size={14} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-[13px] font-medium text-foreground">
+              {previewFileName}
+            </span>
+            {isDirty ? (
+              <Badge variant="outline" className="border-warning/30 bg-warning/10 text-warning">
+                Unsaved
+              </Badge>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            {selectedPath ? (
+              <span className="truncate">{selectedPath.split("/").slice(-2, -1)[0] || ""}/</span>
+            ) : null}
+            {preview?.size != null ? (
+              <span className="shrink-0">{formatFileSize(preview.size)}</span>
+            ) : null}
+            {preview?.modifiedAt ? (
+              <>
+                <span className="shrink-0 text-border">·</span>
+                <span className="shrink-0">{formatModified(preview.modifiedAt)}</span>
+              </>
+            ) : null}
+          </div>
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden p-2.5">
+      {/* Content area */}
+      <div className="min-h-0 flex-1 overflow-hidden">
         {previewLoading ? (
-          <div className="grid h-full place-items-center rounded-lg border border-border bg-muted text-sm text-muted-foreground">
-            Loading file...
+          <div className="grid h-full place-items-center">
+            <div className="text-center">
+              <Loader2 size={16} className="mx-auto animate-spin text-muted-foreground" />
+              <div className="mt-2 text-xs text-muted-foreground">Loading file...</div>
+            </div>
           </div>
         ) : previewError ? (
-          <div className="grid h-full place-items-center rounded-lg border border-destructive/30 bg-destructive/5 px-4 text-center text-sm text-destructive">
-            {previewError}
+          <div className="grid h-full place-items-center px-6 text-center">
+            <div>
+              <div className="text-sm font-medium text-destructive">Cannot preview</div>
+              <div className="mt-1 text-xs text-muted-foreground">{previewError}</div>
+            </div>
           </div>
         ) : preview?.kind === "text" ? (
           isMarkdownPreview && textPreviewMode === "preview" ? (
-            <div className="h-full overflow-auto rounded-lg border border-border bg-muted/55 p-4">
-              {previewDraft.trim() ? (
-                <SimpleMarkdown
-                  className="chat-markdown text-sm text-foreground"
-                  onLinkClick={openPreviewLink}
-                >
-                  {previewDraft}
-                </SimpleMarkdown>
-              ) : (
-                <div className="grid h-full min-h-[120px] place-items-center text-sm text-muted-foreground">
-                  Nothing to preview yet.
-                </div>
-              )}
+            <div className="h-full overflow-auto">
+              <div className="mx-auto max-w-2xl px-6 py-6">
+                {previewDraft.trim() ? (
+                  <SimpleMarkdown
+                    className="chat-markdown text-sm leading-7 text-foreground"
+                    onLinkClick={openPreviewLink}
+                  >
+                    {previewDraft}
+                  </SimpleMarkdown>
+                ) : (
+                  <div className="py-12 text-center text-xs text-muted-foreground">
+                    Empty file — switch to Edit to add content.
+                  </div>
+                )}
+              </div>
             </div>
           ) : (
-            <textarea
-              value={previewDraft}
-              onChange={(event) => setPreviewDraft(event.target.value)}
-              readOnly={!preview.isEditable}
-              spellCheck={false}
-              className={`h-full w-full resize-none rounded-lg border border-border bg-muted p-4 font-mono text-xs leading-6 text-foreground outline-none transition-colors ${
-                preview.isEditable
-                  ? "embedded-input focus:border-border/70"
-                  : "cursor-default opacity-90"
-              }`}
-            />
+            <div className="h-full overflow-auto bg-muted/20">
+              <textarea
+                value={previewDraft}
+                onChange={(event) => setPreviewDraft(event.target.value)}
+                readOnly={!preview.isEditable}
+                spellCheck={false}
+                className={`h-full min-h-full w-full resize-none border-0 bg-transparent px-6 py-5 font-mono text-[13px] leading-6 text-foreground outline-none ${
+                  preview.isEditable
+                    ? ""
+                    : "cursor-default opacity-80"
+                }`}
+              />
+            </div>
           )
         ) : preview?.kind === "image" && preview.dataUrl ? (
-          <div className="flex h-full items-center justify-center overflow-auto rounded-lg border border-border bg-muted p-3">
+          <div className="flex h-full items-center justify-center overflow-auto bg-muted/20 p-6">
             <img
               src={preview.dataUrl}
               alt={preview.name}
-              className="max-h-full max-w-full rounded-md object-contain"
+              className="max-h-full max-w-full rounded-lg object-contain shadow-sm"
             />
           </div>
         ) : preview?.kind === "pdf" && preview.dataUrl ? (
-          <div className="h-full overflow-hidden rounded-lg border border-border bg-white">
+          <div className="h-full overflow-hidden">
             <iframe
               src={preview.dataUrl}
               title={preview.name}

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -12,11 +12,7 @@ interface InternalSurfacePaneProps {
   htmlContent?: string | null;
 }
 
-const MARKDOWN_PREVIEW_EXTENSIONS = new Set([
-  ".md",
-  ".mdx",
-  ".markdown",
-]);
+const MARKDOWN_PREVIEW_EXTENSIONS = new Set([".md", ".mdx", ".markdown"]);
 type TextPreviewMode = "edit" | "preview";
 
 function resolveWorkspaceTargetPath(
@@ -67,7 +63,11 @@ export function InternalSurfacePane({
   }, []);
 
   useEffect(() => {
-    if (typeof resourceId !== "string" || !resourceId || (surface !== "document" && surface !== "file")) {
+    if (
+      typeof resourceId !== "string" ||
+      !resourceId ||
+      (surface !== "document" && surface !== "file")
+    ) {
       setPreview(null);
       setPreviewDraft("");
       setTextPreviewMode("edit");
@@ -88,13 +88,22 @@ export function InternalSurfacePane({
       try {
         let targetPath = targetResource;
         if (selectedWorkspaceId) {
-          const workspaceRoot = await window.electronAPI.workspace.getWorkspaceRoot(selectedWorkspaceId);
+          const workspaceRoot =
+            await window.electronAPI.workspace.getWorkspaceRoot(
+              selectedWorkspaceId,
+            );
           if (cancelled) {
             return;
           }
-          targetPath = resolveWorkspaceTargetPath(workspaceRoot, targetResource);
+          targetPath = resolveWorkspaceTargetPath(
+            workspaceRoot,
+            targetResource,
+          );
         }
-        const nextPreview = await window.electronAPI.fs.readFilePreview(targetPath, selectedWorkspaceId ?? null);
+        const nextPreview = await window.electronAPI.fs.readFilePreview(
+          targetPath,
+          selectedWorkspaceId ?? null,
+        );
         if (!cancelled) {
           setPreview(nextPreview);
           setPreviewDraft(nextPreview.content ?? "");
@@ -108,7 +117,11 @@ export function InternalSurfacePane({
           setPreviewDraft("");
           setTextPreviewMode("edit");
           setActiveTableSheetIndex(0);
-          setErrorMessage(error instanceof Error ? error.message : "Failed to load output preview.");
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : "Failed to load output preview.",
+          );
           setIsSaving(false);
         }
       } finally {
@@ -160,7 +173,12 @@ export function InternalSurfacePane({
 
   const body = useMemo(() => {
     if (surface === "event") {
-      return <EmptyState title="Event detail" detail="This output remains inside Holaboss and does not resolve to a file-backed preview." />;
+      return (
+        <EmptyState
+          title="Event detail"
+          detail="This output remains inside Holaboss and does not resolve to a file-backed preview."
+        />
+      );
     }
 
     if (surface === "preview") {
@@ -176,11 +194,21 @@ export function InternalSurfacePane({
           </div>
         );
       }
-      return <EmptyState title="Preview surface" detail="Structured preview rendering is not available for this output." />;
+      return (
+        <EmptyState
+          title="Preview surface"
+          detail="Structured preview rendering is not available for this output."
+        />
+      );
     }
 
     if (!resourceId) {
-      return <EmptyState title="No target" detail="This output does not include a file target yet." />;
+      return (
+        <EmptyState
+          title="No target"
+          detail="This output does not include a file target yet."
+        />
+      );
     }
 
     if (isLoading) {
@@ -195,21 +223,33 @@ export function InternalSurfacePane({
     }
 
     if (errorMessage) {
-      return <EmptyState title="Preview failed" detail={errorMessage} tone="error" />;
+      return (
+        <EmptyState title="Preview failed" detail={errorMessage} tone="error" />
+      );
     }
 
     if (!preview) {
-      return <EmptyState title="No preview" detail="File preview is not available yet." />;
+      return (
+        <EmptyState
+          title="No preview"
+          detail="File preview is not available yet."
+        />
+      );
     }
 
     if (preview.kind === "text") {
       return (
-        <div className="grid min-h-0 gap-3">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <MetadataRow
-              label="Modified"
-              value={new Date(preview.modifiedAt).toLocaleString()}
-            />
+        <div className="flex h-full min-h-0 flex-col">
+          {/* Toolbar */}
+          <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/30 px-4 py-2">
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium text-foreground">{preview.name}</div>
+              <div className="text-[11px] text-muted-foreground">
+                {new Date(preview.modifiedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                {preview.size != null ? ` · ${formatPreviewSize(preview.size)}` : ""}
+                {isDirty ? " · Unsaved changes" : ""}
+              </div>
+            </div>
             <div className="flex shrink-0 items-center gap-2">
               {isMarkdownPreview ? (
                 <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
@@ -247,123 +287,140 @@ export function InternalSurfacePane({
               ) : null}
             </div>
           </div>
-          {isMarkdownPreview && textPreviewMode === "preview" ? (
-            <div className="min-h-0 overflow-auto rounded-[18px] border border-border/35 bg-black/10 p-4">
-              {previewDraft.trim() ? (
-                <SimpleMarkdown
-                  className="chat-markdown text-sm text-foreground/90"
-                  onLinkClick={openPreviewLink}
-                >
-                  {previewDraft}
-                </SimpleMarkdown>
-              ) : (
-                <div className="grid min-h-[160px] place-items-center text-[12px] text-muted-foreground">
-                  Nothing to preview yet.
-                </div>
-              )}
-            </div>
-          ) : (
-            <textarea
-              value={previewDraft}
-              onChange={(event) => setPreviewDraft(event.target.value)}
-              readOnly={!preview.isEditable}
-              spellCheck={false}
-              className={`min-h-[60vh] w-full resize-none rounded-[18px] border border-border/35 p-4 font-mono text-[12px] leading-6 text-foreground/88 outline-none transition-colors ${
-                preview.isEditable
-                  ? "embedded-input bg-black/20 focus:border-border/70"
-                  : "cursor-default bg-black/20 opacity-90"
-              }`}
-            />
-          )}
+
+          {/* Content */}
+          <div className="min-h-0 flex-1 overflow-auto">
+            {isMarkdownPreview && textPreviewMode === "preview" ? (
+              <div className="mx-auto max-w-2xl px-6 py-6">
+                {previewDraft.trim() ? (
+                  <SimpleMarkdown
+                    className="chat-markdown text-sm leading-7 text-foreground"
+                    onLinkClick={openPreviewLink}
+                  >
+                    {previewDraft}
+                  </SimpleMarkdown>
+                ) : (
+                  <div className="py-12 text-center text-xs text-muted-foreground">
+                    Empty file — switch to Edit to add content.
+                  </div>
+                )}
+              </div>
+            ) : (
+              <textarea
+                value={previewDraft}
+                onChange={(event) => setPreviewDraft(event.target.value)}
+                readOnly={!preview.isEditable}
+                spellCheck={false}
+                className={`h-full min-h-full w-full resize-none border-0 bg-transparent px-6 py-5 font-mono text-[13px] leading-6 text-foreground outline-none ${
+                  preview.isEditable ? "" : "cursor-default opacity-80"
+                }`}
+              />
+            )}
+          </div>
         </div>
       );
     }
 
     if (preview.kind === "image" && preview.dataUrl) {
       return (
-        <div className="grid min-h-0 gap-3">
-          <div className="overflow-auto rounded-[18px] border border-border/35 bg-black/20 p-4">
-            <img src={preview.dataUrl} alt={preview.name} className="mx-auto max-h-[60vh] max-w-full rounded-[12px]" />
-          </div>
+        <div className="flex h-full items-center justify-center overflow-auto bg-muted/20 p-6">
+          <img
+            src={preview.dataUrl}
+            alt={preview.name}
+            className="max-h-full max-w-full rounded-lg object-contain shadow-sm"
+          />
         </div>
       );
     }
 
     if (preview.kind === "pdf" && preview.dataUrl) {
       return (
-        <div className="grid min-h-0 gap-3">
-          <iframe title={preview.name} src={preview.dataUrl} className="min-h-[60vh] w-full rounded-[18px] border border-border/35 bg-white" />
-        </div>
+        <iframe
+          title={preview.name}
+          src={preview.dataUrl}
+          className="h-full w-full border-0"
+        />
       );
     }
 
-    if (preview.kind === "table" && preview.tableSheets && preview.tableSheets.length > 0) {
-      const activeSheet = preview.tableSheets[Math.min(activeTableSheetIndex, preview.tableSheets.length - 1)];
+    if (
+      preview.kind === "table" &&
+      preview.tableSheets &&
+      preview.tableSheets.length > 0
+    ) {
+      const activeSheet =
+        preview.tableSheets[
+          Math.min(activeTableSheetIndex, preview.tableSheets.length - 1)
+        ];
       if (activeSheet) {
         return (
-          <div className="grid min-h-0 gap-3">
-            <div className="flex min-h-0 flex-col overflow-hidden rounded-[18px] border border-border/35 bg-black/10">
-              {preview.tableSheets.length > 1 ? (
-                <div className="flex items-center gap-1 overflow-x-auto border-b border-border/35 p-2">
-                  {preview.tableSheets.map((sheet, index) => {
-                    const isActive = index === activeTableSheetIndex;
-                    return (
-                      <Button
-                        key={`${sheet.name}-${sheet.index}`}
-                        type="button"
-                        variant={isActive ? "secondary" : "outline"}
-                        size="xs"
-                        onClick={() => setActiveTableSheetIndex(index)}
-                        className={isActive ? "border-primary/35 bg-primary/12 text-primary" : ""}
-                      >
-                        {sheet.name}
-                      </Button>
-                    );
-                  })}
-                </div>
-              ) : null}
-              <div className="min-h-0 overflow-auto">
-                <table className="w-max min-w-full border-collapse text-[12px]">
-                  <thead className="sticky top-0 z-[1] bg-muted">
-                    <tr>
-                      <th className="border-b border-r border-border/35 px-2 py-1 text-left text-[11px] text-muted-foreground">#</th>
-                      {activeSheet.columns.map((column, columnIndex) => (
-                        <th
-                          key={`${column}-${columnIndex}`}
-                          className="border-b border-r border-border/35 px-2 py-1 text-left text-[11px] text-muted-foreground"
-                        >
-                          {column}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {activeSheet.rows.length === 0 ? (
-                      <tr>
-                        <td
-                          colSpan={activeSheet.columns.length + 1}
-                          className="px-3 py-4 text-center text-[12px] text-muted-foreground"
-                        >
-                          No rows in this sheet.
-                        </td>
-                      </tr>
-                    ) : (
-                      activeSheet.rows.map((row, rowIndex) => (
-                        <tr key={`row-${rowIndex}`}>
-                          <td className="border-b border-r border-border/35 px-2 py-1 text-[11px] text-muted-foreground">
-                            {rowIndex + 1}
-                          </td>
-                          {row.map((value, columnIndex) => (
-                            <td key={`cell-${rowIndex}-${columnIndex}`} className="max-w-[320px] border-b border-r border-border/35 px-2 py-1">
-                              <div className="break-words whitespace-pre-wrap">{value || "\u00a0"}</div>
-                            </td>
-                          ))}
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
+          <div className="flex h-full min-h-0 flex-col overflow-hidden">
+            {preview.tableSheets.length > 1 ? (
+              <div className="flex items-center gap-1 overflow-x-auto border-b border-border/30 px-3 py-2">
+                {preview.tableSheets.map((sheet, index) => {
+                  const isActive = index === activeTableSheetIndex;
+                  return (
+                    <Button
+                      key={`${sheet.name}-${sheet.index}`}
+                      type="button"
+                      variant={isActive ? "secondary" : "ghost"}
+                      size="xs"
+                      onClick={() => setActiveTableSheetIndex(index)}
+                    >
+                      {sheet.name}
+                    </Button>
+                  );
+                })}
               </div>
+            ) : null}
+            <div className="min-h-0 flex-1 overflow-auto">
+              <table className="w-max min-w-full border-collapse text-xs">
+                <thead className="sticky top-0 z-[1] bg-muted">
+                  <tr>
+                    <th className="border-b border-r border-border/30 px-2.5 py-1.5 text-left text-[11px] font-medium text-muted-foreground">
+                      #
+                    </th>
+                    {activeSheet.columns.map((column, columnIndex) => (
+                      <th
+                        key={`${column}-${columnIndex}`}
+                        className="border-b border-r border-border/30 px-2.5 py-1.5 text-left text-[11px] font-medium text-muted-foreground"
+                      >
+                        {column}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeSheet.rows.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={activeSheet.columns.length + 1}
+                        className="px-3 py-6 text-center text-xs text-muted-foreground"
+                      >
+                        No rows in this sheet.
+                      </td>
+                    </tr>
+                  ) : (
+                    activeSheet.rows.map((row, rowIndex) => (
+                      <tr key={`row-${rowIndex}`} className="hover:bg-muted/30">
+                        <td className="border-b border-r border-border/20 px-2.5 py-1.5 text-[11px] text-muted-foreground">
+                          {rowIndex + 1}
+                        </td>
+                        {row.map((value, columnIndex) => (
+                          <td
+                            key={`cell-${rowIndex}-${columnIndex}`}
+                            className="max-w-[320px] border-b border-r border-border/20 px-2.5 py-1.5"
+                          >
+                            <div className="break-words whitespace-pre-wrap">
+                              {value || "\u00a0"}
+                            </div>
+                          </td>
+                        ))}
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
             </div>
           </div>
         );
@@ -373,7 +430,10 @@ export function InternalSurfacePane({
     return (
       <EmptyState
         title="Preview unavailable"
-        detail={preview.unsupportedReason || "This file type is not yet previewable in the desktop output viewer."}
+        detail={
+          preview.unsupportedReason ||
+          "This file type is not yet previewable."
+        }
       />
     );
   }, [
@@ -394,17 +454,27 @@ export function InternalSurfacePane({
   ]);
 
   return (
-    <section className="theme-shell soft-vignette neon-border relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-[var(--radius-xl)] shadow-lg">
-      <div className="min-h-0 flex-1 overflow-auto p-5">{body}</div>
+    <section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border/40 bg-background">
+      <div className="min-h-0 flex-1 overflow-auto">{body}</div>
     </section>
   );
 }
 
+function formatPreviewSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function MetadataRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-[16px] border border-border/35 bg-muted px-3 py-2">
-      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground/72">{label}</div>
-      <div className="mt-1 break-all text-[12px] text-foreground/86">{value}</div>
+    <div className="rounded-lg border border-border/30 bg-muted/50 px-3 py-1.5">
+      <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-0.5 break-all text-xs text-foreground">
+        {value}
+      </div>
     </div>
   );
 }
@@ -412,7 +482,7 @@ function MetadataRow({ label, value }: { label: string; value: string }) {
 function EmptyState({
   title,
   detail,
-  tone = "neutral"
+  tone = "neutral",
 }: {
   title: string;
   detail: string;
@@ -428,10 +498,18 @@ function EmptyState({
     >
       <div className="max-w-[520px]">
         <div className="mx-auto grid h-10 w-10 place-items-center rounded-full border border-border/35 text-primary/80">
-          {tone === "error" ? <FileWarning size={18} /> : <FileText size={18} />}
+          {tone === "error" ? (
+            <FileWarning size={18} />
+          ) : (
+            <FileText size={18} />
+          )}
         </div>
-        <div className="mt-3 text-[16px] font-medium text-foreground">{title}</div>
-        <div className="mt-2 text-[12px] leading-6 text-muted-foreground/82">{detail}</div>
+        <div className="mt-3 text-[16px] font-medium text-foreground">
+          {title}
+        </div>
+        <div className="mt-2 text-[12px] leading-6 text-muted-foreground/82">
+          {detail}
+        </div>
       </div>
     </div>
   );

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { FileText, FileWarning, Loader2, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -212,40 +213,37 @@ export function InternalSurfacePane({
             <div className="flex shrink-0 items-center gap-2">
               {isMarkdownPreview ? (
                 <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
-                  <button
+                  <Button
                     type="button"
+                    variant={textPreviewMode === "preview" ? "secondary" : "ghost"}
+                    size="xs"
                     onClick={() => setTextPreviewMode("preview")}
-                    className={`rounded px-2 py-1 text-xs transition-colors ${
-                      textPreviewMode === "preview"
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                    }`}
+                    className={textPreviewMode === "preview" ? "shadow-sm" : ""}
                   >
                     Preview
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    variant={textPreviewMode === "edit" ? "secondary" : "ghost"}
+                    size="xs"
                     onClick={() => setTextPreviewMode("edit")}
-                    className={`rounded px-2 py-1 text-xs transition-colors ${
-                      textPreviewMode === "edit"
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                    }`}
+                    className={textPreviewMode === "edit" ? "shadow-sm" : ""}
                   >
                     Edit
-                  </button>
+                  </Button>
                 </div>
               ) : null}
               {preview.isEditable ? (
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="sm"
                   onClick={() => void savePreview()}
                   disabled={!isDirty || isSaving}
-                  className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   <Save size={12} />
                   {isSaving ? "Saving" : "Save"}
-                </button>
+                </Button>
               ) : null}
             </div>
           </div>
@@ -310,18 +308,16 @@ export function InternalSurfacePane({
                   {preview.tableSheets.map((sheet, index) => {
                     const isActive = index === activeTableSheetIndex;
                     return (
-                      <button
+                      <Button
                         key={`${sheet.name}-${sheet.index}`}
                         type="button"
+                        variant={isActive ? "secondary" : "outline"}
+                        size="xs"
                         onClick={() => setActiveTableSheetIndex(index)}
-                        className={`rounded-md border px-2 py-1 text-[11px] transition-colors ${
-                          isActive
-                            ? "border-primary/35 bg-primary/12 text-primary"
-                            : "border-border/40 text-muted-foreground hover:bg-black/10 hover:text-foreground"
-                        }`}
+                        className={isActive ? "border-primary/35 bg-primary/12 text-primary" : ""}
                       >
                         {sheet.name}
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>

--- a/desktop/src/components/panes/MarketplacePane.tsx
+++ b/desktop/src/components/panes/MarketplacePane.tsx
@@ -2,6 +2,8 @@ import { AppsGallery } from "@/components/marketplace/AppsGallery";
 import { KitDetail } from "@/components/marketplace/KitDetail";
 import { KitEmoji } from "@/components/marketplace/KitEmoji";
 import { MarketplaceGallery } from "@/components/marketplace/MarketplaceGallery";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { Loader2 } from "lucide-react";
@@ -161,13 +163,15 @@ export function MarketplacePane() {
             />
           ) : view === "creating" ? (
             <div className="flex h-full min-h-0 flex-col">
-              <button
+              <Button
                 type="button"
+                variant="link"
+                size="sm"
                 onClick={() => setView("detail")}
-                className="mb-4 self-start text-[12px] text-muted-foreground underline transition-colors hover:text-foreground"
+                className="mb-4 self-start text-muted-foreground"
               >
                 &larr; Back
-              </button>
+              </Button>
 
               {isCreatingWorkspace ? (
                 <div className="flex flex-1 items-center justify-center">
@@ -194,13 +198,15 @@ export function MarketplacePane() {
                           {detailTemplate.apps.map((a) => a.name).join(", ")}
                         </div>
                       </div>
-                      <button
+                      <Button
                         type="button"
+                        variant="link"
+                        size="xs"
                         onClick={() => setView("gallery")}
-                        className="shrink-0 text-xs text-muted-foreground underline transition-colors hover:text-foreground"
+                        className="shrink-0 text-muted-foreground"
                       >
                         Change
-                      </button>
+                      </Button>
                     </div>
                   ) : null}
 
@@ -208,11 +214,11 @@ export function MarketplacePane() {
                     <span className="text-xs font-medium text-muted-foreground">
                       Workspace name
                     </span>
-                    <input
+                    <Input
                       value={newWorkspaceName}
                       onChange={(e) => setNewWorkspaceName(e.target.value)}
                       placeholder="My workspace"
-                      className="mt-1.5 h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring"
+                      className="mt-1.5 h-9"
                     />
                   </label>
 
@@ -222,33 +228,36 @@ export function MarketplacePane() {
                     </div>
                   ) : null}
 
-                  <button
+                  <Button
                     type="button"
+                    size="lg"
                     disabled={
                       !newWorkspaceName.trim() || isResolvingIntegrations
                     }
                     onClick={handleCreate}
-                    className="mt-4 w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="mt-4 w-full"
                   >
                     {isResolvingIntegrations
                       ? "Checking integrations…"
                       : "Create workspace"}
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>
           ) : view === "connect_integrations" && pendingIntegrations ? (
             <div className="flex h-full min-h-0 flex-col">
-              <button
+              <Button
                 type="button"
+                variant="link"
+                size="sm"
                 onClick={() => {
                   clearPendingIntegrations();
                   setView("creating");
                 }}
-                className="mb-4 self-start text-xs text-muted-foreground underline transition-colors hover:text-foreground"
+                className="mb-4 self-start text-muted-foreground"
               >
                 &larr; Back
-              </button>
+              </Button>
               <div className="mx-auto w-full max-w-sm">
                 <h3 className="text-base font-semibold text-foreground">
                   Connect accounts
@@ -265,16 +274,16 @@ export function MarketplacePane() {
                       <span className="text-sm font-medium text-foreground">
                         {providerDisplayName(provider)}
                       </span>
-                      <button
+                      <Button
                         type="button"
+                        size="sm"
                         disabled={connectingProvider !== null}
                         onClick={() => void handleConnectProvider(provider)}
-                        className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
                       >
                         {connectingProvider === provider
                           ? "Connecting…"
                           : "Connect"}
-                      </button>
+                      </Button>
                     </div>
                   ))}
                 </div>

--- a/desktop/src/components/panes/SkillsPane.tsx
+++ b/desktop/src/components/panes/SkillsPane.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CheckCircle2, FileWarning, Loader2, MoreHorizontal, Search, Sparkles, X } from "lucide-react";
-import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 
 function formatDate(value: string) {
@@ -274,14 +275,15 @@ function SkillDetailDialog({
             </div>
             <div className="mt-0.5 text-xs text-muted-foreground">Skill</div>
           </div>
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="icon"
             onClick={onClose}
             aria-label="Close"
-            className="grid h-8 w-8 place-items-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
             <X size={14} />
-          </button>
+          </Button>
         </div>
 
         {/* Content */}

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 import { ChevronLeft, ChevronRight, Globe, Loader2, RefreshCcw, Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/IconButton";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
@@ -181,19 +182,21 @@ export function SpaceBrowserDisplayPane({
             </div>
           </form>
 
-          <button
+          <Button
             type="button"
+            variant={isBookmarked ? "secondary" : "outline"}
+            size="icon"
             onClick={onToggleBookmark}
             disabled={!activeTab.url}
-            className={`grid size-8 shrink-0 place-items-center rounded-full border transition ${
+            className={`shrink-0 rounded-full ${
               isBookmarked
                 ? "border-primary/50 bg-primary/10 text-primary"
-                : "border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                : ""
             }`}
             aria-label={isBookmarked ? "Remove bookmark" : "Add bookmark"}
           >
             <Star size={13} fill={isBookmarked ? "currentColor" : "none"} />
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -1,13 +1,13 @@
+import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
-  FormEvent,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { ChevronLeft, ChevronRight, Globe, Loader2, RefreshCcw, Star } from "lucide-react";
+  ChevronLeft,
+  ChevronRight,
+  Globe,
+  Loader2,
+  RefreshCcw,
+  Star,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { IconButton } from "@/components/ui/IconButton";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
 const HOME_URL = "https://www.google.com";
@@ -56,9 +56,8 @@ export function SpaceBrowserDisplayPane({
 }: SpaceBrowserDisplayPaneProps) {
   const [inputValue, setInputValue] = useState("");
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const { activeTab, activeBookmark, isBookmarked } = useWorkspaceBrowser(
-    browserSpace,
-  );
+  const { activeTab, activeBookmark, isBookmarked } =
+    useWorkspaceBrowser(browserSpace);
 
   useEffect(() => {
     setInputValue(activeTab.url || "");
@@ -146,29 +145,35 @@ export function SpaceBrowserDisplayPane({
           : "rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm"
       }`}
     >
-      <div className="shrink-0 border-b border-border/45 px-4 py-3">
+      <div className="shrink-0 border-b border-border/45 px-4 py-2">
         <div className="flex items-center gap-1.5">
-          <IconButton
-            icon={<ChevronLeft size={13} />}
-            label="Back"
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Back"
             onClick={() => void window.electronAPI.browser.back()}
             disabled={!activeTab.canGoBack}
-            className="size-8"
-          />
-          <IconButton
-            icon={<ChevronRight size={13} />}
-            label="Forward"
+          >
+            <ChevronLeft size={14} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Forward"
             onClick={() => void window.electronAPI.browser.forward()}
             disabled={!activeTab.canGoForward}
-            className="size-8"
-          />
-          <IconButton
-            icon={<RefreshCcw size={13} />}
-            label="Refresh"
+          >
+            <ChevronRight size={14} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Refresh"
             onClick={() => void window.electronAPI.browser.reload()}
             disabled={!activeTab.initialized}
-            className="size-8"
-          />
+          >
+            <RefreshCcw size={13} />
+          </Button>
 
           <form onSubmit={onSubmit} className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 transition-colors focus-within:border-ring">
@@ -189,9 +194,7 @@ export function SpaceBrowserDisplayPane({
             onClick={onToggleBookmark}
             disabled={!activeTab.url}
             className={`shrink-0 rounded-full ${
-              isBookmarked
-                ? "border-primary/50 bg-primary/10 text-primary"
-                : ""
+              isBookmarked ? "border-primary/50 bg-primary/10 text-primary" : ""
             }`}
             aria-label={isBookmarked ? "Remove bookmark" : "Add bookmark"}
           >
@@ -215,7 +218,9 @@ export function SpaceBrowserDisplayPane({
                   Starting {browserSpace === "agent" ? "agent" : "user"} browser
                 </div>
                 <div className="mt-1.5 text-[12px] leading-6 text-muted-foreground">
-                  Opening the embedded {browserSpace === "agent" ? "agent" : "user"} browser for this workspace.
+                  Opening the embedded{" "}
+                  {browserSpace === "agent" ? "agent" : "user"} browser for this
+                  workspace.
                 </div>
               </div>
             </div>

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -1,5 +1,7 @@
 import { Bot, Globe, Plus, Star, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
 interface SpaceBrowserExplorerPaneProps {
@@ -36,56 +38,50 @@ export function SpaceBrowserExplorerPane({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
-      <div className="border-b border-border/45 px-3 py-3">
-        <div className="flex items-center gap-2">
-          <div className="inline-flex min-w-0 flex-1 items-center rounded-md border border-border bg-muted/50 p-0.5">
-            <button
-              type="button"
-              onClick={() => openBrowserSpace("user")}
-              className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-[11px] font-medium transition ${
-                browserSpace === "user"
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              }`}
-            >
+      <div className="border-b border-border/45 px-3 py-2.5">
+        <Tabs
+          value={browserSpace}
+          onValueChange={(value) => openBrowserSpace(value as BrowserSpaceId)}
+        >
+          <TabsList className="w-full">
+            <TabsTrigger value="user" className="flex-1 gap-1.5">
               <Globe size={12} />
-              <span>User</span>
-              <span className="rounded-full bg-foreground/8 px-1.5 py-0.5 text-[10px] text-current/80">
+              User
+              <Badge
+                variant="secondary"
+                className="ml-0.5 px-1.5 py-0 text-[10px]"
+              >
                 {browserState.tabCounts.user}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => openBrowserSpace("agent")}
-              className={`inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-[11px] font-medium transition ${
-                browserSpace === "agent"
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              }`}
-            >
+              </Badge>
+            </TabsTrigger>
+            <TabsTrigger value="agent" className="flex-1 gap-1.5">
               <Bot size={12} />
-              <span>Agent</span>
-              <span className="rounded-full bg-foreground/8 px-1.5 py-0.5 text-[10px] text-current/80">
+              Agent
+              <Badge
+                variant="secondary"
+                className="ml-0.5 px-1.5 py-0 text-[10px]"
+              >
                 {browserState.tabCounts.agent}
-              </span>
-            </button>
-          </div>
-        </div>
+              </Badge>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
-        <div className="space-y-1">
+        <div className="space-y-0.5">
           {bookmarks.length === 0 ? (
-            <div className="px-1 py-1 text-[12px] leading-6 text-muted-foreground/72">
+            <div className="px-2 py-1 text-xs text-muted-foreground/70">
               Saved bookmarks will appear here.
             </div>
           ) : (
             bookmarks.map((bookmark) => (
-              <button
+              <Button
                 key={bookmark.id}
-                type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => openBookmark(bookmark)}
-                className="flex w-full items-center gap-2 rounded-md border border-transparent px-3 py-2 text-left transition hover:bg-accent hover:text-accent-foreground"
+                className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-left"
               >
                 {bookmark.faviconUrl ? (
                   <img
@@ -99,21 +95,21 @@ export function SpaceBrowserExplorerPane({
                   </div>
                 )}
                 <div className="min-w-0">
-                  <div className="truncate text-[12px] font-medium text-foreground/88">
+                  <div className="truncate text-xs font-medium text-foreground">
                     {bookmark.title}
                   </div>
-                  <div className="truncate text-[11px] text-muted-foreground/72">
+                  <div className="truncate text-[11px] text-muted-foreground">
                     {bookmark.url}
                   </div>
                 </div>
-              </button>
+              </Button>
             ))
           )}
         </div>
 
-        <div className="mt-4 border-t border-border/40 pt-4">
-          <div className="mb-2 flex items-center justify-between gap-2 px-1">
-            <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+        <div className="mt-4 border-t border-border/40 pt-3">
+          <div className="mb-2 flex items-center justify-between gap-2 px-2">
+            <div className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
               Tabs
             </div>
             <Button
@@ -123,75 +119,76 @@ export function SpaceBrowserExplorerPane({
               onClick={openNewTab}
               aria-label="Open new tab"
             >
-              <Plus size={12} />
-              <span>New Tab</span>
+              <Plus size={11} />
+              New Tab
             </Button>
           </div>
-          <div className="space-y-1">
-          {browserState.tabs.length === 0 ? (
-            <div className="rounded-[16px] border border-dashed border-border/50 px-3 py-3 text-[12px] leading-6 text-muted-foreground/72">
-              No open tabs in the {browserSpace} browser.
-            </div>
-          ) : (
-            browserState.tabs.map((tab) => {
-              const isActive = tab.id === activeTab.id;
-              return (
-                <div
-                  key={tab.id}
-                  className={`group flex items-center gap-2 rounded-md border border-transparent px-3 py-2 transition ${
-                    isActive
-                      ? "border-primary/35 bg-primary/10 text-primary"
-                      : "hover:bg-accent hover:text-accent-foreground"
-                  }`}
-                >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onActivateDisplay();
-                      void window.electronAPI.browser.setActiveTab(tab.id);
-                    }}
-                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
-                    title={tab.title || tab.url}
+          <div className="space-y-0.5">
+            {browserState.tabs.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border/40 px-3 py-3 text-xs text-muted-foreground/70">
+                No open tabs in the {browserSpace} browser.
+              </div>
+            ) : (
+              browserState.tabs.map((tab) => {
+                const isActive = tab.id === activeTab.id;
+                return (
+                  <div
+                    key={tab.id}
+                    className={`group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors ${
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent/50"
+                    }`}
                   >
-                    {tab.faviconUrl ? (
-                      <img
-                        src={tab.faviconUrl}
-                        alt=""
-                        className="size-4 shrink-0 rounded-sm"
-                      />
-                    ) : (
-                      <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-foreground/8 text-muted-foreground">
-                        {browserSpace === "agent" ? (
-                          <Bot size={10} />
-                        ) : (
-                          <Globe size={10} />
-                        )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onActivateDisplay();
+                        void window.electronAPI.browser.setActiveTab(tab.id);
+                      }}
+                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      title={tab.title || tab.url}
+                    >
+                      {tab.faviconUrl ? (
+                        <img
+                          src={tab.faviconUrl}
+                          alt=""
+                          className="size-4 shrink-0 rounded-sm"
+                        />
+                      ) : (
+                        <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-muted text-muted-foreground">
+                          {browserSpace === "agent" ? (
+                            <Bot size={10} />
+                          ) : (
+                            <Globe size={10} />
+                          )}
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <div className="truncate text-xs font-medium">
+                          {tab.title || "New Tab"}
+                        </div>
+                        <div className="truncate text-[11px] text-muted-foreground">
+                          {tab.url || "about:blank"}
+                        </div>
                       </div>
-                    )}
-                    <div className="min-w-0">
-                      <div className="truncate text-[12px] font-medium text-current">
-                        {tab.title || "New Tab"}
-                      </div>
-                      <div className="truncate text-[11px] text-current/70">
-                        {tab.url || "about:blank"}
-                      </div>
-                    </div>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onActivateDisplay();
-                      void window.electronAPI.browser.closeTab(tab.id);
-                    }}
-                    className="grid size-6 shrink-0 place-items-center rounded-full text-muted-foreground/75 transition hover:bg-accent hover:text-accent-foreground"
-                    aria-label={`Close ${tab.title || "tab"}`}
-                  >
-                    <X size={12} />
-                  </button>
-                </div>
-              );
-            })
-          )}
+                    </button>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={() => {
+                        onActivateDisplay();
+                        void window.electronAPI.browser.closeTab(tab.id);
+                      }}
+                      aria-label={`Close ${tab.title || "tab"}`}
+                      className="shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100"
+                    >
+                      <X size={11} />
+                    </Button>
+                  </div>
+                );
+              })
+            )}
           </div>
         </div>
       </div>

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -1,4 +1,5 @@
 import { Bot, Globe, Plus, Star, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
 interface SpaceBrowserExplorerPaneProps {
@@ -115,15 +116,16 @@ export function SpaceBrowserExplorerPane({
             <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
               Tabs
             </div>
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="xs"
               onClick={openNewTab}
-              className="inline-flex items-center gap-1 rounded-md border border-border bg-card/80 px-2 py-1 text-[11px] font-medium text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
               aria-label="Open new tab"
             >
               <Plus size={12} />
               <span>New Tab</span>
-            </button>
+            </Button>
           </div>
           <div className="space-y-1">
           {browserState.tabs.length === 0 ? (

--- a/desktop/src/components/publish/PublishDialog.tsx
+++ b/desktop/src/components/publish/PublishDialog.tsx
@@ -364,13 +364,14 @@ export function PublishDialog({
               )}
               {success && <span />}
               {!isSubmitting && (
-                <button
-                  type="button"
-                  className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
                   onClick={close}
+                  aria-label="Close"
                 >
                   <X className="size-4" />
-                </button>
+                </Button>
               )}
             </div>
 
@@ -473,9 +474,9 @@ export function PublishDialog({
                         <span className="text-xs text-muted-foreground">
                           {selectedApps.size} of {installedApps.length} selected
                         </span>
-                        <button
-                          type="button"
-                          className="text-xs text-primary hover:underline"
+                        <Button
+                          variant="link"
+                          size="sm"
                           onClick={() => {
                             if (selectedApps.size === installedApps.length) {
                               setSelectedApps(new Set());
@@ -485,11 +486,12 @@ export function PublishDialog({
                               );
                             }
                           }}
+                          className="h-auto p-0 text-xs"
                         >
                           {selectedApps.size === installedApps.length
                             ? "Deselect all"
                             : "Select all"}
-                        </button>
+                        </Button>
                       </div>
                       <div className="space-y-1.5">
                         {installedApps.map((app) => (
@@ -649,8 +651,8 @@ export function PublishDialog({
               {/* Success state */}
               {success && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center px-8">
-                  <div className="mb-5 flex size-20 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950/40">
-                    <Check className="size-10 text-emerald-600 dark:text-emerald-400" />
+                  <div className="mb-5 flex size-20 items-center justify-center rounded-full bg-success/10">
+                    <Check className="size-10 text-success" />
                   </div>
 
                   <h3 className="mb-2 text-xl font-semibold tracking-tight">
@@ -749,13 +751,14 @@ function ReviewCard({
         <p className="truncate text-sm font-medium">{title}</p>
         <p className="truncate text-xs text-muted-foreground">{detail}</p>
       </div>
-      <button
-        type="button"
-        className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+      <Button
+        variant="ghost"
+        size="icon-xs"
         onClick={onEdit}
+        aria-label={`Edit ${label}`}
       >
         <Pencil className="size-3.5" />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/desktop/src/components/settings/SubmissionsPanel.tsx
+++ b/desktop/src/components/settings/SubmissionsPanel.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
   XCircle,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 
@@ -35,22 +36,22 @@ const STATUS_CONFIG: Record<
   { label: string; icon: typeof Clock; badgeClass: string }
 > = {
   pending_review: {
-    label: "Pending Review",
+    label: "Pending",
     icon: Clock,
     badgeClass:
-      "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      "border-warning/30 bg-warning/10 text-warning",
   },
   published: {
     label: "Published",
     icon: CheckCircle2,
     badgeClass:
-      "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+      "border-success/30 bg-success/10 text-success",
   },
   rejected: {
     label: "Rejected",
     icon: XCircle,
     badgeClass:
-      "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
+      "border-destructive/30 bg-destructive/10 text-destructive",
   },
 };
 
@@ -61,6 +62,14 @@ function formatDate(dateString: string): string {
     month: "short",
     day: "numeric",
   });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** i;
+  return `${value < 10 && i > 0 ? value.toFixed(1) : Math.round(value)} ${units[i]}`;
 }
 
 function categoryFromManifest(
@@ -174,7 +183,7 @@ export function SubmissionsPanel() {
               Your template submissions are only available after you sign in.
             </p>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-              Connect this desktop app to your Holaboss account to review and
+              Connect this desktop app to your account to review and
               manage marketplace submissions.
             </p>
           </div>
@@ -206,7 +215,14 @@ export function SubmissionsPanel() {
   }
 
   return (
-    <div className="grid max-w-[920px] gap-3">
+    <div className="max-w-[920px]">
+      <div className="grid grid-cols-[minmax(0,1fr)_100px_80px_110px_40px] items-center gap-3 border-b border-border/40 px-4 pb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <span>Template</span>
+        <span>Status</span>
+        <span>Size</span>
+        <span>Date</span>
+        <span />
+      </div>
       {submissions.map((submission) => {
         const config = STATUS_CONFIG[submission.status] ?? {
           label: submission.status,
@@ -215,60 +231,47 @@ export function SubmissionsPanel() {
             "border-border/40 bg-muted/50 text-muted-foreground",
         };
         const StatusIcon = config.icon;
-        const category = categoryFromManifest(submission.manifest);
 
         return (
-          <div
-            key={submission.id}
-            className="rounded-[18px] border border-border/40 bg-card/80 px-5 py-4"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2.5">
-                  <span className="truncate text-sm font-medium text-foreground">
-                    {submission.template_name}
-                  </span>
-                  {category ? (
-                    <span className="shrink-0 rounded-full border border-border/35 px-2 py-0.5 text-xs text-muted-foreground">
-                      {category}
-                    </span>
-                  ) : null}
-                </div>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Submitted {formatDate(submission.created_at)}
-                </p>
-              </div>
-
-              <div className="flex shrink-0 items-center gap-2">
-                <span
-                  className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${config.badgeClass}`}
-                >
-                  <StatusIcon className="size-3" />
-                  {config.label}
-                </span>
+          <div key={submission.id}>
+            <div className="grid grid-cols-[minmax(0,1fr)_100px_80px_110px_40px] items-center gap-3 border-b border-border/30 px-4 py-3 text-sm">
+              <span className="truncate font-medium text-foreground">
+                {submission.template_name}
+              </span>
+              <Badge variant="outline" className={`w-fit gap-1 ${config.badgeClass}`}>
+                <StatusIcon className="size-3" />
+                {config.label}
+              </Badge>
+              <span className="tabular-nums text-muted-foreground">
+                {formatBytes(submission.archive_size_bytes)}
+              </span>
+              <span className="text-muted-foreground">
+                {formatDate(submission.created_at)}
+              </span>
+              <span>
                 {submission.status !== "published" ? (
-                  <button
-                    type="button"
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
                     disabled={deletingId === submission.id}
                     onClick={() => void handleDelete(submission)}
-                    className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                    className="text-muted-foreground hover:text-destructive"
                   >
                     {deletingId === submission.id ? (
                       <Loader2 className="size-3.5 animate-spin" />
                     ) : (
                       <Trash2 className="size-3.5" />
                     )}
-                  </button>
+                  </Button>
                 ) : null}
-              </div>
+              </span>
             </div>
-
             {submission.status === "rejected" && submission.review_notes ? (
-              <div className="mt-3 rounded-[12px] border border-red-500/15 bg-red-500/5 px-3.5 py-2.5">
-                <p className="text-xs font-medium text-red-600 dark:text-red-400">
+              <div className="mx-4 my-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+                <p className="text-xs font-medium text-destructive">
                   Review feedback
                 </p>
-                <p className="mt-1 text-xs leading-relaxed text-red-600/80 dark:text-red-400/80">
+                <p className="mt-1 text-xs leading-relaxed text-destructive/80">
                   {submission.review_notes}
                 </p>
               </div>

--- a/desktop/src/components/ui/switch.tsx
+++ b/desktop/src/components/ui/switch.tsx
@@ -1,0 +1,19 @@
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+
+import { cn } from "@/lib/utils";
+
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      className={cn(
+        "group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb className="pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0" />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -130,20 +130,22 @@ body {
 /* ---- Scrollbars ---- */
 
 ::-webkit-scrollbar {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: color-mix(in oklch, var(--background) 90%, transparent);
-  border-radius: 9999px;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: color-mix(in oklch, var(--primary) 28%, transparent);
+  background: color-mix(in oklch, var(--foreground) 15%, transparent);
   border-radius: 9999px;
-  border: 1px solid transparent;
-  background-clip: padding-box;
+  max-height: 120px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--foreground) 25%, transparent);
 }
 
 .chat-scrollbar-hidden {

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -33,6 +33,8 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -56,9 +58,11 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
-/* Fallback radius — themes override everything else via [data-theme] */
+/* Fallback radius and semantic status colors — themes can override */
 :root {
   --radius: 0.675rem;
+  --success: oklch(0.72 0.19 145);
+  --warning: oklch(0.82 0.17 83);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Comprehensive UI consistency pass across the desktop app — 24 files, based on latest main.

- **shadcn migration**: ~60 raw buttons → Button, raw inputs → Input, hand-rolled badges → Badge, segmented controls → Tabs, IconButton → Button, new Switch component
- **Semantic color tokens**: `--success`/`--warning` CSS vars, replace all hardcoded emerald/amber/rose/neon-green
- **Settings density**: dialog 880×680, sidebar 220px, all sub-panels tightened
- **Providers flattened**: remove 4-level nesting → single flat list + "Task Configuration" section
- **BillingSummaryCard redesigned**: compact header, plan Badge, inline refresh
- **SubmissionsPanel**: clean data table with columns
- **File preview (InternalSurfacePane)**: remove grey bg-black/10, clean document viewer with filename header
- **Browser panes**: Tabs for Files/Browser and User/Agent, IconButton replaced
- **ProactiveStatusCard**: Switch toggle, flat schedule editor
- **Scrollbar**: neutral gray instead of primary orange, max-height 120px
- **Holaboss cleanup**: "Your account", workspace name as assistant label