### PR TITLE
fix(desktop): align sidebar app icons with marketplace

### DIFF
--- a/desktop/src/components/marketplace/AppCatalogCard.tsx
+++ b/desktop/src/components/marketplace/AppCatalogCard.tsx
@@ -4,11 +4,6 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { providerIcon } from "@/components/onboarding/constants";
 
-/** Maps app_id → providerIcon key when they differ */
-const APP_PROVIDER_MAP: Record<string, string> = {
-  sheets: "googlesheets",
-};
-
 type AppCardState = "available" | "installing" | "installed";
 
 interface AppCatalogCardProps {
@@ -21,8 +16,7 @@ interface AppCatalogCardProps {
 export function AppCatalogCard({ entry, state, disabled, onInstall }: AppCatalogCardProps) {
   const label = entry.name || entry.app_id;
   const description = entry.description ?? "";
-  const providerKey = APP_PROVIDER_MAP[entry.app_id] ?? entry.app_id;
-  const icon = providerIcon(providerKey, 22);
+  const icon = providerIcon(entry.app_id, 22);
   return (
     <Card size="sm">
       <CardHeader>

--- a/desktop/src/components/onboarding/constants.ts
+++ b/desktop/src/components/onboarding/constants.ts
@@ -15,13 +15,23 @@ export function providerDisplayName(provider: string): string {
 }
 
 /**
+ * Aliases mapping app_id (as used in the runtime catalog) to the canonical
+ * provider key recognized by `providerIcon`. Add an entry whenever an app's
+ * id and its brand-icon key diverge.
+ */
+const PROVIDER_ALIASES: Record<string, string> = {
+  sheets: "googlesheets",
+};
+
+/**
  * Minimal brand-recognizable SVG icons for integration providers.
  * Each renders at the given size (default 20) with the provider's brand color.
  */
 export function providerIcon(provider: string, size = 20): ReactElement | null {
   const s = String(size);
+  const key = PROVIDER_ALIASES[provider] ?? provider;
 
-  switch (provider) {
+  switch (key) {
     case "gmail":
       // Simplified envelope with Gmail red accent
       return createElement(


### PR DESCRIPTION
## Summary
- Sidebar rendered installed apps by passing `app.id` straight to `providerIcon`, so `sheets` never matched the `googlesheets` switch case and fell back to "GS" initials. Marketplace had a local workaround the sidebar didn't share.
- Moved the alias table (`sheets → googlesheets`) into `constants.ts` and applied it inside `providerIcon`, so every caller gets the right icon automatically.
- Removed the now-duplicate `APP_PROVIDER_MAP` from `AppCatalogCard`.

## Test plan
- [x] `npm run typecheck` in `desktop/`
- [x] Sidebar shows the green Sheets icon (not "GS")
- [x] Marketplace card still renders the Sheets icon
- [x] Other apps (gmail, github, linkedin, reddit, twitter) still render correctly in both surfaces