### PR TITLE
fix: ensure desktop builds the local app sdk before startup

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "clean": "rm -rf out build",
     "rebuild:native": "node ./node_modules/@electron/rebuild/lib/cli.js -f -w better-sqlite3",
-    "predev": "node scripts/validate-dev-env.mjs && kill-port 5173 && npm run rebuild:native && node scripts/ensure-runtime-bundle.mjs && node scripts/patch-electron-plist.mjs",
+    "predev": "node scripts/ensure-app-sdk.mjs && node scripts/validate-dev-env.mjs && kill-port 5173 && npm run rebuild:native && node scripts/ensure-runtime-bundle.mjs && node scripts/patch-electron-plist.mjs",
+    "prebuild": "node scripts/ensure-app-sdk.mjs",
+    "pretypecheck": "node scripts/ensure-app-sdk.mjs",
     "dev": "cross-env HOLABOSS_DESKTOP_USER_DATA_DIR=holaboss-local-dev concurrently -k \"npm:dev:renderer\" \"npm:dev:electron:build\" \"npm:dev:runtime:watch\" \"npm:dev:electron:run\"",
     "dev:cp:local": "cross-env HOLABOSS_INTERNAL_DEV=1 npm run dev",
     "dev:cp:local:verbose": "cross-env HOLABOSS_INTERNAL_DEV=1 HOLABOSS_VERBOSE_TELEMETRY=1 npm run dev",

--- a/desktop/scripts/ensure-app-sdk.mjs
+++ b/desktop/scripts/ensure-app-sdk.mjs
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const desktopRoot = process.cwd();
+const appSdkRoot = path.resolve(desktopRoot, "..", "sdk", "app-sdk");
+const appSdkNodeModulesPath = path.join(appSdkRoot, "node_modules");
+const appSdkSourceInputs = [
+  path.join(appSdkRoot, "package.json"),
+  path.join(appSdkRoot, "tsdown.config.ts"),
+  path.join(appSdkRoot, "src"),
+];
+const appSdkRequiredOutputs = [
+  path.join(appSdkRoot, "dist", "index.js"),
+  path.join(appSdkRoot, "dist", "index.d.ts"),
+  path.join(appSdkRoot, "dist", "core.js"),
+  path.join(appSdkRoot, "dist", "core.d.ts"),
+];
+
+function newestExistingMtime(targetPath) {
+  if (!fs.existsSync(targetPath)) {
+    return 0;
+  }
+  const stat = fs.statSync(targetPath);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let newest = stat.mtimeMs;
+  for (const entry of fs.readdirSync(targetPath)) {
+    newest = Math.max(
+      newest,
+      newestExistingMtime(path.join(targetPath, entry)),
+    );
+  }
+  return newest;
+}
+
+function allOutputsExist() {
+  return appSdkRequiredOutputs.every((targetPath) => fs.existsSync(targetPath));
+}
+
+function runNpm(args) {
+  const result = spawnSync("npm", args, {
+    cwd: appSdkRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const outputsExist = allOutputsExist();
+const newestSourceStamp = Math.max(
+  ...appSdkSourceInputs.map((targetPath) => newestExistingMtime(targetPath)),
+);
+const newestOutputStamp = Math.max(
+  ...appSdkRequiredOutputs.map((targetPath) => newestExistingMtime(targetPath)),
+);
+const outputsStale = outputsExist && newestSourceStamp > newestOutputStamp;
+
+if (!outputsExist || outputsStale) {
+  if (!fs.existsSync(appSdkNodeModulesPath)) {
+    console.log(
+      "[ensure-app-sdk] installing sdk/app-sdk dependencies for local desktop usage.",
+    );
+    runNpm(["install"]);
+  }
+
+  console.log(
+    outputsExist
+      ? "[ensure-app-sdk] sdk/app-sdk build is stale; rebuilding."
+      : "[ensure-app-sdk] sdk/app-sdk build output missing; building.",
+  );
+  runNpm(["run", "build"]);
+}


### PR DESCRIPTION
## Context
Fresh worktrees can fail to start the desktop app even after `desktop:install` and `desktop:prepare-runtime:local`, because `desktop` imports `@holaboss/app-sdk/core` from the local `file:../sdk/app-sdk` package and that package may not have built `dist/` artifacts yet.

This PR only fixes that startup/build fragility. It does not implement or close issue #104.

Related to #104.

## What Changed
- add `desktop/scripts/ensure-app-sdk.mjs` to install and build `sdk/app-sdk` when required
- run that check before desktop `dev`, `build`, and `typecheck`
- keep desktop startup self-healing in fresh worktrees where the linked SDK package has no built output

## Validation
- `npm run typecheck`
- `node -e "import('@holaboss/app-sdk/core').then(() => console.log('ok'))"`
