### PR TITLE
feat: add reasoning effort selection across desktop and runtime

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -70,6 +70,10 @@ import {
   listMarketplaceTemplates as sdkListMarketplaceTemplates,
   materializeMarketplaceTemplate as sdkMaterializeMarketplaceTemplate,
 } from "@holaboss/app-sdk/core";
+import {
+  type ModelCatalogInputModality,
+} from "../shared/model-catalog.js";
+import * as modelCatalog from "../shared/model-catalog.js";
 import { buildAppSdkClient } from "./appSdkClient.js";
 import { ensureWorkspaceGitRepo } from "./workspace-git.js";
 
@@ -495,6 +499,11 @@ interface RuntimeConfigPayload {
 interface RuntimeProviderModelPayload {
   token: string;
   modelId: string;
+  label?: string;
+  reasoning?: boolean;
+  thinkingValues?: string[];
+  defaultThinkingValue?: string | null;
+  inputModalities?: ModelCatalogInputModality[];
   capabilities?: string[];
 }
 
@@ -2519,6 +2528,7 @@ interface HolabossQueueSessionInputPayload {
   idempotency_key?: string | null;
   priority?: number;
   model?: string | null;
+  thinking_value?: string | null;
 }
 
 interface HolabossPauseSessionRunPayload {
@@ -4566,6 +4576,127 @@ function runtimeModelCapabilityList(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
 }
 
+function normalizeRuntimeModelThinkingValues(rawValues: unknown[]): string[] {
+  const seen = new Set<string>();
+  const thinkingValues: string[] = [];
+  for (const value of rawValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    thinkingValues.push(normalized);
+  }
+  return thinkingValues;
+}
+
+function runtimeModelThinkingValueList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeRuntimeModelInputModality(
+  value: string,
+): ModelCatalogInputModality | "" {
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case "text":
+    case "image":
+    case "audio":
+    case "video":
+      return normalized;
+    default:
+      return "";
+  }
+}
+
+function normalizeRuntimeModelInputModalities(
+  rawValues: unknown[],
+): ModelCatalogInputModality[] {
+  const seen = new Set<ModelCatalogInputModality>();
+  const inputModalities: ModelCatalogInputModality[] = [];
+  for (const value of rawValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalized = normalizeRuntimeModelInputModality(value);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    inputModalities.push(normalized);
+  }
+  return inputModalities;
+}
+
+function runtimeModelInputModalityList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function runtimeModelMetadataFromPayload(
+  providerId: string,
+  modelId: string,
+  payload: Record<string, unknown>,
+): Partial<RuntimeProviderModelPayload> {
+  const fallback = modelCatalog.catalogMetadataForProviderModel(
+    providerId,
+    modelId,
+  );
+  const label =
+    runtimeFirstNonEmptyString(
+      payload.label as string | undefined,
+      payload.display_label as string | undefined,
+      payload.displayLabel as string | undefined,
+      payload.name as string | undefined,
+    ) || fallback?.label;
+  const explicitReasoning =
+    typeof payload.reasoning === "boolean" ? payload.reasoning : undefined;
+  const useFallbackReasoningMetadata = explicitReasoning !== false;
+  const explicitThinkingValues = normalizeRuntimeModelThinkingValues([
+    ...runtimeModelThinkingValueList(payload.thinking_values),
+    ...runtimeModelThinkingValueList(payload.thinkingValues),
+  ]);
+  const explicitInputModalities = normalizeRuntimeModelInputModalities([
+    ...runtimeModelInputModalityList(payload.input_modalities),
+    ...runtimeModelInputModalityList(payload.inputModalities),
+    ...runtimeModelInputModalityList(payload.input),
+  ]);
+  const explicitDefaultThinkingValue =
+    payload.default_thinking_value === null || payload.defaultThinkingValue === null
+      ? null
+      : runtimeFirstNonEmptyString(
+          payload.default_thinking_value as string | undefined,
+          payload.defaultThinkingValue as string | undefined,
+        );
+  const thinkingValues =
+    explicitThinkingValues.length > 0
+      ? explicitThinkingValues
+      : useFallbackReasoningMetadata
+        ? fallback?.thinkingValues
+        : [];
+  const inputModalities =
+    explicitInputModalities.length > 0
+      ? explicitInputModalities
+      : fallback?.inputModalities;
+  const defaultThinkingValue =
+    explicitDefaultThinkingValue !== undefined
+      ? explicitDefaultThinkingValue
+      : useFallbackReasoningMetadata
+        ? fallback?.defaultThinkingValue
+        : null;
+  const reasoning = explicitReasoning ?? fallback?.reasoning;
+
+  return {
+    ...(label ? { label } : {}),
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(thinkingValues !== undefined ? { thinkingValues } : {}),
+    ...(defaultThinkingValue !== undefined ? { defaultThinkingValue } : {}),
+    ...(inputModalities !== undefined ? { inputModalities } : {}),
+  };
+}
+
 function upsertRuntimeProviderModel(
   models: Map<string, RuntimeProviderModelPayload>,
   payload: RuntimeProviderModelPayload,
@@ -4578,6 +4709,29 @@ function upsertRuntimeProviderModel(
   models.set(payload.token, {
     token: payload.token,
     modelId: payload.modelId,
+    ...(payload.label?.trim() || existing?.label
+      ? { label: payload.label?.trim() || existing?.label }
+      : {}),
+    ...(payload.reasoning !== undefined
+      ? { reasoning: payload.reasoning }
+      : existing?.reasoning !== undefined
+        ? { reasoning: existing.reasoning }
+        : {}),
+    ...(payload.thinkingValues !== undefined
+      ? { thinkingValues: [...payload.thinkingValues] }
+      : existing?.thinkingValues !== undefined
+        ? { thinkingValues: [...existing.thinkingValues] }
+        : {}),
+    ...(payload.defaultThinkingValue !== undefined
+      ? { defaultThinkingValue: payload.defaultThinkingValue }
+      : existing?.defaultThinkingValue !== undefined
+        ? { defaultThinkingValue: existing.defaultThinkingValue }
+        : {}),
+    ...(payload.inputModalities !== undefined
+      ? { inputModalities: [...payload.inputModalities] }
+      : existing?.inputModalities !== undefined
+        ? { inputModalities: [...existing.inputModalities] }
+        : {}),
     ...(mergedCapabilities.length > 0
       ? { capabilities: mergedCapabilities }
       : {}),
@@ -4673,9 +4827,15 @@ function normalizeRuntimeProviderModelGroups(
         ...runtimeModelCapabilityList(modelPayload.modalities),
         ...runtimeModelCapabilityList(modelPayload.model_modalities),
       ]);
+      const metadata = runtimeModelMetadataFromPayload(
+        providerId,
+        modelId,
+        modelPayload,
+      );
       upsertRuntimeProviderModel(ensureProviderGroup(providerId), {
         token,
         modelId,
+        ...metadata,
         ...(capabilities.length > 0 ? { capabilities } : {}),
       });
     }
@@ -4747,6 +4907,7 @@ function runtimeProviderModelGroups(
     token: string,
     modelId: string,
     capabilities?: string[],
+    metadata?: Partial<RuntimeProviderModelPayload>,
   ) => {
     const normalizedProviderId = canonicalRuntimeProviderId(providerId);
     const normalizedModelId = normalizeRuntimeProviderModelId(
@@ -4780,6 +4941,7 @@ function runtimeProviderModelGroups(
     upsertRuntimeProviderModel(group, {
       token: normalizedToken,
       modelId: normalizedModelId,
+      ...(metadata ?? {}),
       ...(Array.isArray(capabilities) && capabilities.length > 0
         ? { capabilities }
         : {}),
@@ -4804,6 +4966,21 @@ function runtimeProviderModelGroups(
           model.token,
           model.modelId,
           Array.isArray(model.capabilities) ? model.capabilities : [],
+          {
+            ...(model.label ? { label: model.label } : {}),
+            ...(model.reasoning !== undefined
+              ? { reasoning: model.reasoning }
+              : {}),
+            ...(model.thinkingValues !== undefined
+              ? { thinkingValues: [...model.thinkingValues] }
+              : {}),
+            ...(model.defaultThinkingValue !== undefined
+              ? { defaultThinkingValue: model.defaultThinkingValue }
+              : {}),
+            ...(model.inputModalities !== undefined
+              ? { inputModalities: [...model.inputModalities] }
+              : {}),
+          },
         );
       }
     }
@@ -4864,7 +5041,17 @@ function runtimeProviderModelGroups(
         continue;
       }
       if (providers.has(normalizedProviderId)) {
-        addModel(normalizedProviderId, token, modelId);
+        addModel(
+          normalizedProviderId,
+          token,
+          modelId,
+          undefined,
+          runtimeModelMetadataFromPayload(
+            normalizedProviderId,
+            modelId,
+            modelPayload,
+          ),
+        );
       }
     }
   }
@@ -10850,6 +11037,7 @@ async function queueSessionInput(
       idempotency_key: idempotencyKey,
       priority: payload.priority ?? 0,
       model: payload.model,
+      thinking_value: payload.thinking_value ?? null,
     },
     retryTransientErrors: true,
   });

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -199,6 +199,11 @@ interface RuntimeConfigPayload {
 interface RuntimeProviderModelPayload {
   token: string;
   modelId: string;
+  label?: string;
+  reasoning?: boolean;
+  thinkingValues?: string[];
+  defaultThinkingValue?: string | null;
+  inputModalities?: ("text" | "image" | "audio" | "video")[];
   capabilities?: string[];
 }
 
@@ -710,10 +715,12 @@ interface HolabossQueueSessionInputPayload {
   text: string;
   workspace_id: string;
   image_urls: string[] | null;
+  attachments?: SessionInputAttachmentPayload[] | null;
   session_id?: string | null;
   idempotency_key?: string | null;
   priority?: number;
   model?: string | null;
+  thinking_value?: string | null;
 }
 
 interface HolabossPauseSessionRunPayload {

--- a/desktop/electron/runtime-provider-models.test.mjs
+++ b/desktop/electron/runtime-provider-models.test.mjs
@@ -6,6 +6,15 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mainSourcePath = path.join(__dirname, "main.ts");
+const chatPaneSourcePath = path.join(
+  __dirname,
+  "..",
+  "src",
+  "components",
+  "panes",
+  "ChatPane.tsx",
+);
+const sharedCatalogPath = path.join(__dirname, "..", "shared", "model-catalog.ts");
 
 test("desktop runtime uses the managed holaboss catalog instead of local seed catalogs", async () => {
   const source = await readFile(mainSourcePath, "utf8");
@@ -25,7 +34,10 @@ test("desktop runtime uses the managed holaboss catalog instead of local seed ca
 test("desktop runtime normalizes stale direct-provider model aliases for Anthropic and Gemini", async () => {
   const source = await readFile(mainSourcePath, "utf8");
 
-  assert.match(source, /const RUNTIME_LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<string, Record<string, string>> = \{/);
+  assert.match(
+    source,
+    /const RUNTIME_LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<[\s\S]*?Record<string, string>[\s\S]*?> = \{/,
+  );
   assert.match(source, /anthropic_direct:\s*\{[\s\S]*"claude-sonnet-4-5": "claude-sonnet-4-6"/);
   assert.match(source, /gemini_direct:\s*\{[\s\S]*"gemini-3.1-pro-preview": "gemini-2.5-pro"/);
   assert.match(source, /function normalizeRuntimeProviderModelId\(/);
@@ -38,4 +50,24 @@ test("desktop runtime recognizes minimax provider label and strips minimax token
 
   assert.match(source, /normalized\.includes\("minimax"\)[\s\S]*?return "MiniMax"/);
   assert.match(source, /normalizedPrefix\.includes\("minimax"\)/);
+});
+
+test("desktop model catalog carries reasoning metadata and the composer persists thinking preferences", async () => {
+  const [mainSource, chatPaneSource, sharedCatalogSource] = await Promise.all([
+    readFile(mainSourcePath, "utf8"),
+    readFile(chatPaneSourcePath, "utf8"),
+    readFile(sharedCatalogPath, "utf8"),
+  ]);
+
+  assert.match(sharedCatalogSource, /export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = \{/);
+  assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"qwen\/qwen3\.6-plus"/);
+  assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"xiaomi\/mimo-v2-pro"/);
+  assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"z-ai\/glm-5-turbo"/);
+  assert.match(sharedCatalogSource, /thinking_values:/);
+  assert.match(sharedCatalogSource, /input_modalities:/);
+  assert.match(mainSource, /catalogMetadataForProviderModel/);
+  assert.match(mainSource, /function runtimeModelMetadataFromPayload\(/);
+  assert.match(chatPaneSource, /CHAT_THINKING_STORAGE_KEY/);
+  assert.match(chatPaneSource, /thinking_value: effectiveThinkingValue/);
+  assert.match(chatPaneSource, /function ThinkingValueSelect\(/);
 });

--- a/desktop/shared/model-catalog.ts
+++ b/desktop/shared/model-catalog.ts
@@ -1,0 +1,375 @@
+export type ModelCatalogInputModality = "text" | "image" | "audio" | "video";
+
+export interface ModelCatalogEntry {
+  model_id: string;
+  label?: string;
+  reasoning: boolean;
+  thinking_values: string[];
+  default_thinking_value?: string | null;
+  input_modalities: ModelCatalogInputModality[];
+}
+
+export interface ProviderCatalogEntry {
+  source: "local" | "backend";
+  models: ModelCatalogEntry[];
+}
+
+export type ProviderModelCatalog = Record<string, ProviderCatalogEntry>;
+
+export interface ModelCatalogMetadata {
+  label?: string;
+  reasoning: boolean;
+  thinkingValues: string[];
+  defaultThinkingValue: string | null;
+  inputModalities: ModelCatalogInputModality[];
+}
+
+const OPENAI_GPT54_THINKING_VALUES = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+const OPENAI_GPT53_CODEX_THINKING_VALUES = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+const OPENROUTER_THINKING_VALUES = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+] as const;
+const ANTHROPIC_BUDGET_THINKING_VALUES = [
+  "1024",
+  "2048",
+  "8192",
+  "16384",
+] as const;
+const ANTHROPIC_ADAPTIVE_THINKING_VALUES = ["low", "medium", "high"] as const;
+const ANTHROPIC_OPUS_ADAPTIVE_THINKING_VALUES = [
+  "low",
+  "medium",
+  "high",
+  "max",
+] as const;
+const GEMINI_PRO_THINKING_VALUES = [
+  "-1",
+  "128",
+  "2048",
+  "8192",
+  "32768",
+] as const;
+const GEMINI_FLASH_THINKING_VALUES = [
+  "0",
+  "-1",
+  "128",
+  "2048",
+  "8192",
+  "24576",
+] as const;
+
+export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = {
+  holaboss_model_proxy: {
+    source: "backend",
+    models: [],
+  },
+  openai_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "gpt-5.4",
+        label: "GPT-5.4",
+        reasoning: true,
+        thinking_values: [...OPENAI_GPT54_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "gpt-5.3-codex",
+        label: "GPT-5.3 Codex",
+        reasoning: true,
+        thinking_values: [...OPENAI_GPT53_CODEX_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+    ],
+  },
+  anthropic_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "claude-sonnet-4-6",
+        label: "Claude Sonnet 4.6",
+        reasoning: true,
+        thinking_values: [...ANTHROPIC_ADAPTIVE_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "claude-opus-4-6",
+        label: "Claude Opus 4.6",
+        reasoning: true,
+        thinking_values: [...ANTHROPIC_OPUS_ADAPTIVE_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "claude-haiku-4-5",
+        label: "Claude Haiku 4.5",
+        reasoning: true,
+        thinking_values: [...ANTHROPIC_BUDGET_THINKING_VALUES],
+        default_thinking_value: "8192",
+        input_modalities: ["text", "image"],
+      },
+    ],
+  },
+  openrouter_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "openai/gpt-5.4",
+        label: "GPT-5.4",
+        reasoning: true,
+        thinking_values: [...OPENROUTER_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "anthropic/claude-sonnet-4-6",
+        label: "Claude Sonnet 4.6",
+        reasoning: true,
+        thinking_values: [...OPENROUTER_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "qwen/qwen3.6-plus",
+        label: "Qwen 3.6 Plus",
+        reasoning: true,
+        thinking_values: [...OPENROUTER_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "xiaomi/mimo-v2-pro",
+        label: "MiMo V2 Pro",
+        reasoning: true,
+        thinking_values: [...OPENROUTER_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text"],
+      },
+      {
+        model_id: "z-ai/glm-5-turbo",
+        label: "GLM 5 Turbo",
+        reasoning: true,
+        thinking_values: [...OPENROUTER_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text"],
+      },
+    ],
+  },
+  gemini_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "gemini-2.5-pro",
+        label: "Gemini 2.5 Pro",
+        reasoning: true,
+        thinking_values: [...GEMINI_PRO_THINKING_VALUES],
+        default_thinking_value: "8192",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "gemini-2.5-flash",
+        label: "Gemini 2.5 Flash",
+        reasoning: true,
+        thinking_values: [...GEMINI_FLASH_THINKING_VALUES],
+        default_thinking_value: "8192",
+        input_modalities: ["text", "image"],
+      },
+    ],
+  },
+  ollama_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "llama3.1:8b",
+        label: "Llama 3.1 8B",
+        reasoning: false,
+        thinking_values: [],
+        input_modalities: ["text"],
+      },
+      {
+        model_id: "qwen3:8b",
+        label: "Qwen3 8B",
+        reasoning: false,
+        thinking_values: [],
+        input_modalities: ["text"],
+      },
+      {
+        model_id: "gpt-oss:20b",
+        label: "gpt-oss 20B",
+        reasoning: false,
+        thinking_values: [],
+        input_modalities: ["text"],
+      },
+    ],
+  },
+  minimax_direct: {
+    source: "local",
+    models: [
+      {
+        model_id: "MiniMax-M2.7",
+        label: "MiniMax M2.7",
+        reasoning: false,
+        thinking_values: [],
+        input_modalities: ["text"],
+      },
+      {
+        model_id: "MiniMax-M2.7-highspeed",
+        label: "MiniMax M2.7 Highspeed",
+        reasoning: false,
+        thinking_values: [],
+        input_modalities: ["text"],
+      },
+    ],
+  },
+};
+
+function normalizeProviderId(providerId: string): string {
+  const normalized = providerId.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "holaboss") {
+    return "holaboss_model_proxy";
+  }
+  if (normalized === "openrouter") {
+    return "openrouter_direct";
+  }
+  return normalized;
+}
+
+function normalizeModelId(modelId: string): string {
+  return modelId.trim();
+}
+
+function cloneMetadata(entry: ModelCatalogEntry): ModelCatalogMetadata {
+  return {
+    ...(entry.label ? { label: entry.label } : {}),
+    reasoning: entry.reasoning,
+    thinkingValues: [...entry.thinking_values],
+    defaultThinkingValue: entry.default_thinking_value ?? null,
+    inputModalities: [...entry.input_modalities],
+  };
+}
+
+function mappedHolabossProxyProviderModel(
+  modelId: string,
+): { providerId: string; modelId: string } | null {
+  const normalizedModelId = normalizeModelId(modelId);
+  if (!normalizedModelId) {
+    return null;
+  }
+  const [prefix, rest] = normalizedModelId.split("/", 2);
+  if (rest) {
+    const normalizedPrefix = prefix.trim().toLowerCase();
+    if (normalizedPrefix === "openai") {
+      return { providerId: "openai_direct", modelId: rest.trim() };
+    }
+    if (normalizedPrefix === "anthropic") {
+      return { providerId: "anthropic_direct", modelId: rest.trim() };
+    }
+    if (normalizedPrefix === "google") {
+      return { providerId: "gemini_direct", modelId: rest.trim() };
+    }
+    if (
+      normalizedPrefix === "qwen" ||
+      normalizedPrefix === "xiaomi" ||
+      normalizedPrefix === "z-ai"
+    ) {
+      return { providerId: "openrouter_direct", modelId: normalizedModelId };
+    }
+  }
+  if (/^gpt-5(?:[.-]|$)/i.test(normalizedModelId)) {
+    return { providerId: "openai_direct", modelId: normalizedModelId };
+  }
+  if (/^claude-/i.test(normalizedModelId)) {
+    return { providerId: "anthropic_direct", modelId: normalizedModelId };
+  }
+  if (/^gemini-/i.test(normalizedModelId)) {
+    return { providerId: "gemini_direct", modelId: normalizedModelId };
+  }
+  if (
+    /^qwen\/qwen3\.6-plus$/i.test(normalizedModelId) ||
+    /^xiaomi\/mimo-v2-pro$/i.test(normalizedModelId) ||
+    /^z-ai\/glm-5-turbo$/i.test(normalizedModelId)
+  ) {
+    return { providerId: "openrouter_direct", modelId: normalizedModelId };
+  }
+  return null;
+}
+
+export function catalogEntryForProviderModel(
+  providerId: string,
+  modelId: string,
+): ModelCatalogEntry | null {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  const normalizedModelId = normalizeModelId(modelId);
+  if (!normalizedProviderId || !normalizedModelId) {
+    return null;
+  }
+  const providerCatalog = PROVIDER_MODEL_CATALOG[normalizedProviderId];
+  if (!providerCatalog) {
+    return null;
+  }
+  return (
+    providerCatalog.models.find(
+      (entry) => normalizeModelId(entry.model_id) === normalizedModelId,
+    ) ?? null
+  );
+}
+
+export function catalogMetadataForProviderModel(
+  providerId: string,
+  modelId: string,
+): ModelCatalogMetadata | null {
+  const exact = catalogEntryForProviderModel(providerId, modelId);
+  if (exact) {
+    return cloneMetadata(exact);
+  }
+
+  if (normalizeProviderId(providerId) !== "holaboss_model_proxy") {
+    return null;
+  }
+
+  const mapped = mappedHolabossProxyProviderModel(modelId);
+  if (!mapped) {
+    return null;
+  }
+  const fallback = catalogEntryForProviderModel(mapped.providerId, mapped.modelId);
+  return fallback ? cloneMetadata(fallback) : null;
+}
+
+export function catalogConfigShapeForProviderModel(
+  providerId: string,
+  modelId: string,
+): Record<string, unknown> | null {
+  const entry = catalogEntryForProviderModel(providerId, modelId);
+  if (!entry) {
+    return null;
+  }
+  return {
+    ...(entry.label ? { label: entry.label } : {}),
+    reasoning: entry.reasoning,
+    thinking_values: [...entry.thinking_values],
+    ...(entry.default_thinking_value !== undefined
+      ? { default_thinking_value: entry.default_thinking_value }
+      : {}),
+    input_modalities: [...entry.input_modalities],
+  };
+}

--- a/desktop/src/components/auth/AuthPanel.test.mjs
+++ b/desktop/src/components/auth/AuthPanel.test.mjs
@@ -57,15 +57,22 @@ test("runtime auth panel keeps model provider settings compact", async () => {
   assert.match(source, /applyBackgroundTaskProviderSelection/);
   assert.match(source, /applyRecallEmbeddingsProviderSelection/);
   assert.match(source, /applyImageGenerationProviderSelection/);
+  assert.match(source, /function providerCatalogChatModelOptions\(/);
+  assert.match(source, /function toggleProviderDraftModel\(/);
+  assert.match(source, /function removeProviderDraftModel\(/);
+  assert.match(source, /import \{ Switch \} from "@\/components\/ui\/switch";/);
+  assert.match(source, /<Switch\s+checked=\{selected\}/);
+  assert.match(source, /aria-label=\{`Toggle \$\{option\.label\}`\}/);
+  assert.match(source, /catalogModelOptions\.map\(\(option\) => \{/);
+  assert.match(source, /selected \? "On" : "Off"/);
+  assert.match(source, /Select at least one configured model before saving\./);
+  assert.match(source, /Some saved models are not in the local catalog\./);
   assert.match(source, /const AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME =/);
   assert.match(source, /hover:border-border\/65/);
   assert.match(source, /overflow-hidden/);
   assert.match(source, /focus-visible:ring-0/);
-  assert.match(source, /const backgroundTaskUsesManagedModelPicker = backgroundTasksDraft\.providerId === "holaboss";/);
   assert.match(source, /const backgroundTaskModelOptions = uniqueValues\(\[/);
-  assert.match(source, /const recallEmbeddingsUsesManagedModelPicker = recallEmbeddingsDraft\.providerId === "holaboss";/);
   assert.match(source, /const recallEmbeddingsModelOptions = uniqueValues\(\[/);
-  assert.match(source, /const imageGenerationUsesManagedModelPicker = imageGenerationDraft\.providerId === "holaboss";/);
   assert.match(source, /const imageGenerationModelOptions = uniqueValues\(\[/);
   assert.match(source, /setShowAdvancedRuntimeSettings\(\(current\) => !current\)/);
   assert.match(source, /const advancedSettingsWarnings = \[/);
@@ -73,12 +80,12 @@ test("runtime auth panel keeps model provider settings compact", async () => {
   assert.match(source, /if \(backgroundTasksDraft\.providerId === "holaboss"\) \{\s*setBackgroundTasksDraft\(\{ providerId: "", model: "" \}\);\s*\}/);
   assert.match(source, /if \(recallEmbeddingsDraft\.providerId === "holaboss"\) \{\s*setRecallEmbeddingsDraft\(\{ providerId: "", model: "" \}\);\s*\}/);
   assert.match(source, /if \(imageGenerationDraft\.providerId === "holaboss"\) \{\s*setImageGenerationDraft\(\{ providerId: "", model: "" \}\);\s*\}/);
-  assert.match(source, /backgroundTaskUsesManagedModelPicker \? \(/);
-  assert.match(source, /recallEmbeddingsUsesManagedModelPicker \? \(/);
   assert.match(source, /backgroundTaskModelOptions\.map\(\(modelId\) => \(/);
   assert.match(source, /recallEmbeddingsModelOptions\.map\(\(modelId\) => \(/);
-  assert.match(source, /imageGenerationUsesManagedModelPicker \? \(/);
   assert.match(source, /imageGenerationModelOptions\.map\(\(modelId\) => \(/);
+  assert.match(source, /!backgroundTasksDraft\.providerId \|\|\s*backgroundTaskModelOptions\.length === 0/);
+  assert.match(source, /!recallEmbeddingsDraft\.providerId \|\|\s*recallEmbeddingsModelOptions\.length === 0/);
+  assert.match(source, /!imageGenerationDraft\.providerId \|\|\s*imageGenerationModelOptions\.length === 0/);
   assert.match(source, /if \(\s*isProviderDraftDirty \|\|\s*recallEmbeddingsDraft\.providerId \|\|\s*connectedRecallEmbeddingProviderIds\.length === 0\s*\) \{\s*return;\s*\}/);
   assert.match(source, /applyRecallEmbeddingsProviderSelection\(connectedRecallEmbeddingProviderIds\[0\] \?\? ""\);/);
   assert.match(source, /Selected provider is not connected\. Background tasks stay disabled until you reconnect it or choose another provider\./);
@@ -98,6 +105,9 @@ test("runtime auth panel keeps model provider settings compact", async () => {
   assert.doesNotMatch(source, /Edit settings, then click Save changes\./);
   assert.doesNotMatch(source, /Reload settings/);
   assert.doesNotMatch(source, /This provider will be disconnected when you save changes\./);
+  assert.doesNotMatch(source, /<textarea/);
+  assert.doesNotMatch(source, /<datalist/);
+  assert.doesNotMatch(source, /set one manually in Advanced settings/);
   assert.match(source, /const setupLoadingPanel = \(/);
   assert.match(source, /Refreshing desktop connection\.\.\.|Connecting your account\.\.\./);
   assert.match(source, /Finalizing your desktop session and runtime binding\. This should only take a moment\./);
@@ -268,7 +278,13 @@ test("holaboss proxy models come from the managed runtime catalog instead of loc
   assert.match(source, /function runtimeProviderStorageId\(/);
   assert.match(source, /providerId === "holaboss" \? "holaboss_model_proxy" : providerId/);
   assert.match(source, /return \["openai\/", "google\/", "anthropic\/", "holaboss\/", "holaboss_model_proxy\/"\]/);
+  assert.match(source, /function holabossSupportedModels\(/);
+  assert.match(source, /runtimeCatalogModelSupportsCapability\(model, "chat"\)/);
   assert.match(source, /Catalog, base URL, and credentials come from your Holaboss runtime binding\./);
+  assert.match(source, /Supported models/);
+  assert.match(source, /No managed models are available yet\. Refresh your runtime binding to load the latest Holaboss catalog\./);
+  assert.match(source, /providerId === "holaboss_model_proxy"/);
+  assert.match(source, /\{isExpanded \? "Hide" : "Show"\}/);
   assert.doesNotMatch(source, /Managed and ready on this desktop\. Expand to edit the background tasks model\./);
 });
 
@@ -321,7 +337,7 @@ test("direct Anthropic, OpenRouter, and Gemini defaults advertise current provid
 
   assert.match(
     openrouterTemplate,
-    /defaultModels: \["openai\/gpt-5\.4", "anthropic\/claude-sonnet-4-6"\]/,
+    /defaultModels: \["openai\/gpt-5\.4", "anthropic\/claude-sonnet-4-6", "qwen\/qwen3\.6-plus"\]/,
   );
   assert.match(openrouterTemplate, /defaultBackgroundModel: "openai\/gpt-5\.4"/);
   assert.match(openrouterTemplate, /defaultImageModel: "google\/gemini-3\.1-flash-image-preview"/);

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -5,6 +5,7 @@ import {
   LogOut,
   RefreshCw,
   ShieldCheck,
+  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import anthropicLogoMarkup from "@/assets/providers/anthropic.svg?raw";
@@ -13,6 +14,7 @@ import minimaxLogoMarkup from "@/assets/providers/minimax.svg?raw";
 import ollamaLogoMarkup from "@/assets/providers/ollama.svg?raw";
 import openaiLogoMarkup from "@/assets/providers/openai.svg?raw";
 import openrouterLogoMarkup from "@/assets/providers/openrouter.svg?raw";
+import * as modelCatalog from "../../../shared/model-catalog.js";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import {
   useDesktopAuthSession,
   type AuthSession
@@ -44,6 +47,8 @@ const KNOWN_PROVIDER_ORDER = ["holaboss", "openai_direct", "anthropic_direct", "
 type KnownProviderId = (typeof KNOWN_PROVIDER_ORDER)[number];
 const AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME =
   "auth-settings-control theme-control-surface relative isolate h-9 w-full overflow-hidden rounded-[10px] border border-border/45 bg-muted px-2.5 text-sm text-foreground shadow-none transition-colors hover:border-border/65 focus-visible:border-border/65 focus-visible:ring-0 focus-visible:ring-transparent aria-invalid:border-border/45 aria-invalid:ring-0";
+const PROVIDER_ROW_ACTIONS_CLASS_NAME = "flex min-w-[224px] shrink-0 items-center justify-end gap-2";
+const PROVIDER_ROW_ACTION_ITEM_CLASS_NAME = "min-w-[104px] justify-center";
 const LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<string, Record<string, string>> = {
   anthropic_direct: {
     "claude-sonnet-4-5": "claude-sonnet-4-6"
@@ -181,7 +186,7 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
     description: "OpenRouter endpoint for provider-aggregated model access.",
     kind: "openrouter",
     defaultBaseUrl: "https://openrouter.ai/api/v1",
-    defaultModels: ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
+    defaultModels: ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6", "qwen/qwen3.6-plus"],
     defaultBackgroundModel: "openai/gpt-5.4",
     defaultImageModel: "google/gemini-3.1-flash-image-preview",
     imageModelSuggestions: ["google/gemini-3.1-flash-image-preview"],
@@ -362,6 +367,49 @@ function parseModelsText(value: string): string[] {
       .map((item) => item.trim())
       .filter(Boolean)
   );
+}
+
+function providerCatalogChatModelOptions(
+  providerId: KnownProviderId,
+): Array<{ modelId: string; label: string }> {
+  if (providerId === "holaboss") {
+    return [];
+  }
+  const providerCatalog = modelCatalog.PROVIDER_MODEL_CATALOG[providerId];
+  if (!providerCatalog) {
+    return [];
+  }
+  return providerCatalog.models.map((entry) => ({
+    modelId: entry.model_id,
+    label: entry.label?.trim() || entry.model_id,
+  }));
+}
+
+function providerModelDisplayLabel(
+  providerId: KnownProviderId,
+  modelId: string,
+): string {
+  return (
+    modelCatalog.catalogMetadataForProviderModel(providerId, modelId)?.label?.trim() ||
+    modelId
+  );
+}
+
+function holabossSupportedModels(
+  runtimeConfig: RuntimeConfigPayload | null,
+): Array<{ modelId: string; label: string }> {
+  const managedGroup = runtimeConfig?.providerModelGroups.find(
+    (group) => group.providerId === "holaboss_model_proxy",
+  );
+  if (!managedGroup) {
+    return [];
+  }
+  return managedGroup.models
+    .filter((model) => runtimeCatalogModelSupportsCapability(model, "chat"))
+    .map((model) => ({
+      modelId: model.modelId,
+      label: model.label?.trim() || model.modelId,
+    }));
 }
 
 function normalizeConfiguredProviderModelId(providerId: string, modelId: string): string {
@@ -1297,7 +1345,6 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     && !connectedProviderIds.includes(backgroundTasksDraft.providerId)
       ? [backgroundTasksDraft.providerId, ...connectedProviderIds]
       : connectedProviderIds;
-  const backgroundTaskUsesManagedModelPicker = backgroundTasksDraft.providerId === "holaboss";
   const backgroundTaskModelOptions = uniqueValues([
     backgroundTasksDraft.model.trim(),
     ...backgroundProviderSuggestions,
@@ -1312,7 +1359,6 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     recallEmbeddingsDraft.providerId,
     effectiveRuntimeConfig,
   );
-  const recallEmbeddingsUsesManagedModelPicker = recallEmbeddingsDraft.providerId === "holaboss";
   const recallEmbeddingsModelOptions = uniqueValues([
     recallEmbeddingsDraft.model.trim(),
     ...recallEmbeddingsProviderSuggestions,
@@ -1327,7 +1373,6 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   const imageGenerationProviderConnected =
     imageGenerationDraft.providerId !== "" &&
     connectedImageProviderIds.includes(imageGenerationDraft.providerId);
-  const imageGenerationUsesManagedModelPicker = imageGenerationDraft.providerId === "holaboss";
   const imageGenerationProviderSuggestions = imageGenerationModelSuggestions(
     imageGenerationDraft.providerId,
     effectiveRuntimeConfig,
@@ -1348,10 +1393,10 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   );
   const advancedSettingsWarnings = [
     !hasResolvableRecallEmbeddingsModel
-      ? "No embedding model can be resolved from the currently connected providers. Recall will stay on the slower staged path until you connect an embedding-capable provider or set one manually in Advanced settings."
+      ? "No embedding model can be resolved from the currently connected providers. Recall will stay on the slower staged path until you connect an embedding-capable provider or choose one in Advanced settings."
       : "",
     !hasResolvableImageGenerationModel
-      ? "No image generation model can be resolved from the currently connected providers. Image generation will stay disabled until you connect a provider with an image model or set one manually in Advanced settings."
+      ? "No image generation model can be resolved from the currently connected providers. Image generation will stay disabled until you connect a provider with an image model or choose one in Advanced settings."
       : "",
   ].filter(Boolean);
 
@@ -1536,6 +1581,37 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
       }
     }));
     markProviderSettingsDirty();
+  }
+
+  function updateProviderDraftModels(
+    providerId: KnownProviderId,
+    modelIds: string[],
+  ) {
+    updateProviderDraft(providerId, { modelsText: uniqueValues(modelIds).join(", ") });
+  }
+
+  function toggleProviderDraftModel(providerId: KnownProviderId, modelId: string) {
+    const normalizedModelId = modelId.trim();
+    if (!normalizedModelId) {
+      return;
+    }
+    const currentModelIds = parseModelsText(providerDrafts[providerId].modelsText);
+    updateProviderDraftModels(
+      providerId,
+      currentModelIds.includes(normalizedModelId)
+        ? currentModelIds.filter((currentModelId) => currentModelId !== normalizedModelId)
+        : [...currentModelIds, normalizedModelId],
+    );
+  }
+
+  function removeProviderDraftModel(providerId: KnownProviderId, modelId: string) {
+    const normalizedModelId = modelId.trim();
+    updateProviderDraftModels(
+      providerId,
+      parseModelsText(providerDrafts[providerId].modelsText).filter(
+        (currentModelId) => currentModelId !== normalizedModelId,
+      ),
+    );
   }
 
   function updateBackgroundTasksDraft(update: Partial<BackgroundTasksDraft>) {
@@ -1790,7 +1866,11 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             const token = `${providerId}/${modelId}`;
             nextModels[token] = {
               provider: providerId,
-              model: modelId
+              model: modelId,
+              ...(modelCatalog.catalogConfigShapeForProviderModel(
+                providerId,
+                modelId,
+              ) ?? {}),
             };
           }
         }
@@ -2082,11 +2162,40 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     const template = KNOWN_PROVIDER_TEMPLATES[providerId];
     const draft = providerDrafts[providerId];
     if (providerId === "holaboss") {
+      const supportedModels = holabossSupportedModels(effectiveRuntimeConfig);
       return (
         <div className="grid gap-2">
           <div className="rounded-[12px] border border-border/35 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
             Catalog, base URL, and credentials come from your Holaboss runtime binding.
           </div>
+          {supportedModels.length > 0 ? (
+            <div className="grid gap-2">
+              <div className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                Supported models
+              </div>
+              <div className="grid gap-1.5">
+                {supportedModels.map((option) => (
+                  <div
+                    key={option.modelId}
+                    className="rounded-[10px] border border-border/35 bg-card/70 px-2.5 py-1.5 text-left"
+                  >
+                    <div className="truncate text-[13px] font-medium leading-4 text-foreground">
+                      {option.label}
+                    </div>
+                    {option.label !== option.modelId ? (
+                      <div className="truncate pt-0.5 text-[10px] leading-4 text-muted-foreground">
+                        {option.modelId}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              No managed models are available yet. Refresh your runtime binding to load the latest Holaboss catalog.
+            </div>
+          )}
         </div>
       );
     }
@@ -2113,13 +2222,104 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
         </label>
         <label className="grid gap-1">
           <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Models</span>
-          <textarea
-            className="auth-settings-control theme-control-surface min-h-[60px] rounded-[10px] border border-border/45 px-2.5 py-2 text-sm leading-5 text-foreground outline-none transition"
-            value={draft.modelsText}
-            onChange={(event) => updateProviderDraft(providerId, { modelsText: event.target.value })}
-            placeholder={template.defaultModels.join(", ")}
-            spellCheck={false}
-          />
+          {(() => {
+            const selectedModelIds = parseModelsText(draft.modelsText);
+            const catalogModelOptions = providerCatalogChatModelOptions(providerId);
+            const unknownSelectedModelIds = selectedModelIds.filter(
+              (modelId) =>
+                !catalogModelOptions.some((option) => option.modelId === modelId),
+            );
+
+            return (
+              <div className="grid gap-2">
+                {catalogModelOptions.length > 0 ? (
+                  <div className="grid gap-2">
+                    <div className="grid gap-1.5">
+                      {catalogModelOptions.map((option) => {
+                        const selected = selectedModelIds.includes(option.modelId);
+                        return (
+                          <div
+                            key={option.modelId}
+                            className={`rounded-[10px] border px-2.5 py-1.5 text-left transition ${
+                              selected
+                                ? "border-primary/25 bg-primary/[0.06] text-foreground"
+                                : "border-border/35 bg-card/70 text-muted-foreground"
+                            }`}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="min-w-0 flex-1">
+                                <div className="truncate text-[13px] font-medium leading-4">
+                                  {option.label}
+                                </div>
+                                {option.label !== option.modelId ? (
+                                  <div className="truncate pt-0.5 text-[10px] leading-4 text-muted-foreground">
+                                    {option.modelId}
+                                  </div>
+                                ) : null}
+                              </div>
+                              <div className="flex shrink-0 items-center gap-1.5 pl-1">
+                                <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/80">
+                                  {selected ? "On" : "Off"}
+                                </span>
+                                <Switch
+                                  checked={selected}
+                                  aria-label={`Toggle ${option.label}`}
+                                  onCheckedChange={() =>
+                                    toggleProviderDraftModel(providerId, option.modelId)
+                                  }
+                                  className="mt-0.5"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                    Add models in <code>desktop/shared/model-catalog.ts</code> to configure this provider.
+                  </div>
+                )}
+
+                {selectedModelIds.length === 0 ? (
+                  <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                    Select at least one configured model before saving.
+                  </div>
+                ) : null}
+
+                {unknownSelectedModelIds.length > 0 ? (
+                  <div className="grid gap-2">
+                    <div className="text-xs leading-5 text-muted-foreground">
+                      Some saved models are not in the local catalog. Add them in{" "}
+                      <code>desktop/shared/model-catalog.ts</code> to make them selectable again.
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {unknownSelectedModelIds.map((modelId) => (
+                        <Badge
+                          key={modelId}
+                          variant="outline"
+                          className="flex items-center gap-1 border-border/45 bg-muted/35 pr-1 text-foreground"
+                        >
+                          <span className="max-w-[220px] truncate">
+                            {providerModelDisplayLabel(providerId, modelId)}
+                          </span>
+                          <button
+                            type="button"
+                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
+                            onClick={() => removeProviderDraftModel(providerId, modelId)}
+                            aria-label={`Remove ${modelId}`}
+                          >
+                            <X size={12} />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })()}
         </label>
         <div className="flex flex-wrap gap-2 pt-1">
           <Button
@@ -2166,16 +2366,31 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             <div className="text-sm font-medium text-foreground">{template.label}</div>
           </div>
 
-          <div className="flex shrink-0 items-center gap-2">
+          <div className={PROVIDER_ROW_ACTIONS_CLASS_NAME}>
             {isHolabossProvider ? (
               isConnected ? (
-                <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary">
-                  Enabled
-                </Badge>
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
+                    onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
+                    disabled={isSavingRuntimeConfigDocument}
+                  >
+                    {isExpanded ? "Hide" : "Show"}
+                  </Button>
+                  <Badge
+                    variant="outline"
+                    className={`border-primary/30 bg-primary/10 text-primary ${PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}`}
+                  >
+                    Enabled
+                  </Badge>
+                </>
               ) : (
                 <Button
                   variant="outline"
                   size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                   onClick={() => void handleStartSignIn()}
                   disabled={isStartingSignIn}
                 >
@@ -2187,6 +2402,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 <Button
                   variant="ghost"
                   size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                   onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
                   disabled={isSavingRuntimeConfigDocument}
                 >
@@ -2195,6 +2411,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 <Button
                   variant="ghost"
                   size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                   onClick={() => void handleDisconnectRuntimeProvider(providerId)}
                   disabled={isSavingRuntimeConfigDocument}
                 >
@@ -2206,6 +2423,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 <Button
                   variant="ghost"
                   size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                   onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
                   disabled={isSavingRuntimeConfigDocument}
                 >
@@ -2214,6 +2432,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 <Button
                   variant="ghost"
                   size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                   onClick={() => {
                     updateProviderDraft(providerId, { enabled: false });
                     setExpandedProviderId((current) => (current === providerId ? null : current));
@@ -2227,6 +2446,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
               <Button
                 variant="outline"
                 size="sm"
+                className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
                 onClick={() => {
                   updateProviderDraft(providerId, { enabled: true });
                   setExpandedProviderId(providerId);
@@ -2326,56 +2546,32 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
 
                       <label className="grid gap-1">
                         <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Model</span>
-                        {backgroundTaskUsesManagedModelPicker ? (
-                          <Select
-                            value={backgroundTasksDraft.model || undefined}
-                            onValueChange={(value) =>
-                              updateBackgroundTasksDraft({ model: value ?? "" })
-                            }
-                            disabled={!backgroundTasksDraft.providerId}
-                          >
-                            <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
-                              <SelectValue
-                                placeholder={backgroundTaskModelPlaceholder(
-                                  backgroundTasksDraft.providerId,
-                                  effectiveRuntimeConfig,
-                                )}
-                              />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {backgroundTaskModelOptions.map((modelId) => (
-                                <SelectItem key={modelId} value={modelId}>
-                                  {modelId}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        ) : (
-                          <>
-                            <Input
-                              value={backgroundTasksDraft.model}
-                              onChange={(event) => updateBackgroundTasksDraft({ model: event.target.value })}
+                        <Select
+                          value={backgroundTasksDraft.model || undefined}
+                          onValueChange={(value) =>
+                            updateBackgroundTasksDraft({ model: value ?? "" })
+                          }
+                          disabled={
+                            !backgroundTasksDraft.providerId ||
+                            backgroundTaskModelOptions.length === 0
+                          }
+                        >
+                          <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
+                            <SelectValue
                               placeholder={backgroundTaskModelPlaceholder(
                                 backgroundTasksDraft.providerId,
                                 effectiveRuntimeConfig,
                               )}
-                              spellCheck={false}
-                              list={
-                                backgroundTasksDraft.providerId
-                                  ? `background-task-models-${backgroundTasksDraft.providerId}`
-                                  : undefined
-                              }
-                              disabled={!backgroundTasksDraft.providerId}
                             />
-                            {backgroundTasksDraft.providerId ? (
-                              <datalist id={`background-task-models-${backgroundTasksDraft.providerId}`}>
-                                {backgroundProviderSuggestions.map((modelId) => (
-                                  <option key={modelId} value={modelId} />
-                                ))}
-                              </datalist>
-                            ) : null}
-                          </>
-                        )}
+                          </SelectTrigger>
+                          <SelectContent>
+                            {backgroundTaskModelOptions.map((modelId) => (
+                              <SelectItem key={modelId} value={modelId}>
+                                {modelId}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </label>
 
                       {backgroundTasksDraft.providerId && !backgroundProviderConnected ? (
@@ -2432,56 +2628,32 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
 
                       <label className="grid gap-1">
                         <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Model</span>
-                        {recallEmbeddingsUsesManagedModelPicker ? (
-                          <Select
-                            value={recallEmbeddingsDraft.model || undefined}
-                            onValueChange={(value) =>
-                              updateRecallEmbeddingsDraft({ model: value ?? "" })
-                            }
-                            disabled={!recallEmbeddingsDraft.providerId}
-                          >
-                            <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
-                              <SelectValue
-                                placeholder={recallEmbeddingsModelPlaceholder(
-                                  recallEmbeddingsDraft.providerId,
-                                  effectiveRuntimeConfig,
-                                )}
-                              />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {recallEmbeddingsModelOptions.map((modelId) => (
-                                <SelectItem key={modelId} value={modelId}>
-                                  {modelId}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        ) : (
-                          <>
-                            <Input
-                              value={recallEmbeddingsDraft.model}
-                              onChange={(event) => updateRecallEmbeddingsDraft({ model: event.target.value })}
+                        <Select
+                          value={recallEmbeddingsDraft.model || undefined}
+                          onValueChange={(value) =>
+                            updateRecallEmbeddingsDraft({ model: value ?? "" })
+                          }
+                          disabled={
+                            !recallEmbeddingsDraft.providerId ||
+                            recallEmbeddingsModelOptions.length === 0
+                          }
+                        >
+                          <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
+                            <SelectValue
                               placeholder={recallEmbeddingsModelPlaceholder(
                                 recallEmbeddingsDraft.providerId,
                                 effectiveRuntimeConfig,
                               )}
-                              spellCheck={false}
-                              list={
-                                recallEmbeddingsDraft.providerId
-                                  ? `recall-embedding-models-${recallEmbeddingsDraft.providerId}`
-                                  : undefined
-                              }
-                              disabled={!recallEmbeddingsDraft.providerId}
                             />
-                            {recallEmbeddingsDraft.providerId ? (
-                              <datalist id={`recall-embedding-models-${recallEmbeddingsDraft.providerId}`}>
-                                {recallEmbeddingsModelOptions.map((modelId) => (
-                                  <option key={modelId} value={modelId} />
-                                ))}
-                              </datalist>
-                            ) : null}
-                          </>
-                        )}
+                          </SelectTrigger>
+                          <SelectContent>
+                            {recallEmbeddingsModelOptions.map((modelId) => (
+                              <SelectItem key={modelId} value={modelId}>
+                                {modelId}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </label>
 
                       {recallEmbeddingsDraft.providerId && !recallEmbeddingsProviderConnected ? (
@@ -2535,56 +2707,32 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
 
                       <label className="grid gap-1">
                         <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Model</span>
-                        {imageGenerationUsesManagedModelPicker ? (
-                          <Select
-                            value={imageGenerationDraft.model || undefined}
-                            onValueChange={(value) =>
-                              updateImageGenerationDraft({ model: value ?? "" })
-                            }
-                            disabled={!imageGenerationDraft.providerId}
-                          >
-                            <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
-                              <SelectValue
-                                placeholder={imageGenerationModelPlaceholder(
-                                  imageGenerationDraft.providerId,
-                                  effectiveRuntimeConfig,
-                                )}
-                              />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {imageGenerationModelOptions.map((modelId) => (
-                                <SelectItem key={modelId} value={modelId}>
-                                  {modelId}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        ) : (
-                          <>
-                            <Input
-                              value={imageGenerationDraft.model}
-                              onChange={(event) => updateImageGenerationDraft({ model: event.target.value })}
+                        <Select
+                          value={imageGenerationDraft.model || undefined}
+                          onValueChange={(value) =>
+                            updateImageGenerationDraft({ model: value ?? "" })
+                          }
+                          disabled={
+                            !imageGenerationDraft.providerId ||
+                            imageGenerationModelOptions.length === 0
+                          }
+                        >
+                          <SelectTrigger className={AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME}>
+                            <SelectValue
                               placeholder={imageGenerationModelPlaceholder(
                                 imageGenerationDraft.providerId,
                                 effectiveRuntimeConfig,
                               )}
-                              spellCheck={false}
-                              list={
-                                imageGenerationDraft.providerId
-                                  ? `image-generation-models-${imageGenerationDraft.providerId}`
-                                  : undefined
-                              }
-                              disabled={!imageGenerationDraft.providerId}
                             />
-                            {imageGenerationDraft.providerId ? (
-                              <datalist id={`image-generation-models-${imageGenerationDraft.providerId}`}>
-                                {imageGenerationProviderSuggestions.map((modelId) => (
-                                  <option key={modelId} value={modelId} />
-                                ))}
-                              </datalist>
-                            ) : null}
-                          </>
-                        )}
+                          </SelectTrigger>
+                          <SelectContent>
+                            {imageGenerationModelOptions.map((modelId) => (
+                              <SelectItem key={modelId} value={modelId}>
+                                {modelId}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </label>
 
                       {imageGenerationDraft.providerId && !imageGenerationProviderConnected ? (

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -44,6 +44,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import {
   EXPLORER_ATTACHMENT_DRAG_TYPE,
@@ -59,6 +66,7 @@ import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
 import { preferredSessionId } from "@/lib/sessionRouting";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+import * as modelCatalog from "../../../shared/model-catalog.js";
 
 type ChatAttachment = SessionInputAttachmentPayload;
 type ChatPaneVariant = "default" | "onboarding";
@@ -188,6 +196,7 @@ const TOOL_TRACE_TERMINAL_PHASES = new Set(["completed", "failed", "error"]);
 const CHAT_AUTO_SCROLL_THRESHOLD_PX = 72;
 const CHAT_SCROLLBAR_MIN_THUMB_HEIGHT_PX = 40;
 const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
+const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
 const LEGACY_UNAVAILABLE_CHAT_MODELS = new Set(["openai/gpt-5.2-mini"]);
 const DEPRECATED_CHAT_MODELS = new Set([
@@ -335,6 +344,58 @@ function loadStoredChatModelPreference() {
   }
 }
 
+function normalizeStoredChatThinkingPreferences(
+  value: string | null | undefined,
+): Record<string, string> {
+  if (!value) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (!isRecord(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+        .map(([key, rawValue]) => [key.trim(), rawValue.trim()])
+        .filter(([key, rawValue]) => Boolean(key) && Boolean(rawValue)),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function loadStoredChatThinkingPreferences() {
+  try {
+    return normalizeStoredChatThinkingPreferences(
+      localStorage.getItem(CHAT_THINKING_STORAGE_KEY),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function runtimeModelThinkingValues(model: RuntimeProviderModelPayload) {
+  if (!Array.isArray(model.thinkingValues)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const values: string[] = [];
+  for (const value of model.thinkingValues) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    values.push(normalized);
+  }
+  return values;
+}
+
 function displayModelLabel(model: string) {
   const trimmed = model.trim();
   if (!trimmed) {
@@ -367,6 +428,10 @@ function displayModelLabel(model: string) {
         : `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`,
     )
     .join(" ");
+}
+
+function runtimeModelDisplayLabel(model: RuntimeProviderModelPayload) {
+  return model.label?.trim() || displayModelLabel(model.modelId || model.token);
 }
 
 function normalizeChatAttachment(value: unknown): ChatAttachment | null {
@@ -1845,6 +1910,9 @@ export function ChatPane({
   const [chatModelPreference, setChatModelPreference] = useState(
     loadStoredChatModelPreference,
   );
+  const [chatThinkingPreferences, setChatThinkingPreferences] = useState(
+    loadStoredChatThinkingPreferences,
+  );
   const [isHistoryViewportPending, setIsHistoryViewportPending] =
     useState(false);
   const [
@@ -2780,6 +2848,17 @@ export function ChatPane({
       // ignore persistence failures
     }
   }, [chatModelPreference]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        CHAT_THINKING_STORAGE_KEY,
+        JSON.stringify(chatThinkingPreferences),
+      );
+    } catch {
+      // ignore persistence failures
+    }
+  }, [chatThinkingPreferences]);
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -3889,6 +3968,7 @@ export function ChatPane({
         session_id: targetSessionId,
         priority: 0,
         model: resolvedChatModel || null,
+        thinking_value: effectiveThinkingValue,
       });
       setActiveSession(queued.session_id);
       pendingInputIdRef.current = queued.input_id;
@@ -4187,7 +4267,7 @@ export function ChatPane({
   const providerModelLabelCounts = new Map<string, number>();
   for (const providerGroup of visibleConfiguredProviderModelGroups) {
     for (const model of providerGroup.models) {
-      const modelLabel = displayModelLabel(model.modelId || model.token);
+      const modelLabel = runtimeModelDisplayLabel(model);
       providerModelLabelCounts.set(
         modelLabel,
         (providerModelLabelCounts.get(modelLabel) ?? 0) + 1,
@@ -4209,7 +4289,7 @@ export function ChatPane({
       ? visibleConfiguredProviderModelGroups.map((providerGroup) => ({
           label: providerGroup.providerLabel,
           options: providerGroup.models.map((model) => {
-            const modelLabel = displayModelLabel(model.modelId || model.token);
+            const modelLabel = runtimeModelDisplayLabel(model);
             const needsProviderPrefix =
               visibleConfiguredProviderModelGroups.length > 1 &&
               (providerModelLabelCounts.get(modelLabel) ?? 0) > 1;
@@ -4281,10 +4361,64 @@ export function ChatPane({
         : ""
       : effectiveChatModelPreference.trim() ||
         (runtimeDefaultModelAvailable ? runtimeDefaultModel : "");
+  const selectedConfiguredModel =
+    visibleConfiguredProviderModelGroups
+      .flatMap((providerGroup) => providerGroup.models)
+      .find((model) => model.token === resolvedChatModel) ?? null;
   const selectedManagedProviderGroup =
     visibleConfiguredProviderModelGroups.find((providerGroup) =>
       providerGroup.models.some((model) => model.token === resolvedChatModel),
     );
+  const selectedFallbackModelMetadata =
+    !selectedConfiguredModel &&
+    !hasConfiguredProviderCatalog &&
+    holabossProxyModelsAvailable &&
+    resolvedChatModel
+      ? modelCatalog.catalogMetadataForProviderModel(
+          "holaboss_model_proxy",
+          resolvedChatModel,
+        )
+      : null;
+  const selectedModelSupportsReasoning = selectedConfiguredModel
+    ? selectedConfiguredModel.reasoning === true
+    : Boolean(selectedFallbackModelMetadata?.reasoning);
+  const selectedThinkingValues = selectedConfiguredModel
+    ? runtimeModelThinkingValues(selectedConfiguredModel)
+    : selectedFallbackModelMetadata?.thinkingValues ?? [];
+  const selectedDefaultThinkingValue = selectedConfiguredModel
+    ? selectedConfiguredModel.defaultThinkingValue?.trim() || null
+    : selectedFallbackModelMetadata?.defaultThinkingValue ?? null;
+  const selectedStoredThinkingValue = resolvedChatModel
+    ? (chatThinkingPreferences[resolvedChatModel] ?? "").trim()
+    : "";
+  const effectiveThinkingValue =
+    !selectedModelSupportsReasoning || selectedThinkingValues.length === 0
+      ? null
+      : selectedThinkingValues.includes(selectedStoredThinkingValue)
+        ? selectedStoredThinkingValue
+        : selectedThinkingValues.includes("medium")
+          ? "medium"
+          : selectedDefaultThinkingValue &&
+              selectedThinkingValues.includes(selectedDefaultThinkingValue)
+            ? selectedDefaultThinkingValue
+            : selectedThinkingValues[0] ?? null;
+  const showThinkingValueSelector =
+    !isOnboardingVariant &&
+    selectedModelSupportsReasoning &&
+    selectedThinkingValues.length > 0;
+  const setSelectedThinkingValue = (value: string | null) => {
+    if (!resolvedChatModel) {
+      return;
+    }
+    const normalizedValue = value?.trim() ?? "";
+    if (!normalizedValue) {
+      return;
+    }
+    setChatThinkingPreferences((current) => ({
+      ...current,
+      [resolvedChatModel]: normalizedValue,
+    }));
+  };
   const usesHostedManagedCredits =
     hasHostedBillingAccount &&
     (hasConfiguredProviderCatalog
@@ -4321,6 +4455,21 @@ export function ChatPane({
     }
     setChatModelPreference(effectiveChatModelPreference);
   }, [chatModelPreference, effectiveChatModelPreference]);
+
+  useEffect(() => {
+    if (!resolvedChatModel || !effectiveThinkingValue) {
+      return;
+    }
+    setChatThinkingPreferences((current) => {
+      if ((current[resolvedChatModel] ?? "") === effectiveThinkingValue) {
+        return current;
+      }
+      return {
+        ...current,
+        [resolvedChatModel]: effectiveThinkingValue,
+      };
+    });
+  }, [effectiveThinkingValue, resolvedChatModel]);
 
   const textareaPlaceholder = isOnboardingVariant
     ? "Answer the onboarding prompt or share setup details"
@@ -4776,12 +4925,16 @@ export function ChatPane({
                         runtimeDefaultModelAvailable={
                           runtimeDefaultModelAvailable
                         }
+                        selectedThinkingValue={effectiveThinkingValue}
+                        thinkingValues={selectedThinkingValues}
+                        showThinkingValueSelector={showThinkingValueSelector}
                         modelSelectionUnavailableReason={
                           modelSelectionUnavailableReason
                         }
                         placeholder={textareaPlaceholder}
                         showModelSelector={!isOnboardingVariant}
                         onModelChange={setChatModelPreference}
+                        onThinkingValueChange={setSelectedThinkingValue}
                         onOpenModelProviders={() =>
                           void window.electronAPI.ui.openSettingsPane(
                             "providers",
@@ -4886,12 +5039,16 @@ export function ChatPane({
                     modelOptions={availableChatModelOptions}
                     modelOptionGroups={availableChatModelOptionGroups}
                     runtimeDefaultModelAvailable={runtimeDefaultModelAvailable}
+                    selectedThinkingValue={effectiveThinkingValue}
+                    thinkingValues={selectedThinkingValues}
+                    showThinkingValueSelector={showThinkingValueSelector}
                     modelSelectionUnavailableReason={
                       modelSelectionUnavailableReason
                     }
                     placeholder={textareaPlaceholder}
                     showModelSelector={!isOnboardingVariant}
                     onModelChange={setChatModelPreference}
+                    onThinkingValueChange={setSelectedThinkingValue}
                     onOpenModelProviders={() =>
                       void window.electronAPI.ui.openSettingsPane("providers")
                     }
@@ -5143,10 +5300,14 @@ interface ComposerProps {
   modelOptions: ChatModelOption[];
   modelOptionGroups: ChatModelOptionGroup[];
   runtimeDefaultModelAvailable: boolean;
+  selectedThinkingValue: string | null;
+  thinkingValues: string[];
+  showThinkingValueSelector: boolean;
   modelSelectionUnavailableReason: string;
   placeholder: string;
   showModelSelector: boolean;
   onModelChange: (value: string) => void;
+  onThinkingValueChange: (value: string | null) => void;
   onOpenModelProviders: () => void;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   fileInputRef: RefObject<HTMLInputElement | null>;
@@ -6351,6 +6512,41 @@ function ModelCombobox({
   );
 }
 
+function ThinkingValueSelect({
+  selectedThinkingValue,
+  thinkingValues,
+  disabled,
+  onThinkingValueChange,
+}: {
+  selectedThinkingValue: string | null;
+  thinkingValues: string[];
+  disabled: boolean;
+  onThinkingValueChange: (value: string | null) => void;
+}) {
+  if (thinkingValues.length === 0 || !selectedThinkingValue) {
+    return null;
+  }
+
+  return (
+    <Select
+      value={selectedThinkingValue}
+      onValueChange={onThinkingValueChange}
+      disabled={disabled}
+    >
+      <SelectTrigger className="h-11 rounded-[11px] bg-card text-xs font-medium">
+        <SelectValue placeholder="Thinking" />
+      </SelectTrigger>
+      <SelectContent side="top" align="end">
+        {thinkingValues.map((value) => (
+          <SelectItem key={value} value={value} className="text-xs">
+            {value}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
 function Composer({
   input,
   attachments,
@@ -6365,10 +6561,14 @@ function Composer({
   modelOptions,
   modelOptionGroups,
   runtimeDefaultModelAvailable,
+  selectedThinkingValue,
+  thinkingValues,
+  showThinkingValueSelector,
   modelSelectionUnavailableReason,
   placeholder,
   showModelSelector,
   onModelChange,
+  onThinkingValueChange,
   onOpenModelProviders,
   textareaRef,
   fileInputRef,
@@ -6511,13 +6711,13 @@ function Composer({
         />
       </div>
 
-      <div className="flex items-center justify-between gap-2 border-t border-border/20 px-3 py-3 text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-3 border-t border-border/20 px-3 py-3 text-muted-foreground">
         {showModelSelector ? (
           <div
             className={
               noAvailableModels
-                ? "min-w-0 flex flex-1 items-center gap-3"
-                : "w-[172px] shrink-0 sm:w-[208px]"
+                ? "min-w-0 basis-full flex flex-wrap items-center gap-3 sm:flex-1 sm:flex-nowrap"
+                : "min-w-0 grow basis-[172px] sm:max-w-[208px] sm:basis-[208px] sm:grow-0"
             }
           >
             {noAvailableModels ? (
@@ -6560,12 +6760,23 @@ function Composer({
             )}
           </div>
         ) : (
-          <div className="text-[11px] leading-6 text-muted-foreground">
+          <div className="min-w-0 flex-1 text-[11px] leading-6 text-muted-foreground">
             Responses here stay in the workspace onboarding thread.
           </div>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
+        {showThinkingValueSelector ? (
+          <div className="min-w-[112px] shrink-0 sm:w-[112px]">
+            <ThinkingValueSelect
+              selectedThinkingValue={selectedThinkingValue}
+              thinkingValues={thinkingValues}
+              disabled={isResponding}
+              onThinkingValueChange={onThinkingValueChange}
+            />
+          </div>
+        ) : null}
+
+        <div className="ml-auto flex shrink-0 items-center gap-2">
           <Button
             variant="outline"
             size="icon"

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -206,6 +206,11 @@ declare global {
   interface RuntimeProviderModelPayload {
     token: string;
     modelId: string;
+    label?: string;
+    reasoning?: boolean;
+    thinkingValues?: string[];
+    defaultThinkingValue?: string | null;
+    inputModalities?: ("text" | "image" | "audio" | "video")[];
     capabilities?: string[];
   }
 
@@ -987,6 +992,7 @@ declare global {
     idempotency_key?: string | null;
     priority?: number;
     model?: string | null;
+    thinking_value?: string | null;
   }
 
   interface HolabossStreamSessionOutputsPayload {

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -17,5 +17,5 @@
     },
     "types": ["vite/client", "node"]
   },
-  "include": ["src", "electron", "vite.config.ts", "tailwind.config.ts"]
+  "include": ["src", "electron", "shared", "vite.config.ts", "tailwind.config.ts"]
 }

--- a/runtime/api-server/src/agent-runtime-config.test.ts
+++ b/runtime/api-server/src/agent-runtime-config.test.ts
@@ -1227,7 +1227,9 @@ test("projectAgentRuntimeConfig keeps direct OpenRouter providers on the provide
         base_url: "https://openrouter.ai/api/v1",
         api_key: "or-key",
         headers: {
-          "HTTP-Referer": "https://holaboss.ai"
+          "HTTP-Referer": "https://override.example",
+          "X-Title": "Legacy Title",
+          "X-Test": "1"
         }
       }
     },
@@ -1280,6 +1282,9 @@ test("projectAgentRuntimeConfig keeps direct OpenRouter providers on the provide
   assert.equal(result.model_client.api_key, "or-key");
   assert.equal(result.model_client.base_url, "https://openrouter.ai/api/v1");
   assert.deepEqual(result.model_client.default_headers, {
-    "HTTP-Referer": "https://holaboss.ai"
+    "X-Test": "1",
+    "HTTP-Referer": "https://holaboss.ai",
+    "X-OpenRouter-Title": "holaOS",
+    "X-OpenRouter-Categories": "personal-agent,general-chat"
   });
 });

--- a/runtime/api-server/src/agent-runtime-config.test.ts
+++ b/runtime/api-server/src/agent-runtime-config.test.ts
@@ -1004,6 +1004,137 @@ test("resolveRuntimeModelClient routes managed Holaboss Gemini models to the ded
   assert.equal(resolved.modelClient.base_url, "https://proxy.example/api/v1/model-proxy/google/v1");
 });
 
+test("resolveRuntimeModelClient routes managed Holaboss Claude models to the dedicated Anthropic proxy path", () => {
+  const root = makeTempDir("hb-agent-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = writeRuntimeConfigDocument(root, {
+    runtime: {
+      default_provider: "holaboss_model_proxy"
+    },
+    providers: {
+      holaboss_model_proxy: {
+        kind: "holaboss_proxy",
+        base_url: "https://proxy.example/api/v1/model-proxy",
+        api_key: "hb-token"
+      }
+    }
+  });
+
+  const resolved = resolveRuntimeModelClient({
+    selectedModel: "holaboss_model_proxy/claude-sonnet-4-6",
+    defaultProviderId: "holaboss_model_proxy",
+    sessionId: "session-1",
+    workspaceId: "workspace-1",
+    inputId: "input-1"
+  });
+
+  assert.equal(resolved.providerId, "anthropic");
+  assert.equal(resolved.configuredProviderId, "holaboss_model_proxy");
+  assert.equal(resolved.modelId, "claude-sonnet-4-6");
+  assert.equal(resolved.modelProxyProvider, "anthropic_native");
+  assert.equal(resolved.modelClient.model_proxy_provider, "anthropic_native");
+  assert.equal(resolved.modelClient.api_key, "hb-token");
+  assert.equal(resolved.modelClient.base_url, "https://proxy.example/api/v1/model-proxy/anthropic/v1");
+});
+
+test("resolveRuntimeModelClient accepts namespaced Holaboss OpenRouter model ids and routes them through the OpenAI-compatible proxy path", () => {
+  const root = makeTempDir("hb-agent-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = writeRuntimeConfigDocument(root, {
+    runtime: {
+      default_provider: "holaboss_model_proxy"
+    },
+    providers: {
+      holaboss_model_proxy: {
+        kind: "holaboss_proxy",
+        base_url: "https://proxy.example/api/v1/model-proxy",
+        api_key: "hb-token"
+      }
+    },
+    models: {
+      "holaboss_model_proxy/xiaomi/mimo-v2-pro": {
+        provider_id: "holaboss_model_proxy",
+        model_id: "xiaomi/mimo-v2-pro"
+      }
+    }
+  });
+
+  const resolved = resolveRuntimeModelClient({
+    selectedModel: "holaboss_model_proxy/xiaomi/mimo-v2-pro",
+    defaultProviderId: "holaboss_model_proxy",
+    sessionId: "session-1",
+    workspaceId: "workspace-1",
+    inputId: "input-1"
+  });
+
+  assert.equal(resolved.providerId, "openai");
+  assert.equal(resolved.configuredProviderId, "holaboss_model_proxy");
+  assert.equal(resolved.modelId, "xiaomi/mimo-v2-pro");
+  assert.equal(resolved.modelProxyProvider, "openai_compatible");
+  assert.equal(resolved.modelClient.model_proxy_provider, "openai_compatible");
+  assert.equal(resolved.modelClient.api_key, "hb-token");
+  assert.equal(resolved.modelClient.base_url, "https://proxy.example/api/v1/model-proxy/openai/v1");
+});
+
+test("projectAgentRuntimeConfig preserves namespaced Holaboss OpenRouter model ids from persisted runtime config", () => {
+  const root = makeTempDir("hb-agent-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = writeRuntimeConfigDocument(root, {
+    runtime: {
+      sandbox_id: "sandbox-from-runtime",
+      default_provider: "holaboss_model_proxy"
+    },
+    providers: {
+      holaboss_model_proxy: {
+        kind: "holaboss_proxy",
+        base_url: "https://proxy.example/api/v1/model-proxy",
+        api_key: "hb-token"
+      }
+    },
+    models: {
+      "holaboss_model_proxy/xiaomi/mimo-v2-pro": {
+        provider_id: "holaboss_model_proxy",
+        model_id: "xiaomi/mimo-v2-pro"
+      }
+    }
+  });
+
+  const result = projectAgentRuntimeConfig({
+    session_id: "session-1",
+    workspace_id: "workspace-1",
+    input_id: "input-1",
+    session_kind: "workspace_session",
+    harness_id: "pi",
+    browser_tools_available: false,
+    browser_tool_ids: [],
+    runtime_tool_ids: [],
+    workspace_command_ids: [],
+    runtime_exec_model_proxy_api_key: "hb-runtime-token",
+    runtime_exec_sandbox_id: "sandbox-from-exec-context",
+    runtime_exec_run_id: "run-1",
+    selected_model: "holaboss_model_proxy/xiaomi/mimo-v2-pro",
+    default_provider_id: "holaboss_model_proxy",
+    session_mode: "code",
+    workspace_config_checksum: "checksum-1",
+    workspace_skill_ids: [],
+    default_tools: ["read"],
+    extra_tools: [],
+    resolved_mcp_tool_refs: [],
+    resolved_output_schemas: {},
+    agent: {
+      id: "workspace.general",
+      model: "gpt-5.2",
+      prompt: "You are concise."
+    }
+  });
+
+  assert.equal(result.provider_id, "openai");
+  assert.equal(result.model_id, "xiaomi/mimo-v2-pro");
+  assert.equal(result.model_client.model_proxy_provider, "openai_compatible");
+  assert.equal(result.model_client.api_key, "hb-runtime-token");
+  assert.equal(result.model_client.base_url, "https://proxy.example/api/v1/model-proxy/openai/v1");
+});
+
 test("resolveRuntimeModelReference infers bare Gemini models as Google-compatible without configured providers", () => {
   const root = makeTempDir("hb-agent-runtime-config-");
   process.env.HB_SANDBOX_ROOT = root;

--- a/runtime/api-server/src/agent-runtime-config.ts
+++ b/runtime/api-server/src/agent-runtime-config.ts
@@ -327,7 +327,6 @@ function modelProxyProviderForConfiguredProvider(provider: ConfiguredRuntimeProv
 function providerRequiresUnscopedModelId(kind: string): boolean {
   const normalizedKind = kind.trim().toLowerCase();
   return (
-    normalizedKind === PROVIDER_KIND_HOLABOSS_PROXY ||
     normalizedKind === PROVIDER_KIND_OPENAI_COMPATIBLE ||
     normalizedKind === PROVIDER_KIND_ANTHROPIC_NATIVE
   );

--- a/runtime/api-server/src/agent-runtime-config.ts
+++ b/runtime/api-server/src/agent-runtime-config.ts
@@ -139,6 +139,15 @@ const DIRECT_OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY";
 const DIRECT_OPENROUTER_BASE_URL_ENV = "OPENROUTER_BASE_URL";
 const DEFAULT_DIRECT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_DIRECT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const OPENROUTER_ATTRIBUTION_REFERER = "https://holaboss.ai";
+const OPENROUTER_ATTRIBUTION_TITLE = "holaOS";
+const OPENROUTER_ATTRIBUTION_CATEGORIES = "personal-agent,general-chat";
+const OPENROUTER_ATTRIBUTION_HEADER_NAMES = new Set([
+  "http-referer",
+  "x-title",
+  "x-openrouter-title",
+  "x-openrouter-categories"
+]);
 const KNOWN_DIRECT_PROVIDER_HOSTS = new Set(["api.openai.com", "api.anthropic.com"]);
 const GEMINI_OPENAI_COMPAT_HOST = "generativelanguage.googleapis.com";
 const GEMINI_OPENAI_COMPAT_PATH = "/v1beta/openai";
@@ -229,6 +238,21 @@ function asStringRecord(value: unknown): Record<string, string> {
     entries.push([normalizedKey, normalizedValue]);
   }
   return Object.fromEntries(entries);
+}
+
+function withOpenRouterAttributionHeaders(kind: string, headers: Record<string, string>): Record<string, string> {
+  if (kind.trim().toLowerCase() !== PROVIDER_KIND_OPENROUTER) {
+    return headers;
+  }
+  const sanitizedEntries = Object.entries(headers).filter(
+    ([key]) => !OPENROUTER_ATTRIBUTION_HEADER_NAMES.has(key.trim().toLowerCase())
+  );
+  return {
+    ...Object.fromEntries(sanitizedEntries),
+    "HTTP-Referer": OPENROUTER_ATTRIBUTION_REFERER,
+    "X-OpenRouter-Title": OPENROUTER_ATTRIBUTION_TITLE,
+    "X-OpenRouter-Categories": OPENROUTER_ATTRIBUTION_CATEGORIES
+  };
 }
 
 function normalizeProviderKind(rawKind: string, providerId: string, baseUrl: string): string {
@@ -430,10 +454,6 @@ function configuredRuntimeModelCatalog(defaultProviderHint: string): RuntimeMode
       options.authToken as string | undefined,
       options.auth_token as string | undefined
     );
-    const headers = {
-      ...asStringRecord(providerPayload.headers),
-      ...asStringRecord(options.headers)
-    };
     const routes = {
       ...asStringRecord(providerPayload.routes),
       ...asStringRecord(options.routes)
@@ -447,6 +467,10 @@ function configuredRuntimeModelCatalog(defaultProviderHint: string): RuntimeMode
       providerId,
       baseUrl
     );
+    const headers = withOpenRouterAttributionHeaders(kind, {
+      ...asStringRecord(providerPayload.headers),
+      ...asStringRecord(options.headers)
+    });
     providers.set(providerId, {
       id: providerId,
       kind,

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -733,11 +733,16 @@ test("runtime image generation tool uses OpenRouter chat image generation for op
   const originalFetch = globalThis.fetch;
   let recordedUrl = "";
   let recordedRequestBody: Record<string, unknown> | null = null;
+  let recordedHeaders: Record<string, string> | null = null;
   globalThis.fetch = (async (input, init) => {
     recordedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     recordedRequestBody =
       typeof init?.body === "string"
         ? (JSON.parse(init.body) as Record<string, unknown>)
+        : null;
+    recordedHeaders =
+      init?.headers && typeof init.headers === "object" && !Array.isArray(init.headers)
+        ? Object.fromEntries(Object.entries(init.headers as Record<string, string>))
         : null;
     return new Response(
       JSON.stringify({
@@ -785,6 +790,13 @@ test("runtime image generation tool uses OpenRouter chat image generation for op
     assert.equal(response.statusCode, 200);
     assert.equal(recordedUrl, "https://openrouter.ai/api/v1/chat/completions");
     assert.ok(recordedRequestBody);
+    assert.deepEqual(recordedHeaders, {
+      "Content-Type": "application/json",
+      Authorization: "Bearer sk-or-test",
+      "HTTP-Referer": "https://holaboss.ai",
+      "X-OpenRouter-Title": "holaOS",
+      "X-OpenRouter-Categories": "personal-agent,general-chat",
+    });
     assert.deepEqual(recordedRequestBody, {
       model: "google/gemini-3.1-flash-image-preview",
       messages: [

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -4286,6 +4286,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         attachments,
         image_urls: Array.isArray(request.body.image_urls) ? request.body.image_urls : [],
         model: nullableString(request.body.model) ?? null,
+        thinking_value: nullableString(request.body.thinking_value) ?? null,
         context: {}
       }
     });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -794,6 +794,7 @@ export async function processClaimedInput(params: {
     attachments,
     context: runtimeContext,
     model: record.payload.model ?? null,
+    thinking_value: record.payload.thinking_value ?? null,
     debug: false
   };
   const memoryWritebackModelContext = writebackModelContext({

--- a/runtime/api-server/src/image-generation-model.test.ts
+++ b/runtime/api-server/src/image-generation-model.test.ts
@@ -198,7 +198,11 @@ test("image generation model client resolves OpenRouter image providers with Ope
   assert.deepEqual(client, {
     baseUrl: "https://openrouter.ai/api/v1",
     apiKey: "sk-or-test",
-    defaultHeaders: null,
+    defaultHeaders: {
+      "HTTP-Referer": "https://holaboss.ai",
+      "X-OpenRouter-Title": "holaOS",
+      "X-OpenRouter-Categories": "personal-agent,general-chat",
+    },
     modelId: "google/gemini-3.1-flash-image-preview",
     apiStyle: "openrouter_image",
   });

--- a/runtime/api-server/src/image-generation.ts
+++ b/runtime/api-server/src/image-generation.ts
@@ -319,6 +319,9 @@ export async function generateWorkspaceImage(
     });
   } else if (client.apiStyle === "openrouter_image") {
     endpoint = `${baseUrl}/chat/completions`;
+    if (!hasExplicitAuthHeader(headers) && client.apiKey.trim()) {
+      headers.Authorization = `Bearer ${client.apiKey.trim()}`;
+    }
     requestBody = openRouterImagePayload({
       modelId: client.modelId,
       prompt,

--- a/runtime/api-server/src/ts-runner-contracts.ts
+++ b/runtime/api-server/src/ts-runner-contracts.ts
@@ -34,6 +34,7 @@ export interface TsRunnerRequest {
   attachments?: TsRunnerInputAttachment[];
   context: JsonObject;
   model?: string | null;
+  thinking_value?: string | null;
   debug: boolean;
 }
 
@@ -180,6 +181,10 @@ export function validateTsRunnerRequest(payload: unknown): TsRunnerRequest {
     attachments: attachments(payload.attachments),
     context: context as JsonObject,
     model: payload.model === undefined || payload.model === null ? null : requiredString(payload.model, "model"),
+    thinking_value:
+      payload.thinking_value === undefined || payload.thinking_value === null
+        ? null
+        : requiredString(payload.thinking_value, "thinking_value"),
     debug: debugValue ?? false
   };
 }

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -256,8 +256,24 @@ test("decodeTsRunnerRequest decodes a valid runner request", () => {
     attachments: [],
     context: { k: "v" },
     model: "openai/gpt-5.4",
+    thinking_value: null,
     debug: true
   });
+});
+
+test("decodeTsRunnerRequest preserves the selected thinking value", () => {
+  const request = decodeTsRunnerRequest(
+    encodeRequest({
+      workspace_id: "workspace-1",
+      session_id: "session-1",
+      input_id: "input-1",
+      instruction: "hello",
+      context: {},
+      thinking_value: "medium",
+    })
+  );
+
+  assert.equal(request.thinking_value, "medium");
 });
 
 test("validateTsRunnerRequest rejects missing required fields", () => {

--- a/runtime/harness-host/src/contracts.test.ts
+++ b/runtime/harness-host/src/contracts.test.ts
@@ -79,6 +79,7 @@ test("decodeRunnerRequestBase64 applies defaults for optional fields", () => {
       },
     },
     model: undefined,
+    thinking_value: undefined,
     debug: false,
   });
 });
@@ -99,6 +100,7 @@ test("decodeHarnessHostPiRequestBase64 validates and normalizes request payloads
       browser_tools_enabled: true,
       input_id: "input-1",
       instruction: "Do the thing",
+      thinking_value: "medium",
       provider_id: "openai",
       model_id: "gpt-5.1",
       timeout_seconds: 30,
@@ -128,6 +130,7 @@ test("decodeHarnessHostPiRequestBase64 validates and normalizes request payloads
     input_id: "input-1",
     instruction: "Do the thing",
     attachments: [],
+    thinking_value: "medium",
     debug: false,
     harness_session_id: undefined,
     persisted_harness_session_id: undefined,

--- a/runtime/harness-host/src/contracts.ts
+++ b/runtime/harness-host/src/contracts.ts
@@ -39,6 +39,7 @@ export interface RunnerRequest {
   attachments?: HarnessHostInputAttachmentPayload[];
   context: JsonObject;
   model?: string | null;
+  thinking_value?: string | null;
   debug: boolean;
 }
 
@@ -68,6 +69,7 @@ export interface HarnessHostPiRequest {
   input_id: string;
   instruction: string;
   attachments?: HarnessHostInputAttachmentPayload[];
+  thinking_value?: string | null;
   debug: boolean;
   harness_session_id?: string | null;
   persisted_harness_session_id?: string | null;
@@ -337,6 +339,7 @@ export function decodeRunnerRequestBase64(encoded: string): RunnerRequest {
     attachments: inputAttachments(parsed.attachments, "attachments"),
     context: jsonObject(parsed.context),
     model: optionalString(parsed.model),
+    thinking_value: optionalString(parsed.thinking_value),
     debug: optionalBoolean(parsed.debug, false),
   };
 }
@@ -354,6 +357,7 @@ export function decodeHarnessHostPiRequestBase64(encoded: string): HarnessHostPi
     input_id: requiredString(parsed.input_id, "input_id"),
     instruction: requiredString(parsed.instruction, "instruction"),
     attachments: inputAttachments(parsed.attachments, "attachments"),
+    thinking_value: optionalString(parsed.thinking_value),
     debug: optionalBoolean(parsed.debug, false),
     harness_session_id: optionalString(parsed.harness_session_id),
     persisted_harness_session_id: optionalString(parsed.persisted_harness_session_id),

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -1264,7 +1264,8 @@ test("buildPiProviderConfig preserves direct OpenRouter endpoints and headers", 
       base_url: "https://openrouter.ai/api/v1",
       default_headers: {
         "HTTP-Referer": "https://holaboss.ai",
-        "X-Title": "Holaboss",
+        "X-OpenRouter-Title": "holaOS",
+        "X-OpenRouter-Categories": "personal-agent,general-chat",
       },
     },
   };
@@ -1276,7 +1277,8 @@ test("buildPiProviderConfig preserves direct OpenRouter endpoints and headers", 
   assert.equal(providerConfig.api, "openai-completions");
   assert.deepEqual(providerConfig.headers, {
     "HTTP-Referer": "https://holaboss.ai",
-    "X-Title": "Holaboss",
+    "X-OpenRouter-Title": "holaOS",
+    "X-OpenRouter-Categories": "personal-agent,general-chat",
   });
   assert.equal(providerConfig.authHeader, true);
   assert.equal(providerConfig.models[0]?.id, "openai/gpt-5.4");

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -18,6 +18,9 @@ import {
   createPiEventMapperState,
   createPiMcpCustomTools,
   mapPiSessionEvent,
+  requestedPiThinkingBudgets,
+  requestedPiThinkingConfig,
+  requestedPiThinkingLevel,
   resolvePiSkillDirs,
   workspaceBoundaryOverrideRequested,
   workspaceBoundaryViolationForToolCall,
@@ -1279,6 +1282,123 @@ test("buildPiProviderConfig preserves direct OpenRouter endpoints and headers", 
   assert.equal(providerConfig.models[0]?.id, "openai/gpt-5.4");
   assert.equal(providerConfig.models[0]?.api, "openai-completions");
   assert.equal(providerConfig.models[0]?.compat, undefined);
+});
+
+test("buildPiProviderConfig uses OpenAI Responses API for direct GPT-5 models", () => {
+  const providerConfig = buildPiProviderConfig({
+    ...baseRequest(),
+    provider_id: "openai_direct",
+    model_id: "gpt-5.4",
+    model_client: {
+      model_proxy_provider: "openai_compatible",
+      api_key: "sk-openai-test",
+      base_url: "https://api.openai.com/v1",
+    },
+  });
+
+  assert.equal(providerConfig.api, "openai-responses");
+  assert.equal(providerConfig.models[0]?.api, "openai-responses");
+  assert.equal(providerConfig.models[0]?.compat, undefined);
+});
+
+test("buildPiProviderConfig uses OpenAI Responses API for managed Holaboss GPT-5 models", () => {
+  const providerConfig = buildPiProviderConfig({
+    ...baseRequest(),
+    provider_id: "holaboss_model_proxy",
+    model_id: "gpt-5.4",
+    model_client: {
+      model_proxy_provider: "openai_compatible",
+      api_key: "hbmk-test",
+      base_url: "http://127.0.0.1:3060/api/v1/model-proxy/openai/v1",
+      default_headers: {
+        "X-Holaboss-User-Id": "user-1",
+      },
+    },
+  });
+
+  assert.equal(providerConfig.api, "openai-responses");
+  assert.equal(providerConfig.models[0]?.api, "openai-responses");
+  assert.deepEqual(providerConfig.headers, {
+    "X-Holaboss-User-Id": "user-1",
+  });
+});
+
+test("buildPiProviderConfig uses Anthropic Messages API for managed Holaboss Claude models", () => {
+  const providerConfig = buildPiProviderConfig({
+    ...baseRequest(),
+    provider_id: "holaboss_model_proxy",
+    model_id: "claude-sonnet-4-6",
+    model_client: {
+      model_proxy_provider: "anthropic_native",
+      api_key: "hbmk-test",
+      base_url: "http://127.0.0.1:3060/api/v1/model-proxy/anthropic/v1",
+      default_headers: {
+        "X-Holaboss-User-Id": "user-1",
+      },
+    },
+  });
+
+  assert.equal(providerConfig.api, "anthropic-messages");
+  assert.equal(providerConfig.models[0]?.api, "anthropic-messages");
+  assert.deepEqual(providerConfig.headers, {
+    "X-Holaboss-User-Id": "user-1",
+  });
+});
+
+test("requestedPiThinkingLevel maps provider-native values into Pi thinking levels", () => {
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "none" }), "off");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "minimal" }), "minimal");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "8192" }), "medium");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "32768" }), "high");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "-1" }), "high");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: "max" }), "xhigh");
+  assert.equal(requestedPiThinkingLevel({ thinking_value: null }), null);
+});
+
+test("requestedPiThinkingConfig preserves provider-native numeric budgets", () => {
+  assert.deepEqual(requestedPiThinkingConfig({ thinking_value: "-1" }), {
+    rawValue: "-1",
+    level: "high",
+    thinkingBudgets: { high: -1 },
+  });
+  assert.deepEqual(requestedPiThinkingConfig({ thinking_value: "24576" }), {
+    rawValue: "24576",
+    level: "high",
+    thinkingBudgets: { high: 24576 },
+  });
+  assert.deepEqual(requestedPiThinkingBudgets({ thinking_value: "128" }), {
+    minimal: 128,
+  });
+});
+
+test("buildPiProviderConfig enables reasoning only when a thinking value is requested", () => {
+  const withoutThinking = buildPiProviderConfig(baseRequest());
+  const withThinking = buildPiProviderConfig({
+    ...baseRequest(),
+    thinking_value: "medium",
+  });
+
+  assert.equal(withoutThinking.models[0]?.reasoning, false);
+  assert.equal(withThinking.models[0]?.reasoning, true);
+});
+
+test("buildPiProviderConfig preserves provider-native reasoning labels for generic OpenAI-compatible routes", () => {
+  const providerConfig = buildPiProviderConfig({
+    ...baseRequest(),
+    provider_id: "custom_openai_compat",
+    model_id: "custom-reasoner",
+    model_client: {
+      model_proxy_provider: "openai_compatible",
+      api_key: "custom-key",
+      base_url: "https://api.example.com/v1",
+    },
+    thinking_value: "default",
+  });
+
+  assert.equal(providerConfig.api, "openai-completions");
+  assert.deepEqual(providerConfig.models[0]?.compat?.reasoningEffortMap, {
+    low: "default",
+  });
 });
 
 test("buildPiProviderConfig uses pi-ai native Google provider for direct Gemini models", () => {

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -65,6 +65,21 @@ export interface PiDeps {
   createSession: (request: HarnessHostPiRequest) => Promise<PiSessionHandle>;
 }
 
+type PiThinkingLevel =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+type PiRequestedThinkingLevel = PiThinkingLevel | "off";
+type PiThinkingBudgetLevel = Exclude<PiThinkingLevel, "xhigh">;
+
+interface PiThinkingSelection {
+  rawValue: string | null;
+  level: PiRequestedThinkingLevel | null;
+  thinkingBudgets?: Partial<Record<PiThinkingBudgetLevel, number>>;
+}
+
 const PI_AGENT_STATE_DIR = ".holaboss/pi-agent";
 const PI_SESSION_DIR = ".holaboss/pi-sessions";
 const PI_HARNESS_CLIENT_NAME = "holaboss-pi-harness";
@@ -3155,6 +3170,9 @@ function piApiForRequest(request: HarnessHostPiRequest): Api {
   if (shouldUseNativeGoogleProvider(request)) {
     return "google-generative-ai";
   }
+  if (shouldUseOpenAiResponsesProvider(request)) {
+    return "openai-responses";
+  }
   return "openai-completions";
 }
 
@@ -3162,6 +3180,41 @@ function shouldUseNativeGoogleProvider(request: HarnessHostPiRequest): boolean {
   const normalizedProvider = request.model_client.model_proxy_provider.trim().toLowerCase();
   const providerId = request.provider_id.trim().toLowerCase();
   return normalizedProvider === "google_compatible" && providerId === "gemini_direct";
+}
+
+function normalizedPiModelId(request: Pick<HarnessHostPiRequest, "model_id">): string {
+  const normalizedModelId = request.model_id.trim().toLowerCase();
+  if (!normalizedModelId) {
+    return "";
+  }
+  if (normalizedModelId.startsWith("openai/")) {
+    return normalizedModelId.slice("openai/".length);
+  }
+  if (normalizedModelId.startsWith("holaboss_model_proxy/")) {
+    return normalizedModelId.slice("holaboss_model_proxy/".length);
+  }
+  return normalizedModelId;
+}
+
+function isOpenAiGpt5Model(modelId: string): boolean {
+  return /^gpt-5(?:[.-]|$)/.test(modelId);
+}
+
+function shouldUseOpenAiResponsesProvider(request: HarnessHostPiRequest): boolean {
+  const normalizedProvider = request.model_client.model_proxy_provider.trim().toLowerCase();
+  const providerId = request.provider_id.trim().toLowerCase();
+  if (normalizedProvider !== "openai_compatible") {
+    return false;
+  }
+  if (
+    providerId !== "openai_direct" &&
+    providerId !== "openai" &&
+    providerId !== "holaboss_model_proxy" &&
+    providerId !== "holaboss"
+  ) {
+    return false;
+  }
+  return isOpenAiGpt5Model(normalizedPiModelId(request));
 }
 
 function piGoogleGenerativeAiBaseUrlForRequest(request: HarnessHostPiRequest): string {
@@ -3197,6 +3250,197 @@ function piOpenAiCompatForRequest(request: HarnessHostPiRequest): Model<"openai-
   return undefined;
 }
 
+function mergePiOpenAiCompat(
+  base: Model<"openai-completions">["compat"] | undefined,
+  extra: Model<"openai-completions">["compat"] | undefined,
+): Model<"openai-completions">["compat"] | undefined {
+  if (!base) {
+    return extra;
+  }
+  if (!extra) {
+    return base;
+  }
+  return {
+    ...base,
+    ...extra,
+    ...(base.reasoningEffortMap || extra.reasoningEffortMap
+      ? {
+          reasoningEffortMap: {
+            ...(base.reasoningEffortMap ?? {}),
+            ...(extra.reasoningEffortMap ?? {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function piInputModalitiesForRequest(
+  request: HarnessHostPiRequest,
+): Array<"text" | "image"> {
+  const providerId = request.provider_id.trim().toLowerCase();
+  const modelId = request.model_id.trim().toLowerCase();
+  if (
+    providerId.includes("ollama") ||
+    providerId.includes("minimax") ||
+    modelId.startsWith("llama") ||
+    modelId.startsWith("qwen3:") ||
+    modelId.startsWith("gpt-oss:")
+  ) {
+    return ["text"];
+  }
+  return ["text", "image"];
+}
+
+export function requestedPiThinkingLevel(
+  request: Pick<HarnessHostPiRequest, "thinking_value">,
+): PiRequestedThinkingLevel | null {
+  return piThinkingSelectionForRequest(request).level;
+}
+
+function piNumericThinkingLevel(value: number): PiThinkingBudgetLevel | "off" {
+  if (value === 0) {
+    return "off";
+  }
+  if (value < 0) {
+    return "high";
+  }
+  if (value <= 1024) {
+    return "minimal";
+  }
+  if (value <= 4096) {
+    return "low";
+  }
+  if (value <= 12288) {
+    return "medium";
+  }
+  return "high";
+}
+
+function piThinkingSelectionForRequest(
+  request: Pick<HarnessHostPiRequest, "thinking_value">,
+): PiThinkingSelection {
+  const rawValue = request.thinking_value?.trim() ?? "";
+  const normalizedValue = rawValue.toLowerCase();
+  if (!normalizedValue) {
+    return {
+      rawValue: null,
+      level: null,
+    };
+  }
+  if (
+    normalizedValue === "off" ||
+    normalizedValue === "none" ||
+    normalizedValue === "false"
+  ) {
+    return {
+      rawValue,
+      level: "off",
+    };
+  }
+  if (
+    normalizedValue === "minimal" ||
+    normalizedValue === "low" ||
+    normalizedValue === "medium" ||
+    normalizedValue === "high" ||
+    normalizedValue === "xhigh"
+  ) {
+    return {
+      rawValue,
+      level: normalizedValue,
+    };
+  }
+  if (normalizedValue === "max") {
+    return {
+      rawValue,
+      level: "xhigh",
+    };
+  }
+  if (normalizedValue === "default") {
+    return {
+      rawValue,
+      level: "low",
+    };
+  }
+  if (normalizedValue === "true" || normalizedValue === "enabled") {
+    return {
+      rawValue,
+      level: "medium",
+    };
+  }
+  const numericValue = Number(normalizedValue);
+  if (!Number.isFinite(numericValue)) {
+    return {
+      rawValue,
+      level: null,
+    };
+  }
+  const level = piNumericThinkingLevel(numericValue);
+  if (level === "off") {
+    return {
+      rawValue,
+      level,
+    };
+  }
+  return {
+    rawValue,
+    level,
+    thinkingBudgets: {
+      [level]: numericValue,
+    },
+  };
+}
+
+function piOpenAiCompatForThinkingSelection(
+  selection: PiThinkingSelection,
+): Model<"openai-completions">["compat"] | undefined {
+  if (!selection.rawValue || !selection.level || selection.level === "off") {
+    return undefined;
+  }
+  const normalizedLevel = selection.level.toLowerCase();
+  const normalizedRawValue = selection.rawValue.trim().toLowerCase();
+  if (
+    normalizedRawValue === normalizedLevel ||
+    Number.isFinite(Number(normalizedRawValue))
+  ) {
+    return undefined;
+  }
+  return {
+    reasoningEffortMap: {
+      [selection.level]: selection.rawValue,
+    },
+  };
+}
+
+export function requestedPiThinkingBudgets(
+  request: Pick<HarnessHostPiRequest, "thinking_value">,
+): Partial<Record<PiThinkingBudgetLevel, number>> | undefined {
+  const selection = piThinkingSelectionForRequest(request);
+  return selection.thinkingBudgets
+    ? { ...selection.thinkingBudgets }
+    : undefined;
+}
+
+function requestedPiOpenAiCompat(
+  request: Pick<HarnessHostPiRequest, "thinking_value">,
+): Model<"openai-completions">["compat"] | undefined {
+  return piOpenAiCompatForThinkingSelection(
+    piThinkingSelectionForRequest(request),
+  );
+}
+
+export function requestedPiThinkingConfig(
+  request: Pick<HarnessHostPiRequest, "thinking_value">,
+): PiThinkingSelection {
+  const selection = piThinkingSelectionForRequest(request);
+  return {
+    rawValue: selection.rawValue,
+    level: selection.level,
+    ...(selection.thinkingBudgets
+      ? { thinkingBudgets: { ...selection.thinkingBudgets } }
+      : {}),
+  };
+}
+
 export function buildPiProviderConfig(request: HarnessHostPiRequest) {
   const providerHeaders = isRecord(request.model_client.default_headers)
     ? Object.fromEntries(
@@ -3218,7 +3462,12 @@ export function buildPiProviderConfig(request: HarnessHostPiRequest) {
     throw new Error(`Pi provider ${request.provider_id} is missing a model client base URL`);
   }
 
-  const compat = api === "openai-completions" ? piOpenAiCompatForRequest(request) : undefined;
+  const compat =
+    api === "openai-completions" ? piOpenAiCompatForRequest(request) : undefined;
+  const requestedThinking = requestedPiThinkingLevel(request);
+  const requestedCompat =
+    api === "openai-completions" ? requestedPiOpenAiCompat(request) : undefined;
+  const mergedCompat = mergePiOpenAiCompat(compat, requestedCompat);
 
   return {
     baseUrl,
@@ -3232,8 +3481,8 @@ export function buildPiProviderConfig(request: HarnessHostPiRequest) {
         id: request.model_id,
         name: request.model_id,
         api,
-        reasoning: false,
-        input: ["text", "image"] as Array<"text" | "image">,
+        reasoning: requestedThinking !== null,
+        input: piInputModalitiesForRequest(request),
         cost: {
           input: 0,
           output: 0,
@@ -3242,7 +3491,7 @@ export function buildPiProviderConfig(request: HarnessHostPiRequest) {
         },
         contextWindow: 65536,
         maxTokens: 8192,
-        ...(compat ? { compat } : {}),
+        ...(mergedCompat ? { compat: mergedCompat } : {}),
       },
     ],
   };
@@ -3264,10 +3513,15 @@ async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSe
   modelRegistry.registerProvider(request.provider_id, buildPiProviderConfig(request));
 
   const model = resolvePiModel(request, modelRegistry);
+  const requestedThinking = requestedPiThinkingLevel(request) ?? "off";
+  const requestedThinkingBudgets = requestedPiThinkingBudgets(request);
   const settingsManager = SettingsManager.inMemory({
     defaultProvider: request.provider_id,
     defaultModel: request.model_id,
-    defaultThinkingLevel: "medium",
+    defaultThinkingLevel: requestedThinking,
+    ...(requestedThinkingBudgets
+      ? { thinkingBudgets: requestedThinkingBudgets }
+      : {}),
   });
   const skillDirs = resolvePiSkillDirs(request);
   const loadedSkills = loadPiSkills(skillDirs);
@@ -3807,6 +4061,12 @@ export async function runPi(request: HarnessHostPiRequest, deps: PiDeps = defaul
   };
 
   const handle = await deps.createSession(request);
+  const requestedThinking = requestedPiThinkingLevel(request) ?? "off";
+  (
+    handle.session as AgentSession & {
+      setThinkingLevel?: (level: PiThinkingLevel) => void;
+    }
+  ).setThinkingLevel?.(requestedThinking);
   const state = createPiEventMapperState(handle.mcpToolMetadata, handle.skillMetadataByAlias);
   let terminalEmitted = false;
   const stateDir = resolvePiStateDir(request.workspace_dir);

--- a/runtime/harness-host/tsconfig.json
+++ b/runtime/harness-host/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "tsup.config.ts"]
+  "include": ["src/**/*.ts", "../../desktop/shared/**/*.ts", "tsup.config.ts"]
 }

--- a/runtime/harnesses/src/pi.ts
+++ b/runtime/harnesses/src/pi.ts
@@ -47,6 +47,7 @@ export const piHarnessDefinition: HarnessDefinition = {
           params.runtimeConfig.context_messages
         ),
         attachments: params.request.attachments ?? [],
+        thinking_value: params.request.thinking_value ?? null,
         debug: Boolean(params.request.debug),
         harness_session_id: params.bootstrap.requestedHarnessSessionId,
         persisted_harness_session_id: params.bootstrap.persistedHarnessSessionId,

--- a/runtime/harnesses/src/types.ts
+++ b/runtime/harnesses/src/types.ts
@@ -27,6 +27,7 @@ export interface HarnessRunnerRequestLike {
   input_id: string;
   instruction: string;
   attachments?: HarnessInputAttachmentPayload[];
+  thinking_value?: string | null;
   debug?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- add a shared desktop model catalog and switch provider setup UI to catalog-driven model selection for managed and direct providers
- add chat composer reasoning-effort selection, persist per-model preferences, and send `thinking_value` with queued session inputs
- extend runtime and harness contracts so requested reasoning effort flows through ts-runner into Pi/OpenAI provider configuration
- add and update desktop and runtime tests for model normalization, provider catalog plumbing, and reasoning config behavior

## Validation
- `cd desktop && npm run typecheck`
- `cd desktop && node --test --test-name-pattern "desktop model catalog carries reasoning metadata and the composer persists thinking preferences|runtime auth panel keeps model provider settings compact" electron/runtime-provider-models.test.mjs src/components/auth/AuthPanel.test.mjs`
- `cd runtime/api-server && npm run typecheck && npm test`
- `cd runtime/harness-host && npm run typecheck && npm test`
