### PR TITLE
fix: stabilize desktop browser oauth and loading flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,9 @@ All deeper technical and product documentation lives at **[holaboss.ai/docs](htt
 | [Model Configuration](https://www.holaboss.ai/docs/desktop/model-configuration) | Providers, defaults, config precedence, and runtime model selection |
 | [Independent Deploy](https://www.holaboss.ai/docs/runtime/independent-deploy) | Running the portable runtime without the desktop app |
 | [Technical Details](https://www.holaboss.ai/docs/reference/technical-details) | Repo layout, common commands, and development notes |
-| [Desktop Packaging](https://www.holaboss.ai/docs/desktop/packaging) | macOS DMG build, signing, notarization, and validation |
 | [Reference](https://www.holaboss.ai/docs/reference/environment-variables) | Environment variables, workspace files, and supporting reference material |
 
 ## OSS Release Notes
 
 - License: MIT. See [LICENSE](LICENSE).
 - Security issues: report privately to `admin@holaboss.ai`. See [SECURITY.md](SECURITY.md).
-- macOS packaging and notarization flows are documented in [Desktop Packaging](https://www.holaboss.ai/docs/desktop/packaging).

--- a/desktop/electron/browser-navigation-abort.test.mjs
+++ b/desktop/electron/browser-navigation-abort.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+const preloadSourcePath = path.join(__dirname, "preload.ts");
+const electronTypesPath = path.join(
+  __dirname,
+  "..",
+  "src",
+  "types",
+  "electron.d.ts",
+);
+
+test("desktop browser ignores aborted loadURL rejections during active navigations", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /function isAbortedBrowserLoadError\(error: unknown\): boolean \{/);
+  assert.match(
+    source,
+    /candidate\.code === "ERR_ABORTED"[\s\S]*candidate\.errno === -3[\s\S]*candidate\.message\.includes\("ERR_ABORTED"\)/,
+  );
+  assert.match(
+    source,
+    /async function navigateActiveBrowserTab\([\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\(workspaceId, space\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /"browser:openHistoryUrl"[\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\(workspace\.workspaceId, activeBrowserSpaceId\);\s*\}/,
+  );
+});
+
+test("desktop browser ignores aborted main-frame load failures and initial tab redirects", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /function isAbortedBrowserLoadFailure\(\s*errorCode: number,\s*errorDescription: string,\s*\): boolean \{/,
+  );
+  assert.match(
+    source,
+    /errorCode === -3 \|\| errorDescription\.trim\(\)\.toUpperCase\(\) === "ERR_ABORTED"/,
+  );
+  assert.match(
+    source,
+    /view\.webContents\.on\(\s*"did-fail-load",[\s\S]*?!isMainFrame \|\|[\s\S]*isAbortedBrowserLoadFailure\(errorCode, errorDescription\)[\s\S]*return;/,
+  );
+  assert.match(
+    source,
+    /if \(hasInitialUrl\) \{[\s\S]*view\.webContents\.loadURL\(initialUrl\)\.catch\(\(error\) => \{[\s\S]*if \(isAbortedBrowserLoadError\(error\)\) \{\s*return;\s*\}/,
+  );
+});
+
+test("desktop browser exposes stop-loading controls through IPC and preload", async () => {
+  const mainSource = await readFile(mainSourcePath, "utf8");
+  const preloadSource = await readFile(preloadSourcePath, "utf8");
+  const electronTypes = await readFile(electronTypesPath, "utf8");
+
+  assert.match(
+    mainSource,
+    /ipcMain\.handle\("browser:stopLoading", async \(\) => \{[\s\S]*if \(activeTab\?\.view\.webContents\.isLoadingMainFrame\(\)\) \{\s*activeTab\.view\.webContents\.stop\(\);/,
+  );
+  assert.match(
+    preloadSource,
+    /stopLoading: \(\) => ipcRenderer\.invoke\("browser:stopLoading"\) as Promise<BrowserTabListPayload>/,
+  );
+  assert.match(
+    electronTypes,
+    /stopLoading: \(\) => Promise<BrowserTabListPayload>;/,
+  );
+});

--- a/desktop/electron/browser-popup-preload.test.mjs
+++ b/desktop/electron/browser-popup-preload.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const preloadSourcePath = path.join(__dirname, "browserPopupPreload.ts");
+const mainSourcePath = path.join(__dirname, "main.ts");
+const tsupConfigPath = path.join(__dirname, "..", "tsup.config.ts");
+
+test("desktop browser popups use a preload bridge that renders a loading overlay", async () => {
+  const preloadSource = await readFile(preloadSourcePath, "utf8");
+
+  assert.match(
+    preloadSource,
+    /const OVERLAY_ID = "holaboss-browser-popup-loading-overlay";/,
+  );
+  assert.match(
+    preloadSource,
+    /overlay\.innerHTML =[\s\S]*class="panel"[\s\S]*class="spinner"/,
+  );
+});
+
+test("desktop browser popup preload injects and dismisses the loading shell around page loads", async () => {
+  const preloadSource = await readFile(preloadSourcePath, "utf8");
+
+  assert.match(preloadSource, /Loading page\.\.\./);
+  assert.match(preloadSource, /animation: holaboss-browser-popup-spin 720ms linear infinite;/);
+  assert.match(preloadSource, /window\.addEventListener\("DOMContentLoaded", ensureOverlay, \{ once: true \}\);/);
+  assert.match(preloadSource, /window\.addEventListener\("beforeunload", ensureOverlay\);/);
+  assert.match(preloadSource, /window\.addEventListener\("load", hideOverlay, \{ once: true \}\);/);
+  assert.match(preloadSource, /document\.addEventListener\("readystatechange", \(\) => \{/);
+});
+
+test("desktop browser popup window policy wires the popup preload into auth-style popup windows", async () => {
+  const mainSource = await readFile(mainSourcePath, "utf8");
+  const tsupConfigSource = await readFile(tsupConfigPath, "utf8");
+
+  assert.match(tsupConfigSource, /"electron\/browserPopupPreload\.ts",/);
+  assert.match(
+    mainSource,
+    /overrideBrowserWindowOptions: \{[\s\S]*webPreferences: \{[\s\S]*preload: path\.join\(__dirname, "browserPopupPreload\.cjs"\),/,
+  );
+});

--- a/desktop/electron/browser-tab-policy.test.mjs
+++ b/desktop/electron/browser-tab-policy.test.mjs
@@ -7,14 +7,50 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mainSourcePath = path.join(__dirname, "main.ts");
 
-test("desktop browser blocks popup windows and promotes tab/new-window dispositions into tabs", async () => {
+test("desktop browser keeps auth-style popup windows while promoting ordinary new-window requests into tabs", async () => {
   const source = await readFile(mainSourcePath, "utf8");
 
+  assert.match(source, /function normalizeBrowserPopupFrameName\(frameName\?: string \| null\): string \{/);
+  assert.match(
+    source,
+    /function isBrowserPopupWindowRequest\(\s*frameName\?: string \| null,\s*features\?: string \| null,\s*\): boolean \{/,
+  );
+  assert.match(
+    source,
+    /if \(normalizeBrowserPopupFrameName\(frameName\)\) \{\s*return true;\s*\}/,
+  );
+  assert.match(
+    source,
+    /normalizedFeatures\.includes\("popup"\)[\s\S]*normalizedFeatures\.includes\("width="\)[\s\S]*normalizedFeatures\.includes\("height="\)/,
+  );
   assert.match(
     source,
     /const shouldOpenAsTab =\s*disposition === "foreground-tab" \|\|\s*disposition === "background-tab" \|\|\s*disposition === "new-window";/,
   );
-  assert.doesNotMatch(source, /view\.webContents\.on\("did-create-window"/);
+  assert.match(
+    source,
+    /view\.webContents\.setWindowOpenHandler\(\s*\(\{ url, disposition, frameName, features \}\) => \{/,
+  );
+  assert.match(
+    source,
+    /if \(isBrowserPopupWindowRequest\(frameName, features\)\) \{\s*return \{\s*action: "allow",[\s\S]*overrideBrowserWindowOptions: \{[\s\S]*parent: mainWindow \?\? undefined,[\s\S]*width: 520,[\s\S]*height: 760,/,
+  );
+  assert.match(
+    source,
+    /handleBrowserWindowOpenAsTab\(\s*workspaceId,\s*normalizedUrl,\s*disposition,\s*frameName,\s*browserSpace,\s*\);/,
+  );
+  assert.match(
+    source,
+    /const existingPopupTab = Array\.from\(tabSpace\.tabs\.entries\(\)\)\.find\([\s\S]*tab\.popupFrameName === normalizedFrameName[\s\S]*tab\.state\.url === normalizedUrl[\s\S]*now - tab\.popupOpenedAtMs <= DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS/,
+  );
+  assert.match(
+    source,
+    /const DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS = 2_000;/,
+  );
+  assert.match(
+    source,
+    /if \(existingPopupTab\) \{[\s\S]*focusBrowserTabInSpace\(workspaceId, tabSpace, existingTabId, space\);[\s\S]*return;\s*\}/,
+  );
 });
 
 test("desktop browser service exposes explicit tab creation endpoint", async () => {

--- a/desktop/electron/browserPopupPreload.ts
+++ b/desktop/electron/browserPopupPreload.ts
@@ -1,0 +1,112 @@
+const OVERLAY_ID = "holaboss-browser-popup-loading-overlay";
+const STYLE_ID = "holaboss-browser-popup-loading-style";
+
+function ensureStyle() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      color-scheme: dark;
+    }
+
+    html, body {
+      background: #050907 !important;
+    }
+
+    #${OVERLAY_ID} {
+      position: fixed;
+      inset: 0;
+      z-index: 2147483647;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at top, rgba(40, 92, 73, 0.24), transparent 48%),
+        rgba(5, 9, 7, 0.78);
+      opacity: 0;
+      transition: opacity 140ms ease;
+      pointer-events: none;
+    }
+
+    #${OVERLAY_ID}[data-visible="true"] {
+      opacity: 1;
+    }
+
+    #${OVERLAY_ID} .panel {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 999px;
+      padding: 10px 14px;
+      background: rgba(11, 15, 13, 0.84);
+      box-shadow: 0 18px 46px rgba(0, 0, 0, 0.32);
+      color: rgba(247, 250, 248, 0.94);
+      font: 500 13px/1.2 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: -0.01em;
+      backdrop-filter: blur(12px);
+    }
+
+    #${OVERLAY_ID} .spinner {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      border: 2px solid rgba(255, 255, 255, 0.18);
+      border-top-color: rgba(123, 255, 194, 0.95);
+      animation: holaboss-browser-popup-spin 720ms linear infinite;
+    }
+
+    @keyframes holaboss-browser-popup-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  `;
+  (document.head || document.documentElement).appendChild(style);
+}
+
+function ensureOverlay() {
+  ensureStyle();
+  if (document.getElementById(OVERLAY_ID)) {
+    return;
+  }
+  const overlay = document.createElement("div");
+  overlay.id = OVERLAY_ID;
+  overlay.dataset.visible = "true";
+  overlay.innerHTML =
+    '<div class="panel"><div class="spinner"></div><div>Loading page...</div></div>';
+  const parent = document.body || document.documentElement;
+  if (!parent) {
+    window.requestAnimationFrame(ensureOverlay);
+    return;
+  }
+  parent.appendChild(overlay);
+}
+
+function hideOverlay() {
+  const overlay = document.getElementById(OVERLAY_ID);
+  if (!overlay) {
+    return;
+  }
+  overlay.dataset.visible = "false";
+  window.setTimeout(() => {
+    overlay.remove();
+  }, 180);
+}
+
+if (document.readyState !== "complete") {
+  ensureOverlay();
+}
+
+window.addEventListener("DOMContentLoaded", ensureOverlay, { once: true });
+window.addEventListener("beforeunload", ensureOverlay);
+window.addEventListener("load", hideOverlay, { once: true });
+document.addEventListener("readystatechange", () => {
+  if (document.readyState === "complete") {
+    hideOverlay();
+  } else {
+    ensureOverlay();
+  }
+});

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -71,6 +71,7 @@ const AUTH_POPUP_WIDTH = 380;
 const AUTH_POPUP_HEIGHT = 460;
 const AUTH_POPUP_CLOSE_DELAY_MS = 260;
 const AUTH_POPUP_MARGIN_PX = 8;
+const DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS = 2_000;
 const OVERFLOW_POPUP_WIDTH = 220;
 const OVERFLOW_POPUP_HEIGHT = 132;
 const ADDRESS_SUGGESTIONS_POPUP_MIN_HEIGHT = 88;
@@ -295,6 +296,8 @@ interface BrowserTabListPayload {
 interface BrowserTabRecord {
   view: BrowserView;
   state: BrowserStatePayload;
+  popupFrameName?: string;
+  popupOpenedAtMs?: number;
 }
 
 interface BrowserTabSpaceState {
@@ -3471,6 +3474,32 @@ function serializeBrowserEvalResult(value: unknown): unknown {
   }
 }
 
+function isAbortedBrowserLoadError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as {
+    code?: unknown;
+    errno?: unknown;
+    message?: unknown;
+  };
+  return (
+    candidate.code === "ERR_ABORTED" ||
+    candidate.errno === -3 ||
+    (typeof candidate.message === "string" &&
+      candidate.message.includes("ERR_ABORTED"))
+  );
+}
+
+function isAbortedBrowserLoadFailure(
+  errorCode: number,
+  errorDescription: string,
+): boolean {
+  return (
+    errorCode === -3 || errorDescription.trim().toUpperCase() === "ERR_ABORTED"
+  );
+}
+
 async function navigateActiveBrowserTab(
   workspaceId: string,
   targetUrl: string,
@@ -3486,6 +3515,9 @@ async function navigateActiveBrowserTab(
     activeTab.state = { ...activeTab.state, error: "" };
     await activeTab.view.webContents.loadURL(targetUrl);
   } catch (error) {
+    if (isAbortedBrowserLoadError(error)) {
+      return browserWorkspaceSnapshot(workspaceId, space);
+    }
     activeTab.state = {
       ...activeTab.state,
       loading: false,
@@ -13726,10 +13758,48 @@ function syncBrowserState(
   void persistBrowserWorkspace(workspaceId);
 }
 
+function normalizeBrowserPopupFrameName(frameName?: string | null): string {
+  const normalized = typeof frameName === "string" ? frameName.trim() : "";
+  return normalized && normalized !== "_blank" ? normalized : "";
+}
+
+function isBrowserPopupWindowRequest(
+  frameName?: string | null,
+  features?: string | null,
+): boolean {
+  if (normalizeBrowserPopupFrameName(frameName)) {
+    return true;
+  }
+  const normalizedFeatures =
+    typeof features === "string" ? features.trim().toLowerCase() : "";
+  return (
+    normalizedFeatures.includes("popup") ||
+    normalizedFeatures.includes("width=") ||
+    normalizedFeatures.includes("height=") ||
+    normalizedFeatures.includes("left=") ||
+    normalizedFeatures.includes("top=")
+  );
+}
+
+function focusBrowserTabInSpace(
+  workspaceId: string,
+  tabSpace: BrowserTabSpaceState,
+  tabId: string,
+  space: BrowserSpaceId,
+) {
+  tabSpace.activeTabId = tabId;
+  if (workspaceId === activeBrowserWorkspaceId && space === activeBrowserSpaceId) {
+    updateAttachedBrowserView();
+  }
+  emitBrowserState(workspaceId, space);
+  void persistBrowserWorkspace(workspaceId);
+}
+
 function handleBrowserWindowOpenAsTab(
   workspaceId: string,
   targetUrl: string,
   disposition: string,
+  frameName: string,
   space: BrowserSpaceId,
 ) {
   const normalizedUrl = targetUrl.trim();
@@ -13747,25 +13817,62 @@ function handleBrowserWindowOpenAsTab(
     return;
   }
 
-  const nextTabId = createBrowserTab(workspaceId, {
-    url: normalizedUrl,
-    browserSpace: space,
-  });
-  if (!nextTabId) {
-    return;
-  }
-
   const workspace = browserWorkspaceFromMap(workspaceId);
   const tabSpace = browserTabSpaceState(workspace, space);
   if (!workspace || !tabSpace) {
     return;
   }
 
-  if (disposition !== "background-tab") {
-    tabSpace.activeTabId = nextTabId;
-    if (workspaceId === activeBrowserWorkspaceId && space === activeBrowserSpaceId) {
-      updateAttachedBrowserView();
+  const normalizedFrameName = normalizeBrowserPopupFrameName(frameName);
+  const now = Date.now();
+  const existingPopupTab = Array.from(tabSpace.tabs.entries()).find(
+    ([, tab]) =>
+      (normalizedFrameName && tab.popupFrameName === normalizedFrameName) ||
+      (!normalizedFrameName &&
+        tab.state.url === normalizedUrl &&
+        typeof tab.popupOpenedAtMs === "number" &&
+        now - tab.popupOpenedAtMs <= DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS),
+  );
+
+  if (existingPopupTab) {
+    const [existingTabId, existingTab] = existingPopupTab;
+    existingTab.popupFrameName =
+      normalizedFrameName || existingTab.popupFrameName;
+    existingTab.popupOpenedAtMs = now;
+    if (existingTab.state.url !== normalizedUrl) {
+      existingTab.state = { ...existingTab.state, error: "" };
+      void existingTab.view.webContents.loadURL(normalizedUrl).catch((error) => {
+        if (isAbortedBrowserLoadError(error)) {
+          return;
+        }
+        existingTab.state = {
+          ...existingTab.state,
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load URL.",
+        };
+        emitBrowserState(workspaceId, space);
+        void persistBrowserWorkspace(workspaceId);
+      });
     }
+    if (disposition !== "background-tab") {
+      focusBrowserTabInSpace(workspaceId, tabSpace, existingTabId, space);
+    }
+    return;
+  }
+
+  const nextTabId = createBrowserTab(workspaceId, {
+    url: normalizedUrl,
+    browserSpace: space,
+    popupFrameName: normalizedFrameName,
+    popupOpenedAtMs: now,
+  });
+  if (!nextTabId) {
+    return;
+  }
+
+  if (disposition !== "background-tab") {
+    focusBrowserTabInSpace(workspaceId, tabSpace, nextTabId, space);
+    return;
   }
 
   emitBrowserState(workspaceId, space);
@@ -13861,6 +13968,7 @@ function showBrowserViewContextMenu(params: {
             workspaceId,
             linkUrl,
             "foreground-tab",
+            "",
             space,
           ),
       },
@@ -13889,6 +13997,7 @@ function showBrowserViewContextMenu(params: {
             workspaceId,
             imageUrl,
             "foreground-tab",
+            "",
             space,
           ),
       },
@@ -13981,6 +14090,8 @@ function createBrowserTab(
     url?: string;
     title?: string;
     faviconUrl?: string;
+    popupFrameName?: string;
+    popupOpenedAtMs?: number;
     skipInitialHistoryRecord?: boolean;
   } = {},
 ) {
@@ -14013,7 +14124,13 @@ function createBrowserTab(
     faviconUrl: options.faviconUrl,
     initialized: !hasInitialUrl,
   });
-  tabSpace.tabs.set(tabId, { view, state });
+  tabSpace.tabs.set(tabId, {
+    view,
+    state,
+    popupFrameName: options.popupFrameName?.trim() || undefined,
+    popupOpenedAtMs:
+      typeof options.popupOpenedAtMs === "number" ? options.popupOpenedAtMs : undefined,
+  });
 
   view.setBounds(browserBounds);
   view.setAutoResize({
@@ -14022,7 +14139,8 @@ function createBrowserTab(
     horizontal: false,
     vertical: false,
   });
-  view.webContents.setWindowOpenHandler(({ url, disposition }) => {
+  view.webContents.setWindowOpenHandler(
+    ({ url, disposition, frameName, features }) => {
     const normalizedUrl = url.trim();
     if (!normalizedUrl) {
       return { action: "deny" };
@@ -14038,6 +14156,24 @@ function createBrowserTab(
       return { action: "deny" };
     }
 
+    if (isBrowserPopupWindowRequest(frameName, features)) {
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: {
+          parent: mainWindow ?? undefined,
+          autoHideMenuBar: true,
+          backgroundColor: "#050907",
+          width: 520,
+          height: 760,
+          minWidth: 420,
+          minHeight: 620,
+          webPreferences: {
+            preload: path.join(__dirname, "browserPopupPreload.cjs"),
+          },
+        },
+      };
+    }
+
     const shouldOpenAsTab =
       disposition === "foreground-tab" ||
       disposition === "background-tab" ||
@@ -14047,11 +14183,13 @@ function createBrowserTab(
         workspaceId,
         normalizedUrl,
         disposition,
+        frameName,
         browserSpace,
       );
     }
     return { action: "deny" };
-  });
+    },
+  );
   view.webContents.setZoomFactor(1);
   view.webContents.setVisualZoomLevelLimits(1, 1).catch(() => undefined);
 
@@ -14140,7 +14278,10 @@ function createBrowserTab(
   view.webContents.on(
     "did-fail-load",
     (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
-      if (!isMainFrame) {
+      if (
+        !isMainFrame ||
+        isAbortedBrowserLoadFailure(errorCode, errorDescription)
+      ) {
         return;
       }
       const currentTab = browserTabSpaceState(
@@ -14163,6 +14304,9 @@ function createBrowserTab(
 
   if (hasInitialUrl) {
     void view.webContents.loadURL(initialUrl).catch((error) => {
+      if (isAbortedBrowserLoadError(error)) {
+        return;
+      }
       const currentTab = browserTabSpaceState(
         browserWorkspaceFromMap(workspaceId),
         browserSpace,
@@ -16748,6 +16892,14 @@ app.whenReady().then(async () => {
     getActiveBrowserTab(undefined, activeBrowserSpaceId)?.view.webContents.reload();
     return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
   });
+  ipcMain.handle("browser:stopLoading", async () => {
+    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
+    const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+    if (activeTab?.view.webContents.isLoadingMainFrame()) {
+      activeTab.view.webContents.stop();
+    }
+    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+  });
   ipcMain.handle("browser:newTab", async (_event, targetUrl?: string) => {
     const workspace = await ensureBrowserWorkspace(
       undefined,
@@ -16915,6 +17067,9 @@ app.whenReady().then(async () => {
         activeTab.state = { ...activeTab.state, error: "" };
         await activeTab.view.webContents.loadURL(targetUrl);
       } catch (error) {
+        if (isAbortedBrowserLoadError(error)) {
+          return browserWorkspaceSnapshot(workspace.workspaceId, activeBrowserSpaceId);
+        }
         activeTab.state = {
           ...activeTab.state,
           loading: false,

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1279,6 +1279,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     back: () => ipcRenderer.invoke("browser:back") as Promise<BrowserTabListPayload>,
     forward: () => ipcRenderer.invoke("browser:forward") as Promise<BrowserTabListPayload>,
     reload: () => ipcRenderer.invoke("browser:reload") as Promise<BrowserTabListPayload>,
+    stopLoading: () => ipcRenderer.invoke("browser:stopLoading") as Promise<BrowserTabListPayload>,
     newTab: (targetUrl?: string) => ipcRenderer.invoke("browser:newTab", targetUrl) as Promise<BrowserTabListPayload>,
     setActiveTab: (tabId: string) => ipcRenderer.invoke("browser:setActiveTab", tabId) as Promise<BrowserTabListPayload>,
     closeTab: (tabId: string) => ipcRenderer.invoke("browser:closeTab", tabId) as Promise<BrowserTabListPayload>,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1319,6 +1319,27 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/desktop/src/components/panes/BrowserPane.test.mjs
+++ b/desktop/src/components/panes/BrowserPane.test.mjs
@@ -55,3 +55,37 @@ test("browser pane preserves explicit URL schemes and supports localhost-style i
   );
   assert.equal(source.includes("return `http://${trimmed}`;"), true);
 });
+
+test("browser pane selects the full address when the navigation field is clicked", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const selectAddressInput = \(\) => \{\s*addressInputRef\.current\?\.focus\(\);\s*addressInputRef\.current\?\.select\(\);\s*\};/);
+  assert.match(
+    source,
+    /ref=\{addressFieldRef\}[\s\S]*onClick=\{\(event\) => \{[\s\S]*event\.target instanceof HTMLElement[\s\S]*event\.target\.closest\("button"\)[\s\S]*selectAddressInput\(\);[\s\S]*\}\}/,
+  );
+  assert.match(source, /onFocus=\{\(event\) => \{\s*event\.currentTarget\.select\(\);/);
+  assert.match(source, /onClick=\{\(event\) => event\.currentTarget\.select\(\)\}/);
+});
+
+test("browser pane keeps loading state in the address bar and turns refresh into stop", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const isActiveTabBusy = activeTab\.loading \|\| !activeTab\.initialized;/);
+  assert.match(source, /aria-label=\{activeTab\.loading \? "Stop loading" : "Refresh"\}/);
+  assert.match(source, /title=\{activeTab\.loading \? "Stop loading" : "Refresh"\}/);
+  assert.match(
+    source,
+    /activeTab\.loading\s*\?\s*window\.electronAPI\.browser\.stopLoading\(\)\s*:\s*window\.electronAPI\.browser\.reload\(\)/,
+  );
+  assert.match(
+    source,
+    /\{activeTab\.loading \? \(\s*<X size=\{13\} \/>\s*\) : \(\s*<RefreshCcw size=\{13\} \/>\s*\)\}/,
+  );
+  assert.match(
+    source,
+    /\{isActiveTabBusy \? \(\s*<Loader2[\s\S]*className="shrink-0 animate-spin text-primary\/85"[\s\S]*\/>\s*\) : \(\s*<Globe size=\{12\} className="shrink-0 text-primary\/85" \/>\s*\)\}/,
+  );
+  assert.doesNotMatch(source, /tab\.loading \? \(\s*<Loader2 size=\{11\} className="shrink-0 animate-spin" \/>\s*\) : null/);
+  assert.doesNotMatch(source, /activeTab\.initialized && activeTab\.loading/);
+});

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -117,6 +117,7 @@ export function BrowserPane({
   );
   const isCompactPane = paneWidth > 0 && paneWidth <= 320;
   const isNarrowPane = paneWidth > 0 && paneWidth <= 240;
+  const isActiveTabBusy = activeTab.loading || !activeTab.initialized;
   const showBookmarkStrip = bookmarks.length > 0 && !isCompactPane;
   const visibleBrowserSpace = browserState.space || DEFAULT_BROWSER_SPACE;
   const alternateBrowserSpace =
@@ -312,6 +313,11 @@ export function BrowserPane({
     const nextUrl = normalizeUrl(rawInput);
     setInputValue(nextUrl);
     void window.electronAPI.browser.navigate(nextUrl);
+  };
+
+  const selectAddressInput = () => {
+    addressInputRef.current?.focus();
+    addressInputRef.current?.select();
   };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -546,9 +552,6 @@ export function BrowserPane({
                         {tab.title || "New Tab"}
                       </span>
                     ) : null}
-                    {tab.loading ? (
-                      <Loader2 size={11} className="shrink-0 animate-spin" />
-                    ) : null}
                   </button>
                   <Button
                     variant="ghost"
@@ -603,11 +606,22 @@ export function BrowserPane({
                 <Button
                   variant="ghost"
                   size="icon-sm"
-                  aria-label="Refresh"
-                  onClick={() => void window.electronAPI.browser.reload()}
-                  disabled={!activeTab.initialized}
+                  aria-label={activeTab.loading ? "Stop loading" : "Refresh"}
+                  onClick={() =>
+                    void (
+                      activeTab.loading
+                        ? window.electronAPI.browser.stopLoading()
+                        : window.electronAPI.browser.reload()
+                    )
+                  }
+                  disabled={!activeTab.initialized && !activeTab.loading}
+                  title={activeTab.loading ? "Stop loading" : "Refresh"}
                 >
-                  <RefreshCcw size={13} />
+                  {activeTab.loading ? (
+                    <X size={13} />
+                  ) : (
+                    <RefreshCcw size={13} />
+                  )}
                 </Button>
                 <Button
                   type="button"
@@ -667,9 +681,25 @@ export function BrowserPane({
               <div
                 ref={addressFieldRef}
                 className="relative flex min-w-0 flex-1"
+                onClick={(event) => {
+                  if (
+                    event.target instanceof HTMLElement &&
+                    event.target.closest("button")
+                  ) {
+                    return;
+                  }
+                  selectAddressInput();
+                }}
               >
                 <div className="border border-border bg-muted/50 transition-colors focus-within:border-ring flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-2.5 py-1.5">
-                  <Globe size={12} className="shrink-0 text-primary/85" />
+                  {isActiveTabBusy ? (
+                    <Loader2
+                      size={12}
+                      className="shrink-0 animate-spin text-primary/85"
+                    />
+                  ) : (
+                    <Globe size={12} className="shrink-0 text-primary/85" />
+                  )}
                   <input
                     ref={addressInputRef}
                     value={inputValue}
@@ -678,6 +708,7 @@ export function BrowserPane({
                       event.currentTarget.select();
                       setAddressFocused(true);
                     }}
+                    onClick={(event) => event.currentTarget.select()}
                     onBlur={() =>
                       window.setTimeout(() => setAddressFocused(false), 120)
                     }
@@ -756,30 +787,12 @@ export function BrowserPane({
             {!activeTab.initialized ? (
               <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
                 <div className="pointer-events-none w-full max-w-[320px] rounded-[24px] border border-border/55 bg-card px-5 py-5 shadow-xl backdrop-blur">
-                  <div className="mx-auto flex size-12 items-center justify-center rounded-[18px] border border-primary/25 bg-primary/8 text-primary">
-                    <Loader2 size={18} className="animate-spin" />
-                  </div>
                   <div className="mt-4 text-[15px] font-medium tracking-[-0.02em] text-foreground">
                     Starting {visibleBrowserSpace === "agent" ? "agent" : "user"} browser
                   </div>
                   <div className="mt-1.5 text-[12px] leading-6 text-muted-foreground">
                     Opening the embedded {visibleBrowserSpace === "agent" ? "agent" : "user"} browser for this workspace.
                   </div>
-                  <div className="bg-muted mt-4 overflow-hidden rounded-full border border-border/40 p-1">
-                    <div className="h-1.5 rounded-full bg-primary/60 animate-pulse" />
-                  </div>
-                </div>
-              </div>
-            ) : null}
-
-            {activeTab.initialized && activeTab.loading ? (
-              <div className="pointer-events-none absolute inset-x-3 top-3 z-10">
-                <div className="inline-flex items-center gap-2 rounded-lg border border-border/50 bg-card px-3 py-1.5 text-xs text-muted-foreground shadow-lg backdrop-blur">
-                  <Loader2
-                    size={12}
-                    className="animate-spin text-primary"
-                  />
-                  <span>Loading page</span>
                 </div>
               </div>
             ) : null}

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "SpaceBrowserDisplayPane.tsx");
+
+test("space browser display selects the full address when the navigation field is clicked", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const addressInputRef = useRef<HTMLInputElement \| null>\(null\);/,
+  );
+  assert.match(
+    source,
+    /const selectAddressInput = \(\) => \{\s*addressInputRef\.current\?\.focus\(\);\s*addressInputRef\.current\?\.select\(\);\s*\};/,
+  );
+  assert.match(
+    source,
+    /className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted\/50 px-3 py-2 transition-colors focus-within:border-ring"[\s\S]*onClick=\{selectAddressInput\}/,
+  );
+  assert.match(source, /ref=\{addressInputRef\}/);
+  assert.match(
+    source,
+    /onFocus=\{\(event\) => \{[\s\S]*event\.currentTarget\.select\(\);[\s\S]*setAddressFocused\(true\);[\s\S]*\}\}/,
+  );
+  assert.match(source, /onClick=\{\(event\) => event\.currentTarget\.select\(\)\}/);
+});
+
+test("space browser display keeps loading state in the address bar and turns refresh into stop", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const isActiveTabBusy = activeTab\.loading \|\| !activeTab\.initialized;/);
+  assert.match(source, /aria-label=\{activeTab\.loading \? "Stop loading" : "Refresh"\}/);
+  assert.match(source, /title=\{activeTab\.loading \? "Stop loading" : "Refresh"\}/);
+  assert.match(
+    source,
+    /activeTab\.loading\s*\?\s*window\.electronAPI\.browser\.stopLoading\(\)\s*:\s*window\.electronAPI\.browser\.reload\(\)/,
+  );
+  assert.match(
+    source,
+    /\{activeTab\.loading \? \(\s*<X size=\{13\} \/>\s*\) : \(\s*<RefreshCcw size=\{13\} \/>\s*\)\}/,
+  );
+  assert.match(
+    source,
+    /\{isActiveTabBusy \? \(\s*<Loader2[\s\S]*className="shrink-0 animate-spin text-primary\/85"[\s\S]*\/>\s*\) : \(\s*<Globe size=\{13\} className="shrink-0 text-muted-foreground" \/>\s*\)\}/,
+  );
+  assert.doesNotMatch(source, /activeTab\.initialized && activeTab\.loading/);
+});
+
+test("space browser display uses stored history entries for address suggestions", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /useWorkspaceBrowser\(browserSpace, \{ includeHistory: true \}\)/,
+  );
+  assert.match(source, /const \[addressFocused, setAddressFocused\] = useState\(false\);/);
+  assert.match(
+    source,
+    /const historySuggestions = useMemo\(\(\) => \{[\s\S]*historyEntries\.filter\(\(entry\) => \{/,
+  );
+  assert.match(
+    source,
+    /window\.electronAPI\.browser\.showAddressSuggestions\(\s*bounds,\s*suggestions,\s*highlightedSuggestionIndex,\s*\)/,
+  );
+  assert.match(
+    source,
+    /window\.electronAPI\.browser\.onAddressSuggestionChosen\(\(index\) => \{[\s\S]*navigateTo\(entry\.url\);/,
+  );
+  assert.match(
+    source,
+    /if \(event\.key === "ArrowDown"\) \{[\s\S]*if \(event\.key === "ArrowUp"\) \{[\s\S]*if \(event\.key === "Enter" && highlightedSuggestionIndex >= 0\)/,
+  );
+  assert.match(
+    source,
+    /onBlur=\{\(\) =>\s*window\.setTimeout\(\(\) => setAddressFocused\(false\), 120\)\s*\}/,
+  );
+});

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -1,4 +1,12 @@
-import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  FormEvent,
+  KeyboardEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -6,6 +14,7 @@ import {
   Loader2,
   RefreshCcw,
   Star,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
@@ -55,9 +64,15 @@ export function SpaceBrowserDisplayPane({
   embedded = false,
 }: SpaceBrowserDisplayPaneProps) {
   const [inputValue, setInputValue] = useState("");
+  const [addressFocused, setAddressFocused] = useState(false);
+  const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] =
+    useState(-1);
+  const addressInputRef = useRef<HTMLInputElement | null>(null);
+  const addressFieldRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const { activeTab, activeBookmark, isBookmarked } =
-    useWorkspaceBrowser(browserSpace);
+  const { activeTab, activeBookmark, historyEntries, isBookmarked } =
+    useWorkspaceBrowser(browserSpace, { includeHistory: true });
+  const isActiveTabBusy = activeTab.loading || !activeTab.initialized;
 
   useEffect(() => {
     setInputValue(activeTab.url || "");
@@ -121,6 +136,150 @@ export function SpaceBrowserDisplayPane({
     void window.electronAPI.browser.navigate(normalizeUrl(inputValue));
   };
 
+  const navigateTo = (rawInput: string) => {
+    const nextUrl = normalizeUrl(rawInput);
+    setInputValue(nextUrl);
+    void window.electronAPI.browser.navigate(nextUrl);
+  };
+
+  const selectAddressInput = () => {
+    addressInputRef.current?.focus();
+    addressInputRef.current?.select();
+  };
+
+  const historySuggestions = useMemo(() => {
+    if (!addressFocused) {
+      return [];
+    }
+
+    const query = inputValue.trim().toLowerCase();
+    const filtered = historyEntries.filter((entry) => {
+      if (!query) {
+        return true;
+      }
+
+      return (
+        entry.url.toLowerCase().includes(query) ||
+        entry.title.toLowerCase().includes(query)
+      );
+    });
+
+    return filtered.filter((entry) => entry.url !== activeTab.url).slice(0, 6);
+  }, [activeTab.url, addressFocused, historyEntries, inputValue]);
+
+  useEffect(() => {
+    if (!historySuggestions.length) {
+      setHighlightedSuggestionIndex(-1);
+      return;
+    }
+
+    setHighlightedSuggestionIndex((current) => {
+      if (current < 0 || current >= historySuggestions.length) {
+        return 0;
+      }
+      return current;
+    });
+  }, [historySuggestions]);
+
+  const getAnchorBounds = (element: HTMLElement | null) => {
+    if (!element) {
+      return null;
+    }
+
+    const rect = element.getBoundingClientRect();
+    return {
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  };
+
+  useEffect(() => {
+    if (!addressFocused || historySuggestions.length === 0) {
+      void window.electronAPI.browser.hideAddressSuggestions();
+      return;
+    }
+
+    const bounds = getAnchorBounds(addressFieldRef.current);
+    if (!bounds) {
+      return;
+    }
+
+    const suggestions: AddressSuggestionPayload[] = historySuggestions.map(
+      (entry) => ({
+        id: entry.id,
+        url: entry.url,
+        title: entry.title,
+        faviconUrl: entry.faviconUrl,
+      }),
+    );
+
+    void window.electronAPI.browser.showAddressSuggestions(
+      bounds,
+      suggestions,
+      highlightedSuggestionIndex,
+    );
+  }, [addressFocused, highlightedSuggestionIndex, historySuggestions]);
+
+  useEffect(() => {
+    return window.electronAPI.browser.onAddressSuggestionChosen((index) => {
+      const entry = historySuggestions[index];
+      if (!entry) {
+        return;
+      }
+
+      setAddressFocused(false);
+      setHighlightedSuggestionIndex(index);
+      navigateTo(entry.url);
+    });
+  }, [historySuggestions]);
+
+  const onAddressKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!historySuggestions.length) {
+      if (event.key === "Escape") {
+        setAddressFocused(false);
+        void window.electronAPI.browser.hideAddressSuggestions();
+      }
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedSuggestionIndex(
+        (current) => (current + 1) % historySuggestions.length,
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedSuggestionIndex((current) =>
+        current <= 0 ? historySuggestions.length - 1 : current - 1,
+      );
+      return;
+    }
+
+    if (event.key === "Enter" && highlightedSuggestionIndex >= 0) {
+      event.preventDefault();
+      const entry = historySuggestions[highlightedSuggestionIndex];
+      if (!entry) {
+        return;
+      }
+
+      setAddressFocused(false);
+      navigateTo(entry.url);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setAddressFocused(false);
+      setHighlightedSuggestionIndex(-1);
+      void window.electronAPI.browser.hideAddressSuggestions();
+    }
+  };
+
   const onToggleBookmark = () => {
     if (!activeTab.url) {
       return;
@@ -168,19 +327,51 @@ export function SpaceBrowserDisplayPane({
           <Button
             variant="ghost"
             size="icon-sm"
-            aria-label="Refresh"
-            onClick={() => void window.electronAPI.browser.reload()}
-            disabled={!activeTab.initialized}
+            aria-label={activeTab.loading ? "Stop loading" : "Refresh"}
+            onClick={() =>
+              void (
+                activeTab.loading
+                  ? window.electronAPI.browser.stopLoading()
+                  : window.electronAPI.browser.reload()
+              )
+            }
+            disabled={!activeTab.initialized && !activeTab.loading}
+            title={activeTab.loading ? "Stop loading" : "Refresh"}
           >
-            <RefreshCcw size={13} />
+            {activeTab.loading ? (
+              <X size={13} />
+            ) : (
+              <RefreshCcw size={13} />
+            )}
           </Button>
 
           <form onSubmit={onSubmit} className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 transition-colors focus-within:border-ring">
-              <Globe size={13} className="shrink-0 text-muted-foreground" />
+            <div
+              ref={addressFieldRef}
+              className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 transition-colors focus-within:border-ring"
+              onClick={selectAddressInput}
+            >
+              {isActiveTabBusy ? (
+                <Loader2
+                  size={13}
+                  className="shrink-0 animate-spin text-primary/85"
+                />
+              ) : (
+                <Globe size={13} className="shrink-0 text-muted-foreground" />
+              )}
               <input
+                ref={addressInputRef}
                 value={inputValue}
                 onChange={(event) => setInputValue(event.target.value)}
+                onFocus={(event) => {
+                  event.currentTarget.select();
+                  setAddressFocused(true);
+                }}
+                onClick={(event) => event.currentTarget.select()}
+                onBlur={() =>
+                  window.setTimeout(() => setAddressFocused(false), 120)
+                }
+                onKeyDown={onAddressKeyDown}
                 className="embedded-input w-full min-w-0 bg-transparent text-[12px] text-foreground outline-none placeholder:text-muted-foreground/55"
                 placeholder="Enter URL or search"
               />
@@ -211,9 +402,6 @@ export function SpaceBrowserDisplayPane({
           {!activeTab.initialized ? (
             <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
               <div className="pointer-events-none w-full max-w-[360px] rounded-[24px] border border-border bg-card/92 px-6 py-6 shadow-lg backdrop-blur-sm">
-                <div className="mx-auto flex size-12 items-center justify-center rounded-[18px] border border-primary/25 bg-primary/10 text-primary">
-                  <Loader2 size={18} className="animate-spin" />
-                </div>
                 <div className="mt-4 text-[15px] font-medium tracking-[-0.02em] text-foreground">
                   Starting {browserSpace === "agent" ? "agent" : "user"} browser
                 </div>
@@ -222,15 +410,6 @@ export function SpaceBrowserDisplayPane({
                   {browserSpace === "agent" ? "agent" : "user"} browser for this
                   workspace.
                 </div>
-              </div>
-            </div>
-          ) : null}
-
-          {activeTab.initialized && activeTab.loading ? (
-            <div className="pointer-events-none absolute inset-x-4 top-4 z-10">
-              <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card/92 px-3 py-1.5 text-[11px] text-muted-foreground shadow-md backdrop-blur-sm">
-                <Loader2 size={12} className="animate-spin text-primary" />
-                <span>Loading page</span>
               </div>
             </div>
           ) : null}

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -1397,6 +1397,7 @@ declare global {
       back: () => Promise<BrowserTabListPayload>;
       forward: () => Promise<BrowserTabListPayload>;
       reload: () => Promise<BrowserTabListPayload>;
+      stopLoading: () => Promise<BrowserTabListPayload>;
       newTab: (targetUrl?: string) => Promise<BrowserTabListPayload>;
       setActiveTab: (tabId: string) => Promise<BrowserTabListPayload>;
       closeTab: (tabId: string) => Promise<BrowserTabListPayload>;

--- a/desktop/tsup.config.ts
+++ b/desktop/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     "electron/main.ts",
     "electron/preload.ts",
+    "electron/browserPopupPreload.ts",
     "electron/authPopupPreload.ts",
     "electron/downloadsPopupPreload.ts",
     "electron/historyPopupPreload.ts",


### PR DESCRIPTION
## Context

This PR fixes the embedded desktop browser behavior around OAuth popups and tightens the loading and address UX that sits around those flows.

Fixes #140.

## What Changed

- preserve auth-style popup windows in Electron so OAuth providers keep window.opener semantics
- ignore benign ERR_ABORTED browser load failures during redirects and stop treating them as hard navigation errors
- add a popup preload loading shell for auth windows while the page is booting
- simplify browser loading feedback to a single address-bar spinner and turn reload into stop while a page is loading
- add stored-history suggestions to the space browser address field
- add regression coverage for popup policy, aborted navigations, popup preload behavior, and browser pane interactions

## Validation

- node --test desktop/electron/browser-tab-policy.test.mjs desktop/electron/browser-navigation-abort.test.mjs desktop/electron/browser-popup-preload.test.mjs desktop/src/components/panes/BrowserPane.test.mjs desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
- npm --prefix desktop run typecheck
