### PR TITLE
fix: route embedded proactive bridge through gateway

### DIFF
--- a/desktop/electron/macos-title-bar-alignment.test.mjs
+++ b/desktop/electron/macos-title-bar-alignment.test.mjs
@@ -8,5 +8,5 @@ test("macOS main window keeps traffic lights aligned with the compact title bar"
   const source = await readFile(MAIN_PATH, "utf8");
 
   assert.match(source, /titleBarStyle: "hiddenInset" as const,/);
-  assert.match(source, /trafficLightPosition: \{ x: 14, y: 25 \},/);
+  assert.match(source, /trafficLightPosition: \{ x: 14, y: 23 \},/);
 });

--- a/desktop/electron/macos-title-bar-alignment.test.mjs
+++ b/desktop/electron/macos-title-bar-alignment.test.mjs
@@ -8,5 +8,5 @@ test("macOS main window keeps traffic lights aligned with the compact title bar"
   const source = await readFile(MAIN_PATH, "utf8");
 
   assert.match(source, /titleBarStyle: "hiddenInset" as const,/);
-  assert.match(source, /trafficLightPosition: \{ x: 14, y: 23 \},/);
+  assert.match(source, /trafficLightPosition: \{ x: 14, y: 25 \},/);
 });

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -16037,7 +16037,7 @@ function createMainWindow() {
     process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset" as const,
-          trafficLightPosition: { x: 14, y: 25 },
+          trafficLightPosition: { x: 14, y: 23 },
         }
       : process.platform === "win32"
         ? {

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -6670,7 +6670,7 @@ function proactiveBaseUrl() {
 }
 
 function runtimeProactiveBridgeBaseUrl() {
-  return DEFAULT_PROACTIVE_URL.replace(/\/+$/, "");
+  return proactiveBaseUrl();
 }
 
 function embeddedRuntimeStartupConfigError() {

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -16037,7 +16037,7 @@ function createMainWindow() {
     process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset" as const,
-          trafficLightPosition: { x: 14, y: 23 },
+          trafficLightPosition: { x: 14, y: 25 },
         }
       : process.platform === "win32"
         ? {

--- a/desktop/electron/runtime-auth-env.test.mjs
+++ b/desktop/electron/runtime-auth-env.test.mjs
@@ -20,12 +20,12 @@ test("embedded runtime launch forwards auth base URL alongside the auth cookie",
   );
 });
 
-test("embedded runtime bridge uses the direct proactive service URL instead of the gateway", async () => {
+test("embedded runtime bridge uses the same proactive base URL resolution as interactive calls", async () => {
   const source = await readFile(mainSourcePath, "utf8");
 
   assert.match(
     source,
-    /function runtimeProactiveBridgeBaseUrl\(\)\s*\{\s*return DEFAULT_PROACTIVE_URL\.replace\(\/\\\/\+\$\/, ""\);\s*\}/,
+    /function runtimeProactiveBridgeBaseUrl\(\)\s*\{\s*return proactiveBaseUrl\(\);\s*\}/,
   );
   assert.match(
     source,

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -20,7 +20,7 @@ export function CreditsPill({
       size="default"
       variant="outline"
       onClick={onClick}
-      className={`inline-flex shrink-0 items-center rounded-lg border text-[13px] transition ${
+      className={`inline-flex h-8 shrink-0 items-center rounded-xl border px-3 text-[13px] transition ${
         isLowBalance
           ? "border-amber-300/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/14"
           : "border-border/55"
@@ -28,9 +28,9 @@ export function CreditsPill({
       aria-label="Open credits and billing details"
     >
       {isLoading ? (
-        <Loader2 size={14} className="animate-spin" />
+        <Loader2 size={13} className="animate-spin" />
       ) : (
-        <Sparkles size={14} className="opacity-80" />
+        <Sparkles size={13} className="opacity-80" />
       )}
       <span className="font-medium tabular-nums">
         {isLoading ? "..." : (balance ?? 0).toLocaleString()}

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -17,10 +17,10 @@ export function CreditsPill({
   return (
     <Button
       type="button"
-      size="default"
+      size="sm"
       variant="outline"
       onClick={onClick}
-      className={`inline-flex h-8 shrink-0 items-center rounded-xl border px-3 text-[13px] transition ${
+      className={`inline-flex h-7 shrink-0 items-center rounded-lg border px-2.5 text-xs transition ${
         isLowBalance
           ? "border-amber-300/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/14"
           : "border-border/55"

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -40,15 +40,15 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const windowControlButtonClassName =\s*"window-no-drag flex h-6 w-6 items-center justify-center rounded-\[8px\]/,
+    /const windowControlButtonClassName =\s*"window-no-drag flex h-5 w-5 items-center justify-center rounded-\[7px\]/,
   );
-  assert.match(source, /className="size-8 shrink-0 rounded-\[10px\] border border-border overflow-hidden"/);
-  assert.match(source, /<FolderKanban size=\{14\} className="shrink-0 text-primary" \/>/);
-  assert.match(source, /<ChevronDown\s+size=\{13\}/);
-  assert.match(source, /size="default"\s+aria-label="Marketplace"/);
-  assert.match(source, /className="gap-2 rounded-lg text-\[13px\]"/);
-  assert.match(source, /<LayoutGrid size=\{13\} \/>/);
-  assert.match(source, /render=\{<Button variant="outline" size="icon" className="relative rounded-lg" \/>\}/);
+  assert.match(source, /className="size-7 shrink-0 rounded-\[9px\] border border-border overflow-hidden"/);
+  assert.match(source, /<FolderKanban size=\{13\} className="shrink-0 text-primary" \/>/);
+  assert.match(source, /<ChevronDown\s+size=\{12\}/);
+  assert.match(source, /size="sm"\s+aria-label="Marketplace"/);
+  assert.match(source, /className="h-7 gap-1\.5 px-2 rounded-lg text-xs"/);
+  assert.match(source, /<LayoutGrid size=\{12\} \/>/);
+  assert.match(source, /render=\{<Button variant="outline" size="icon-sm" className="relative rounded-lg" \/>\}/);
   assert.match(source, /window\.electronAPI\.ui\.getWindowState\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.minimizeWindow\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.closeWindow\(\)/);

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -24,11 +24,11 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /h-\[46px\] px-2 pt-0\.5 sm:px-3/,
+    /h-\[42px\] px-2 pt-0\.5 sm:px-3/,
   );
   assert.match(
     source,
-    /grid-cols-\[36px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[46px_minmax\(240px,420px\)_minmax\(0,1fr\)_auto\]/,
+    /grid-cols-\[32px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[42px_minmax\(220px,400px\)_minmax\(0,1fr\)_auto\]/,
   );
   assert.match(
     source,
@@ -36,7 +36,7 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-1\.5 px-2\.5 rounded-xl text-\[13px\]";/,
+    /const workspaceSwitcherButtonClassName =\s*"h-7 w-full justify-start gap-1\.5 px-2 rounded-lg text-xs";/,
   );
   assert.match(
     source,

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -24,11 +24,11 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /h-\[42px\] px-2 pt-0\.5 sm:px-3/,
+    /h-\[46px\] px-2 pt-0\.5 sm:px-3/,
   );
   assert.match(
     source,
-    /grid-cols-\[32px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[42px_minmax\(220px,400px\)_minmax\(0,1fr\)_auto\]/,
+    /grid-cols-\[36px_minmax\(0,1fr\)_auto\][\s\S]*lg:grid-cols-\[46px_minmax\(240px,420px\)_minmax\(0,1fr\)_auto\]/,
   );
   assert.match(
     source,
@@ -36,7 +36,7 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-2 px-2\.5 rounded-lg text-\[13px\]";/,
+    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-1\.5 px-2\.5 rounded-xl text-\[13px\]";/,
   );
   assert.match(
     source,

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -247,20 +247,20 @@ export function TopTabsBar({
 
   const headerClassName = integratedTitleBar
     ? isWindowsIntegratedTitleBar
-      ? "window-drag relative h-[46px] px-2 pt-0.5 sm:px-3"
-      : "window-drag relative h-[46px] px-2 sm:px-3"
-    : "rounded-xl border border-border bg-card/80 px-2.5 py-1 shadow-md backdrop-blur-sm sm:px-4";
+      ? "window-drag relative h-[42px] px-2 pt-0.5 sm:px-3"
+      : "window-drag relative h-[42px] px-2 sm:px-3"
+    : "rounded-xl border border-border bg-card/80 px-2.5 py-0.5 shadow-md backdrop-blur-sm sm:px-4";
   const headerGridClassName = isWindowsIntegratedTitleBar
-    ? "relative z-10 grid min-w-0 grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[46px_minmax(240px,420px)_minmax(0,1fr)_auto]"
-    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-2 lg:h-full lg:grid-cols-[minmax(280px,460px)_minmax(0,1fr)_auto] ${
+    ? "relative z-10 grid min-w-0 grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[42px_minmax(220px,400px)_minmax(0,1fr)_auto]"
+    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-1.5 lg:h-full lg:grid-cols-[minmax(260px,440px)_minmax(0,1fr)_auto] ${
         isMacIntegratedTitleBar ? "pl-20" : ""
       }`;
 
   const windowControlButtonClassName =
-    "window-no-drag flex h-6 w-6 items-center justify-center rounded-[8px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+    "window-no-drag flex h-5 w-5 items-center justify-center rounded-[7px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative min-w-55 max-w-full`;
   const workspaceSwitcherButtonClassName =
-    "h-8 w-full justify-start gap-1.5 px-2.5 rounded-xl text-[13px]";
+    "h-7 w-full justify-start gap-1.5 px-2 rounded-lg text-xs";
 
   return (
     <header
@@ -273,7 +273,7 @@ export function TopTabsBar({
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
+              className="size-7 shrink-0 rounded-[9px] border border-border overflow-hidden"
             />
           </div>
         ) : (
@@ -281,7 +281,7 @@ export function TopTabsBar({
             <img
               src={holabossLogoUrl}
               alt="Holaboss"
-              className="size-8 shrink-0 rounded-[10px] border border-border overflow-hidden"
+              className="size-7 shrink-0 rounded-[9px] border border-border overflow-hidden"
             />
             <div
               ref={workspaceSwitcherRef}
@@ -367,9 +367,9 @@ export function TopTabsBar({
               size="sm"
               aria-label="Marketplace"
               onClick={onOpenMarketplace}
-              className="h-8 gap-1.5 px-2.5 rounded-xl text-[13px]"
+              className="h-7 gap-1.5 px-2 rounded-lg text-xs"
             >
-              <LayoutGrid size={13} />
+              <LayoutGrid size={12} />
               <span className="hidden sm:inline">Marketplace</span>
             </Button>
           ) : null}
@@ -384,7 +384,7 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon" className="relative rounded-xl" />}
+              render={<Button variant="outline" size="icon-sm" className="relative rounded-lg" />}
             >
               <User2 />
               <span

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -247,12 +247,12 @@ export function TopTabsBar({
 
   const headerClassName = integratedTitleBar
     ? isWindowsIntegratedTitleBar
-      ? "window-drag relative h-[42px] px-2 pt-0.5 sm:px-3"
-      : "window-drag relative h-[42px] px-2 sm:px-3"
-    : "rounded-xl border border-border bg-card/80 px-2.5 py-0.5 shadow-md backdrop-blur-sm sm:px-4";
+      ? "window-drag relative h-[46px] px-2 pt-0.5 sm:px-3"
+      : "window-drag relative h-[46px] px-2 sm:px-3"
+    : "rounded-xl border border-border bg-card/80 px-2.5 py-1 shadow-md backdrop-blur-sm sm:px-4";
   const headerGridClassName = isWindowsIntegratedTitleBar
-    ? "relative z-10 grid min-w-0 grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[42px_minmax(220px,400px)_minmax(0,1fr)_auto]"
-    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-1.5 lg:h-full lg:grid-cols-[minmax(260px,440px)_minmax(0,1fr)_auto] ${
+    ? "relative z-10 grid min-w-0 grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-1 lg:h-full lg:grid-cols-[46px_minmax(240px,420px)_minmax(0,1fr)_auto]"
+    : `relative z-10 grid min-w-0 items-center gap-1 sm:gap-2 lg:h-full lg:grid-cols-[minmax(280px,460px)_minmax(0,1fr)_auto] ${
         isMacIntegratedTitleBar ? "pl-20" : ""
       }`;
 
@@ -260,7 +260,7 @@ export function TopTabsBar({
     "window-no-drag flex h-6 w-6 items-center justify-center rounded-[8px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative min-w-55 max-w-full`;
   const workspaceSwitcherButtonClassName =
-    "h-8 w-full justify-start gap-2 px-2.5 rounded-lg text-[13px]";
+    "h-8 w-full justify-start gap-1.5 px-2.5 rounded-xl text-[13px]";
 
   return (
     <header
@@ -306,12 +306,12 @@ export function TopTabsBar({
                 }}
                 className={workspaceSwitcherButtonClassName}
               >
-                <FolderKanban size={14} className="shrink-0 text-primary" />
+                <FolderKanban size={13} className="shrink-0 text-primary" />
                 <span className="min-w-0 flex-1 truncate text-left font-medium">
                   {selectedWorkspace?.name || "Select workspace"}
                 </span>
                 <ChevronDown
-                  size={13}
+                  size={12}
                   className={`shrink-0 text-muted-foreground transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
                 />
               </Button>
@@ -343,12 +343,12 @@ export function TopTabsBar({
                 }}
                 className={workspaceSwitcherButtonClassName}
               >
-                <FolderKanban size={14} className="shrink-0 text-primary" />
+                <FolderKanban size={13} className="shrink-0 text-primary" />
                 <span className="min-w-0 flex-1 truncate text-left font-medium">
                   {selectedWorkspace?.name || "Select workspace"}
                 </span>
                 <ChevronDown
-                  size={13}
+                  size={12}
                   className={`shrink-0 text-muted-foreground transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
                 />
               </Button>
@@ -364,10 +364,10 @@ export function TopTabsBar({
           {onOpenMarketplace ? (
             <Button
               variant={isMarketplaceActive ? "secondary" : "outline"}
-              size="default"
+              size="sm"
               aria-label="Marketplace"
               onClick={onOpenMarketplace}
-              className="gap-2 rounded-lg text-[13px]"
+              className="h-8 gap-1.5 px-2.5 rounded-xl text-[13px]"
             >
               <LayoutGrid size={13} />
               <span className="hidden sm:inline">Marketplace</span>
@@ -384,7 +384,7 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon" className="relative rounded-lg" />}
+              render={<Button variant="outline" size="icon" className="relative rounded-xl" />}
             >
               <User2 />
               <span


### PR DESCRIPTION
## Context
The embedded runtime bridge was still resolving `PROACTIVE_BRIDGE_BASE_URL` to the direct proactive service, while interactive desktop proactive calls already resolved through the gateway when auth was configured. Now that the dev gateway supports proactive bridge service auth, the runtime bridge should follow the same base URL resolution so both paths hit the same proactive instance.

## Changes
- route `runtimeProactiveBridgeBaseUrl()` through `proactiveBaseUrl()` in `desktop/electron/main.ts`
- update the runtime auth env regression test to assert shared proactive base URL resolution instead of the old direct-service expectation

## Validation
- `node --test electron/runtime-auth-env.test.mjs electron/proactive-preference-fetch.test.mjs`

## Notes
- no migrations or environment changes in this PR
- verified locally that the embedded runtime now launches with `PROACTIVE_BRIDGE_BASE_URL=https://api.imerchstaging.com/gateway/proactive` when auth/gateway is configured