### PR TITLE
feat: merge chat reasoning into execution trace timeline

### DIFF
--- a/desktop/src/chat-markdown-styles.test.mjs
+++ b/desktop/src/chat-markdown-styles.test.mjs
@@ -12,13 +12,14 @@ test("chat markdown styles wrap long content without disabling code block scroll
 
   assert.match(source, /\.chat-markdown \{\s*max-width: 100%;[\s\S]*overflow-wrap: anywhere;[\s\S]*word-break: break-word;/);
   assert.match(source, /\.chat-user-markdown \{\s*font-size: 13px;[\s\S]*line-height: 1\.75;/);
-  assert.match(source, /\.chat-assistant-markdown \{\s*font-size: 15px;[\s\S]*line-height: 2;/);
+  assert.match(source, /\.chat-assistant-markdown \{\s*font-size: 14px;[\s\S]*line-height: 1\.8;/);
+  assert.match(source, /\.chat-thinking-markdown \{\s*font-size: 12px;[\s\S]*line-height: 1\.55;/);
   assert.match(source, /\.chat-markdown \.md-link,[\s\S]*\.chat-markdown \.md-table th \{\s*overflow-wrap: anywhere;[\s\S]*word-break: break-word;/);
   assert.match(source, /\.simple-markdown \.md-code-block \{[\s\S]*overflow-x: auto;/);
   assert.match(source, /\.simple-markdown \.md-code-block > code \{[\s\S]*background: transparent;/);
   assert.match(source, /\.simple-markdown \.md-ul \{[\s\S]*list-style: disc;/);
   assert.match(source, /\.simple-markdown \.md-ol \{[\s\S]*list-style: decimal;/);
-  assert.match(source, /\.chat-markdown \.md-h1 \{[\s\S]*font-size: 20px;[\s\S]*line-height: 1\.45;/);
+  assert.match(source, /\.chat-markdown \.md-h1 \{[\s\S]*font-size: 17px;[\s\S]*line-height: 1\.5;/);
   assert.match(source, /\.chat-markdown \.md-p:first-child,[\s\S]*\.chat-markdown \.md-table:first-child \{[\s\S]*margin-top: 0;/);
   assert.match(source, /\.chat-markdown \.md-p:last-child,[\s\S]*\.chat-markdown \.md-table:last-child \{[\s\S]*margin-bottom: 0;/);
 });

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -268,6 +268,10 @@ test("chat pane renders an execution timeline that interleaves thinking segments
   assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*executionItems = upsertExecutionTimelineTraceItem\(/);
   assert.match(source, /appendLiveThinkingDelta\(delta: string, order: number\)/);
   assert.match(source, /appendExecutionTimelineThinkingDelta\(prev, delta, order\)/);
+  assert.match(
+    source,
+    /function ExecutionTimelineThinkingEntry[\s\S]*className="py-1"[\s\S]*className="-ml-2\.5 w-\[calc\(100%\+0\.625rem\)\] rounded-\[16px\] border border-border\/25 bg-muted\/30 px-3\.5 py-3"/,
+  );
   assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{message\.executionItems \?\? \[\]\}/);
   assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{liveExecutionItems\}/);
   assert.match(source, /<TraceStepGroup[\s\S]*items=\{executionItems\}/);

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -59,7 +59,6 @@ test("chat pane shows provider setup CTA when no chat models are available", asy
     /onOpenModelProviders=\{\(\) =>[\s\S]*window\.electronAPI\.ui\.openSettingsPane\("providers"\)[\s\S]*\}/,
   );
   assert.match(source, /aria-label="Configure model providers"/);
-  assert.match(source, />Set up providers</);
   assert.match(
     source,
     /<Waypoints[\s\S]*size=\{13\}[\s\S]*className="shrink-0 text-muted-foreground"[\s\S]*\/>/,
@@ -67,7 +66,12 @@ test("chat pane shows provider setup CTA when no chat models are available", asy
   assert.match(source, /Open provider settings to connect a model\./);
   assert.match(
     source,
-    /className=\{[\s\S]*noAvailableModels[\s\S]*\? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"[\s\S]*: "min-w-0 flex-1 basis-\[220px\] max-w-\[240px\]"[\s\S]*\}/,
+    /className=\{[\s\S]*compactComposerControls[\s\S]*\? "min-w-0 shrink-0"[\s\S]*: noAvailableModels[\s\S]*\? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"[\s\S]*: "min-w-0 flex-1 basis-\[220px\] max-w-\[240px\]"[\s\S]*\}/,
+  );
+  assert.match(source, /\{compactComposerControls \? "Providers" : "Set up providers"\}/);
+  assert.match(
+    source,
+    /className=\{`min-w-0 text-\[10px\] leading-5 text-muted-foreground \$\{[\s\S]*compactComposerControls \? "hidden" : ""[\s\S]*`\}/,
   );
   assert.doesNotMatch(source, /title=\{modelSelectionUnavailableReason\}/);
   assert.doesNotMatch(
@@ -99,10 +103,76 @@ test("chat composer footer wraps controls based on available pane width instead 
 
   assert.match(
     source,
-    /<div className="flex flex-wrap items-center gap-2 border-t border-border\/20 px-3 py-3 text-muted-foreground">/,
+    /const COMPOSER_FULL_MODEL_CONTROL_WIDTH_PX = 240;/,
   );
-  assert.match(source, /className="ml-auto flex items-center gap-2"/);
+  assert.match(source, /const syncComposerFooterLayout = \(\) => \{/);
+  assert.match(source, /const footerStyle = window\.getComputedStyle\(footer\);/);
+  assert.match(
+    source,
+    /const horizontalPadding =[\s\S]*footerStyle\.paddingLeft[\s\S]*footerStyle\.paddingRight/,
+  );
+  assert.match(
+    source,
+    /const width = Math\.max\(\s*0,\s*Math\.round\(footer\.clientWidth - horizontalPadding\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /const resizeObserver = new ResizeObserver\(\(\) => \{\s*syncComposerFooterLayout\(\);\s*\}\);/,
+  );
+  assert.match(
+    source,
+    /const compactComposerControls =\s*showModelSelector &&[\s\S]*composerFooterLayout\.wraps[\s\S]*composerFooterLayout\.width < fullFooterControlWidth/,
+  );
+  assert.match(
+    source,
+    /const compactModelControlWidth = compactComposerControls[\s\S]*COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX[\s\S]*compactFooterControlWidth -[\s\S]*COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX/,
+  );
+  assert.match(
+    source,
+    /const compactThinkingControlWidth = showThinkingValueSelector[\s\S]*COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX[\s\S]*compactFooterControlWidth - compactModelControlWidth/,
+  );
+  assert.match(
+    source,
+    /className=\{`border-t border-border\/20 px-3 py-3 text-muted-foreground \$\{[\s\S]*compactComposerControls[\s\S]*\? "flex items-center gap-2 overflow-hidden"[\s\S]*: "flex flex-wrap items-center gap-2"[\s\S]*`\}/,
+  );
+  assert.match(
+    source,
+    /className=\{\s*compactComposerControls[\s\S]*\? "min-w-0 shrink-0"[\s\S]*: noAvailableModels[\s\S]*"min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"[\s\S]*\}/,
+  );
+  assert.match(
+    source,
+    /style=\{\s*compactComposerControls\s*\?\s*\{ width: `\$\{compactModelControlWidth\}px` \}\s*:\s*undefined\s*\}/,
+  );
+  assert.match(
+    source,
+    /className="ml-auto flex shrink-0 items-center gap-2"/,
+  );
+  assert.match(source, /compact=\{compactComposerControls\}/);
   assert.doesNotMatch(source, /sm:w-\[208px\]/);
+});
+
+test("chat composer switches model and thinking selectors into icon-led compact triggers", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /function compactComposerModelLabel\(label: string\)/);
+  assert.match(source, /function displayThinkingValueLabel\(value: string\)/);
+  assert.match(source, /const compactLabel = compactComposerModelLabel\(displayLabel\);/);
+  assert.match(
+    source,
+    /compact \? \(\s*<span className="flex min-w-0 items-center gap-2">[\s\S]*<Waypoints[\s\S]*<span className="truncate">\{compactLabel\}<\/span>/,
+  );
+  assert.match(
+    source,
+    /const selectedThinkingLabel = displayThinkingValueLabel\(selectedThinkingValue\);/,
+  );
+  assert.match(
+    source,
+    /aria-label=\{\s*compact \? `Reasoning effort: \$\{selectedThinkingLabel\}` : undefined\s*\}/,
+  );
+  assert.match(
+    source,
+    /compact \? \(\s*<span className="flex min-w-0 flex-1 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<span className="truncate">\{selectedThinkingLabel\}<\/span>/,
+  );
 });
 
 test("chat trace summary only surfaces terminal run failures in the summary label", async () => {

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -272,6 +272,10 @@ test("chat pane renders an execution timeline that interleaves thinking segments
     source,
     /function ExecutionTimelineThinkingEntry[\s\S]*className="py-1"[\s\S]*className="-ml-2\.5 w-\[calc\(100%\+0\.625rem\)\] rounded-\[16px\] border border-border\/25 bg-muted\/30 px-3\.5 py-3"/,
   );
+  assert.match(
+    source,
+    /function ExecutionTimelineThinkingEntry[\s\S]*className="chat-markdown chat-thinking-markdown max-w-full text-foreground\/82"/,
+  );
   assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{message\.executionItems \?\? \[\]\}/);
   assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{liveExecutionItems\}/);
   assert.match(source, /<TraceStepGroup[\s\S]*items=\{executionItems\}/);

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -67,7 +67,7 @@ test("chat pane shows provider setup CTA when no chat models are available", asy
   assert.match(source, /Open provider settings to connect a model\./);
   assert.match(
     source,
-    /className=\{[\s\S]*noAvailableModels[\s\S]*\? "min-w-0 flex flex-1 items-center gap-3"[\s\S]*: "w-\[172px\] shrink-0 sm:w-\[208px\]"[\s\S]*\}/,
+    /className=\{[\s\S]*noAvailableModels[\s\S]*\? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"[\s\S]*: "min-w-0 flex-1 basis-\[220px\] max-w-\[240px\]"[\s\S]*\}/,
   );
   assert.doesNotMatch(source, /title=\{modelSelectionUnavailableReason\}/);
   assert.doesNotMatch(
@@ -92,6 +92,17 @@ test("chat pane falls back to provider setup instead of holaboss pending state w
     source,
     /const requiresModelProviderSetup =\s*!hasConfiguredProviderCatalog && !holabossProxyModelsAvailable;/,
   );
+});
+
+test("chat composer footer wraps controls based on available pane width instead of viewport breakpoints", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /<div className="flex flex-wrap items-center gap-2 border-t border-border\/20 px-3 py-3 text-muted-foreground">/,
+  );
+  assert.match(source, /className="ml-auto flex items-center gap-2"/);
+  assert.doesNotMatch(source, /sm:w-\[208px\]/);
 });
 
 test("chat trace summary only surfaces terminal run failures in the summary label", async () => {
@@ -174,7 +185,27 @@ test("chat pane renders live placeholder status as faint text with animated trai
   assert.doesNotMatch(source, /Queued\.\.\./);
   assert.doesNotMatch(source, /Working\.\.\./);
   assert.doesNotMatch(source, /Checking workspace context\.\.\./);
-  assert.doesNotMatch(source, /Thinking\.\.\./);
+});
+
+test("chat pane renders an execution timeline that interleaves thinking segments with trace entries", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /executionItems\?: ChatExecutionTimelineItem\[];/);
+  assert.match(source, /function appendExecutionTimelineThinkingDelta\(/);
+  assert.match(source, /function upsertExecutionTimelineTraceItem\(/);
+  assert.match(source, /function traceStepsFromExecutionItems\(items: ChatExecutionTimelineItem\[]\)/);
+  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*executionItems = appendExecutionTimelineThinkingDelta\(/);
+  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*executionItems = upsertExecutionTimelineTraceItem\(/);
+  assert.match(source, /appendLiveThinkingDelta\(delta: string, order: number\)/);
+  assert.match(source, /appendExecutionTimelineThinkingDelta\(prev, delta, order\)/);
+  assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{message\.executionItems \?\? \[\]\}/);
+  assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{liveExecutionItems\}/);
+  assert.match(source, /<TraceStepGroup[\s\S]*items=\{executionItems\}/);
+  assert.match(source, /<ExecutionTimelineThinkingEntry/);
+  assert.match(source, /<TraceTimelineStepEntry/);
+  assert.doesNotMatch(source, /<ThinkingPanel/);
+  assert.doesNotMatch(source, /thinkingCollapsed/);
+  assert.doesNotMatch(source, /onToggleThinking/);
 });
 
 test("chat trace tool errors surface stderr text instead of a generic error label", async () => {
@@ -560,8 +591,9 @@ test("live trace auto-expands during the run and collapses when output starts", 
 
   assert.match(
     source,
-    /function TraceStepGroup\(\{[\s\S]*live = false,[\s\S]*liveOutputStarted = false,/,
+    /function TraceStepGroup\(\{[\s\S]*items,[\s\S]*live = false,[\s\S]*liveOutputStarted = false,/,
   );
+  assert.match(source, /const steps = traceStepsFromExecutionItems\(items\);/);
   assert.match(
     source,
     /const \[groupExpanded, setGroupExpanded\] = useState\(\s*live && !liveOutputStarted,\s*\);/,
@@ -576,7 +608,7 @@ test("live trace auto-expands during the run and collapses when output starts", 
   );
   assert.match(
     source,
-    /<TraceStepGroup[\s\S]*live=\{live\}[\s\S]*liveOutputStarted=\{live && Boolean\(text\)\}/,
+    /<TraceStepGroup[\s\S]*items=\{executionItems\}[\s\S]*live=\{live\}[\s\S]*liveOutputStarted=\{live && Boolean\(text\)\}/,
   );
 });
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -69,8 +69,7 @@ interface ChatMessage {
   text: string;
   createdAt?: string;
   attachments?: ChatAttachment[];
-  thinkingText?: string;
-  traceSteps?: ChatTraceStep[];
+  executionItems?: ChatExecutionTimelineItem[];
   outputs?: WorkspaceOutputRecordPayload[];
   memoryProposals?: MemoryUpdateProposalRecordPayload[];
 }
@@ -85,6 +84,20 @@ interface ChatTraceStep {
   details: string[];
   order: number;
 }
+
+type ChatExecutionTimelineItem =
+  | {
+      id: string;
+      kind: "thinking";
+      text: string;
+      order: number;
+    }
+  | {
+      id: string;
+      kind: "trace_step";
+      step: ChatTraceStep;
+      order: number;
+    };
 
 type ChatTodoStatus =
   | "pending"
@@ -429,8 +442,7 @@ function hasRenderableMessageContent(
 function hasRenderableAssistantTurn(message: ChatMessage) {
   return (
     hasRenderableMessageContent(message.text, message.attachments ?? []) ||
-    Boolean(message.thinkingText) ||
-    (message.traceSteps?.length ?? 0) > 0 ||
+    (message.executionItems?.length ?? 0) > 0 ||
     (message.outputs?.length ?? 0) > 0 ||
     (message.memoryProposals?.length ?? 0) > 0
   );
@@ -1627,14 +1639,103 @@ function finalizeTraceSteps(
   );
 }
 
+function appendExecutionTimelineThinkingDelta(
+  previous: ChatExecutionTimelineItem[],
+  delta: string,
+  order: number,
+) {
+  if (!delta) {
+    return previous;
+  }
+
+  const lastItem = previous[previous.length - 1];
+  if (lastItem?.kind === "thinking") {
+    const nextItem: ChatExecutionTimelineItem = {
+      ...lastItem,
+      text: `${lastItem.text}${delta}`,
+    };
+    return [
+      ...previous.slice(0, -1),
+      nextItem,
+    ];
+  }
+
+  const nextItem: ChatExecutionTimelineItem = {
+    id: `thinking:${order}`,
+    kind: "thinking",
+    text: delta,
+    order,
+  };
+  return [
+    ...previous,
+    nextItem,
+  ];
+}
+
+function upsertExecutionTimelineTraceItem(
+  previous: ChatExecutionTimelineItem[],
+  step: ChatTraceStep,
+) {
+  const existingIndex = previous.findIndex(
+    (item) => item.kind === "trace_step" && item.step.id === step.id,
+  );
+  if (existingIndex < 0) {
+    const nextItem: ChatExecutionTimelineItem = {
+      id: `trace:${step.id}`,
+      kind: "trace_step",
+      step,
+      order: step.order,
+    };
+    return [...previous, nextItem].sort((left, right) => left.order - right.order);
+  }
+
+  return previous.map((item, index) =>
+    index === existingIndex && item.kind === "trace_step"
+      ? ({
+          ...item,
+          step: {
+            ...item.step,
+            ...step,
+            order: Math.min(item.step.order, step.order),
+          },
+        } satisfies ChatExecutionTimelineItem)
+      : item,
+  );
+}
+
+function finalizeExecutionTimelineTraceItems(
+  previous: ChatExecutionTimelineItem[],
+  status: Extract<ChatTraceStepStatus, "completed" | "error" | "waiting">,
+) {
+  return previous.map((item) =>
+    item.kind === "trace_step" && item.step.status === "running"
+      ? {
+          ...item,
+          step: {
+            ...item.step,
+            status,
+          },
+        }
+      : item,
+  );
+}
+
+function traceStepsFromExecutionItems(items: ChatExecutionTimelineItem[]) {
+  return items
+    .filter(
+      (item): item is Extract<ChatExecutionTimelineItem, { kind: "trace_step" }> =>
+        item.kind === "trace_step",
+    )
+    .map((item) => item.step);
+}
+
 function assistantHistoryStateFromOutputEvents(
   outputEvents: SessionOutputEventPayload[],
 ) {
   const orderedEvents = [...outputEvents].sort(
     (left, right) => left.sequence - right.sequence || left.id - right.id,
   );
-  let thinkingText = "";
-  let traceSteps: ChatTraceStep[] = [];
+  let executionItems: ChatExecutionTimelineItem[] = [];
 
   for (const event of orderedEvents) {
     const eventPayload = isRecord(event.payload) ? event.payload : {};
@@ -1642,9 +1743,11 @@ function assistantHistoryStateFromOutputEvents(
     if (event.event_type === "thinking_delta") {
       const delta =
         typeof eventPayload.delta === "string" ? eventPayload.delta : "";
-      if (delta) {
-        thinkingText = `${thinkingText}${delta}`;
-      }
+      executionItems = appendExecutionTimelineThinkingDelta(
+        executionItems,
+        delta,
+        event.sequence,
+      );
     }
 
     const phaseStep = phaseTraceStepFromEvent(
@@ -1653,7 +1756,10 @@ function assistantHistoryStateFromOutputEvents(
       event.sequence,
     );
     if (phaseStep) {
-      traceSteps = upsertTraceStep(traceSteps, phaseStep);
+      executionItems = upsertExecutionTimelineTraceItem(
+        executionItems,
+        phaseStep,
+      );
     }
 
     const toolStep = toolTraceStepFromEvent(
@@ -1662,7 +1768,10 @@ function assistantHistoryStateFromOutputEvents(
       event.sequence,
     );
     if (toolStep) {
-      traceSteps = upsertTraceStep(traceSteps, toolStep);
+      executionItems = upsertExecutionTimelineTraceItem(
+        executionItems,
+        toolStep,
+      );
     }
 
     if (event.event_type === "run_completed") {
@@ -1670,20 +1779,22 @@ function assistantHistoryStateFromOutputEvents(
         typeof eventPayload.status === "string"
           ? eventPayload.status.trim().toLowerCase()
           : "";
-      traceSteps = finalizeTraceSteps(
-        traceSteps,
+      executionItems = finalizeExecutionTimelineTraceItems(
+        executionItems,
         completedStatus === "paused" || completedStatus === "waiting_user"
           ? "waiting"
           : "completed",
       );
     } else if (event.event_type === "run_failed") {
-      traceSteps = finalizeTraceSteps(traceSteps, "error");
+      executionItems = finalizeExecutionTimelineTraceItems(
+        executionItems,
+        "error",
+      );
     }
   }
 
   return {
-    thinkingText: thinkingText || undefined,
-    traceSteps: traceSteps.length > 0 ? traceSteps : undefined,
+    executionItems: executionItems.length > 0 ? executionItems : undefined,
   };
 }
 
@@ -1823,12 +1934,10 @@ export function ChatPane({
     WorkspaceOutputRecordPayload[]
   >([]);
   const [liveAssistantText, setLiveAssistantText] = useState("");
-  const [liveThinkingText, setLiveThinkingText] = useState("");
-  const [liveThinkingExpanded, setLiveThinkingExpanded] = useState(false);
   const [liveAgentStatus, setLiveAgentStatus] = useState("");
-  const [liveTraceSteps, setLiveTraceSteps] = useState<ChatTraceStep[]>([]);
-  const [collapsedThinkingByMessageId, setCollapsedThinkingByMessageId] =
-    useState<Record<string, boolean>>({});
+  const [liveExecutionItems, setLiveExecutionItems] = useState<
+    ChatExecutionTimelineItem[]
+  >([]);
   const [collapsedTraceByStepId, setCollapsedTraceByStepId] = useState<
     Record<string, boolean>
   >({});
@@ -1913,9 +2022,7 @@ export function ChatPane({
     useRef<ChatPaneSessionOpenRequest | null>(null);
   const draftParentSessionIdRef = useRef<string | null>(null);
   const liveAssistantTextRef = useRef("");
-  const liveThinkingTextRef = useRef("");
-  const liveThinkingExpandedRef = useRef(false);
-  const liveTraceStepsRef = useRef<ChatTraceStep[]>([]);
+  const liveExecutionItemsRef = useRef<ChatExecutionTimelineItem[]>([]);
   const historyViewportGenerationRef = useRef(0);
   const [activeSessionId, setActiveSessionId] = useState("");
   const effectiveSessionOpenRequest =
@@ -2073,15 +2180,11 @@ export function ChatPane({
 
   function resetLiveTurn() {
     liveAssistantTextRef.current = "";
-    liveThinkingTextRef.current = "";
-    liveThinkingExpandedRef.current = false;
-    liveTraceStepsRef.current = [];
+    liveExecutionItemsRef.current = [];
     activeAssistantMessageIdRef.current = null;
     setLiveAssistantText("");
-    setLiveThinkingText("");
-    setLiveThinkingExpanded(false);
     setLiveAgentStatus("");
-    setLiveTraceSteps([]);
+    setLiveExecutionItems([]);
   }
 
   function clearSessionView() {
@@ -2094,7 +2197,6 @@ export function ChatPane({
     setEditingMemoryProposalId(null);
     setMemoryProposalDrafts({});
     resetLiveTurn();
-    setCollapsedThinkingByMessageId({});
     setCollapsedTraceByStepId({});
     shouldAutoScrollRef.current = true;
   }
@@ -2177,11 +2279,8 @@ export function ChatPane({
             const turnMemoryProposals = sortMemoryUpdateProposals(
               memoryProposalsByInputId.get(inputId) ?? [],
             );
-            if (restoredAssistantState.thinkingText) {
-              nextMessage.thinkingText = restoredAssistantState.thinkingText;
-            }
-            if (restoredAssistantState.traceSteps) {
-              nextMessage.traceSteps = restoredAssistantState.traceSteps;
+            if (restoredAssistantState.executionItems) {
+              nextMessage.executionItems = restoredAssistantState.executionItems;
             }
             if (turnMemoryProposals.length > 0) {
               nextMessage.memoryProposals = turnMemoryProposals;
@@ -2360,15 +2459,13 @@ export function ChatPane({
     });
   }
 
-  function appendLiveThinkingDelta(delta: string) {
+  function appendLiveThinkingDelta(delta: string, order: number) {
     flushSync(() => {
-      setLiveThinkingText((prev) => {
-        const next = `${prev}${delta}`;
-        liveThinkingTextRef.current = next;
+      setLiveExecutionItems((prev) => {
+        const next = appendExecutionTimelineThinkingDelta(prev, delta, order);
+        liveExecutionItemsRef.current = next;
         return next;
       });
-      liveThinkingExpandedRef.current = true;
-      setLiveThinkingExpanded(true);
     });
   }
 
@@ -2376,9 +2473,8 @@ export function ChatPane({
     const messageId =
       activeAssistantMessageIdRef.current ?? `assistant-${Date.now()}`;
     const assistantText = liveAssistantTextRef.current;
-    const thinkingText = liveThinkingTextRef.current;
-    const traceSteps = liveTraceStepsRef.current;
-    if (!assistantText && !thinkingText && traceSteps.length === 0) {
+    const executionItems = liveExecutionItemsRef.current;
+    if (!assistantText && executionItems.length === 0) {
       resetLiveTurn();
       return;
     }
@@ -2389,14 +2485,9 @@ export function ChatPane({
         id: messageId,
         role: "assistant",
         text: assistantText,
-        thinkingText: thinkingText || undefined,
-        traceSteps: traceSteps.length > 0 ? traceSteps : undefined,
+        executionItems: executionItems.length > 0 ? executionItems : undefined,
       },
     ]);
-    setCollapsedThinkingByMessageId((prev) => ({
-      ...prev,
-      [messageId]: true,
-    }));
     resetLiveTurn();
   }
 
@@ -2507,13 +2598,6 @@ export function ChatPane({
     }
   }
 
-  function toggleThinkingPanel(messageId: string) {
-    setCollapsedThinkingByMessageId((prev) => ({
-      ...prev,
-      [messageId]: !prev[messageId],
-    }));
-  }
-
   function toggleTraceStep(stepId: string) {
     setCollapsedTraceByStepId((prev) => ({
       ...prev,
@@ -2521,9 +2605,9 @@ export function ChatPane({
     }));
   }
 
-  function setLiveTraceStepsState(nextSteps: ChatTraceStep[]) {
-    liveTraceStepsRef.current = nextSteps;
-    setLiveTraceSteps(nextSteps);
+  function setLiveExecutionItemsState(nextItems: ChatExecutionTimelineItem[]) {
+    liveExecutionItemsRef.current = nextItems;
+    setLiveExecutionItems(nextItems);
   }
 
   function syncChatScrollMetrics(container?: HTMLDivElement | null) {
@@ -2667,15 +2751,21 @@ export function ChatPane({
   }
 
   function upsertLiveTraceStep(step: ChatTraceStep) {
-    const next = upsertTraceStep(liveTraceStepsRef.current, step);
-    setLiveTraceStepsState(next);
+    const next = upsertExecutionTimelineTraceItem(
+      liveExecutionItemsRef.current,
+      step,
+    );
+    setLiveExecutionItemsState(next);
   }
 
   function finalizeLiveTraceSteps(
     status: Extract<ChatTraceStepStatus, "completed" | "error" | "waiting">,
   ) {
-    const next = finalizeTraceSteps(liveTraceStepsRef.current, status);
-    setLiveTraceStepsState(next);
+    const next = finalizeExecutionTimelineTraceItems(
+      liveExecutionItemsRef.current,
+      status,
+    );
+    setLiveExecutionItemsState(next);
   }
 
   useEffect(() => {
@@ -2696,8 +2786,7 @@ export function ChatPane({
     isHistoryViewportPending,
     isResponding,
     liveAssistantText,
-    liveThinkingText,
-    liveTraceSteps,
+    liveExecutionItems,
     messages,
   ]);
 
@@ -3539,7 +3628,7 @@ export function ChatPane({
             });
             return;
           }
-          appendLiveThinkingDelta(delta);
+          appendLiveThinkingDelta(delta, eventSequence);
           appendStreamTelemetry({
             streamId: payload.streamId,
             transportType: payload.type,
@@ -3559,8 +3648,7 @@ export function ChatPane({
           finalizeLiveTraceSteps("error");
           if (
             liveAssistantTextRef.current ||
-            liveThinkingTextRef.current ||
-            liveTraceStepsRef.current.length > 0
+            liveExecutionItemsRef.current.length > 0
           ) {
             commitLiveAssistantMessage();
           }
@@ -4081,8 +4169,7 @@ export function ChatPane({
   const showLiveAssistantTurn =
     isResponding ||
     Boolean(liveAssistantText) ||
-    Boolean(liveThinkingText) ||
-    liveTraceSteps.length > 0;
+    liveExecutionItems.length > 0;
   const hasMessages = messages.length > 0 || showLiveAssistantTurn;
   const streamTelemetryTail = useMemo(
     () => streamTelemetry.slice(-80).reverse(),
@@ -4399,8 +4486,7 @@ export function ChatPane({
     composerBlockHeight,
     hasMessages,
     liveAssistantText,
-    liveThinkingText,
-    liveTraceSteps,
+    liveExecutionItems,
     messages,
   ]);
 
@@ -4638,12 +4724,7 @@ export function ChatPane({
                         label={assistantLabel}
                         mode={assistantMode}
                         text={message.text}
-                        thinkingText={message.thinkingText}
-                        thinkingCollapsed={
-                          collapsedThinkingByMessageId[message.id] ?? true
-                        }
-                        onToggleThinking={() => toggleThinkingPanel(message.id)}
-                        traceSteps={message.traceSteps ?? []}
+                        executionItems={message.executionItems ?? []}
                         memoryProposals={message.memoryProposals ?? []}
                         outputs={message.outputs ?? []}
                         sessionOutputs={sessionOutputs}
@@ -4689,14 +4770,7 @@ export function ChatPane({
                       label={assistantLabel}
                       mode={assistantMode}
                       text={liveAssistantText}
-                      thinkingText={liveThinkingText}
-                      thinkingCollapsed={!liveThinkingExpanded}
-                      onToggleThinking={() => {
-                        const next = !liveThinkingExpandedRef.current;
-                        liveThinkingExpandedRef.current = next;
-                        setLiveThinkingExpanded(next);
-                      }}
-                      traceSteps={liveTraceSteps}
+                      executionItems={liveExecutionItems}
                       memoryProposals={[]}
                       outputs={[]}
                       sessionOutputs={sessionOutputs}
@@ -5161,13 +5235,6 @@ interface ComposerProps {
   onRemoveAttachment: (attachmentId: string) => void;
 }
 
-interface ThinkingPanelProps {
-  text: string;
-  collapsed: boolean;
-  onToggle: () => void;
-  live?: boolean;
-}
-
 function UserTurn({
   text,
   createdAt,
@@ -5266,10 +5333,7 @@ function AssistantTurn({
   label,
   mode,
   text,
-  thinkingText,
-  thinkingCollapsed,
-  onToggleThinking,
-  traceSteps,
+  executionItems,
   memoryProposals,
   outputs,
   sessionOutputs,
@@ -5291,10 +5355,7 @@ function AssistantTurn({
   label: string;
   mode: string;
   text: string;
-  thinkingText?: string;
-  thinkingCollapsed: boolean;
-  onToggleThinking: () => void;
-  traceSteps: ChatTraceStep[];
+  executionItems: ChatExecutionTimelineItem[];
   memoryProposals: MemoryUpdateProposalRecordPayload[];
   outputs: WorkspaceOutputRecordPayload[];
   sessionOutputs: WorkspaceOutputRecordPayload[];
@@ -5319,11 +5380,11 @@ function AssistantTurn({
   live?: boolean;
 }) {
   const normalizedStatus = status.replace(/\.+$/, "").trim();
+  const traceSteps = traceStepsFromExecutionItems(executionItems);
   const showStatusPlaceholder =
     Boolean(normalizedStatus) &&
     !text &&
-    traceSteps.length === 0 &&
-    !thinkingText;
+    executionItems.length === 0;
 
   return (
     <div className="flex min-w-0 justify-start">
@@ -5338,22 +5399,14 @@ function AssistantTurn({
           </div>
         ) : null}
 
-        {traceSteps.length > 0 ? (
+        {executionItems.length > 0 ? (
           <TraceStepGroup
-            steps={traceSteps}
+            items={executionItems}
             collapsedByStepId={collapsedTraceByStepId}
             onToggleStep={onToggleTraceStep}
             live={live}
             liveOutputStarted={live && Boolean(text)}
-          />
-        ) : null}
-
-        {thinkingText ? (
-          <ThinkingPanel
-            text={thinkingText}
-            collapsed={thinkingCollapsed}
-            onToggle={onToggleThinking}
-            live={live}
+            onLinkClick={onLinkClick}
           />
         ) : null}
 
@@ -5918,19 +5971,109 @@ function LiveStatusEllipsis() {
   );
 }
 
+function summarizeThinking(text: string) {
+  const firstContentLine =
+    text
+      .split("\n")
+      .map((line) => line.replace(/[*_`#>-]/g, "").trim())
+      .find(Boolean) || "Reasoning available";
+
+  return firstContentLine.length > 88
+    ? `${firstContentLine.slice(0, 85).trimEnd()}...`
+    : firstContentLine;
+}
+
+function TraceTimelineStepEntry({
+  step,
+  collapsedByStepId,
+  onToggleStep,
+}: {
+  step: ChatTraceStep;
+  collapsedByStepId: Record<string, boolean>;
+  onToggleStep: (stepId: string) => void;
+}) {
+  const expanded = !(collapsedByStepId[step.id] ?? true);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => step.details.length > 0 && onToggleStep(step.id)}
+        className={`flex w-full items-start gap-2 rounded-md px-2.5 -ml-2.5 py-1 text-left text-xs transition-colors ${step.details.length > 0 ? "hover:bg-muted/50 cursor-pointer" : "cursor-default"}`}
+      >
+        <span className="mt-0.5 shrink-0">
+          {step.status === "completed" ? (
+            <Check size={12} className="text-emerald-500" />
+          ) : step.status === "error" ? (
+            <AlertTriangle size={12} className="text-destructive" />
+          ) : step.status === "running" ? (
+            <Loader2 size={12} className="animate-spin text-muted-foreground" />
+          ) : (
+            <Clock3 size={12} className="text-muted-foreground" />
+          )}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="font-medium text-foreground/80">{step.title}</span>
+          {step.details.length > 0 ? (
+            <span className="ml-1.5 text-muted-foreground/70">
+              {step.details[0]}
+            </span>
+          ) : null}
+        </span>
+        {step.details.length > 1 ? (
+          <ChevronDown
+            size={12}
+            className={`mt-0.5 shrink-0 text-muted-foreground/50 transition-transform ${expanded ? "rotate-180" : ""}`}
+          />
+        ) : null}
+      </button>
+      {expanded && step.details.length > 1 ? (
+        <div className="ml-6 mt-0.5 mb-1 rounded-md border border-border/30 bg-muted/30 px-3 py-2 text-[11px] leading-5 text-muted-foreground whitespace-pre-wrap">
+          {step.details.slice(1).join("\n")}
+        </div>
+      ) : null}
+      {step.status === "error" ? (
+        <IntegrationErrorBanner details={step.details} />
+      ) : null}
+    </div>
+  );
+}
+
+function ExecutionTimelineThinkingEntry({
+  text,
+  onLinkClick,
+}: {
+  text: string;
+  onLinkClick?: (url: string) => void;
+}) {
+  return (
+    <div className="ml-5 mr-1 rounded-[16px] border border-border/25 bg-muted/30 px-3.5 py-3">
+      <SimpleMarkdown
+        className="chat-markdown chat-assistant-markdown max-w-full text-[12px] leading-6 text-foreground/82"
+        onLinkClick={onLinkClick}
+      >
+        {text}
+      </SimpleMarkdown>
+    </div>
+  );
+}
+
 function TraceStepGroup({
-  steps,
+  items,
   collapsedByStepId,
   onToggleStep,
   live = false,
   liveOutputStarted = false,
+  onLinkClick,
 }: {
-  steps: ChatTraceStep[];
+  items: ChatExecutionTimelineItem[];
   collapsedByStepId: Record<string, boolean>;
   onToggleStep: (stepId: string) => void;
   live?: boolean;
   liveOutputStarted?: boolean;
+  onLinkClick?: (url: string) => void;
 }) {
+  const steps = traceStepsFromExecutionItems(items);
   const [groupExpanded, setGroupExpanded] = useState(
     live && !liveOutputStarted,
   );
@@ -5961,10 +6104,38 @@ function TraceStepGroup({
       .find((step) => step.status === "running" || step.status === "waiting") ??
     null;
   const latestStep = steps.length > 0 ? steps[steps.length - 1] : null;
+  const latestThinkingItem =
+    [...items]
+      .reverse()
+      .find(
+        (
+          item,
+        ): item is Extract<ChatExecutionTimelineItem, { kind: "thinking" }> =>
+          item.kind === "thinking",
+      ) ?? null;
   const summaryStep = activeStep ?? (groupIsLive ? latestStep : null);
   const summarySuffix = groupHasTerminalError
     ? ` (${terminalErrorCount} failed)`
     : "";
+  const summaryLabel = summaryStep
+    ? summaryStep === activeStep || summaryStep.status === "waiting"
+      ? `${traceStatusLabel(summaryStep.status)}: ${summaryStep.title}`
+      : groupIsLive
+        ? summaryStep.title
+        : `${traceStatusLabel(summaryStep.status)}: ${summaryStep.title}`
+    : groupIsLive
+      ? latestThinkingItem
+        ? summarizeThinking(latestThinkingItem.text)
+        : stepCount > 0
+          ? `Working through ${stepLabel}...`
+          : "Thinking..."
+      : runningCount > 0
+        ? `Running ${stepLabel}...`
+        : latestThinkingItem
+          ? summarizeThinking(latestThinkingItem.text)
+          : stepCount > 0
+            ? `Used ${stepLabel}`
+            : "Execution trace";
 
   return (
     <div className="mt-3">
@@ -5981,17 +6152,7 @@ function TraceStepGroup({
           <Check size={13} className="text-emerald-500" />
         )}
         <span>
-          {summaryStep
-            ? summaryStep === activeStep || summaryStep.status === "waiting"
-              ? `${traceStatusLabel(summaryStep.status)}: ${summaryStep.title}`
-              : groupIsLive
-                ? summaryStep.title
-                : `${traceStatusLabel(summaryStep.status)}: ${summaryStep.title}`
-            : groupIsLive
-              ? `Working through ${stepLabel}...`
-              : runningCount > 0
-                ? `Running ${stepLabel}...`
-                : `Used ${stepLabel}`}
+          {summaryLabel}
           {summarySuffix}
         </span>
         <ChevronDown
@@ -6002,116 +6163,22 @@ function TraceStepGroup({
 
       {groupExpanded ? (
         <div className="mt-1 ml-1 space-y-0.5">
-          {steps.map((step) => {
-            const expanded = !(collapsedByStepId[step.id] ?? true);
-            return (
-              <div key={step.id}>
-                <button
-                  type="button"
-                  onClick={() =>
-                    step.details.length > 0 && onToggleStep(step.id)
-                  }
-                  className={`flex w-full items-start gap-2 rounded-md px-2.5 -ml-2.5 py-1 text-left text-xs transition-colors ${step.details.length > 0 ? "hover:bg-muted/50 cursor-pointer" : "cursor-default"}`}
-                >
-                  <span className="mt-0.5 shrink-0">
-                    {step.status === "completed" ? (
-                      <Check size={12} className="text-emerald-500" />
-                    ) : step.status === "error" ? (
-                      <AlertTriangle size={12} className="text-destructive" />
-                    ) : step.status === "running" ? (
-                      <Loader2
-                        size={12}
-                        className="animate-spin text-muted-foreground"
-                      />
-                    ) : (
-                      <Clock3 size={12} className="text-muted-foreground" />
-                    )}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="font-medium text-foreground/80">
-                      {step.title}
-                    </span>
-                    {step.details.length > 0 ? (
-                      <span className="ml-1.5 text-muted-foreground/70">
-                        {step.details[0]}
-                      </span>
-                    ) : null}
-                  </span>
-                  {step.details.length > 1 ? (
-                    <ChevronDown
-                      size={12}
-                      className={`mt-0.5 shrink-0 text-muted-foreground/50 transition-transform ${expanded ? "rotate-180" : ""}`}
-                    />
-                  ) : null}
-                </button>
-                {expanded && step.details.length > 1 ? (
-                  <div className="ml-6 mt-0.5 mb-1 rounded-md border border-border/30 bg-muted/30 px-3 py-2 text-[11px] leading-5 text-muted-foreground whitespace-pre-wrap">
-                    {step.details.slice(1).join("\n")}
-                  </div>
-                ) : null}
-                {step.status === "error" ? (
-                  <IntegrationErrorBanner details={step.details} />
-                ) : null}
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function summarizeThinking(text: string) {
-  const firstContentLine =
-    text
-      .split("\n")
-      .map((line) => line.replace(/[*_`#>-]/g, "").trim())
-      .find(Boolean) || "Reasoning available";
-
-  return firstContentLine.length > 88
-    ? `${firstContentLine.slice(0, 85).trimEnd()}...`
-    : firstContentLine;
-}
-
-function ThinkingPanel({
-  text,
-  collapsed,
-  onToggle,
-  live = false,
-}: ThinkingPanelProps) {
-  const summary = summarizeThinking(text);
-
-  return (
-    <div className="mt-4">
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={!collapsed}
-        className="bg-muted flex w-full items-center justify-between gap-3 rounded-[18px] border border-border/35 px-3.5 py-3 text-left transition hover:border-border/55"
-      >
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-              {live ? "Thinking" : "Reasoning"}
-            </span>
-            {live ? (
-              <span className="rounded-full border border-[rgba(247,90,84,0.18)] bg-[rgba(247,90,84,0.08)] px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[rgba(206,92,84,0.92)]">
-                LIVE
-              </span>
-            ) : null}
-          </div>
-          <div className="mt-1 truncate text-[12px] text-muted-foreground/76">
-            {collapsed ? summary : "Expanded reasoning trace"}
-          </div>
-        </div>
-        <ChevronDown
-          size={14}
-          className={`shrink-0 text-muted-foreground transition ${collapsed ? "" : "rotate-180"}`}
-        />
-      </button>
-      {!collapsed ? (
-        <div className="theme-chat-thinking-inner mt-2 whitespace-pre-wrap rounded-[18px] border border-border/30 px-4 py-3 text-[12px] leading-6 text-muted-foreground/86">
-          {text}
+          {items.map((item) =>
+            item.kind === "thinking" ? (
+              <ExecutionTimelineThinkingEntry
+                key={item.id}
+                text={item.text}
+                onLinkClick={onLinkClick}
+              />
+            ) : (
+              <TraceTimelineStepEntry
+                key={item.id}
+                step={item.step}
+                collapsedByStepId={collapsedByStepId}
+                onToggleStep={onToggleStep}
+              />
+            ),
+          )}
         </div>
       ) : null}
     </div>
@@ -6511,13 +6578,13 @@ function Composer({
         />
       </div>
 
-      <div className="flex items-center justify-between gap-2 border-t border-border/20 px-3 py-3 text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-2 border-t border-border/20 px-3 py-3 text-muted-foreground">
         {showModelSelector ? (
           <div
             className={
               noAvailableModels
-                ? "min-w-0 flex flex-1 items-center gap-3"
-                : "w-[172px] shrink-0 sm:w-[208px]"
+                ? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"
+                : "min-w-0 flex-1 basis-[220px] max-w-[240px]"
             }
           >
             {noAvailableModels ? (

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -208,6 +208,13 @@ const STREAM_TELEMETRY_LIMIT = 240;
 const TOOL_TRACE_TERMINAL_PHASES = new Set(["completed", "failed", "error"]);
 const CHAT_AUTO_SCROLL_THRESHOLD_PX = 72;
 const CHAT_SCROLLBAR_MIN_THUMB_HEIGHT_PX = 40;
+const COMPOSER_FOOTER_GAP_PX = 8;
+const COMPOSER_FULL_MODEL_CONTROL_WIDTH_PX = 240;
+const COMPOSER_FULL_THINKING_CONTROL_WIDTH_PX = 112;
+const COMPOSER_FULL_PROVIDER_SETUP_WIDTH_PX = 320;
+const COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX = 240;
+const COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX = 56;
+const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 148;
 const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
 const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
@@ -440,6 +447,53 @@ function displayModelLabel(model: string) {
         ? part
         : `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`,
     )
+    .join(" ");
+}
+
+function compactComposerModelLabel(label: string) {
+  const normalizedLabel = label.trim();
+  if (!normalizedLabel) {
+    return "Model";
+  }
+
+  const autoMatch = normalizedLabel.match(/^Auto \((.+)\)$/i);
+  if (autoMatch?.[1]) {
+    return autoMatch[1].trim();
+  }
+
+  const segments = normalizedLabel
+    .split("·")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  return segments[segments.length - 1] ?? normalizedLabel;
+}
+
+function displayThinkingValueLabel(value: string) {
+  const normalizedValue = value.trim().toLowerCase();
+  if (!normalizedValue) {
+    return "Thinking";
+  }
+
+  if (normalizedValue === "xhigh") {
+    return "Extra High";
+  }
+  if (
+    normalizedValue === "none" ||
+    normalizedValue === "minimal" ||
+    normalizedValue === "low" ||
+    normalizedValue === "medium" ||
+    normalizedValue === "high" ||
+    normalizedValue === "max"
+  ) {
+    return `${normalizedValue[0]?.toUpperCase() ?? ""}${normalizedValue.slice(1)}`;
+  }
+  if (/^-?\d+$/.test(normalizedValue)) {
+    return Number(normalizedValue).toLocaleString();
+  }
+  return normalizedValue
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
     .join(" ");
 }
 
@@ -6397,6 +6451,7 @@ function ModelCombobox({
   modelOptions,
   modelOptionGroups,
   disabled,
+  compact = false,
   onModelChange,
 }: {
   selectedModel: string;
@@ -6406,6 +6461,7 @@ function ModelCombobox({
   modelOptions: ChatModelOption[];
   modelOptionGroups: ChatModelOptionGroup[];
   disabled: boolean;
+  compact?: boolean;
   onModelChange: (value: string) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -6468,6 +6524,7 @@ function ModelCombobox({
     selectedModel === CHAT_MODEL_USE_RUNTIME_DEFAULT
       ? `Auto (${runtimeDefaultModelLabel})`
       : selectedModelLabel || "Select model";
+  const compactLabel = compactComposerModelLabel(displayLabel);
 
   const hasFilteredOptions =
     Boolean(filteredAutoOption) ||
@@ -6523,9 +6580,21 @@ function ModelCombobox({
           <Button
             variant="outline"
             size="lg"
-            className="w-full justify-between text-xs font-medium"
+            className={`w-full justify-between rounded-[11px] bg-card text-xs font-medium ${
+              compact ? "px-2.5" : ""
+            }`}
           >
-            <span className="truncate">{displayLabel}</span>
+            {compact ? (
+              <span className="flex min-w-0 items-center gap-2">
+                <Waypoints
+                  size={13}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <span className="truncate">{compactLabel}</span>
+              </span>
+            ) : (
+              <span className="truncate">{displayLabel}</span>
+            )}
             <ChevronDown size={13} className="shrink-0 text-muted-foreground" />
           </Button>
         }
@@ -6583,16 +6652,19 @@ function ThinkingValueSelect({
   selectedThinkingValue,
   thinkingValues,
   disabled,
+  compact = false,
   onThinkingValueChange,
 }: {
   selectedThinkingValue: string | null;
   thinkingValues: string[];
   disabled: boolean;
+  compact?: boolean;
   onThinkingValueChange: (value: string | null) => void;
 }) {
   if (thinkingValues.length === 0 || !selectedThinkingValue) {
     return null;
   }
+  const selectedThinkingLabel = displayThinkingValueLabel(selectedThinkingValue);
 
   return (
     <Select
@@ -6600,13 +6672,30 @@ function ThinkingValueSelect({
       onValueChange={onThinkingValueChange}
       disabled={disabled}
     >
-      <SelectTrigger className="h-11 rounded-[11px] bg-card text-xs font-medium">
-        <SelectValue placeholder="Thinking" />
+      <SelectTrigger
+        aria-label={
+          compact ? `Reasoning effort: ${selectedThinkingLabel}` : undefined
+        }
+        className={`h-11 rounded-[11px] bg-card text-xs font-medium ${
+          compact ? "w-full min-w-0 px-2.5" : ""
+        }`}
+      >
+        {compact ? (
+          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+            <Lightbulb
+              size={13}
+              className="shrink-0 text-muted-foreground"
+            />
+            <span className="truncate">{selectedThinkingLabel}</span>
+          </span>
+        ) : (
+          <SelectValue placeholder="Thinking" />
+        )}
       </SelectTrigger>
       <SelectContent side="top" align="end">
         {thinkingValues.map((value) => (
           <SelectItem key={value} value={value} className="text-xs">
-            {value}
+            {displayThinkingValueLabel(value)}
           </SelectItem>
         ))}
       </SelectContent>
@@ -6650,6 +6739,13 @@ function Composer({
   onRemoveAttachment,
 }: ComposerProps) {
   const [isDragActive, setIsDragActive] = useState(false);
+  const composerFooterRef = useRef<HTMLDivElement | null>(null);
+  const composerActionsRef = useRef<HTMLDivElement | null>(null);
+  const [composerFooterLayout, setComposerFooterLayout] = useState({
+    width: 0,
+    actionsWidth: 0,
+    wraps: false,
+  });
   const noAvailableModels =
     !runtimeDefaultModelAvailable &&
     modelOptions.length === 0 &&
@@ -6667,6 +6763,125 @@ function Composer({
       ?.selectedLabel ??
     modelOptions.find((option) => option.value === selectedModel)?.label ??
     resolvedModelLabel;
+  const syncComposerFooterLayout = () => {
+    const footer = composerFooterRef.current;
+    if (!footer) {
+      return;
+    }
+    const footerStyle = window.getComputedStyle(footer);
+    const horizontalPadding =
+      Number.parseFloat(footerStyle.paddingLeft || "0") +
+      Number.parseFloat(footerStyle.paddingRight || "0");
+    const width = Math.max(
+      0,
+      Math.round(footer.clientWidth - horizontalPadding),
+    );
+    const actionsWidth = Math.round(
+      composerActionsRef.current?.getBoundingClientRect().width ?? 0,
+    );
+    const visibleRowOffsets = Array.from(footer.children)
+      .filter(
+        (child): child is HTMLElement =>
+          child instanceof HTMLElement && child.offsetParent !== null,
+      )
+      .map((child) => child.offsetTop);
+    const wraps = new Set(visibleRowOffsets).size > 1;
+    setComposerFooterLayout((current) =>
+      current.width === width &&
+      current.actionsWidth === actionsWidth &&
+      current.wraps === wraps
+        ? current
+        : { width, actionsWidth, wraps },
+    );
+  };
+  useLayoutEffect(() => {
+    const footer = composerFooterRef.current;
+    if (!footer) {
+      return;
+    }
+
+    syncComposerFooterLayout();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      syncComposerFooterLayout();
+    });
+    resizeObserver.observe(footer);
+    if (composerActionsRef.current) {
+      resizeObserver.observe(composerActionsRef.current);
+    }
+    Array.from(footer.children).forEach((child) => {
+      if (child instanceof HTMLElement) {
+        resizeObserver.observe(child);
+      }
+    });
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [
+    noAvailableModels,
+    resolvedModelLabel,
+    runtimeDefaultModelAvailable,
+    selectedModel,
+    selectedModelOptionLabel,
+    selectedThinkingValue,
+    showModelSelector,
+    showThinkingValueSelector,
+    thinkingValues,
+  ]);
+  const visibleFooterControlCount =
+    1 + (showThinkingValueSelector ? 1 : 0) + 1;
+  const fullPrimaryControlWidth = showModelSelector
+    ? noAvailableModels
+      ? COMPOSER_FULL_PROVIDER_SETUP_WIDTH_PX
+      : COMPOSER_FULL_MODEL_CONTROL_WIDTH_PX
+    : 0;
+  const fullFooterControlWidth =
+    fullPrimaryControlWidth +
+    (showThinkingValueSelector ? COMPOSER_FULL_THINKING_CONTROL_WIDTH_PX : 0) +
+    composerFooterLayout.actionsWidth +
+    Math.max(0, visibleFooterControlCount - 1) * COMPOSER_FOOTER_GAP_PX;
+  const compactFooterControlWidth = Math.max(
+    0,
+    composerFooterLayout.width -
+      composerFooterLayout.actionsWidth -
+      Math.max(0, visibleFooterControlCount - 1) * COMPOSER_FOOTER_GAP_PX,
+  );
+  const compactComposerControls =
+    showModelSelector &&
+    (composerFooterLayout.wraps ||
+      (composerFooterLayout.width > 0 &&
+        composerFooterLayout.actionsWidth > 0 &&
+        composerFooterLayout.width < fullFooterControlWidth));
+  const compactModelControlWidth = compactComposerControls
+    ? Math.min(
+        COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX,
+        Math.max(
+          0,
+          compactFooterControlWidth -
+            (showThinkingValueSelector
+              ? Math.min(
+                  COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX,
+                  compactFooterControlWidth,
+                )
+              : 0),
+        ),
+      )
+    : 0;
+  const compactThinkingControlWidth = showThinkingValueSelector
+    ? Math.max(
+        Math.min(
+          COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX,
+          compactFooterControlWidth - compactModelControlWidth,
+        ),
+        Math.min(
+          COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX,
+          compactFooterControlWidth,
+        ),
+      )
+    : 0;
 
   const allowAttachmentDrop = (dataTransfer: DataTransfer | null) => {
     if (!dataTransfer || disabled || isResponding) {
@@ -6778,13 +6993,27 @@ function Composer({
         />
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 border-t border-border/20 px-3 py-3 text-muted-foreground">
+      <div
+        ref={composerFooterRef}
+        className={`border-t border-border/20 px-3 py-3 text-muted-foreground ${
+          compactComposerControls
+            ? "flex items-center gap-2 overflow-hidden"
+            : "flex flex-wrap items-center gap-2"
+        }`}
+      >
         {showModelSelector ? (
           <div
             className={
-              noAvailableModels
-                ? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"
-                : "min-w-0 flex-1 basis-[220px] max-w-[240px]"
+              compactComposerControls
+                ? "min-w-0 shrink-0"
+                : noAvailableModels
+                  ? "min-w-0 flex flex-1 basis-full flex-wrap items-center gap-2"
+                  : "min-w-0 flex-1 basis-[220px] max-w-[240px]"
+            }
+            style={
+              compactComposerControls
+                ? { width: `${compactModelControlWidth}px` }
+                : undefined
             }
           >
             {noAvailableModels ? (
@@ -6794,7 +7023,9 @@ function Composer({
                   variant="outline"
                   size="lg"
                   onClick={onOpenModelProviders}
-                  className="shrink-0 justify-between rounded-[11px] bg-card text-[12px] font-semibold hover:border-primary/35 hover:bg-card/92"
+                  className={`shrink-0 justify-between rounded-[11px] bg-card text-[12px] font-semibold hover:border-primary/35 hover:bg-card/92 ${
+                    compactComposerControls ? "px-2.5" : ""
+                  }`}
                   aria-label="Configure model providers"
                 >
                   <span className="flex min-w-0 items-center gap-2">
@@ -6802,14 +7033,20 @@ function Composer({
                       size={13}
                       className="shrink-0 text-muted-foreground"
                     />
-                    <span className="truncate">Set up providers</span>
+                    <span className="truncate">
+                      {compactComposerControls ? "Providers" : "Set up providers"}
+                    </span>
                   </span>
                   <ArrowRight
                     size={14}
                     className="shrink-0 text-muted-foreground"
                   />
                 </Button>
-                <div className="min-w-0 text-[10px] leading-5 text-muted-foreground">
+                <div
+                  className={`min-w-0 text-[10px] leading-5 text-muted-foreground ${
+                    compactComposerControls ? "hidden" : ""
+                  }`}
+                >
                   Open provider settings to connect a model.
                 </div>
               </>
@@ -6822,6 +7059,7 @@ function Composer({
                 modelOptions={modelOptions}
                 modelOptionGroups={modelOptionGroups}
                 disabled={isResponding}
+                compact={compactComposerControls}
                 onModelChange={onModelChange}
               />
             )}
@@ -6833,17 +7071,32 @@ function Composer({
         )}
 
         {showThinkingValueSelector ? (
-          <div className="min-w-[112px] shrink-0 sm:w-[112px]">
+          <div
+            className={
+              compactComposerControls
+                ? "shrink-0"
+                : "min-w-[112px] shrink-0 sm:w-[112px]"
+            }
+            style={
+              compactComposerControls
+                ? { width: `${compactThinkingControlWidth}px` }
+                : undefined
+            }
+          >
             <ThinkingValueSelect
               selectedThinkingValue={selectedThinkingValue}
               thinkingValues={thinkingValues}
               disabled={isResponding}
+              compact={compactComposerControls}
               onThinkingValueChange={onThinkingValueChange}
             />
           </div>
         ) : null}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div
+          ref={composerActionsRef}
+          className="ml-auto flex shrink-0 items-center gap-2"
+        >
           <Button
             variant="outline"
             size="icon"

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -6265,7 +6265,7 @@ function ExecutionTimelineThinkingEntry({
     <div className="py-1">
       <div className="-ml-2.5 w-[calc(100%+0.625rem)] rounded-[16px] border border-border/25 bg-muted/30 px-3.5 py-3">
         <SimpleMarkdown
-          className="chat-markdown chat-assistant-markdown max-w-full text-[12px] leading-6 text-foreground/82"
+          className="chat-markdown chat-thinking-markdown max-w-full text-foreground/82"
           onLinkClick={onLinkClick}
         >
           {text}

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -6262,13 +6262,15 @@ function ExecutionTimelineThinkingEntry({
   onLinkClick?: (url: string) => void;
 }) {
   return (
-    <div className="ml-5 mr-1 rounded-[16px] border border-border/25 bg-muted/30 px-3.5 py-3">
-      <SimpleMarkdown
-        className="chat-markdown chat-assistant-markdown max-w-full text-[12px] leading-6 text-foreground/82"
-        onLinkClick={onLinkClick}
-      >
-        {text}
-      </SimpleMarkdown>
+    <div className="py-1">
+      <div className="-ml-2.5 w-[calc(100%+0.625rem)] rounded-[16px] border border-border/25 bg-muted/30 px-3.5 py-3">
+        <SimpleMarkdown
+          className="chat-markdown chat-assistant-markdown max-w-full text-[12px] leading-6 text-foreground/82"
+          onLinkClick={onLinkClick}
+        >
+          {text}
+        </SimpleMarkdown>
+      </div>
     </div>
   );
 }

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -679,6 +679,11 @@ webview {
   line-height: 1.8;
 }
 
+.chat-thinking-markdown {
+  font-size: 12px;
+  line-height: 1.55;
+}
+
 .chat-markdown .md-link,
 .chat-markdown .md-p,
 .chat-markdown .md-li,

--- a/website/docs/docs/.vitepress/theme/components/DiagramLocalStack.vue
+++ b/website/docs/docs/.vitepress/theme/components/DiagramLocalStack.vue
@@ -18,7 +18,7 @@
         <div class="hb-diagram-stack__runtime-grid">
           <div class="hb-diagram-stack__node">
             <span class="hb-diagram-stack__node-name">Embedded Runtime API</span>
-            <span class="hb-diagram-stack__node-meta">Fastify :5060 in desktop dev</span>
+            <span class="hb-diagram-stack__node-meta">Fastify :5160 in desktop dev</span>
           </div>
           <div class="hb-diagram-stack__node">
             <span class="hb-diagram-stack__node-name">State Store</span>

--- a/website/docs/docs/build-on-holaos/agent-harness/internals.md
+++ b/website/docs/docs/build-on-holaos/agent-harness/internals.md
@@ -20,6 +20,28 @@ For the shipped `pi` path, a single run currently moves through these seams:
 
 If you are unsure where a behavior belongs, trace this path before you patch anything.
 
+Representative reduced host request from `runtime/harnesses/src/pi.ts`:
+
+```ts
+{
+  workspace_id: params.request.workspace_id,
+  workspace_dir: params.bootstrap.workspaceDir,
+  session_id: params.request.session_id,
+  input_id: params.request.input_id,
+  instruction: instructionWithContextMessages(
+    params.request.instruction,
+    params.runtimeConfig.context_messages,
+  ),
+  attachments: params.request.attachments ?? [],
+  thinking_value: params.request.thinking_value ?? null,
+  provider_id: params.runtimeConfig.provider_id,
+  model_id: params.runtimeConfig.model_id,
+  model_client: params.runtimeConfig.model_client,
+  mcp_servers: params.mcpServers,
+  mcp_tool_refs: params.mcpToolRefs,
+}
+```
+
 ## Main code seams
 
 - `runtime/harnesses/src/types.ts`: canonical harness contracts, including adapter capabilities, runner prep plans, prompt-layer payloads, prepared MCP payloads, and host request build parameters.
@@ -34,6 +56,36 @@ If you are unsure where a behavior belongs, trace this path before you patch any
 - `runtime/harness-host/src/pi-runtime-tools.ts`: runtime-managed tool bridge for onboarding, cronjobs, image generation, and `write_report`. This is also where the host attaches workspace/session/input/model headers to runtime-tool calls.
 - `runtime/harness-host/src/pi-web-search.ts`: hosted native web search bridge for the current `web_search` tool.
 - `runtime/harnesses/src/desktop-browser-tools.ts`, `runtime/harnesses/src/runtime-agent-tools.ts`, and `runtime/harnesses/src/native-web-search-tools.ts`: canonical ids and descriptions for the projected browser, runtime, and native web-search surfaces.
+
+Representative event normalization from `runtime/harness-host/src/pi.ts`:
+
+```ts
+switch (event.type) {
+  case "message_update":
+    return event.assistantMessageEvent.type === "thinking_delta"
+      ? [{ event_type: "thinking_delta", payload: { delta_kind: "thinking" } }]
+      : [{ event_type: "output_delta", payload: { delta_kind: "output" } }];
+  case "tool_execution_start":
+  case "tool_execution_end":
+    return [{ event_type: "tool_call", payload: { source: "pi" } }];
+}
+```
+
+Representative reasoning normalization in the host:
+
+```ts
+const requestedThinking = requestedPiThinkingLevel(request) ?? "off";
+const requestedThinkingBudgets = requestedPiThinkingBudgets(request);
+
+const settingsManager = SettingsManager.inMemory({
+  defaultProvider: request.provider_id,
+  defaultModel: request.model_id,
+  defaultThinkingLevel: requestedThinking,
+  ...(requestedThinkingBudgets
+    ? { thinkingBudgets: requestedThinkingBudgets }
+    : {}),
+});
+```
 
 ## Change the right seam
 

--- a/website/docs/docs/build-on-holaos/agent-harness/internals.md
+++ b/website/docs/docs/build-on-holaos/agent-harness/internals.md
@@ -13,9 +13,9 @@ For the shipped `pi` path, a single run currently moves through these seams:
 1. `runtime/api-server/src/ts-runner.ts`: compiles the workspace runtime plan, stages MCP and app state, loads or persists harness session state, and decides which harness plugin to use.
 2. `runtime/api-server/src/agent-runtime-config.ts`: projects prompt layers, response-delivery policy, operator-surface context, capability manifests, selected model client config, and the tool map passed into the harness.
 3. `runtime/api-server/src/harness-registry.ts`: selects the runtime harness plugin, timeout behavior, browser tools, runtime tools, and MCP preparation policy.
-4. `runtime/harnesses/src/pi.ts`: builds the reduced host request that crosses from runtime code into the harness host.
+4. `runtime/harnesses/src/pi.ts`: builds the reduced host request that crosses from runtime code into the harness host, including the raw `thinking_value` requested for this run.
 5. `runtime/harness-host/src/index.ts`: dispatches the registered host plugin by command.
-6. `runtime/harness-host/src/pi.ts`: creates the Pi session, loads skills, injects runtime and browser tools, materializes allowlisted MCP tools, enforces workspace boundaries, and maps native events back out.
+6. `runtime/harness-host/src/pi.ts`: creates the Pi session, loads skills, injects runtime and browser tools, materializes allowlisted MCP tools, enforces workspace boundaries, maps `thinking_value` onto Pi-native reasoning settings, and maps native events back out.
 7. `runtime/harness-host/src/contracts.ts`: defines the normalized runner event types that the host emits back to the runtime.
 
 If you are unsure where a behavior belongs, trace this path before you patch anything.
@@ -29,7 +29,7 @@ If you are unsure where a behavior belongs, trace this path before you patch any
 - `runtime/api-server/src/agent-runtime-config.ts`: prompt and capability projection. This is where prompt layers, recalled memory, recent runtime context, operator-surface context, response-delivery policy, capability manifests, and tool visibility are composed before the harness runs.
 - `runtime/harness-host/src/contracts.ts`: host-side request and event contracts. This is the source of truth for the decoded host request and the normalized runner event types the host must emit back.
 - `runtime/harness-host/src/index.ts`: harness-host CLI entrypoint that dispatches a registered host plugin by command.
-- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, and materializes allowlisted MCP tools.
+- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, materializes allowlisted MCP tools, and normalizes provider-native `thinking_value` choices onto Pi reasoning levels or budgets.
 - `runtime/harness-host/src/pi-browser-tools.ts`: desktop browser bridge used by the current host.
 - `runtime/harness-host/src/pi-runtime-tools.ts`: runtime-managed tool bridge for onboarding, cronjobs, image generation, and `write_report`. This is also where the host attaches workspace/session/input/model headers to runtime-tool calls.
 - `runtime/harness-host/src/pi-web-search.ts`: hosted native web search bridge for the current `web_search` tool.
@@ -39,6 +39,7 @@ If you are unsure where a behavior belongs, trace this path before you patch any
 
 - If you are changing prompt layers, model selection, or capability projection, start in `runtime/api-server/src/agent-runtime-config.ts`.
 - If you are changing run bootstrap, session reuse, or the order of preparation steps, start in `runtime/api-server/src/ts-runner.ts`.
+- If you are changing which reasoning-effort values appear in the desktop or how they map into the executor, inspect `desktop/shared/model-catalog.ts`, `desktop/src/components/panes/ChatPane.tsx`, and `runtime/harness-host/src/pi.ts` together.
 - If you are changing which tools the harness can see, inspect both `runtime/api-server/src/harness-registry.ts` and the tool-definition files under `runtime/harnesses/src/`.
 - If you are changing report-artifact behavior or runtime-tool request metadata, inspect both `runtime/harness-host/src/pi-runtime-tools.ts` and `runtime/api-server/src/runtime-agent-tools.ts`.
 - If you are changing event normalization, waiting-user behavior, or tool-call event mapping, inspect `runtime/harness-host/src/contracts.ts` and `runtime/harness-host/src/pi.ts`.

--- a/website/docs/docs/build-on-holaos/desktop/internals.md
+++ b/website/docs/docs/build-on-holaos/desktop/internals.md
@@ -16,7 +16,10 @@ That means desktop work is usually spread across four boundaries: React renderer
 ## Main code seams
 
 - `desktop/src/components/layout/AppShell.tsx`: the shell composition and top-level product routing. This is where the agent pane, browser panes, file explorer, app surfaces, operations drawer, notifications, settings overlays, and reported non-browser operator surfaces are coordinated.
+- `desktop/shared/model-catalog.ts`: shipped fallback model metadata for direct providers and Holaboss Proxy model mapping, including reasoning support, allowed thinking values, and input modalities.
 - `desktop/src/lib/workspaceDesktop.tsx` and `desktop/src/lib/workspaceSelection.tsx`: renderer-side workspace state and shell coordination.
+- `desktop/src/components/auth/AuthPanel.tsx`: provider settings, catalog-backed defaults, background-task selection, recall embeddings, and image-generation configuration.
+- `desktop/src/components/panes/ChatPane.tsx`: model picker, per-model reasoning-effort selector, queued chat inputs, and stream/timeline rendering.
 - `desktop/src/components/panes/BrowserPane.tsx`, `SpaceBrowserExplorerPane.tsx`, and `SpaceBrowserDisplayPane.tsx`: the browser-space UI for the `user` and `agent` browser surfaces.
 - `desktop/src/components/panes/FileExplorerPane.tsx`: workspace file explorer, previews, editing, bookmarking, and file-watch behavior.
 - `desktop/src/components/layout/NotificationToastStack.tsx`: runtime-backed notification rendering and activation behavior.
@@ -30,7 +33,7 @@ The desktop does not talk to the runtime through a vague helper. `desktop/electr
 
 1. Resolve the staged runtime bundle under `desktop/out/runtime-<platform>` or an override such as `HOLABOSS_RUNTIME_ROOT`.
 2. Validate that the bundle includes the executable, packaged Node runtime, packaged Python runtime, `package-metadata.json`, and `runtime/api-server/dist/index.mjs`.
-3. Spawn `bin/sandbox-runtime` with desktop-owned env such as `HB_SANDBOX_ROOT`, `SANDBOX_AGENT_BIND_HOST=127.0.0.1`, `SANDBOX_AGENT_BIND_PORT=5060`, `SANDBOX_AGENT_HARNESS`, `HOLABOSS_RUNTIME_DB_PATH`, and the bridge settings.
+3. Spawn `bin/sandbox-runtime` with desktop-owned env such as `HB_SANDBOX_ROOT`, `SANDBOX_AGENT_BIND_HOST=127.0.0.1`, `SANDBOX_AGENT_BIND_PORT=5160`, `SANDBOX_AGENT_HARNESS`, `HOLABOSS_RUNTIME_DB_PATH`, and the bridge settings.
 4. Wait for the embedded runtime health check to pass.
 5. Stream stdout and stderr into `runtime.log` under the Electron `userData` directory.
 6. On app quit, block final Electron exit until desktop-owned cleanup tears down the embedded runtime and browser service.
@@ -75,6 +78,16 @@ Important behavior to understand:
 The desktop browser service is now more than a browser-tool bridge. In addition to page and tab routes, it exposes `/api/v1/browser/operator-surface-context`, which lets the embedded runtime load the current active operator surfaces for the workspace. That payload combines browser-owned surfaces with the non-browser surfaces `AppShell` reports through `workspace.setOperatorSurfaceContext(...)`.
 
 This split is why browser behavior belongs to desktop internals, not to generic UI code alone.
+
+## Model catalog and reasoning controls
+
+The desktop model path is now catalog-driven rather than a flat model string list.
+
+- `desktop/electron/main.ts` refreshes a managed runtime model catalog from the control plane when a signed-in Holaboss session is active, caches that catalog, and merges it with the locally persisted `runtime-config.json`.
+- The merged runtime-config snapshot exposes `providerModelGroups`, `catalogVersion`, and managed defaults for background tasks, embeddings, and image generation.
+- `AuthPanel.tsx` uses that snapshot to show the actual configured provider/model surface instead of a blind text field.
+- `ChatPane.tsx` uses the same provider groups plus the local fallback catalog to decide whether the selected model supports reasoning and which `thinking_value` choices to show.
+- The selected `thinking_value` is a chat-composer preference, not a `runtime-config.json` field. On submit the renderer queues it with the session input so the runtime can apply it per run.
 
 ## File explorer contract
 

--- a/website/docs/docs/build-on-holaos/desktop/internals.md
+++ b/website/docs/docs/build-on-holaos/desktop/internals.md
@@ -40,6 +40,27 @@ The desktop does not talk to the runtime through a vague helper. `desktop/electr
 
 If you are debugging runtime startup from desktop, inspect `runtime.log` and the `sandbox-host` directory under Electron `userData` before you change UI code.
 
+Representative launch shape from `desktop/electron/main.ts`:
+
+```ts
+const child = spawn(launchSpec.command, launchSpec.args, {
+  cwd: runtimeRoot,
+  env: {
+    ...process.env,
+    HB_SANDBOX_ROOT: sandboxRoot,
+    SANDBOX_AGENT_BIND_HOST: "127.0.0.1",
+    SANDBOX_AGENT_BIND_PORT: String(RUNTIME_API_PORT),
+    HOLABOSS_EMBEDDED_RUNTIME: "1",
+    SANDBOX_AGENT_HARNESS: harness,
+    HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
+    PROACTIVE_ENABLE_REMOTE_BRIDGE: "1",
+    HOLABOSS_AUTH_COOKIE: authCookieHeader() ?? "",
+  },
+});
+```
+
+`HOLABOSS_RUNTIME_ROOT` can override the staged bundle location when you need the desktop to boot a different packaged runtime tree.
+
 ## Renderer-to-main contract
 
 The desktop renderer does not talk to Electron internals directly. It goes through namespaced bridge contracts exposed by `electronAPI`.
@@ -64,6 +85,40 @@ If you change the desktop contract, update all three layers together:
 2. `desktop/src/types/electron.d.ts`
 3. the `ipcMain` handler in `desktop/electron/main.ts`, usually wired through `handleTrustedIpc(...)`
 
+Minimal bridge example:
+
+```ts
+// preload
+runtime: {
+  getConfig: () => ipcRenderer.invoke("runtime:getConfig"),
+  setConfig: (payload) => ipcRenderer.invoke("runtime:setConfig", payload),
+},
+workspace: {
+  queueSessionInput: (payload) =>
+    ipcRenderer.invoke("workspace:queueSessionInput", payload),
+}
+```
+
+```ts
+// main
+handleTrustedIpc("runtime:getConfig", ["main", "auth-popup"], () =>
+  getRuntimeConfig(),
+);
+handleTrustedIpc(
+  "runtime:setConfig",
+  ["main", "auth-popup"],
+  async (_event, payload) => {
+    const currentConfig = await readRuntimeConfigFile();
+    const nextConfig = await writeRuntimeConfigFile(payload);
+    await restartEmbeddedRuntimeIfNeeded(currentConfig, nextConfig);
+    return getRuntimeConfig();
+  },
+);
+handleTrustedIpc("workspace:queueSessionInput", ["main"], async (_event, payload) =>
+  queueSessionInput(payload),
+);
+```
+
 ## Browser protocol
 
 The browser system is not just a webview dropped into React. The current path uses BrowserView orchestration in the main process and synchronizes the visible viewport from the renderer using `browser.setBounds`.
@@ -79,6 +134,16 @@ The desktop browser service is now more than a browser-tool bridge. In addition 
 
 This split is why browser behavior belongs to desktop internals, not to generic UI code alone.
 
+The non-browser half of that context comes from the renderer:
+
+```ts
+await window.electronAPI.workspace.setOperatorSurfaceContext(
+  workspaceId,
+  reportedOperatorSurfaceContext,
+);
+// runtime later reads GET /api/v1/browser/operator-surface-context
+```
+
 ## Model catalog and reasoning controls
 
 The desktop model path is now catalog-driven rather than a flat model string list.
@@ -88,6 +153,29 @@ The desktop model path is now catalog-driven rather than a flat model string lis
 - `AuthPanel.tsx` uses that snapshot to show the actual configured provider/model surface instead of a blind text field.
 - `ChatPane.tsx` uses the same provider groups plus the local fallback catalog to decide whether the selected model supports reasoning and which `thinking_value` choices to show.
 - The selected `thinking_value` is a chat-composer preference, not a `runtime-config.json` field. On submit the renderer queues it with the session input so the runtime can apply it per run.
+
+Representative catalog metadata and queue handoff:
+
+```ts
+const entry = {
+  model_id: "gpt-5.4",
+  reasoning: true,
+  thinking_values: ["none", "low", "medium", "high", "xhigh"],
+  default_thinking_value: "medium",
+  input_modalities: ["text", "image"],
+};
+```
+
+```ts
+const selectedModelSupportsReasoning = selectedConfiguredModel
+  ? selectedConfiguredModel.reasoning === true
+  : Boolean(selectedFallbackModelMetadata?.reasoning);
+
+await window.electronAPI.workspace.queueSessionInput({
+  model: resolvedChatModel || null,
+  thinking_value: effectiveThinkingValue,
+});
+```
 
 ## File explorer contract
 

--- a/website/docs/docs/build-on-holaos/independent-deploy.md
+++ b/website/docs/docs/build-on-holaos/independent-deploy.md
@@ -98,6 +98,32 @@ $HB_SANDBOX_ROOT/
 
 Optional product-facing env such as `HOLABOSS_RUNTIME_WORKFLOW_BACKEND`, `PROACTIVE_ENABLE_REMOTE_BRIDGE`, and `PROACTIVE_BRIDGE_BASE_URL` are only needed when you want standalone runtime behavior to match the desktop-backed workflow path.
 
+Representative `runtime-config.json` for a product-backed standalone runtime:
+
+```json
+{
+  "runtime": {
+    "mode": "product",
+    "default_model": "openai/gpt-5.4",
+    "default_provider": "holaboss_model_proxy"
+  },
+  "integrations": {
+    "holaboss": {
+      "enabled": true,
+      "auth_token": "hbrt.v1.your-runtime-token",
+      "user_id": "user_123",
+      "sandbox_id": "sandbox_123"
+    }
+  },
+  "providers": {
+    "holaboss_model_proxy": {
+      "kind": "holaboss_proxy",
+      "base_url": "https://runtime.example/api/v1/model-proxy"
+    }
+  }
+}
+```
+
 ## Install and run examples
 
 Linux:

--- a/website/docs/docs/build-on-holaos/index.md
+++ b/website/docs/docs/build-on-holaos/index.md
@@ -11,6 +11,15 @@ Use it when you are:
 
 The source of truth for this section is the code, not a conceptual product story.
 
+## About vs Build
+
+Use the docs split deliberately:
+
+- `About holaOS` explains the system model, boundaries, and why the layers exist.
+- `Build on holaOS` explains the code seams, request shapes, scripts, ports, and validation paths that developers change in practice.
+
+If a page needs exact commands, routes, payload fields, or source-file ownership, it belongs here rather than in the conceptual `holaOS` section.
+
 ## How To Use This Section
 
 The practical builder flow is:

--- a/website/docs/docs/build-on-holaos/runtime-apis.md
+++ b/website/docs/docs/build-on-holaos/runtime-apis.md
@@ -19,7 +19,7 @@ The same API server shows up under different ports depending on how you started 
 
 - Running `runtime/api-server/dist/index.mjs` directly defaults to `0.0.0.0:3060` unless `SANDBOX_RUNTIME_API_PORT`, `SANDBOX_AGENT_BIND_PORT`, or `PORT` is set.
 - The packaged runtime launcher defaults to `0.0.0.0:8080` through `runtime/deploy/bootstrap/shared.sh`.
-- The embedded desktop runtime binds to `127.0.0.1:5060` because `desktop/electron/main.ts` launches it that way.
+- The embedded desktop runtime binds to `127.0.0.1:5160` because `desktop/electron/main.ts` launches it that way.
 
 Use the right port before you assume a route is broken.
 
@@ -46,6 +46,20 @@ Runtime-tool routes are not generic anonymous helpers. The runtime and harness h
 - `x-holaboss-selected-model`
 
 That is how `write_report` and other runtime tools can persist outputs with stable session and input context instead of falling back to detached file writes.
+
+## Queue requests can carry model and reasoning overrides
+
+The desktop chat surface does not only queue raw text. `POST /api/v1/agent-sessions/queue` can also carry:
+
+- `model`
+- `thinking_value`
+
+The runtime stores both on the queued input record, then `claimed-input-executor.ts` forwards them into the `TsRunnerRequest`. The important split is:
+
+- `model` is resolved into the run's provider and model client later by the runtime config path
+- `thinking_value` stays as request-scoped execution metadata that the harness host maps onto executor-native reasoning controls
+
+If a run is using the right model but the wrong reasoning effort, inspect both the queue payload and the harness-host mapping instead of only the runtime config file.
 
 ## Streaming surfaces
 
@@ -79,8 +93,8 @@ That path now matters for report artifacts because the runtime can persist them 
 For a local embedded desktop runtime:
 
 ```bash
-curl http://127.0.0.1:5060/healthz
-curl http://127.0.0.1:5060/api/v1/runtime/status
+curl http://127.0.0.1:5160/healthz
+curl http://127.0.0.1:5160/api/v1/runtime/status
 ```
 
 For standalone runtime debugging, change the port to the one you actually bound, usually `8080` or `3060`.

--- a/website/docs/docs/build-on-holaos/runtime-apis.md
+++ b/website/docs/docs/build-on-holaos/runtime-apis.md
@@ -47,6 +47,23 @@ Runtime-tool routes are not generic anonymous helpers. The runtime and harness h
 
 That is how `write_report` and other runtime tools can persist outputs with stable session and input context instead of falling back to detached file writes.
 
+Representative `write_report` call:
+
+```bash
+curl -X POST http://127.0.0.1:5160/api/v1/capabilities/runtime-tools/reports \
+  -H 'x-holaboss-workspace-id: workspace-1' \
+  -H 'x-holaboss-session-id: session-main' \
+  -H 'x-holaboss-input-id: input-1' \
+  -H 'x-holaboss-selected-model: openai_direct/gpt-5.4' \
+  -H 'content-type: application/json' \
+  -d '{
+    "title": "Tariff update brief",
+    "filename": "tariff-update-brief",
+    "summary": "Short research brief on current tariff developments.",
+    "content": "# Tariff update brief\n\n- Court challenges are active.\n- Consumer impact remains debated.\n"
+  }'
+```
+
 ## Queue requests can carry model and reasoning overrides
 
 The desktop chat surface does not only queue raw text. `POST /api/v1/agent-sessions/queue` can also carry:
@@ -61,6 +78,21 @@ The runtime stores both on the queued input record, then `claimed-input-executor
 
 If a run is using the right model but the wrong reasoning effort, inspect both the queue payload and the harness-host mapping instead of only the runtime config file.
 
+Representative queue request:
+
+```http
+POST /api/v1/agent-sessions/queue
+Content-Type: application/json
+
+{
+  "workspace_id": "workspace-1",
+  "session_id": "session-main",
+  "text": "Please review the deploy plan.",
+  "model": "openai_direct/gpt-5.4",
+  "thinking_value": "low"
+}
+```
+
 ## Streaming surfaces
 
 The runtime has several streaming endpoints. If you change event shape or long-running execution behavior, trace these paths first:
@@ -71,6 +103,13 @@ The runtime has several streaming endpoints. If you change event shape or long-r
 - `GET /api/v1/agent-sessions/:sessionId/outputs/stream`
 
 Execution usually crosses `runtime/api-server/src/ts-runner.ts`, the harness registry, the harness host, and the state store before the desktop sees the result.
+
+Representative SSE debug call for session outputs:
+
+```bash
+curl -N \
+  'http://127.0.0.1:5160/api/v1/agent-sessions/session-main/outputs/stream?include_history=false&stop_on_terminal=true'
+```
 
 If you change a runtime-tool route that creates outputs or artifacts, also inspect:
 

--- a/website/docs/docs/build-on-holaos/runtime/run-compilation.md
+++ b/website/docs/docs/build-on-holaos/runtime/run-compilation.md
@@ -39,6 +39,45 @@ Today the reference collection is intentionally narrow:
 
 That means app manifests are runtime-plan inputs, but arbitrary workspace files are not unless later code stages them explicitly.
 
+Representative authored inputs from `workspace-runtime-plan.test.ts`:
+
+```yaml
+# workspace.yaml
+template_id: social_operator
+name: Social Operator
+agents:
+  id: workspace.general
+  model: gpt-4o
+applications:
+  - app_id: holaposter-ts-lite
+    config_path: apps/holaposter-ts-lite/app.runtime.yaml
+mcp_registry:
+  allowlist:
+    tool_ids:
+      - holaposter.create_post
+  servers:
+    holaposter:
+      type: remote
+      url: "http://localhost:3099/mcp"
+      enabled: true
+```
+
+```yaml
+# apps/holaposter-ts-lite/app.runtime.yaml
+app_id: holaposter-ts-lite
+healthchecks:
+  mcp:
+    path: /mcp/health
+    timeout_s: 60
+    interval_s: 5
+mcp:
+  transport: http-sse
+  port: 3099
+  path: /mcp
+env_contract:
+  - HOLABOSS_USER_ID
+```
+
 ## Stage 2: Compile `workspace.yaml`
 
 `compileWorkspaceRuntimePlan()` turns the authored workspace contract into a structured plan with:
@@ -128,6 +167,24 @@ Model selection and reasoning effort split here:
 - the queued input can also carry `thinking_value`, but that value is not folded into `runtime-config.json` or the projected model client
 
 That separation is intentional. The runtime owns model routing, while the harness host owns executor-specific reasoning controls.
+
+Representative projection shape:
+
+```ts
+const selectedModel = request.selected_model?.trim() || request.agent.model;
+const target = resolveRuntimeModelTarget(selectedModel, request.default_provider_id);
+
+return {
+  provider_id: target.providerId,
+  model_id: target.modelId,
+  model_client: resolveModelClientConfig(request, target),
+  tools,
+  workspace_tool_ids: workspaceToolIds,
+  workspace_skill_ids: request.workspace_skill_ids ?? [],
+  output_schema_member_id: outputSchemaMemberId,
+  output_format: outputFormat,
+};
+```
 
 ## Stage 6: Build the Harness Request and Snapshot It
 

--- a/website/docs/docs/build-on-holaos/runtime/run-compilation.md
+++ b/website/docs/docs/build-on-holaos/runtime/run-compilation.md
@@ -121,6 +121,14 @@ Important outputs include:
 
 This is also where response-delivery guidance and operator surface context become prompt-visible context for the run. If the harness sees the wrong tools, wrong prompt layers, wrong selected model, or wrong output schema, this is usually the page and code seam you wanted.
 
+Model selection and reasoning effort split here:
+
+- the queued input can carry a selected `model`
+- `projectAgentRuntimeConfig()` resolves that into `provider_id`, `model_id`, and `model_client`
+- the queued input can also carry `thinking_value`, but that value is not folded into `runtime-config.json` or the projected model client
+
+That separation is intentional. The runtime owns model routing, while the harness host owns executor-specific reasoning controls.
+
 ## Stage 6: Build the Harness Request and Snapshot It
 
 After runtime config projection, the harness adapter builds the host request.
@@ -130,6 +138,7 @@ After runtime config projection, the harness adapter builds the host request.
 - computes a request fingerprint
 - measures the `persist_turn_request_snapshot` bootstrap stage and calls `persistTurnRequestSnapshot()`
 - persists a sanitized `turn_request_snapshot` in `runtime.db`
+- carries request-scoped execution metadata such as `thinking_value` into the reduced host request alongside the resolved model client
 - includes MCP server mapping metadata and bootstrap timing details in the run-started payload
 - launches the harness host with the reduced request payload
 
@@ -148,6 +157,7 @@ That snapshot is the runtime’s replay and debugging seam. It is how the system
 - Missing MCP tools often come from `mcp_registry` compile rules or server-id mapping, not from the host implementation.
 - Ambiguous `here`, `this page`, or `what am I looking at` behavior usually comes from operator surface context loading, not from `workspace.yaml`.
 - Wrong prompt context often comes from runtime context loading or `projectAgentRuntimeConfig()`, not from `workspace.yaml`.
+- Wrong reasoning effort usually comes from the queued `thinking_value`, catalog metadata, or harness-host normalization, not from `workspace.yaml`.
 - If the runtime-plan compile fails before a run starts, use the dedicated workspace-runtime-plan CLI entrypoint from `runtime/api-server`.
 
 ## Validation

--- a/website/docs/docs/build-on-holaos/runtime/state-store.md
+++ b/website/docs/docs/build-on-holaos/runtime/state-store.md
@@ -129,6 +129,38 @@ Current important behavior from `store.ts` and `store.test.ts`:
 
 If you change queue semantics, you are changing scheduling behavior for the whole runtime, not just one worker. The current contract is intentionally trying to prevent the same session from being processed twice in parallel when global concurrency is greater than one.
 
+The tests exercise that behavior like this:
+
+```ts
+const sessionOneFirst = store.enqueueInput({
+  workspaceId: "workspace-1",
+  sessionId: "session-one",
+  payload: { text: "session-one-first" },
+  priority: 5,
+});
+store.enqueueInput({
+  workspaceId: "workspace-1",
+  sessionId: "session-one",
+  payload: { text: "session-one-second" },
+  priority: 4,
+});
+store.enqueueInput({
+  workspaceId: "workspace-1",
+  sessionId: "session-two",
+  payload: { text: "session-two" },
+  priority: 3,
+});
+
+const claimed = store.claimInputs({
+  limit: 2,
+  claimedBy: "worker-1",
+  leaseSeconds: 60,
+  distinctSessions: true,
+});
+```
+
+With `distinctSessions: true`, the second claim comes from `session-two` instead of taking two queued items from `session-one`.
+
 ## Database vs Filesystem Contract
 
 Do not collapse the persistence model into one place.
@@ -175,6 +207,13 @@ For development, the tests are usually the better executable reference than manu
 - expired-claim handling
 - output and notification behavior
 - proposal and memory-update flows
+
+The CLI expects `cli <operation> --request-base64 <base64-json>`. A representative claim flow looks like this:
+
+```bash
+REQ='{"options":{"dbPath":"/tmp/runtime.db","workspaceRoot":"/tmp/workspace"},"claimed_by":"worker-1","limit":2,"lease_seconds":60,"distinct_sessions":true}'
+holaboss-state-store claim-inputs --request-base64 "$(printf '%s' "$REQ" | base64 | tr -d '\n')"
+```
 
 ## Practical Rules
 

--- a/website/docs/docs/build-on-holaos/start-developing/contributing.md
+++ b/website/docs/docs/build-on-holaos/start-developing/contributing.md
@@ -39,6 +39,17 @@ Add `npm run desktop:e2e` when the change crosses renderer, preload, main-proces
 - Include the validation commands you ran in the commit body when they are important to understanding the change.
 - PRs should call out user-visible behavior changes, migrations, workspace-format changes, new env vars, and any required follow-up deploy steps.
 
+Representative commit shape:
+
+```text
+feat: add reasoning effort selection across desktop and runtime
+
+- add catalog-driven reasoning metadata to desktop model configuration
+- pass thinking_value through queued inputs and the reduced harness request
+- map provider-native reasoning values onto the harness runtime config
+- Validation: npm run desktop:typecheck; npm run runtime:test; npm run docs:test
+```
+
 ## Review expectations
 
 - Keep PRs narrow enough that reviewers can reason about behavior changes without reconstructing the entire system.

--- a/website/docs/docs/build-on-holaos/start-developing/index.md
+++ b/website/docs/docs/build-on-holaos/start-developing/index.md
@@ -63,7 +63,8 @@ Use the package-specific test commands when you are only touching one slice. Use
 
 ## Fast local checks
 
-- The embedded desktop runtime binds to `http://127.0.0.1:5060`. That is the right health endpoint for `npm run desktop:dev`.
+- The embedded desktop runtime binds to `http://127.0.0.1:5160`. That is the right health endpoint for `npm run desktop:dev`.
+- The desktop main process deliberately uses `5160` instead of `5060` because Node's fetch stack treats `5060` as a blocked port.
 - A packaged standalone runtime usually binds to `8080` unless you override `SANDBOX_AGENT_BIND_PORT`.
 - Running `runtime/api-server/dist/index.mjs` directly defaults to `3060` unless `SANDBOX_RUNTIME_API_PORT`, `SANDBOX_AGENT_BIND_PORT`, or `PORT` is set.
 - The staged runtime bundle should exist under `desktop/out/runtime-<platform>` and include `package-metadata.json`, `runtime/metadata.json`, and `runtime/api-server/dist/index.mjs`.

--- a/website/docs/docs/build-on-holaos/start-developing/index.md
+++ b/website/docs/docs/build-on-holaos/start-developing/index.md
@@ -19,6 +19,12 @@ For local development, think in three layers: desktop operator UI, a runtime bun
 
 The root wrapper runs `npm --prefix desktop run dev`. Inside `desktop/package.json`, `predev` does the heavy lifting:
 
+```bash
+npm run desktop:dev
+# root wrapper -> npm --prefix desktop run dev
+# desktop predev validates env, rebuilds native modules, and refreshes the staged runtime bundle first
+```
+
 - `node scripts/ensure-app-sdk.mjs`: makes sure the local app SDK is built before the renderer compiles against it
 - `node scripts/validate-dev-env.mjs`: fails early unless `desktop/.env` provides a control-plane URL such as `HOLABOSS_BACKEND_BASE_URL` or `HOLABOSS_PROACTIVE_URL`
 - `kill-port 5173`: clears a stale Vite port
@@ -41,6 +47,18 @@ The runtime watcher is not guessing. `desktop/scripts/watch-runtime-bundle.mjs` 
 - the active platform packager under `runtime/deploy/package_<platform>_runtime.*`
 
 When any of those inputs changes, the watcher rebuilds the staged runtime bundle and touches `desktop/out/dist-electron/main.cjs` so Electron restarts against the new runtime bits.
+
+Representative watcher inputs from `desktop/scripts/runtime-bundle-state.mjs`:
+
+```js
+runtimeSourceInputs: [
+  path.join(repoRoot, "runtime", "api-server", "src"),
+  path.join(repoRoot, "runtime", "state-store", "src"),
+  path.join(repoRoot, "runtime", "harness-host", "src"),
+  path.join(repoRoot, "runtime", "harnesses", "src"),
+  path.join(repoRoot, "runtime", "deploy", "bootstrap"),
+]
+```
 
 ## Runtime-only verification
 
@@ -69,6 +87,11 @@ Use the package-specific test commands when you are only touching one slice. Use
 - Running `runtime/api-server/dist/index.mjs` directly defaults to `3060` unless `SANDBOX_RUNTIME_API_PORT`, `SANDBOX_AGENT_BIND_PORT`, or `PORT` is set.
 - The staged runtime bundle should exist under `desktop/out/runtime-<platform>` and include `package-metadata.json`, `runtime/metadata.json`, and `runtime/api-server/dist/index.mjs`.
 - The Electron user-data directory controls the embedded sandbox root and `runtime.log`. In dev, `desktop:dev` sets `HOLABOSS_DESKTOP_USER_DATA_DIR=holaboss-local-dev` unless `HOLABOSS_DESKTOP_USER_DATA_PATH` overrides it.
+
+```bash
+curl http://127.0.0.1:5160/healthz
+bash desktop/scripts/check-runtime-status.sh
+```
 
 ## Main source-of-truth files
 

--- a/website/docs/docs/build-on-holaos/troubleshooting.md
+++ b/website/docs/docs/build-on-holaos/troubleshooting.md
@@ -46,6 +46,11 @@ The desktop dev loop only uses the staged bundle under `desktop/out/runtime-<pla
 
 If you want to throw away the staged bundle entirely, delete `desktop/out/runtime-<platform>` and rerun the staging command.
 
+```bash
+rm -rf desktop/out/runtime-<platform>
+npm run desktop:prepare-runtime:local
+```
+
 ## The standalone or packaged runtime is on the wrong port
 
 The launch mode controls the default port:
@@ -68,6 +73,13 @@ Check the provider path first:
 The runtime config parser merges values from `runtime`, `providers.holaboss_model_proxy`, `integrations.holaboss`, and `capabilities.desktop_browser`. The executable examples for this are in `runtime/api-server/src/runtime-config.test.ts`.
 
 If you are using direct provider fallback instead of the Holaboss model proxy path, verify the corresponding direct-provider env vars such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENROUTER_API_KEY`.
+
+From the Electron `userData` directory, a quick shape check looks like this:
+
+```bash
+jq '.providers.holaboss_model_proxy, .integrations.holaboss, .capabilities.desktop_browser' \
+  "<userData>/sandbox-host/state/runtime-config.json"
+```
 
 ## App setup fails inside an isolated app environment or container
 
@@ -92,6 +104,10 @@ The browser tool surface is not always available.
 - Confirm that runtime config enables the desktop browser capability and includes both the browser URL and auth token.
 - Confirm that you are running a `workspace_session`. The harness registry only stages browser tools for workspace sessions.
 - If the runtime reports browser unavailable, inspect `runtime-config.json` and `/api/v1/runtime/status` before you patch the harness.
+
+```bash
+curl http://127.0.0.1:5160/api/v1/runtime/status | jq .
+```
 
 ## The runtime starts but workspace data looks wrong
 

--- a/website/docs/docs/build-on-holaos/troubleshooting.md
+++ b/website/docs/docs/build-on-holaos/troubleshooting.md
@@ -10,7 +10,7 @@ For the desktop dev loop:
 
 ```bash
 npm run desktop:typecheck
-curl http://127.0.0.1:5060/healthz
+curl http://127.0.0.1:5160/healthz
 bash desktop/scripts/check-runtime-status.sh
 ```
 
@@ -27,12 +27,13 @@ Most early failures happen in the desktop `predev` hook, before the app window e
 
 ## The embedded runtime does not pass health checks
 
-In desktop dev, the embedded runtime is supposed to come up on `127.0.0.1:5060`, not `8080` or `3060`.
+In desktop dev, the embedded runtime is supposed to come up on `127.0.0.1:5160`, not `8080` or `3060`.
 
-- Check `curl http://127.0.0.1:5060/healthz`.
+- Check `curl http://127.0.0.1:5160/healthz`.
 - Inspect `runtime.log` under the Electron `userData` directory.
 - Inspect the embedded sandbox root under `sandbox-host/`, especially `sandbox-host/state/runtime-config.json` and `sandbox-host/state/runtime.db`.
 - If you set a custom user-data path, make sure you are looking in `HOLABOSS_DESKTOP_USER_DATA_PATH`. Otherwise `desktop:dev` defaults to an Electron `userData` directory derived from `HOLABOSS_DESKTOP_USER_DATA_DIR=holaboss-local-dev`.
+- The desktop code pins `5160` because Node's fetch stack blocks `5060` as a bad port.
 
 ## The runtime bundle is stale
 
@@ -49,7 +50,7 @@ If you want to throw away the staged bundle entirely, delete `desktop/out/runtim
 
 The launch mode controls the default port:
 
-- embedded desktop runtime: `5060`
+- embedded desktop runtime: `5160`
 - packaged launcher: `8080`
 - raw `runtime/api-server/dist/index.mjs`: `3060`
 

--- a/website/docs/docs/desktop/model-configuration.md
+++ b/website/docs/docs/desktop/model-configuration.md
@@ -4,6 +4,8 @@
 
 Holaboss ships with a default model setup. In most cases, you do not need to edit `runtime-config.json` by hand, because the desktop app already exposes the main configuration surfaces for provider connection, managed model catalogs, background tasks, recall embeddings, and image generation.
 
+This page is the configuration reference for operators and builders. For the Electron IPC path, runtime model-catalog refresh flow, queued `thinking_value` handoff, and other execution internals, continue into [Desktop Internals](/build-on-holaos/desktop/internals) and [Runtime APIs](/build-on-holaos/runtime-apis).
+
 The baseline defaults are:
 
 - default model: `openai/gpt-5.4`

--- a/website/docs/docs/desktop/model-configuration.md
+++ b/website/docs/docs/desktop/model-configuration.md
@@ -2,7 +2,7 @@
 
 ![Model Settings](/images/model-settings.png)
 
-Holaboss ships with a default model setup. In most cases, you do not need to edit `runtime-config.json` by hand, because the desktop app already exposes the main configuration surfaces for provider connection, background tasks, recall embeddings, and image generation.
+Holaboss ships with a default model setup. In most cases, you do not need to edit `runtime-config.json` by hand, because the desktop app already exposes the main configuration surfaces for provider connection, managed model catalogs, background tasks, recall embeddings, and image generation.
 
 The baseline defaults are:
 
@@ -35,6 +35,53 @@ Holaboss already provides model configuration in the desktop app:
 - changes autosave to `runtime-config.json`, and the chat model picker uses the configured provider models
 
 When the first direct provider is connected, the desktop seeds background tasks to that provider and its built-in default background model. Holaboss-managed sessions can also inject managed background and embedding defaults through the runtime binding. For `ollama_direct`, the provider can be selected, but you must choose a model explicitly before background LLM tasks are enabled.
+
+## Catalog-driven chat models
+
+The current desktop no longer treats chat models as only freeform strings.
+
+- Direct providers use the shipped fallback catalog in `desktop/shared/model-catalog.ts`.
+- Signed-in Holaboss-managed sessions can also fetch a managed runtime model catalog from the control plane.
+- The desktop merges that managed catalog with the locally persisted `runtime-config.json` and exposes the result as `providerModelGroups` in the runtime-config snapshot.
+- Managed defaults for background tasks, embeddings, and image generation are also carried with that snapshot as `defaultBackgroundModel`, `defaultEmbeddingModel`, and `defaultImageModel`.
+
+In practice, that means the model picker and settings UI are both catalog-aware:
+
+- `Settings -> Model Providers` uses the catalog to seed provider defaults and suggestions.
+- The chat composer uses the resolved provider groups to show only the models that are actually available for the current runtime.
+- Deprecated or unsupported model ids are filtered before they reach the renderer.
+
+## Reasoning effort in chat
+
+Reasoning effort is selected in the chat composer, not in `runtime-config.json`.
+
+The current flow is:
+
+1. select a chat model in the composer
+2. if that model advertises `reasoning: true` and has non-empty `thinkingValues`, the composer shows a `Thinking` selector
+3. the desktop remembers the last selected value per resolved model locally
+4. when the message is queued, the desktop sends both `model` and `thinking_value` to `/api/v1/agent-sessions/queue`
+
+That `thinking_value` is run-scoped metadata. It does not become a new global default model setting.
+
+## Current shipped reasoning-value sets
+
+The shipped fallback catalog currently exposes these reasoning controls:
+
+| Provider / model | Reasoning values |
+| --- | --- |
+| `openai_direct/gpt-5.4` | `none`, `low`, `medium`, `high`, `xhigh` |
+| `openai_direct/gpt-5.3-codex` | `low`, `medium`, `high`, `xhigh` |
+| `anthropic_direct/claude-sonnet-4-6` | `low`, `medium`, `high` |
+| `anthropic_direct/claude-opus-4-6` | `low`, `medium`, `high`, `max` |
+| `anthropic_direct/claude-haiku-4-5` | `1024`, `2048`, `8192`, `16384` |
+| `openrouter_direct/*` shipped chat models | `minimal`, `low`, `medium`, `high` |
+| `gemini_direct/gemini-2.5-pro` | `-1`, `128`, `2048`, `8192`, `32768` |
+| `gemini_direct/gemini-2.5-flash` | `0`, `-1`, `128`, `2048`, `8192`, `24576` |
+| `ollama_direct/*` shipped models | no reasoning selector |
+| `minimax_direct/*` shipped models | no reasoning selector |
+
+For Holaboss Proxy, the managed catalog can provide explicit reasoning metadata. If it does not, the desktop falls back to provider-mapped metadata for known OpenAI, Anthropic, Gemini, and shipped OpenRouter models.
 
 ## Customization mode
 
@@ -97,6 +144,8 @@ You can override that path with:
   - default model selection
 - `HOLABOSS_DEFAULT_MODEL`
   - environment override for the default model
+
+There is no `runtime.thinking_value` field. Reasoning effort is chosen per run in the chat composer and queued with the session input.
 
 ## Background task provider defaults
 

--- a/website/docs/docs/desktop/workspace-experience.md
+++ b/website/docs/docs/desktop/workspace-experience.md
@@ -4,6 +4,8 @@ This page defines the design contract for the workspace surface in Holaboss Desk
 
 Use it when you are building or refining the workspace UI. For the underlying filesystem and runtime model, see [Workspace Model](/holaos/workspace-model).
 
+This page is about the operator-facing surface, not the Electron implementation seam. For IPC contracts, embedded-runtime launch behavior, BrowserView ownership, and the browser service, continue into [Desktop Internals](/build-on-holaos/desktop/internals).
+
 ## Why the workspace surface matters
 
 The workspace is the operator's entrypoint into the `holaOS` environment. The UI should not behave like a generic folder browser. It should expose the operating context the agent is actually working inside.

--- a/website/docs/docs/desktop/workspace-experience.md
+++ b/website/docs/docs/desktop/workspace-experience.md
@@ -21,6 +21,7 @@ A workspace is a stable operating context for one workflow. In the UI, that cont
 - its session and continuity state
 - its memory and outputs
 - its model and provider settings
+- its active reasoning profile for the next run when the selected model supports it
 
 That means the desktop is not just opening a folder. It is opening a complete operating environment.
 
@@ -31,7 +32,7 @@ The workspace UI should make these areas discoverable:
 | Area | What the operator should be able to answer | Why it matters |
 | --- | --- | --- |
 | Workspace identity | Which workspace is open right now? | Prevents work in the wrong context. |
-| Active configuration | Which model, provider, and runtime settings are in effect? | Determines how the next run will behave. |
+| Active configuration | Which model, provider, reasoning profile, and runtime settings are in effect? | Determines how the next run will behave. |
 | Active operator surface | Where is the user currently working, and which surfaces belong to the agent instead? | Keeps "here", "this page", and "continue from this" grounded in the right place. |
 | Apps and capabilities | What can this workspace do right now? | Shows the actual capability surface, not just installed code. |
 | Integrations | Which external accounts are connected? | Determines whether apps can use external services. |

--- a/website/docs/docs/holaos/agent-harness/adapter-capabilities.md
+++ b/website/docs/docs/holaos/agent-harness/adapter-capabilities.md
@@ -2,9 +2,11 @@
 
 The runtime adapter is where the shipped harness path declares what it supports before a run ever reaches the host.
 
-## Current coded truth
+This page explains the capability boundary conceptually. For the exact adapter implementation, request builder, and host payload shape, continue into [Agent Harness Internals](/build-on-holaos/agent-harness/internals).
 
-In `runtime/harnesses/src/pi.ts`, the current `pi` adapter declares:
+## Current behavior
+
+The current shipped `pi` adapter declares:
 
 - `supportsWaitingUser: true`
 - `supportsSkills: true`

--- a/website/docs/docs/holaos/agent-harness/index.md
+++ b/website/docs/docs/holaos/agent-harness/index.md
@@ -2,6 +2,8 @@
 
 A harness is the execution and control layer that turns a model or agent runtime into a usable agent. In `holaOS`, the harness is the swappable execution subsystem inside the runtime boundary. The runtime still owns the environment contract around it: workspace structure, memory and continuity, capability projection, app orchestration, and the reduced execution package passed into the harness.
 
+This section stays at the boundary-and-responsibility level. For the current adapter contract, host request shape, event mapping, and runtime code seams, continue into [Agent Harness Internals](/build-on-holaos/agent-harness/internals).
+
 ## Where it sits
 
 1. The workspace holds authored inputs such as `workspace.yaml`, `AGENTS.md`, installed app manifests, and skills.

--- a/website/docs/docs/holaos/agent-harness/index.md
+++ b/website/docs/docs/holaos/agent-harness/index.md
@@ -46,6 +46,7 @@ Today the runtime prepares a harness request that includes:
 - workspace, session, and input identity
 - the current instruction and staged input attachments
 - selected provider and model client configuration
+- requested reasoning effort for this run when the operator selected one
 - the composed system prompt and runtime context messages
 - workspace skill directories
 - resolved MCP servers and allowlisted MCP tool refs

--- a/website/docs/docs/holaos/agent-harness/model-routing.md
+++ b/website/docs/docs/holaos/agent-harness/model-routing.md
@@ -14,8 +14,29 @@ That includes:
 - API key
 - base URL
 - default headers where relevant
+- requested `thinking_value` for this run when the operator selected a reasoning effort
 
 The runtime chooses this model path before invoking the harness, then passes the prepared client payload into the host request.
+
+## Reasoning effort is adjacent to routing, not part of routing
+
+The current chat path separates two decisions:
+
+- which provider and model client should execute the run
+- how much reasoning effort the selected model should use for this run
+
+The runtime owns the first decision. It resolves provider id, model id, transport kind, and auth headers before the harness starts.
+
+The queued input can also carry a `thinking_value`, but that value stays request-scoped. It is not a global runtime default and it is not part of `runtime.default_model`.
+
+That matters because the allowed values are model-specific rather than universal:
+
+- OpenAI shipped models use labels such as `none`, `low`, `medium`, `high`, and `xhigh`
+- OpenRouter shipped models use `minimal`, `low`, `medium`, and `high`
+- Anthropic shipped models can use adaptive labels or numeric budgets depending on the model
+- Gemini shipped models use numeric budgets, including sentinel values such as `0` or `-1`
+
+The host then normalizes those values onto executor-native reasoning controls. In the current `pi` path, generic OpenAI-compatible routes can also preserve provider-native labels when the underlying client expects them.
 
 ## Currently supported providers
 
@@ -59,13 +80,3 @@ The provider kind is not the whole routing story. The runtime also resolves a mo
 - `google_compatible`
 
 `gemini_direct` is the important special case here. It is configured as an OpenAI-compatible direct provider in the desktop UI, but the runtime resolves it onto the `google_compatible` transport path before the host executes the run.
-
-## Routing responsibility
-
-This is one of the places where `holaOS` keeps responsibility in the environment layer:
-
-- runtime resolves provider and model selection
-- runtime normalizes the provider kind and model-proxy path
-- harness executes the prepared run against that resolved model client
-
-That keeps execution consistent across harnesses instead of duplicating provider logic in each executor.

--- a/website/docs/docs/holaos/agent-harness/model-routing.md
+++ b/website/docs/docs/holaos/agent-harness/model-routing.md
@@ -2,6 +2,8 @@
 
 The harness request includes the model path the runtime has already resolved for this execution. The harness does not own model-provider resolution for the whole environment.
 
+This page explains routing responsibility, not the exact request payload. For the current runtime fields, harness-host request shape, and code seams, continue into [Run Compilation](/build-on-holaos/runtime/run-compilation) and [Agent Harness Internals](/build-on-holaos/agent-harness/internals).
+
 ## What the request carries
 
 The request also carries the selected provider and model client configuration for the run.
@@ -14,7 +16,7 @@ That includes:
 - API key
 - base URL
 - default headers where relevant
-- requested `thinking_value` for this run when the operator selected a reasoning effort
+- any run-scoped reasoning preference the operator selected
 
 The runtime chooses this model path before invoking the harness, then passes the prepared client payload into the host request.
 
@@ -27,7 +29,7 @@ The current chat path separates two decisions:
 
 The runtime owns the first decision. It resolves provider id, model id, transport kind, and auth headers before the harness starts.
 
-The queued input can also carry a `thinking_value`, but that value stays request-scoped. It is not a global runtime default and it is not part of `runtime.default_model`.
+The queued input can also carry a run-scoped reasoning preference, but that value stays request-scoped. It is not a global runtime default and it is not part of `runtime.default_model`.
 
 That matters because the allowed values are model-specific rather than universal:
 

--- a/website/docs/docs/holaos/agent-harness/skills-usage.md
+++ b/website/docs/docs/holaos/agent-harness/skills-usage.md
@@ -22,13 +22,3 @@ Skill frontmatter can grant additional managed tools or workspace commands for t
 - `holaboss_granted_commands`
 
 So the skill system is not just about loading instructions. It can also widen the effective tool or command surface in a controlled, inspectable way.
-
-## What this changes
-
-This keeps skills aligned with the environment model:
-
-- skills are explicit artifacts in the workspace
-- widening is tied to metadata rather than hidden state
-- the runtime and host can audit how capability changed during the run
-
-That is much more coherent than burying extra permissions inside executor-specific prompt logic.

--- a/website/docs/docs/holaos/apps.md
+++ b/website/docs/docs/holaos/apps.md
@@ -4,6 +4,8 @@ An app is the packaged capability unit that a workspace installs.
 
 It is how `holaOS` gives a workspace durable, inspectable, domain-specific behavior without collapsing that behavior into the harness, the prompt, or the desktop shell.
 
+This page explains why the app layer exists and how it fits into the system. For manifest fields, lifecycle hooks, MCP registration, and output-publishing behavior, continue into the app-development and `Build on holaOS` pages.
+
 ## Why the app layer exists
 
 `holaOS` is not only a runtime and memory system. It also needs a stable way to package capability.

--- a/website/docs/docs/holaos/concepts.md
+++ b/website/docs/docs/holaos/concepts.md
@@ -4,6 +4,8 @@ This page is the shared vocabulary for `holaOS`. It defines the core layers, art
 
 Holaboss Desktop is the operator-facing product surface. `holaOS` is the environment layer underneath it. The concepts below give you the working model for how those pieces fit together, so the rest of the docs are easier to scan and reason about.
 
+This page is intentionally conceptual. It defines responsibilities and boundaries, not exact implementation seams. If you need commands, payload fields, runtime routes, or source-file ownership, continue into [Build on holaOS](/build-on-holaos/).
+
 ## The system at a glance
 
 <DiagramSystemOverview />

--- a/website/docs/docs/holaos/overview.md
+++ b/website/docs/docs/holaos/overview.md
@@ -4,6 +4,8 @@ The overview now lives on the docs landing page.
 
 Use [Overview](/) for the merged entry page, then continue with [Environment Engineering](/holaos/environment-engineering).
 
+This section stays conceptual on purpose. It explains the environment model, layer boundaries, and durable system surfaces. When you need exact commands, payloads, routes, or source-file seams, continue into [Build on holaOS](/build-on-holaos/).
+
 ## Read next
 
 <DocCards>

--- a/website/docs/docs/holaos/workspace-model.md
+++ b/website/docs/docs/holaos/workspace-model.md
@@ -144,6 +144,8 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
 
 The workspace model is split deliberately: human-authored policy, runtime contracts, execution truth, and durable memory do not live in the same place.
 
+This page explains what the workspace surfaces mean. It is not the page for runner bootstrap order, compile-stage validation, or reduced harness-request payloads. For those implementation details, continue into [Run Compilation](/build-on-holaos/runtime/run-compilation).
+
 The diagram above is the canonical filesystem layout. The sections below explain what each surface is for.
 
 ## What each part means

--- a/website/docs/index.test.mjs
+++ b/website/docs/index.test.mjs
@@ -142,8 +142,24 @@ const HOLAOS_CONCEPTS_PATH = new URL(
   "./docs/holaos/concepts.md",
   import.meta.url
 );
+const HOLAOS_OVERVIEW_PATH = new URL(
+  "./docs/holaos/overview.md",
+  import.meta.url
+);
 const HOLAOS_WORKSPACE_MODEL_PATH = new URL(
   "./docs/holaos/workspace-model.md",
+  import.meta.url
+);
+const HOLAOS_HARNESS_INDEX_PATH = new URL(
+  "./docs/holaos/agent-harness/index.md",
+  import.meta.url
+);
+const HOLAOS_HARNESS_MODEL_ROUTING_PATH = new URL(
+  "./docs/holaos/agent-harness/model-routing.md",
+  import.meta.url
+);
+const HOLAOS_HARNESS_ADAPTER_CAPABILITIES_PATH = new URL(
+  "./docs/holaos/agent-harness/adapter-capabilities.md",
   import.meta.url
 );
 const ENVIRONMENT_ENGINEERING_PATH = new URL(
@@ -300,14 +316,21 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(buildOnOverview, /\/build-on-holaos\/desktop\/internals/);
 
   assert.match(startDeveloping, /npm run desktop:dev/);
+  assert.match(startDeveloping, /npm --prefix desktop run dev/);
   assert.match(startDeveloping, /desktop\/scripts\/watch-runtime-bundle\.mjs/);
+  assert.match(startDeveloping, /runtimeSourceInputs/);
   assert.match(startDeveloping, /desktop\/out\/runtime-<platform>/);
   assert.match(startDeveloping, /http:\/\/127\.0\.0\.1:5160/);
   assert.match(startDeveloping, /blocked port/);
+  assert.match(startDeveloping, /desktop\/scripts\/check-runtime-status\.sh/);
 
   assert.match(contributing, /Conventional Commits/);
   assert.match(contributing, /npm run docs:test/);
   assert.match(contributing, /desktop\/electron\/preload\.ts/);
+  assert.match(
+    contributing,
+    /feat: add reasoning effort selection across desktop and runtime/
+  );
 
   assert.match(modelConfiguration, /desktop\/shared\/model-catalog\.ts/);
   assert.match(modelConfiguration, /providerModelGroups/);
@@ -325,6 +348,8 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(desktopInternals, /providerModelGroups/);
   assert.match(desktopInternals, /thinking_value/);
   assert.match(desktopInternals, /5160/);
+  assert.match(desktopInternals, /spawn\(launchSpec\.command, launchSpec\.args/);
+  assert.match(desktopInternals, /ipcRenderer\.invoke\("runtime:getConfig"\)/);
 
   assert.match(runtimeApis, /runtime\/api-server\/src\/app\.ts/);
   assert.match(runtimeApis, /\/api\/v1\/agent-runs\/stream/);
@@ -336,6 +361,12 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeApis, /x-holaboss-selected-model/);
   assert.match(runtimeApis, /thinking_value/);
   assert.match(runtimeApis, /127\.0\.0\.1:5160/);
+  assert.match(runtimeApis, /POST \/api\/v1\/agent-sessions\/queue/);
+  assert.match(runtimeApis, /curl -X POST http:\/\/127\.0\.0\.1:5160\/api\/v1\/capabilities\/runtime-tools\/reports/);
+  assert.match(
+    runtimeApis,
+    /api\/v1\/agent-sessions\/session-main\/outputs\/stream/
+  );
 
   assert.match(runtimeRunCompilation, /workspace-runtime-plan\.ts/);
   assert.match(runtimeRunCompilation, /workspace_config_checksum/);
@@ -343,6 +374,8 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeRunCompilation, /runtime\/api-server\/src\/ts-runner\.ts/);
   assert.match(runtimeRunCompilation, /operator surface context/);
   assert.match(runtimeRunCompilation, /thinking_value/);
+  assert.match(runtimeRunCompilation, /# workspace\.yaml/);
+  assert.match(runtimeRunCompilation, /resolveRuntimeModelTarget\(selectedModel/);
 
   assert.match(runtimeStateStore, /runtime\/state-store\/src\/store\.ts/);
   assert.match(runtimeStateStore, /HOLABOSS_RUNTIME_DB_PATH/);
@@ -350,11 +383,15 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeStateStore, /claimInputs/);
   assert.match(runtimeStateStore, /runtime:state-store:test/);
   assert.match(runtimeStateStore, /exclude specific session ids/);
+  assert.match(runtimeStateStore, /distinctSessions:\s*true/);
+  assert.match(runtimeStateStore, /claim-inputs --request-base64/);
 
   assert.match(independentDeploy, /package-metadata\.json/);
   assert.match(independentDeploy, /runtime\/metadata\.json/);
   assert.match(independentDeploy, /HB_SANDBOX_ROOT/);
   assert.match(independentDeploy, /runtime\/deploy\/build_runtime_root/);
+  assert.match(independentDeploy, /"holaboss_model_proxy"/);
+  assert.match(independentDeploy, /"kind": "holaboss_proxy"/);
 
   assert.match(harnessInternals, /runtime\/api-server\/src\/ts-runner\.ts/);
   assert.match(harnessInternals, /runtime\/harness-host\/src\/pi\.ts/);
@@ -362,12 +399,17 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(harnessInternals, /write_report/);
   assert.match(harnessInternals, /pi-runtime-tools\.ts/);
   assert.match(harnessInternals, /thinking_value/);
+  assert.match(harnessInternals, /instructionWithContextMessages/);
+  assert.match(harnessInternals, /tool_execution_start/);
+  assert.match(harnessInternals, /defaultThinkingLevel/);
 
   assert.match(troubleshooting, /desktop\/scripts\/check-runtime-status\.sh/);
   assert.match(troubleshooting, /HOLABOSS_BACKEND_BASE_URL/);
   assert.match(troubleshooting, /workspace_session/);
   assert.match(troubleshooting, /desktop\/out\/runtime-/);
   assert.match(troubleshooting, /127\.0\.0\.1:5160/);
+  assert.match(troubleshooting, /rm -rf desktop\/out\/runtime-<platform>/);
+  assert.match(troubleshooting, /\/api\/v1\/runtime\/status/);
 });
 
 test("app development and templates pages expose runtime-true developer contracts", async () => {
@@ -428,8 +470,18 @@ test("app development and templates pages expose runtime-true developer contract
 
 test("high-level docs route developers into the concrete builder pages", async () => {
   const learningPath = await readFile(LEARNING_PATH_PATH, "utf8");
+  const holaosOverview = await readFile(HOLAOS_OVERVIEW_PATH, "utf8");
   const holaosApps = await readFile(HOLAOS_APPS_PATH, "utf8");
   const concepts = await readFile(HOLAOS_CONCEPTS_PATH, "utf8");
+  const harnessIndex = await readFile(HOLAOS_HARNESS_INDEX_PATH, "utf8");
+  const harnessModelRouting = await readFile(
+    HOLAOS_HARNESS_MODEL_ROUTING_PATH,
+    "utf8"
+  );
+  const adapterCapabilities = await readFile(
+    HOLAOS_HARNESS_ADAPTER_CAPABILITIES_PATH,
+    "utf8"
+  );
   const workspaceModel = await readFile(HOLAOS_WORKSPACE_MODEL_PATH, "utf8");
   const environmentEngineering = await readFile(
     ENVIRONMENT_ENGINEERING_PATH,
@@ -439,12 +491,37 @@ test("high-level docs route developers into the concrete builder pages", async (
   const docsIndex = await readFile(new URL("./docs/index.md", import.meta.url), "utf8");
 
   assert.match(learningPath, /\/build-on-holaos\//);
+  assert.match(holaosOverview, /This section stays conceptual on purpose/);
   assert.match(holaosApps, /applications:/);
+  assert.match(
+    holaosApps,
+    /For manifest fields, lifecycle hooks, MCP registration, and output-publishing behavior/
+  );
   assert.match(holaosApps, /mcp\.tools/);
+  assert.match(
+    concepts,
+    /This page is intentionally conceptual\. It defines responsibilities and boundaries/
+  );
   assert.match(concepts, /workspace registers it under `applications\[\]`/);
   assert.match(concepts, /Operator Surface/);
   assert.match(concepts, /\/build-on-holaos\//);
+  assert.match(
+    harnessIndex,
+    /For the current adapter contract, host request shape, event mapping, and runtime code seams/
+  );
+  assert.match(
+    harnessModelRouting,
+    /This page explains routing responsibility, not the exact request payload/
+  );
+  assert.match(
+    adapterCapabilities,
+    /This page explains the capability boundary conceptually/
+  );
   assert.match(workspaceModel, /applications\[\]\.app_id/);
+  assert.match(
+    workspaceModel,
+    /It is not the page for runner bootstrap order, compile-stage validation/
+  );
   assert.match(workspaceModel, /\/templates\/materialization/);
   assert.match(environmentEngineering, /\/build-on-holaos\//);
   assert.match(quickStart, /\/build-on-holaos\/start-developing\//);

--- a/website/docs/index.test.mjs
+++ b/website/docs/index.test.mjs
@@ -126,6 +126,10 @@ const TEMPLATES_VERSIONING_PATH = new URL(
   "./docs/templates/versioning.md",
   import.meta.url
 );
+const MODEL_CONFIGURATION_PATH = new URL(
+  "./docs/desktop/model-configuration.md",
+  import.meta.url
+);
 const LEARNING_PATH_PATH = new URL(
   "./docs/getting-started/learning-path.md",
   import.meta.url
@@ -279,6 +283,7 @@ test("build on holaOS pages expose the real developer seams and validation paths
   const buildOnOverview = await readFile(BUILD_ON_OVERVIEW_PATH, "utf8");
   const startDeveloping = await readFile(START_DEVELOPING_PATH, "utf8");
   const contributing = await readFile(CONTRIBUTING_PATH, "utf8");
+  const modelConfiguration = await readFile(MODEL_CONFIGURATION_PATH, "utf8");
   const desktopInternals = await readFile(DESKTOP_INTERNALS_PATH, "utf8");
   const runtimeApis = await readFile(RUNTIME_APIS_PATH, "utf8");
   const runtimeRunCompilation = await readFile(
@@ -297,17 +302,29 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(startDeveloping, /npm run desktop:dev/);
   assert.match(startDeveloping, /desktop\/scripts\/watch-runtime-bundle\.mjs/);
   assert.match(startDeveloping, /desktop\/out\/runtime-<platform>/);
-  assert.match(startDeveloping, /http:\/\/127\.0\.0\.1:5060/);
+  assert.match(startDeveloping, /http:\/\/127\.0\.0\.1:5160/);
+  assert.match(startDeveloping, /blocked port/);
 
   assert.match(contributing, /Conventional Commits/);
   assert.match(contributing, /npm run docs:test/);
   assert.match(contributing, /desktop\/electron\/preload\.ts/);
+
+  assert.match(modelConfiguration, /desktop\/shared\/model-catalog\.ts/);
+  assert.match(modelConfiguration, /providerModelGroups/);
+  assert.match(modelConfiguration, /thinking_value/);
+  assert.match(modelConfiguration, /gpt-5\.4/);
+  assert.match(modelConfiguration, /gemini-2\.5-pro/);
+  assert.match(modelConfiguration, /There is no `runtime\.thinking_value` field/);
 
   assert.match(desktopInternals, /handleTrustedIpc/);
   assert.match(desktopInternals, /HB_SANDBOX_ROOT/);
   assert.match(desktopInternals, /runtime\.log/);
   assert.match(desktopInternals, /operator-surface-context/);
   assert.match(desktopInternals, /workspace\.setOperatorSurfaceContext/);
+  assert.match(desktopInternals, /desktop\/shared\/model-catalog\.ts/);
+  assert.match(desktopInternals, /providerModelGroups/);
+  assert.match(desktopInternals, /thinking_value/);
+  assert.match(desktopInternals, /5160/);
 
   assert.match(runtimeApis, /runtime\/api-server\/src\/app\.ts/);
   assert.match(runtimeApis, /\/api\/v1\/agent-runs\/stream/);
@@ -317,12 +334,15 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeApis, /\/build-on-holaos\/runtime\/run-compilation/);
   assert.match(runtimeApis, /\/api\/v1\/capabilities\/runtime-tools\/reports/);
   assert.match(runtimeApis, /x-holaboss-selected-model/);
+  assert.match(runtimeApis, /thinking_value/);
+  assert.match(runtimeApis, /127\.0\.0\.1:5160/);
 
   assert.match(runtimeRunCompilation, /workspace-runtime-plan\.ts/);
   assert.match(runtimeRunCompilation, /workspace_config_checksum/);
   assert.match(runtimeRunCompilation, /persist_turn_request_snapshot/);
   assert.match(runtimeRunCompilation, /runtime\/api-server\/src\/ts-runner\.ts/);
   assert.match(runtimeRunCompilation, /operator surface context/);
+  assert.match(runtimeRunCompilation, /thinking_value/);
 
   assert.match(runtimeStateStore, /runtime\/state-store\/src\/store\.ts/);
   assert.match(runtimeStateStore, /HOLABOSS_RUNTIME_DB_PATH/);
@@ -341,11 +361,13 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(harnessInternals, /npm run runtime:harness-host:test/);
   assert.match(harnessInternals, /write_report/);
   assert.match(harnessInternals, /pi-runtime-tools\.ts/);
+  assert.match(harnessInternals, /thinking_value/);
 
   assert.match(troubleshooting, /desktop\/scripts\/check-runtime-status\.sh/);
   assert.match(troubleshooting, /HOLABOSS_BACKEND_BASE_URL/);
   assert.match(troubleshooting, /workspace_session/);
   assert.match(troubleshooting, /desktop\/out\/runtime-/);
+  assert.match(troubleshooting, /127\.0\.0\.1:5160/);
 });
 
 test("app development and templates pages expose runtime-true developer contracts", async () => {


### PR DESCRIPTION
## Context
- replace the separate reasoning panel with a single execution timeline that interleaves thinking segments and tool traces in assistant turns
- keep the live trace expanded during execution and collapse it once the final answer starts streaming
- tighten the chat composer footer so it compacts based on actual pane width, progressively budgets space between model and reasoning selectors, and keeps actions pinned to the right
- align inline thinking cards with the trace row gutter and add a bit more breathing room around them

## What Changed
- add ordered `executionItems` handling for restored and live assistant turns so thinking and tool activity render in timeline order
- render thinking inline inside the trace timeline and keep final assistant output and artifacts separate below the timeline
- replace viewport breakpoint-based composer footer wrapping with measured pane-width compaction and compact icon-led selectors
- cap compact model and reasoning selector growth, fix footer width measurement to use inner content width, and prevent action buttons from clipping or drifting left
- align execution timeline thinking cards with trace rows and add small vertical spacing between thinking cards and tool traces

## Validation
- `cd desktop && npm run typecheck`
- `cd desktop && node --test --test-name-pattern "chat pane renders an execution timeline that interleaves thinking segments with trace entries|live trace auto-expands during the run and collapses when output starts|chat pane renders live placeholder status as faint text with animated trailing dots|chat pane shows provider setup CTA when no chat models are available" src/components/panes/ChatPane.test.mjs`
- `cd desktop && node --test --test-name-pattern "chat pane shows provider setup CTA when no chat models are available|chat composer footer wraps controls based on available pane width instead of viewport breakpoints|chat composer switches model and thinking selectors into icon-led compact triggers" src/components/panes/ChatPane.test.mjs`

## UI Notes
- UI-affecting change in the chat execution timeline and composer footer
- screenshots not attached in CLI-created PR
