### PR TITLE
fix: separate evolve proposals and compact desktop chrome

### DIFF
--- a/desktop/electron/macos-title-bar-alignment.test.mjs
+++ b/desktop/electron/macos-title-bar-alignment.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+
+test("macOS main window keeps traffic lights aligned with the compact title bar", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(source, /titleBarStyle: "hiddenInset" as const,/);
+  assert.match(source, /trafficLightPosition: \{ x: 14, y: 25 \},/);
+});

--- a/desktop/electron/macos-title-bar-alignment.test.mjs
+++ b/desktop/electron/macos-title-bar-alignment.test.mjs
@@ -8,5 +8,5 @@ test("macOS main window keeps traffic lights aligned with the compact title bar"
   const source = await readFile(MAIN_PATH, "utf8");
 
   assert.match(source, /titleBarStyle: "hiddenInset" as const,/);
-  assert.match(source, /trafficLightPosition: \{ x: 14, y: 25 \},/);
+  assert.match(source, /trafficLightPosition: \{ x: 14, y: 23 \},/);
 });

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -15834,7 +15834,7 @@ function createMainWindow() {
     process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset" as const,
-          trafficLightPosition: { x: 14, y: 30 },
+          trafficLightPosition: { x: 14, y: 25 },
         }
       : process.platform === "win32"
         ? {

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -6490,8 +6490,12 @@ function proactiveBaseUrl() {
     : DEFAULT_PROACTIVE_URL.replace(/\/+$/, "");
 }
 
+function runtimeProactiveBridgeBaseUrl() {
+  return DEFAULT_PROACTIVE_URL.replace(/\/+$/, "");
+}
+
 function embeddedRuntimeStartupConfigError() {
-  if (proactiveBaseUrl()) {
+  if (runtimeProactiveBridgeBaseUrl()) {
     return "";
   }
   return (
@@ -11565,7 +11569,7 @@ async function startEmbeddedRuntime() {
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
           HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
           PROACTIVE_ENABLE_REMOTE_BRIDGE: "1",
-          PROACTIVE_BRIDGE_BASE_URL: proactiveBaseUrl(),
+          PROACTIVE_BRIDGE_BASE_URL: runtimeProactiveBridgeBaseUrl(),
           PYTHONDONTWRITEBYTECODE: "1",
           HOLABOSS_AUTH_BASE_URL: AUTH_BASE_URL,
           HOLABOSS_AUTH_COOKIE: authCookieHeader() ?? "",
@@ -15834,7 +15838,7 @@ function createMainWindow() {
     process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset" as const,
-          trafficLightPosition: { x: 14, y: 25 },
+          trafficLightPosition: { x: 14, y: 23 },
         }
       : process.platform === "win32"
         ? {

--- a/desktop/electron/runtime-auth-env.test.mjs
+++ b/desktop/electron/runtime-auth-env.test.mjs
@@ -19,3 +19,16 @@ test("embedded runtime launch forwards auth base URL alongside the auth cookie",
     /env:\s*\{[\s\S]*HOLABOSS_AUTH_BASE_URL:\s*AUTH_BASE_URL,[\s\S]*HOLABOSS_AUTH_COOKIE:\s*authCookieHeader\(\)\s*\?\?\s*"",/,
   );
 });
+
+test("embedded runtime bridge uses the direct proactive service URL instead of the gateway", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /function runtimeProactiveBridgeBaseUrl\(\)\s*\{\s*return DEFAULT_PROACTIVE_URL\.replace\(\/\\\/\+\$\/, ""\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /PROACTIVE_BRIDGE_BASE_URL:\s*runtimeProactiveBridgeBaseUrl\(\)/,
+  );
+});

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -861,8 +861,7 @@
     "../sdk/app-sdk/node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "../sdk/app-sdk/node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -973,7 +972,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1712,7 +1710,6 @@
       "version": "4.12.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1928,7 +1925,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -2439,8 +2435,7 @@
     "../sdk/app-sdk/node_modules/openapi-types": {
       "version": "12.1.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "../sdk/app-sdk/node_modules/openapi3-ts": {
       "version": "4.5.0",
@@ -2709,7 +2704,6 @@
       "version": "19.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2854,7 +2848,6 @@
       "version": "1.0.0-rc.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3311,7 +3304,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3416,7 +3408,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3801,7 +3792,6 @@
     "../sdk/app-sdk/node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3828,7 +3818,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4243,7 +4232,6 @@
     "node_modules/@better-auth/core": {
       "version": "1.5.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -4361,12 +4349,10 @@
     },
     "node_modules/@better-auth/utils": {
       "version": "0.3.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "peer": true
+      "version": "1.1.21"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -4849,6 +4835,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4868,6 +4855,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4882,6 +4870,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4894,8 +4883,30 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -5861,6 +5872,7 @@
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6029,7 +6041,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6047,7 +6058,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -6058,7 +6068,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6417,7 +6426,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6432,7 +6440,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -6448,7 +6455,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7822,7 +7828,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7878,18 +7883,19 @@
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7990,7 +7996,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8016,7 +8021,6 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8555,7 +8559,6 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8663,7 +8666,6 @@
     "node_modules/better-auth": {
       "version": "1.5.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -8767,7 +8769,6 @@
     "node_modules/better-call": {
       "version": "1.3.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -8787,7 +8788,6 @@
       "version": "12.8.0",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8869,7 +8869,6 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8910,7 +8909,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8928,6 +8926,7 @@
     "node_modules/bson": {
       "version": "7.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -9574,7 +9573,6 @@
     "node_modules/conf": {
       "version": "15.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -9793,7 +9791,8 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -9981,7 +9980,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10008,7 +10006,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10058,7 +10055,6 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10118,7 +10114,6 @@
       "version": "26.8.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -10314,7 +10309,6 @@
     "node_modules/eciesjs/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -10355,7 +10349,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -10544,6 +10537,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10562,6 +10556,7 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10708,7 +10703,6 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10717,7 +10711,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10766,7 +10759,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11638,7 +11630,6 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -11655,7 +11646,6 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.7.4",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -11667,7 +11657,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11736,7 +11725,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11830,7 +11818,6 @@
     "node_modules/hono": {
       "version": "4.12.12",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12336,7 +12323,6 @@
     "node_modules/jose": {
       "version": "6.2.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12393,7 +12379,6 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -12479,7 +12464,6 @@
     "node_modules/kysely": {
       "version": "0.28.14",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -12940,7 +12924,6 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13216,7 +13199,8 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -14045,6 +14029,7 @@
     "node_modules/mongodb-connection-string-url": {
       "version": "7.0.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -14165,7 +14150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -14396,7 +14380,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14872,6 +14855,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14887,6 +14871,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -15159,7 +15144,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15167,7 +15151,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15456,7 +15439,6 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -15678,7 +15660,6 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15729,7 +15710,6 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16230,7 +16210,6 @@
       "version": "2.8.7",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -16296,13 +16275,13 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -16629,6 +16608,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16806,6 +16786,7 @@
     "node_modules/tr46": {
       "version": "5.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -16974,7 +16955,6 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -17021,7 +17001,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17354,7 +17333,6 @@
     "node_modules/vite": {
       "version": "8.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17485,6 +17463,7 @@
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -17492,6 +17471,7 @@
     "node_modules/whatwg-url": {
       "version": "14.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -17599,7 +17579,6 @@
     "node_modules/yaml": {
       "version": "2.8.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17724,7 +17703,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -17,10 +17,10 @@ export function CreditsPill({
   return (
     <Button
       type="button"
-      size="default"
+      size="sm"
       variant="outline"
       onClick={onClick}
-      className={`inline-flex h-8 shrink-0 items-center rounded-xl border px-3 text-[13px] transition ${
+      className={`inline-flex h-7 shrink-0 items-center rounded-lg border px-2.5 text-xs transition ${
         isLowBalance
           ? "border-amber-300/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/14"
           : "border-border/55"

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -17,10 +17,10 @@ export function CreditsPill({
   return (
     <Button
       type="button"
-      size="lg"
+      size="default"
       variant="outline"
       onClick={onClick}
-      className={`inline-flex h-9 shrink-0 items-center border px-3 text-sm transition ${
+      className={`inline-flex h-8 shrink-0 items-center rounded-xl border px-3 text-[13px] transition ${
         isLowBalance
           ? "border-amber-300/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/14"
           : "border-border/55"
@@ -28,9 +28,9 @@ export function CreditsPill({
       aria-label="Open credits and billing details"
     >
       {isLoading ? (
-        <Loader2 size={14} className="animate-spin" />
+        <Loader2 size={13} className="animate-spin" />
       ) : (
-        <Sparkles size={14} className="opacity-80" />
+        <Sparkles size={13} className="opacity-80" />
       )}
       <span className="font-medium tabular-nums">
         {isLoading ? "..." : (balance ?? 0).toLocaleString()}

--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -396,6 +396,15 @@ test("app shell reloads proactive preference after workspace hydration completes
   assert.match(source, /\}, \[hasHydratedWorkspaceList, selectedWorkspaceId\]\);/);
 });
 
+test("app shell keeps polling task proposals even when proactive auth preferences are unavailable", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /workspace\.listTaskProposals\(\s*selectedWorkspace\.id,/);
+  assert.doesNotMatch(source, /if \(!hasLoadedProactiveTaskProposalsPreference\) \{\s*setIsLoadingTaskProposals\(false\);\s*return;\s*\}/);
+  assert.doesNotMatch(source, /if \(!proactiveTaskProposalsEnabled\) \{\s*setIsLoadingTaskProposals\(false\);\s*return;\s*\}/);
+  assert.match(source, /\}, \[selectedWorkspace, selectedWorkspaceId\]\);/);
+});
+
 test("app shell no longer renders a separate right panel in space mode", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -2061,16 +2061,6 @@ function AppShellContent() {
       return;
     }
 
-    if (!hasLoadedProactiveTaskProposalsPreference) {
-      setIsLoadingTaskProposals(false);
-      return;
-    }
-
-    if (!proactiveTaskProposalsEnabled) {
-      setIsLoadingTaskProposals(false);
-      return;
-    }
-
     let cancelled = false;
 
     const load = async () => {
@@ -2103,12 +2093,7 @@ function AppShellContent() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [
-    hasLoadedProactiveTaskProposalsPreference,
-    proactiveTaskProposalsEnabled,
-    selectedWorkspace,
-    selectedWorkspaceId,
-  ]);
+  }, [selectedWorkspace, selectedWorkspaceId]);
 
   useEffect(() => {
     if (

--- a/desktop/src/components/layout/OperationsDrawer.test.mjs
+++ b/desktop/src/components/layout/OperationsDrawer.test.mjs
@@ -24,6 +24,16 @@ test("operations drawer shows proposal source lane and rationale copy", async ()
   assert.match(source, /Why: \{proposal\.task_generation_rationale\}/);
 });
 
+test("operations drawer keeps local proposals visible while signed out", async () => {
+  const source = await readFile(OPERATIONS_DRAWER_PATH, "utf8");
+
+  assert.match(source, /Backend proposals require sign-in/);
+  assert.match(source, /Sign in for synced proactive controls\./);
+  assert.match(source, /size="xs"/);
+  assert.doesNotMatch(source, /!\s*isSignedIn \?\s*\(\s*<SignedOutInboxNotice/);
+  assert.doesNotMatch(source, /isSignedIn && proposalStatusMessage/);
+});
+
 test("operations drawer session rows expose pointer cursor affordance", async () => {
   const source = await readFile(OPERATIONS_DRAWER_PATH, "utf8");
 

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -692,7 +692,7 @@ function InboxPanel({
       ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-        {isSignedIn && proposalStatusMessage ? (
+        {proposalStatusMessage ? (
           <div className="mb-3 rounded-[18px] border border-border/45 bg-muted/35 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
             {proposalStatusMessage}
           </div>
@@ -728,13 +728,13 @@ function InboxPanel({
               compact
             />
           </div>
-        ) : null}
-        {!isSignedIn ? (
+        ) : (
           <SignedOutInboxNotice
             onRequestSignIn={onRequestSignIn}
             isAuthPending={isAuthPending}
           />
-        ) : !hasWorkspace ? (
+        )}
+        {!hasWorkspace ? (
           <EmptyNotice
             icon={<FolderOpen size={24} strokeWidth={1.5} />}
             message="Select a workspace to review proposals."
@@ -846,32 +846,31 @@ function SignedOutInboxNotice({
   isAuthPending: boolean;
 }) {
   return (
-    <div className="rounded-[22px] border border-warning/20 bg-warning/10 px-4 py-5">
-      <div className="flex flex-col gap-4">
-        <div className="space-y-1">
-          <div className="text-sm font-semibold text-foreground">
-            Sign in to review task proposals
+    <div className="rounded-[18px] border border-warning/20 bg-warning/10 px-3 py-2.5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-semibold text-foreground">
+            Backend proposals require sign-in
           </div>
-          <div className="text-sm leading-6 text-muted-foreground">
-            Sign in to connect this desktop to your account and review Inbox
-            proposals.
+          <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            Sign in for synced proactive controls. Evolve proposals still show
+            here.
           </div>
         </div>
-        <div>
-          <Button
-            type="button"
-            size="sm"
-            onClick={onRequestSignIn}
-            disabled={isAuthPending}
-          >
-            {isAuthPending ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <LogIn size={14} />
-            )}
-            <span>Sign in</span>
-          </Button>
-        </div>
+        <Button
+          type="button"
+          size="xs"
+          onClick={onRequestSignIn}
+          disabled={isAuthPending}
+          className="shrink-0"
+        >
+          {isAuthPending ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <LogIn size={12} />
+          )}
+          <span>Sign in</span>
+        </Button>
       </div>
     </div>
   );

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -24,11 +24,11 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /px-2 pt-1\.5 sm:px-3/,
+    /h-\[46px\] px-2 pt-0\.5 sm:px-3/,
   );
   assert.match(
     source,
-    /grid-cols-\[44px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[60px_minmax\(276px,476px\)_minmax\(0,1fr\)_auto\]/,
+    /grid-cols-\[36px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[46px_minmax\(240px,420px\)_minmax\(0,1fr\)_auto\]/,
   );
   assert.match(
     source,
@@ -36,7 +36,7 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const workspaceSwitcherButtonClassName =\s*"w-full justify-start gap-2\.5 px-3";/,
+    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-1\.5 px-2\.5 rounded-xl text-\[13px\]";/,
   );
   assert.match(source, /window\.electronAPI\.ui\.getWindowState\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.minimizeWindow\(\)/);

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -24,11 +24,11 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /h-\[46px\] px-2 pt-0\.5 sm:px-3/,
+    /h-\[42px\] px-2 pt-0\.5 sm:px-3/,
   );
   assert.match(
     source,
-    /grid-cols-\[36px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[46px_minmax\(240px,420px\)_minmax\(0,1fr\)_auto\]/,
+    /grid-cols-\[32px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[42px_minmax\(220px,400px\)_minmax\(0,1fr\)_auto\]/,
   );
   assert.match(
     source,
@@ -36,7 +36,7 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-1\.5 px-2\.5 rounded-xl text-\[13px\]";/,
+    /const workspaceSwitcherButtonClassName =\s*"h-7 w-full justify-start gap-1\.5 px-2 rounded-lg text-xs";/,
   );
   assert.match(source, /window\.electronAPI\.ui\.getWindowState\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.minimizeWindow\(\)/);

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -247,20 +247,20 @@ export function TopTabsBar({
 
   const headerClassName = integratedTitleBar
     ? isWindowsIntegratedTitleBar
-      ? "window-drag relative h-[60px] px-2 pt-1.5 sm:px-3"
-      : "window-drag relative h-[60px] px-2 sm:px-3"
-    : "rounded-xl border border-border bg-card/80 px-2.5 py-2 shadow-md backdrop-blur-sm sm:px-4";
+      ? "window-drag relative h-[46px] px-2 pt-0.5 sm:px-3"
+      : "window-drag relative h-[46px] px-2 sm:px-3"
+    : "rounded-xl border border-border bg-card/80 px-2.5 py-1 shadow-md backdrop-blur-sm sm:px-4";
   const headerGridClassName = isWindowsIntegratedTitleBar
-    ? "relative z-10 grid min-w-0 grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-2 lg:h-full lg:grid-cols-[60px_minmax(276px,476px)_minmax(0,1fr)_auto]"
-    : `relative z-10 grid min-w-0 items-center gap-2 sm:gap-3 lg:h-full lg:grid-cols-[minmax(320px,520px)_minmax(0,1fr)_auto] ${
+    ? "relative z-10 grid min-w-0 grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[46px_minmax(240px,420px)_minmax(0,1fr)_auto]"
+    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-2 lg:h-full lg:grid-cols-[minmax(280px,460px)_minmax(0,1fr)_auto] ${
         isMacIntegratedTitleBar ? "pl-20" : ""
       }`;
 
   const windowControlButtonClassName =
-    "window-no-drag flex h-7 w-7 items-center justify-center rounded-[9px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+    "window-no-drag flex h-6 w-6 items-center justify-center rounded-[8px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative min-w-55 max-w-full`;
   const workspaceSwitcherButtonClassName =
-    "w-full justify-start gap-2.5 px-3";
+    "h-8 w-full justify-start gap-1.5 px-2.5 rounded-xl text-[13px]";
 
   return (
     <header
@@ -273,15 +273,15 @@ export function TopTabsBar({
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-9 shrink-0 rounded-lg border border-border overflow-hidden"
+              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
             />
           </div>
         ) : (
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-9 shrink-0 rounded-lg border border-border overflow-hidden"
+              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
             />
             <div
               ref={workspaceSwitcherRef}
@@ -290,7 +290,7 @@ export function TopTabsBar({
               <Button
                 ref={workspaceSwitcherButtonRef}
                 variant={workspaceSwitcherOpen ? "secondary" : "outline"}
-                size="lg"
+                size="default"
                 onClick={() => {
                   setWorkspaceSwitcherOpen((open) => {
                     const nextOpen = !open;
@@ -306,12 +306,12 @@ export function TopTabsBar({
                 }}
                 className={workspaceSwitcherButtonClassName}
               >
-                <FolderKanban size={14} className="shrink-0 text-primary" />
+                <FolderKanban size={13} className="shrink-0 text-primary" />
                 <span className="min-w-0 flex-1 truncate text-left font-medium">
                   {selectedWorkspace?.name || "Select workspace"}
                 </span>
                 <ChevronDown
-                  size={13}
+                  size={12}
                   className={`shrink-0 text-muted-foreground transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
                 />
               </Button>
@@ -327,7 +327,7 @@ export function TopTabsBar({
               <Button
                 ref={workspaceSwitcherButtonRef}
                 variant={workspaceSwitcherOpen ? "secondary" : "outline"}
-                size="lg"
+                size="default"
                 onClick={() => {
                   setWorkspaceSwitcherOpen((open) => {
                     const nextOpen = !open;
@@ -343,12 +343,12 @@ export function TopTabsBar({
                 }}
                 className={workspaceSwitcherButtonClassName}
               >
-                <FolderKanban size={14} className="shrink-0 text-primary" />
+                <FolderKanban size={13} className="shrink-0 text-primary" />
                 <span className="min-w-0 flex-1 truncate text-left font-medium">
                   {selectedWorkspace?.name || "Select workspace"}
                 </span>
                 <ChevronDown
-                  size={13}
+                  size={12}
                   className={`shrink-0 text-muted-foreground transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
                 />
               </Button>
@@ -359,17 +359,17 @@ export function TopTabsBar({
         <div className="hidden lg:block" />
 
         <div
-          className={`${integratedTitleBar ? "window-no-drag " : ""}flex items-center justify-self-end gap-2`}
+          className={`${integratedTitleBar ? "window-no-drag " : ""}flex items-center justify-self-end gap-1.5`}
         >
           {onOpenMarketplace ? (
             <Button
               variant={isMarketplaceActive ? "secondary" : "outline"}
-              size="lg"
+              size="sm"
               aria-label="Marketplace"
               onClick={onOpenMarketplace}
-              className="gap-2 px-3"
+              className="h-8 gap-1.5 px-2.5 rounded-xl text-[13px]"
             >
-              <LayoutGrid size={14} />
+              <LayoutGrid size={13} />
               <span className="hidden sm:inline">Marketplace</span>
             </Button>
           ) : null}
@@ -384,7 +384,7 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon-lg" className="relative" />}
+              render={<Button variant="outline" size="icon" className="relative rounded-xl" />}
             >
               <User2 />
               <span

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -247,20 +247,20 @@ export function TopTabsBar({
 
   const headerClassName = integratedTitleBar
     ? isWindowsIntegratedTitleBar
-      ? "window-drag relative h-[46px] px-2 pt-0.5 sm:px-3"
-      : "window-drag relative h-[46px] px-2 sm:px-3"
-    : "rounded-xl border border-border bg-card/80 px-2.5 py-1 shadow-md backdrop-blur-sm sm:px-4";
+      ? "window-drag relative h-[42px] px-2 pt-0.5 sm:px-3"
+      : "window-drag relative h-[42px] px-2 sm:px-3"
+    : "rounded-xl border border-border bg-card/80 px-2.5 py-0.5 shadow-md backdrop-blur-sm sm:px-4";
   const headerGridClassName = isWindowsIntegratedTitleBar
-    ? "relative z-10 grid min-w-0 grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[46px_minmax(240px,420px)_minmax(0,1fr)_auto]"
-    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-2 lg:h-full lg:grid-cols-[minmax(280px,460px)_minmax(0,1fr)_auto] ${
+    ? "relative z-10 grid min-w-0 grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[42px_minmax(220px,400px)_minmax(0,1fr)_auto]"
+    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-1.5 lg:h-full lg:grid-cols-[minmax(260px,440px)_minmax(0,1fr)_auto] ${
         isMacIntegratedTitleBar ? "pl-20" : ""
       }`;
 
   const windowControlButtonClassName =
-    "window-no-drag flex h-6 w-6 items-center justify-center rounded-[8px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+    "window-no-drag flex h-5 w-5 items-center justify-center rounded-[7px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative min-w-55 max-w-full`;
   const workspaceSwitcherButtonClassName =
-    "h-8 w-full justify-start gap-1.5 px-2.5 rounded-xl text-[13px]";
+    "h-7 w-full justify-start gap-1.5 px-2 rounded-lg text-xs";
 
   return (
     <header
@@ -273,7 +273,7 @@ export function TopTabsBar({
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
+              className="size-7 shrink-0 rounded-[9px] border border-border overflow-hidden"
             />
           </div>
         ) : (
@@ -281,7 +281,7 @@ export function TopTabsBar({
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
+              className="size-7 shrink-0 rounded-[9px] border border-border overflow-hidden"
             />
             <div
               ref={workspaceSwitcherRef}
@@ -367,9 +367,9 @@ export function TopTabsBar({
               size="sm"
               aria-label="Marketplace"
               onClick={onOpenMarketplace}
-              className="h-8 gap-1.5 px-2.5 rounded-xl text-[13px]"
+              className="h-7 gap-1.5 px-2 rounded-lg text-xs"
             >
-              <LayoutGrid size={13} />
+              <LayoutGrid size={12} />
               <span className="hidden sm:inline">Marketplace</span>
             </Button>
           ) : null}
@@ -384,7 +384,7 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon" className="relative rounded-xl" />}
+              render={<Button variant="outline" size="icon-sm" className="relative rounded-lg" />}
             >
               <User2 />
               <span

--- a/desktop/src/components/layout/appShellLayout.ts
+++ b/desktop/src/components/layout/appShellLayout.ts
@@ -14,10 +14,10 @@ export function appShellMainGridClassName({
     hasWorkspaces
       ? "grid-rows-[auto_minmax(0,1fr)]"
       : "grid-rows-[minmax(0,1fr)]",
-    "gap-2",
-    "p-2",
+    "gap-1.5",
+    "p-1.5",
     hasIntegratedTitleBar
-      ? "sm:gap-2.5 sm:px-3 sm:pb-3 sm:pt-2.5"
-      : "sm:gap-3 sm:p-3",
+      ? "sm:gap-2 sm:px-3 sm:pb-2.5 sm:pt-2"
+      : "sm:gap-2.5 sm:p-2.5",
   ].join(" ");
 }

--- a/runtime/api-server/package-lock.json
+++ b/runtime/api-server/package-lock.json
@@ -786,7 +786,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -808,7 +807,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
       "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -821,7 +819,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1213,7 +1210,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
       "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1230,7 +1226,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -1248,7 +1243,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1934,7 +1928,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/runtime/api-server/src/evolve-skill-review.ts
+++ b/runtime/api-server/src/evolve-skill-review.ts
@@ -15,7 +15,7 @@ import { queryMemoryModelJson } from "./memory-model-client.js";
 import type { MemoryServiceLike } from "./memory.js";
 import { resolveWorkspaceSkills } from "./workspace-skills.js";
 
-const SKILL_REVIEW_INTERVAL_TURNS = 5;
+const SKILL_REVIEW_INTERVAL_TURNS = 3;
 const RECENT_SKILL_REVIEW_TURN_LIMIT = 5;
 const RECENT_SKILL_REVIEW_USER_MESSAGES_LIMIT = 4;
 const EXISTING_WORKSPACE_SKILL_PROMPT_LIMIT = 6;

--- a/runtime/api-server/src/evolve.test.ts
+++ b/runtime/api-server/src/evolve.test.ts
@@ -175,7 +175,7 @@ test("createEvolveTaskProposal tags task proposals with the evolve source", () =
 test("skill review only proposes candidates on the configured completed-turn cadence", async () => {
   const { store } = makeRuntimeState("hb-evolve-skill-cadence-");
   seedWorkspace(store);
-  for (let index = 1; index <= 4; index += 1) {
+  for (let index = 1; index <= 2; index += 1) {
     store.upsertTurnResult({
       workspaceId: "workspace-1",
       sessionId: "session-main",
@@ -190,7 +190,7 @@ test("skill review only proposes candidates on the configured completed-turn cad
   const turnResult = store.upsertTurnResult({
     workspaceId: "workspace-1",
     sessionId: "session-main",
-    inputId: "input-5",
+    inputId: "input-3",
     startedAt: "2026-04-10T12:00:00.000Z",
     completedAt: "2026-04-10T12:00:05.000Z",
     status: "completed",
@@ -203,7 +203,7 @@ test("skill review only proposes candidates on the configured completed-turn cad
     sessionId: "session-main",
     role: "user",
     text: "Document the reusable release verification workflow.",
-    messageId: "user-5",
+    messageId: "user-3",
     createdAt: "2026-04-10T12:00:00.000Z",
   });
 
@@ -275,7 +275,7 @@ test("skill review can target an existing workspace skill as a patch candidate",
     ].join("\n"),
     "utf8"
   );
-  for (let index = 1; index <= 4; index += 1) {
+  for (let index = 1; index <= 2; index += 1) {
     store.upsertTurnResult({
       workspaceId: "workspace-1",
       sessionId: "session-main",
@@ -290,7 +290,7 @@ test("skill review can target an existing workspace skill as a patch candidate",
   const turnResult = store.upsertTurnResult({
     workspaceId: "workspace-1",
     sessionId: "session-main",
-    inputId: "input-patch-5",
+    inputId: "input-patch-3",
     startedAt: "2026-04-10T12:10:00.000Z",
     completedAt: "2026-04-10T12:10:05.000Z",
     status: "completed",
@@ -303,7 +303,7 @@ test("skill review can target an existing workspace skill as a patch candidate",
     sessionId: "session-main",
     role: "user",
     text: "Update the release verification skill to include the new build check.",
-    messageId: "user-patch-5",
+    messageId: "user-patch-3",
     createdAt: "2026-04-10T12:10:00.000Z",
   });
 

--- a/sdk/app-sdk/package-lock.json
+++ b/sdk/app-sdk/package-lock.json
@@ -152,6 +152,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1089,8 +1112,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -1201,7 +1223,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1940,7 +1961,6 @@
       "version": "4.12.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2156,7 +2176,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -2907,8 +2926,7 @@
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/openapi3-ts": {
       "version": "4.5.0",
@@ -3163,7 +3181,6 @@
       "version": "19.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3308,7 +3325,6 @@
       "version": "1.0.0-rc.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3775,7 +3791,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3880,7 +3895,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4513,7 +4527,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- keep local evolve proposals visible and polling even when proactive auth preferences are unavailable
- scope the signed-out inbox notice to backend proactive controls instead of hiding the proposal lane
- compact the desktop top bar, normalize top-bar control sizing, and align macOS traffic lights with the new title bar height
- add regression coverage for signed-out inbox behavior, compact top-bar sizing, and macOS title-bar alignment

## Validation
- `node --test src/components/layout/AppShell.test.mjs src/components/layout/OperationsDrawer.test.mjs src/components/layout/TopTabsBar.test.mjs electron/macos-title-bar-alignment.test.mjs`

## Notes
- the branch worktree still has unrelated unstaged changes outside this commit; they are not part of this PR