### PR TITLE
fix: refresh artifact visibility in the explorer

### DIFF
--- a/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
+++ b/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
@@ -84,6 +84,18 @@ test("desktop file explorer enforces the selected workspace root as a filesystem
     source,
     /"fs:createPath"[\s\S]*parentPath: string \| null \| undefined,[\s\S]*kind: FileSystemCreateKind,[\s\S]*createExplorerPath\(parentPath, kind, workspaceId\)/,
   );
+  assert.match(source, /type ExplorerExternalImportEntryPayload =/);
+  assert.match(source, /interface ExplorerExternalImportResultPayload \{\s*absolutePaths: string\[];\s*\}/);
+  assert.match(source, /function normalizeExplorerImportRelativePath\(/);
+  assert.match(source, /function normalizeExplorerImportEntries\(/);
+  assert.match(source, /async function importExternalExplorerEntries\(/);
+  assert.match(source, /await nextAvailableExplorerCreatePath\(\s*destinationAbsolutePath,\s*rootName,\s*\)/);
+  assert.match(source, /await fs\.mkdir\(absolutePath, \{ recursive: true \}\);/);
+  assert.match(source, /await fs\.writeFile\(absolutePath, Buffer\.from\(fileEntry\.content\)\);/);
+  assert.match(
+    source,
+    /"fs:importExternalEntries"[\s\S]*destinationDirectoryPath: string,[\s\S]*entries: ExplorerExternalImportEntryPayload\[\],[\s\S]*importExternalExplorerEntries\(\s*destinationDirectoryPath,\s*entries,\s*workspaceId,\s*\)/,
+  );
   assert.match(
     source,
     /"fs:watchFile"[\s\S]*async \(_event, targetPath: string, workspaceId\?: string \| null\) =>\s*watchFilePreviewPath\(targetPath, workspaceId\)/,
@@ -117,6 +129,11 @@ test("desktop preload exposes file preview watch subscriptions and change events
   assert.match(
     source,
     /createPath: \(\s*parentPath: string \| null \| undefined,\s*kind: "file" \| "directory",\s*workspaceId\?: string \| null,\s*\) =>[\s\S]*ipcRenderer\.invoke\("fs:createPath", parentPath, kind, workspaceId\) as Promise<FileSystemMutationPayload>/,
+  );
+  assert.match(source, /type ExplorerExternalImportEntryPayload =/);
+  assert.match(
+    source,
+    /importExternalEntries: \(\s*destinationDirectoryPath: string,\s*entries: ExplorerExternalImportEntryPayload\[\],\s*workspaceId\?: string \| null,\s*\) =>[\s\S]*ipcRenderer\.invoke\(\s*"fs:importExternalEntries",\s*destinationDirectoryPath,\s*entries,\s*workspaceId,\s*\) as Promise<ExplorerExternalImportResultPayload>/,
   );
   assert.match(
     source,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -306,6 +306,21 @@ interface FileSystemMutationPayload {
   absolutePath: string;
 }
 
+type ExplorerExternalImportEntryPayload =
+  | {
+      kind: "directory";
+      relativePath: string;
+    }
+  | {
+      kind: "file";
+      relativePath: string;
+      content: Uint8Array;
+    };
+
+interface ExplorerExternalImportResultPayload {
+  absolutePaths: string[];
+}
+
 type FileSystemCreateKind = "file" | "directory";
 
 interface FilePreviewWatchSubscriptionPayload {
@@ -15146,6 +15161,210 @@ async function createExplorerPath(
   };
 }
 
+function normalizeExplorerImportRelativePath(relativePath: string) {
+  const normalized = relativePath
+    .trim()
+    .replace(/[\\/]+/g, "/")
+    .replace(/^\/+|\/+$/g, "");
+  if (!normalized) {
+    throw new Error("Imported path cannot be empty.");
+  }
+
+  const segments = normalized
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (
+    segments.length === 0 ||
+    segments.some(
+      (segment) =>
+        segment === "." ||
+        segment === ".." ||
+        segment.includes("/") ||
+        segment.includes("\\"),
+    )
+  ) {
+    throw new Error(`Imported path is invalid: ${relativePath}`);
+  }
+
+  return segments.join("/");
+}
+
+function normalizeExplorerImportEntries(
+  entries: unknown,
+): ExplorerExternalImportEntryPayload[] {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error("No files or folders were dropped.");
+  }
+
+  const normalizedEntries: ExplorerExternalImportEntryPayload[] = [];
+  const seenRelativePaths = new Set<string>();
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("Dropped content could not be parsed.");
+    }
+
+    const kind = "kind" in entry ? entry.kind : "";
+    const relativePath =
+      "relativePath" in entry && typeof entry.relativePath === "string"
+        ? normalizeExplorerImportRelativePath(entry.relativePath)
+        : "";
+    if (!relativePath) {
+      throw new Error("Dropped content is missing a relative path.");
+    }
+    if (seenRelativePaths.has(relativePath)) {
+      continue;
+    }
+    seenRelativePaths.add(relativePath);
+
+    if (kind === "directory") {
+      normalizedEntries.push({
+        kind: "directory",
+        relativePath,
+      });
+      continue;
+    }
+
+    if (kind !== "file") {
+      throw new Error(`Unsupported dropped item kind: ${String(kind)}`);
+    }
+
+    const contentValue = "content" in entry ? entry.content : null;
+    const content =
+      contentValue instanceof Uint8Array
+        ? contentValue
+        : contentValue instanceof ArrayBuffer
+          ? new Uint8Array(contentValue)
+          : ArrayBuffer.isView(contentValue)
+            ? new Uint8Array(
+                contentValue.buffer.slice(
+                  contentValue.byteOffset,
+                  contentValue.byteOffset + contentValue.byteLength,
+                ),
+              )
+            : Array.isArray(contentValue)
+              ? Uint8Array.from(contentValue)
+              : null;
+    if (!content) {
+      throw new Error(`Dropped file content is invalid: ${relativePath}`);
+    }
+
+    normalizedEntries.push({
+      kind: "file",
+      relativePath,
+      content,
+    });
+  }
+
+  return normalizedEntries;
+}
+
+function importedEntryDepth(relativePath: string) {
+  return normalizeExplorerImportRelativePath(relativePath).split("/").length;
+}
+
+function resolveImportedEntryAbsolutePath(
+  rootPathMap: Map<string, string>,
+  relativePath: string,
+) {
+  const segments = normalizeExplorerImportRelativePath(relativePath).split("/");
+  const rootAbsolutePath = rootPathMap.get(segments[0]);
+  if (!rootAbsolutePath) {
+    throw new Error(`Missing import root for ${relativePath}`);
+  }
+
+  if (segments.length === 1) {
+    return rootAbsolutePath;
+  }
+
+  return path.join(rootAbsolutePath, ...segments.slice(1));
+}
+
+async function importExternalExplorerEntries(
+  destinationDirectoryPath: string,
+  entries: unknown,
+  workspaceId?: string | null,
+): Promise<ExplorerExternalImportResultPayload> {
+  const normalizedEntries = normalizeExplorerImportEntries(entries);
+  const { absolutePath: destinationAbsolutePath, workspaceRoot } =
+    await resolveWorkspaceScopedExplorerPath(
+      destinationDirectoryPath,
+      workspaceId,
+    );
+  const destinationStat = await fs.stat(destinationAbsolutePath);
+  if (!destinationStat.isDirectory()) {
+    throw new Error("Destination is not a directory.");
+  }
+
+  const rootNames: string[] = [];
+  for (const entry of normalizedEntries) {
+    const [rootName = ""] = normalizeExplorerImportRelativePath(
+      entry.relativePath,
+    ).split("/");
+    if (rootName && !rootNames.includes(rootName)) {
+      rootNames.push(rootName);
+    }
+  }
+
+  const rootPathMap = new Map<string, string>();
+  for (const rootName of rootNames) {
+    const nextRootAbsolutePath = await nextAvailableExplorerCreatePath(
+      destinationAbsolutePath,
+      rootName,
+    );
+    if (workspaceRoot && !isPathWithinRoot(workspaceRoot, nextRootAbsolutePath)) {
+      throw new Error("Imported path escapes workspace root.");
+    }
+    rootPathMap.set(rootName, nextRootAbsolutePath);
+  }
+
+  const directoryEntries = normalizedEntries
+    .filter(
+      (
+        entry,
+      ): entry is Extract<ExplorerExternalImportEntryPayload, { kind: "directory" }> =>
+        entry.kind === "directory",
+    )
+    .sort((left, right) => importedEntryDepth(left.relativePath) - importedEntryDepth(right.relativePath));
+  for (const directoryEntry of directoryEntries) {
+    const absolutePath = resolveImportedEntryAbsolutePath(
+      rootPathMap,
+      directoryEntry.relativePath,
+    );
+    if (workspaceRoot && !isPathWithinRoot(workspaceRoot, absolutePath)) {
+      throw new Error("Imported path escapes workspace root.");
+    }
+    await fs.mkdir(absolutePath, { recursive: true });
+  }
+
+  const fileEntries = normalizedEntries
+    .filter(
+      (
+        entry,
+      ): entry is Extract<ExplorerExternalImportEntryPayload, { kind: "file" }> =>
+        entry.kind === "file",
+    )
+    .sort((left, right) => importedEntryDepth(left.relativePath) - importedEntryDepth(right.relativePath));
+  for (const fileEntry of fileEntries) {
+    const absolutePath = resolveImportedEntryAbsolutePath(
+      rootPathMap,
+      fileEntry.relativePath,
+    );
+    if (workspaceRoot && !isPathWithinRoot(workspaceRoot, absolutePath)) {
+      throw new Error("Imported path escapes workspace root.");
+    }
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, Buffer.from(fileEntry.content));
+  }
+
+  return {
+    absolutePaths: rootNames
+      .map((rootName) => rootPathMap.get(rootName) ?? "")
+      .filter(Boolean),
+  };
+}
+
 async function renameExplorerPath(
   targetPath: string,
   nextName: string,
@@ -18454,6 +18673,21 @@ app.whenReady().then(async () => {
       kind: FileSystemCreateKind,
       workspaceId?: string | null,
     ) => createExplorerPath(parentPath, kind, workspaceId),
+  );
+  handleTrustedIpc(
+    "fs:importExternalEntries",
+    ["main"],
+    async (
+      _event,
+      destinationDirectoryPath: string,
+      entries: ExplorerExternalImportEntryPayload[],
+      workspaceId?: string | null,
+    ) =>
+      importExternalExplorerEntries(
+        destinationDirectoryPath,
+        entries,
+        workspaceId,
+      ),
   );
   handleTrustedIpc(
     "fs:renamePath",

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -54,6 +54,21 @@ interface FileSystemMutationPayload {
   absolutePath: string;
 }
 
+type ExplorerExternalImportEntryPayload =
+  | {
+      kind: "directory";
+      relativePath: string;
+    }
+  | {
+      kind: "file";
+      relativePath: string;
+      content: Uint8Array;
+    };
+
+interface ExplorerExternalImportResultPayload {
+  absolutePaths: string[];
+}
+
 interface DiagnosticsExportPayload {
   bundlePath: string;
   fileName: string;
@@ -998,6 +1013,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
       workspaceId?: string | null,
     ) =>
       ipcRenderer.invoke("fs:createPath", parentPath, kind, workspaceId) as Promise<FileSystemMutationPayload>,
+    importExternalEntries: (
+      destinationDirectoryPath: string,
+      entries: ExplorerExternalImportEntryPayload[],
+      workspaceId?: string | null,
+    ) =>
+      ipcRenderer.invoke(
+        "fs:importExternalEntries",
+        destinationDirectoryPath,
+        entries,
+        workspaceId,
+      ) as Promise<ExplorerExternalImportResultPayload>,
     renamePath: (targetPath: string, nextName: string, workspaceId?: string | null) =>
       ipcRenderer.invoke("fs:renamePath", targetPath, nextName, workspaceId) as Promise<FileSystemMutationPayload>,
     movePath: (

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -165,13 +165,22 @@ test("chat composer switches model and thinking selectors into icon-led compact 
     source,
     /const selectedThinkingLabel = displayThinkingValueLabel\(selectedThinkingValue\);/,
   );
+  assert.match(source, /const \[open, setOpen\] = useState\(false\);/);
   assert.match(
     source,
     /aria-label=\{\s*compact \? `Reasoning effort: \$\{selectedThinkingLabel\}` : undefined\s*\}/,
   );
   assert.match(
     source,
-    /compact \? \(\s*showCompactLabel \? \(\s*<span className="flex min-w-0 flex-1 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<span className="truncate">\{selectedThinkingLabel\}<\/span>[\s\S]*\) : \(\s*<span className="flex min-w-0 flex-1 items-center justify-start">[\s\S]*<Lightbulb/,
+    /compact\s*\?\s*showCompactLabel\s*\?\s*"min-w-0 justify-between px-2\.5"\s*:\s*"min-w-0 justify-start gap-1\.5 px-2\.5"/,
+  );
+  assert.match(
+    source,
+    /compact \? \(\s*showCompactLabel \? \(\s*<>\s*<span className="flex min-w-0 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<span className="truncate">\{selectedThinkingLabel\}<\/span>[\s\S]*<ChevronDown[\s\S]*<\/>\s*\) : \(\s*<span className="flex min-w-0 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<ChevronDown/,
+  );
+  assert.match(
+    source,
+    /<PopoverContent[\s\S]*align="start"[\s\S]*side="top"[\s\S]*sideOffset=\{8\}[\s\S]*className="w-\[220px\] p-0"[\s\S]*Reasoning effort[\s\S]*thinkingValues\.map\(\(value\) => renderOption\(value\)\)/,
   );
 });
 

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -171,7 +171,7 @@ test("chat composer switches model and thinking selectors into icon-led compact 
   );
   assert.match(
     source,
-    /compact \? \(\s*<span className="flex min-w-0 flex-1 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<span className="truncate">\{selectedThinkingLabel\}<\/span>/,
+    /compact \? \(\s*showCompactLabel \? \(\s*<span className="flex min-w-0 flex-1 items-center gap-1\.5">[\s\S]*<Lightbulb[\s\S]*<span className="truncate">\{selectedThinkingLabel\}<\/span>[\s\S]*\) : \(\s*<span className="flex min-w-0 flex-1 items-center justify-start">[\s\S]*<Lightbulb/,
   );
 });
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -45,13 +45,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import {
   EXPLORER_ATTACHMENT_DRAG_TYPE,
@@ -235,8 +228,8 @@ const COMPOSER_FULL_MODEL_CONTROL_WIDTH_PX = 168;
 const COMPOSER_FULL_THINKING_CONTROL_WIDTH_PX = 88;
 const COMPOSER_FULL_PROVIDER_SETUP_WIDTH_PX = 320;
 const COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX = 168;
-const COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX = 72;
-const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 120;
+const COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX = 56;
+const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 56;
 const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
 const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
@@ -6949,6 +6942,8 @@ function ThinkingValueSelect({
   compactWidth?: number;
   onThinkingValueChange: (value: string | null) => void;
 }) {
+  const [open, setOpen] = useState(false);
+
   if (thinkingValues.length === 0 || !selectedThinkingValue) {
     return null;
   }
@@ -6959,49 +6954,105 @@ function ThinkingValueSelect({
     typeof compactWidth !== "number" ||
     compactWidth >= compactLabelMinWidth;
 
-  return (
-    <Select
-      value={selectedThinkingValue}
-      onValueChange={onThinkingValueChange}
-      disabled={disabled}
-    >
-      <SelectTrigger
-        aria-label={
-          compact ? `Reasoning effort: ${selectedThinkingLabel}` : undefined
-        }
-        className={`h-11 rounded-[11px] bg-card text-xs font-medium ${
-          compact ? "w-full min-w-0 px-2.5" : ""
+  const renderOption = (value: string) => {
+    const active = value === selectedThinkingValue;
+    return (
+      <button
+        key={value}
+        type="button"
+        onClick={() => {
+          onThinkingValueChange(value);
+          setOpen(false);
+        }}
+        className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs transition-colors ${
+          active
+            ? "bg-accent text-accent-foreground"
+            : "text-foreground hover:bg-accent/50"
         }`}
       >
-        {compact ? (
-          showCompactLabel ? (
-            <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              <Lightbulb
-                size={13}
-                className="shrink-0 text-muted-foreground"
-              />
-              <span className="truncate">{selectedThinkingLabel}</span>
-            </span>
-          ) : (
-            <span className="flex min-w-0 flex-1 items-center justify-start">
-              <Lightbulb
-                size={13}
-                className="shrink-0 text-muted-foreground"
-              />
-            </span>
-          )
-        ) : (
-          <SelectValue placeholder="Thinking" />
-        )}
-      </SelectTrigger>
-      <SelectContent side="top" align="end">
-        {thinkingValues.map((value) => (
-          <SelectItem key={value} value={value} className="text-xs">
-            {displayThinkingValueLabel(value)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+        <span className="truncate">{displayThinkingValueLabel(value)}</span>
+        {active ? (
+          <Check size={13} className="shrink-0 text-primary" />
+        ) : null}
+      </button>
+    );
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+      }}
+    >
+      <PopoverTrigger
+        disabled={disabled}
+        render={
+          <Button
+            variant="outline"
+            size="lg"
+            aria-label={
+              compact ? `Reasoning effort: ${selectedThinkingLabel}` : undefined
+            }
+            className={`w-full rounded-[11px] bg-card text-xs font-medium ${
+              compact
+                ? showCompactLabel
+                  ? "min-w-0 justify-between px-2.5"
+                  : "min-w-0 justify-start gap-1.5 px-2.5"
+                : "justify-between"
+            }`}
+          >
+            {compact ? (
+              showCompactLabel ? (
+                <>
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <Lightbulb
+                      size={13}
+                      className="shrink-0 text-muted-foreground"
+                    />
+                    <span className="truncate">{selectedThinkingLabel}</span>
+                  </span>
+                  <ChevronDown
+                    size={13}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </>
+              ) : (
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <Lightbulb
+                    size={13}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                  <ChevronDown
+                    size={13}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </span>
+              )
+            ) : (
+              <>
+                <span className="truncate">{selectedThinkingLabel}</span>
+                <ChevronDown
+                  size={13}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </>
+            )}
+          </Button>
+        }
+      />
+      <PopoverContent
+        align="start"
+        side="top"
+        sideOffset={8}
+        className="w-[220px] p-0"
+      >
+        <div className="border-b border-border/40 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
+          Reasoning effort
+        </div>
+        <div className="py-1">{thinkingValues.map((value) => renderOption(value))}</div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -6974,19 +6974,22 @@ function ThinkingValueSelect({
         }`}
       >
         {compact ? (
-          <span
-            className={`flex min-w-0 flex-1 items-center ${
-              showCompactLabel ? "gap-1.5" : "justify-center"
-            }`}
-          >
-            <Lightbulb
-              size={13}
-              className="shrink-0 text-muted-foreground"
-            />
-            {showCompactLabel ? (
+          showCompactLabel ? (
+            <span className="flex min-w-0 flex-1 items-center gap-1.5">
+              <Lightbulb
+                size={13}
+                className="shrink-0 text-muted-foreground"
+              />
               <span className="truncate">{selectedThinkingLabel}</span>
-            ) : null}
-          </span>
+            </span>
+          ) : (
+            <span className="flex min-w-0 flex-1 items-center justify-start">
+              <Lightbulb
+                size={13}
+                className="shrink-0 text-muted-foreground"
+              />
+            </span>
+          )
         ) : (
           <SelectValue placeholder="Thinking" />
         )}

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -336,7 +336,10 @@ test("file explorer can move dragged files into folder rows", async () => {
     /const \[directoryDropTargetPath, setDirectoryDropTargetPath\] = useState<[\s\S]*string \| null[\s\S]*>\(null\);/,
   );
   assert.match(source, /const canDropDraggedEntryIntoDirectory = useCallback\(/);
-  assert.match(source, /event\.dataTransfer\.dropEffect = "move";/);
+  assert.match(
+    source,
+    /event\.dataTransfer\.dropEffect = canMoveDraggedEntry\s*\?\s*"move"\s*:\s*"copy";/,
+  );
   assert.match(
     source,
     /void moveEntryToDirectory\(\s*draggedEntryPath,\s*entry\.absolutePath,\s*\);/,
@@ -353,6 +356,41 @@ test("file explorer can move dragged files into folder rows", async () => {
     source,
     /await Promise\.all\(\s*refreshTargets\.map\(\(targetPath\) => refreshDirectoryEntries\(targetPath\)\),\s*\);/,
   );
+});
+
+test("file explorer imports dragged external files and folders into the tree", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /type ExplorerExternalImportEntry =/);
+  assert.match(source, /webkitGetAsEntry\?: \(\) => ExplorerExternalDropEntry \| null;/);
+  assert.match(source, /async function collectDroppedExternalEntriesFromEntry\(/);
+  assert.match(
+    source,
+    /const childEntries = await readExternalDropDirectoryEntries\(\s*entry as FileSystemDirectoryEntry,\s*\);/,
+  );
+  assert.match(source, /content: new Uint8Array\(await file\.arrayBuffer\(\)\),/);
+  assert.match(source, /function hasExternalExplorerDropData\(dataTransfer: DataTransfer \| null\)/);
+  assert.match(source, /const \[paneExternalDropTarget, setPaneExternalDropTarget\] = useState\(false\);/);
+  assert.match(source, /const importExternalEntriesToDirectory = useCallback\(/);
+  assert.match(
+    source,
+    /window\.electronAPI\.fs\.importExternalEntries\(\s*normalizedDestinationDirectoryPath,\s*importedEntries,\s*selectedWorkspaceId \?\? null,\s*\)/,
+  );
+  assert.match(
+    source,
+    /const refreshTargets = \[\s*normalizedDestinationDirectoryPath,\s*getParentFolderPath\(normalizedDestinationDirectoryPath\),\s*\]\.filter\(/,
+  );
+  assert.match(source, /event\.dataTransfer\.dropEffect = canMoveDraggedEntry\s*\?\s*"move"\s*:\s*"copy";/);
+  assert.match(
+    source,
+    /void importExternalEntriesToDirectory\(\s*event\.dataTransfer,\s*entry\.absolutePath,\s*\);/,
+  );
+  assert.match(
+    source,
+    /className=\{`chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1\.5 pb-1\.5 pt-1 \$\{[\s\S]*paneExternalDropTarget[\s\S]*"rounded-md bg-emerald-500\/10 ring-1 ring-emerald-500\/30"[\s\S]*\}`\}/,
+  );
+  assert.match(source, /onDragOver=\{onPaneDragOver\}/);
+  assert.match(source, /onDrop=\{onPaneDrop\}/);
 });
 
 test("file explorer does not expose a pane-level close action", async () => {

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -24,16 +24,57 @@ test("file explorer syncs the workspace root only when the selected workspace ch
   assert.doesNotMatch(source, /currentPath === workspaceRoot/);
 });
 
-test("file explorer polls the current directory to surface live file changes", async () => {
+test("file explorer refreshes the current directory and expanded folders to surface live file changes", async () => {
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(
     source,
-    /const payload = await window\.electronAPI\.fs\.listDirectory\(\s*currentPath,\s*selectedWorkspaceId \?\? null,\s*\);/,
+    /const refreshTargets = \[\s*currentPath,\s*\.\.\.Object\.entries\(expandedDirectoryPaths\)[\s\S]*\.filter\(\s*\(\[, isExpanded\]\) => isExpanded\s*\)[\s\S]*\.map\(\(\[targetPath\]\) => targetPath\),\s*\]\.filter\(/,
   );
-  assert.match(source, /const timer = window\.setInterval\(\(\) => \{\s*void refreshCurrentDirectory\(\);\s*\}, 1200\);/);
+  assert.match(source, /const refreshedDirectories = await Promise\.allSettled\(/);
+  assert.match(source, /refreshTargets\.map\(\(targetPath\) =>/);
+  assert.match(
+    source,
+    /window\.electronAPI\.fs\.listDirectory\(\s*targetPath,\s*selectedWorkspaceId \?\? null,\s*\)/,
+  );
+  assert.match(
+    source,
+    /setDirectoryEntriesByPath\(\(current\) => \(\{\s*\.\.\.current,\s*\.\.\.refreshedEntriesByPath,\s*\}\)\);/,
+  );
+  assert.match(source, /const timer = window\.setInterval\(\(\) => \{\s*void refreshLoadedDirectories\(\);\s*\}, 1200\);/);
   assert.match(source, /window\.clearInterval\(timer\);/);
-  assert.match(source, /\}, \[currentPath, selectedWorkspaceId\]\);/);
+  assert.match(source, /\}, \[currentPath, expandedDirectoryPaths, selectedWorkspaceId\]\);/);
+});
+
+test("file explorer live-refreshes inline previews from file watch events without overwriting dirty edits", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const isDirtyRef = useRef\(false\);/);
+  assert.match(source, /const isSavingRef = useRef\(false\);/);
+  assert.match(source, /isDirtyRef\.current = isDirty;/);
+  assert.match(source, /isSavingRef\.current = saving;/);
+  assert.match(
+    source,
+    /const watchedPath = preview\?\.absolutePath\?\.trim\(\) \|\| "";\s*if \(!previewInPane \|\| !watchedPath\) \{\s*return;\s*\}/,
+  );
+  assert.match(
+    source,
+    /window\.electronAPI\.fs\.onFileChange\(\(payload\) => \{\s*if \(\s*normalizeComparablePath\(payload\.absolutePath\) !==\s*normalizeComparablePath\(watchedPath\)\s*\) \{\s*return;\s*\}\s*void refreshPreviewFromDisk\(\);\s*\}\);/,
+  );
+  assert.match(
+    source,
+    /window\.electronAPI\.fs[\s\S]*\.watchFile\(/,
+  );
+  assert.match(source, /watchedPath,\s*selectedWorkspaceId \?\? null/);
+  assert.match(
+    source,
+    /if \(\s*cancelled \|\|\s*refreshInFlight \|\|\s*isDirtyRef\.current \|\|\s*isSavingRef\.current\s*\) \{\s*return;\s*\}/,
+  );
+  assert.match(
+    source,
+    /const nextPreview = await window\.electronAPI\.fs\.readFilePreview\(\s*watchedPath,\s*selectedWorkspaceId \?\? null,\s*\);[\s\S]*setPreview\(nextPreview\);[\s\S]*setPreviewDraft\(nextPreview\.content \?\? ""\);/,
+  );
+  assert.match(source, /void window\.electronAPI\.fs\.unwatchFile\(subscriptionId\);/);
 });
 
 test("file explorer switches folders to inline tree expansion and keeps explorer-only file opening", async () => {

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type DragEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import {
   ArrowLeft,
@@ -182,6 +189,165 @@ type FileExplorerVisibleRow =
       tone: "loading" | "error";
       message: string;
     };
+
+type ExplorerExternalImportEntry =
+  | {
+      kind: "directory";
+      relativePath: string;
+    }
+  | {
+      kind: "file";
+      relativePath: string;
+      content: Uint8Array;
+    };
+
+type ExplorerExternalDropEntry = FileSystemEntry;
+
+type ExplorerExternalDropDataTransferItem = DataTransferItem & {
+  webkitGetAsEntry?: () => ExplorerExternalDropEntry | null;
+};
+
+function joinExplorerImportPath(parentPath: string, name: string) {
+  const trimmedName = name.trim().replace(/[\\/]+/g, "/").replace(/^\/+|\/+$/g, "");
+  if (!parentPath) {
+    return trimmedName;
+  }
+  return trimmedName ? `${parentPath}/${trimmedName}` : parentPath;
+}
+
+async function readExternalDropDirectoryEntries(
+  entry: FileSystemDirectoryEntry,
+) {
+  const reader = entry.createReader();
+  const entries: ExplorerExternalDropEntry[] = [];
+
+  while (true) {
+    const nextBatch = await new Promise<ExplorerExternalDropEntry[]>(
+      (resolve, reject) => {
+        reader.readEntries(resolve, (error) => {
+          reject(error ?? new Error(`Failed to read ${entry.name}.`));
+        });
+      },
+    );
+    if (nextBatch.length === 0) {
+      break;
+    }
+    entries.push(...nextBatch);
+  }
+
+  return entries;
+}
+
+async function readExternalDropFile(
+  entry: FileSystemFileEntry,
+) {
+  return new Promise<File>((resolve, reject) => {
+    entry.file(resolve, (error) => {
+      reject(error ?? new Error(`Failed to read ${entry.name}.`));
+    });
+  });
+}
+
+async function collectDroppedExternalEntriesFromEntry(
+  entry: ExplorerExternalDropEntry,
+  parentRelativePath = "",
+): Promise<ExplorerExternalImportEntry[]> {
+  const relativePath = joinExplorerImportPath(parentRelativePath, entry.name);
+  if (!relativePath) {
+    return [];
+  }
+
+  if (entry.isFile) {
+    const file = await readExternalDropFile(entry as FileSystemFileEntry);
+    return [
+      {
+        kind: "file",
+        relativePath,
+        content: new Uint8Array(await file.arrayBuffer()),
+      },
+    ];
+  }
+
+  const childEntries = await readExternalDropDirectoryEntries(
+    entry as FileSystemDirectoryEntry,
+  );
+  const importedEntries: ExplorerExternalImportEntry[] = [
+    { kind: "directory", relativePath },
+  ];
+  for (const childEntry of childEntries) {
+    importedEntries.push(
+      ...(await collectDroppedExternalEntriesFromEntry(childEntry, relativePath)),
+    );
+  }
+  return importedEntries;
+}
+
+function dedupeExplorerExternalImportEntries(
+  entries: ExplorerExternalImportEntry[],
+) {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = `${entry.kind}:${entry.relativePath}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function hasExternalExplorerDropData(dataTransfer: DataTransfer | null) {
+  if (!dataTransfer) {
+    return false;
+  }
+
+  const types = Array.from(dataTransfer.types ?? []);
+  if (types.includes(EXPLORER_ATTACHMENT_DRAG_TYPE)) {
+    return false;
+  }
+
+  if ((dataTransfer.files?.length ?? 0) > 0) {
+    return true;
+  }
+
+  return Array.from(dataTransfer.items ?? []).some((item) => item.kind === "file");
+}
+
+async function collectDroppedExternalEntries(dataTransfer: DataTransfer | null) {
+  if (!dataTransfer) {
+    return [];
+  }
+
+  const importedEntries: ExplorerExternalImportEntry[] = [];
+  for (const item of Array.from(dataTransfer.items ?? [])) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const filesystemEntry = (
+      item as ExplorerExternalDropDataTransferItem
+    ).webkitGetAsEntry?.();
+    if (!filesystemEntry) {
+      continue;
+    }
+    importedEntries.push(
+      ...(await collectDroppedExternalEntriesFromEntry(filesystemEntry)),
+    );
+  }
+
+  if (importedEntries.length > 0) {
+    return dedupeExplorerExternalImportEntries(importedEntries);
+  }
+
+  const fileEntries = await Promise.all(
+    Array.from(dataTransfer.files ?? []).map(async (file) => ({
+      kind: "file" as const,
+      relativePath: file.name,
+      content: new Uint8Array(await file.arrayBuffer()),
+    })),
+  );
+  return dedupeExplorerExternalImportEntries(fileEntries);
+}
 
 function getComparableFileName(targetName: string) {
   const normalized = targetName
@@ -615,6 +781,7 @@ export function FileExplorerPane({
   const renameInFlightRef = useRef(false);
   const createInFlightRef = useRef(false);
   const moveInFlightRef = useRef(false);
+  const importInFlightRef = useRef(false);
   const dragPreviewRef = useRef<HTMLDivElement | null>(null);
   const lastSyncedWorkspaceRootRef = useRef<{
     workspaceId: string;
@@ -667,6 +834,7 @@ export function FileExplorerPane({
   const [directoryDropTargetPath, setDirectoryDropTargetPath] = useState<
     string | null
   >(null);
+  const [paneExternalDropTarget, setPaneExternalDropTarget] = useState(false);
   const { selectedWorkspaceId } = useWorkspaceSelection();
 
   currentPathRef.current = currentPath;
@@ -1705,6 +1873,74 @@ export function FileExplorerPane({
     ],
   );
 
+  const importExternalEntriesToDirectory = useCallback(
+    async (dataTransfer: DataTransfer | null, destinationDirectoryPath: string) => {
+      const normalizedDestinationDirectoryPath = destinationDirectoryPath.trim();
+      if (!normalizedDestinationDirectoryPath || importInFlightRef.current) {
+        return;
+      }
+
+      closeContextMenu();
+      stopRenamingEntry();
+      setDirectoryDropTargetPath(null);
+      setPaneExternalDropTarget(false);
+      setError("");
+      importInFlightRef.current = true;
+
+      try {
+        const importedEntries = await collectDroppedExternalEntries(dataTransfer);
+        if (importedEntries.length === 0) {
+          return;
+        }
+
+        const payload = await window.electronAPI.fs.importExternalEntries(
+          normalizedDestinationDirectoryPath,
+          importedEntries,
+          selectedWorkspaceId ?? null,
+        );
+        setExpandedDirectoryPaths((current) => ({
+          ...current,
+          [normalizedDestinationDirectoryPath]: true,
+        }));
+
+        const refreshTargets = [
+          normalizedDestinationDirectoryPath,
+          getParentFolderPath(normalizedDestinationDirectoryPath),
+        ].filter(
+          (targetPath, index, paths) =>
+            Boolean(targetPath) &&
+            paths.findIndex(
+              (candidatePath) =>
+                normalizeComparablePath(candidatePath ?? "") ===
+                normalizeComparablePath(targetPath ?? ""),
+            ) === index,
+        ) as string[];
+        await Promise.all(
+          refreshTargets.map((targetPath) => refreshDirectoryEntries(targetPath)),
+        );
+
+        const firstImportedPath = payload.absolutePaths[0] ?? "";
+        if (firstImportedPath) {
+          await revealPathInTree(firstImportedPath);
+          setSelectedPath(firstImportedPath);
+        }
+      } catch (cause) {
+        const message =
+          cause instanceof Error ? cause.message : "Failed to import items.";
+        setError(message);
+      } finally {
+        importInFlightRef.current = false;
+      }
+    },
+    [
+      closeContextMenu,
+      refreshDirectoryEntries,
+      revealPathInTree,
+      selectedWorkspaceId,
+      stopRenamingEntry,
+    ],
+  );
+
   const moveEntryToDirectory = useCallback(
     async (sourcePath: string, destinationDirectoryPath: string) => {
       const normalizedSourcePath = sourcePath.trim();
@@ -1829,6 +2065,61 @@ export function FileExplorerPane({
       );
     },
     [draggedEntryPath],
+  );
+
+  const onPaneDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (
+        !hasExternalExplorerDropData(event.dataTransfer) ||
+        !currentPathRef.current
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "copy";
+      setDirectoryDropTargetPath(null);
+      if (!paneExternalDropTarget) {
+        setPaneExternalDropTarget(true);
+      }
+    },
+    [paneExternalDropTarget],
+  );
+
+  const onPaneDragLeave = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!paneExternalDropTarget) {
+        return;
+      }
+      const relatedTarget = event.relatedTarget;
+      if (
+        typeof Node !== "undefined" &&
+        relatedTarget instanceof Node &&
+        event.currentTarget.contains(relatedTarget)
+      ) {
+        return;
+      }
+      setPaneExternalDropTarget(false);
+    },
+    [paneExternalDropTarget],
+  );
+
+  const onPaneDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (
+        !hasExternalExplorerDropData(event.dataTransfer) ||
+        !currentPathRef.current
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      void importExternalEntriesToDirectory(
+        event.dataTransfer,
+        currentPathRef.current,
+      );
+    },
+    [importExternalEntriesToDirectory],
   );
 
   const deleteEntryFromContextMenu = useCallback(
@@ -2131,7 +2422,16 @@ export function FileExplorerPane({
           </div>
         </div>
 
-        <div className="chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1">
+        <div
+          className={`chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1 ${
+            paneExternalDropTarget
+              ? "rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/30"
+              : ""
+          }`}
+          onDragOver={onPaneDragOver}
+          onDragLeave={onPaneDragLeave}
+          onDrop={onPaneDrop}
+        >
           {loading ? (
             <div className="px-2 py-4 text-xs text-muted-foreground">
               Loading directory...
@@ -2267,18 +2567,28 @@ export function FileExplorerPane({
                     className={rowClassName}
                     title={
                       entry.isDirectory
-                        ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, drop a file to move it here`
+                        ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, drop files or folders here`
                         : previewInPane
                           ? `${entry.name} — drag into chat to attach`
                           : `${entry.name} — click to open file, drag into chat to attach`
                     }
                     onDragOver={(event) => {
-                      if (!canDropDraggedEntryIntoDirectory(entry)) {
+                      const canMoveDraggedEntry =
+                        canDropDraggedEntryIntoDirectory(entry);
+                      const canImportExternalEntries = hasExternalExplorerDropData(
+                        event.dataTransfer,
+                      );
+                      if (!canMoveDraggedEntry && !canImportExternalEntries) {
                         return;
                       }
                       event.preventDefault();
                       event.stopPropagation();
-                      event.dataTransfer.dropEffect = "move";
+                      event.dataTransfer.dropEffect = canMoveDraggedEntry
+                        ? "move"
+                        : "copy";
+                      if (paneExternalDropTarget) {
+                        setPaneExternalDropTarget(false);
+                      }
                       if (directoryDropTargetPath !== entry.absolutePath) {
                         setDirectoryDropTargetPath(entry.absolutePath);
                       }
@@ -2298,16 +2608,28 @@ export function FileExplorerPane({
                       setDirectoryDropTargetPath(null);
                     }}
                     onDrop={(event) => {
+                      const canMoveDraggedEntry =
+                        canDropDraggedEntryIntoDirectory(entry);
+                      const canImportExternalEntries = hasExternalExplorerDropData(
+                        event.dataTransfer,
+                      );
                       if (
-                        !canDropDraggedEntryIntoDirectory(entry) ||
-                        !draggedEntryPath
+                        !canMoveDraggedEntry &&
+                        !canImportExternalEntries
                       ) {
                         return;
                       }
                       event.preventDefault();
                       event.stopPropagation();
-                      void moveEntryToDirectory(
-                        draggedEntryPath,
+                      if (canMoveDraggedEntry && draggedEntryPath) {
+                        void moveEntryToDirectory(
+                          draggedEntryPath,
+                          entry.absolutePath,
+                        );
+                        return;
+                      }
+                      void importExternalEntriesToDirectory(
+                        event.dataTransfer,
                         entry.absolutePath,
                       );
                     }}
@@ -2377,7 +2699,7 @@ export function FileExplorerPane({
                           className="w-full min-w-0 cursor-pointer text-left"
                           title={
                             entry.isDirectory
-                              ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, drop a file to move it here`
+                              ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, drop files or folders here`
                               : previewInPane
                                 ? `${entry.name} — drag into chat to attach`
                                 : `${entry.name} — click to open file, drag into chat to attach`

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -622,6 +622,8 @@ export function FileExplorerPane({
   } | null>(null);
   const lastProcessedFocusRequestKeyRef = useRef<number | null>(null);
   const currentPathRef = useRef("");
+  const isDirtyRef = useRef(false);
+  const isSavingRef = useRef(false);
   const [currentPath, setCurrentPath] = useState<string>("");
   const [entries, setEntries] = useState<LocalFileEntry[]>([]);
   const [directoryEntriesByPath, setDirectoryEntriesByPath] = useState<
@@ -772,48 +774,92 @@ export function FileExplorerPane({
     let cancelled = false;
     let refreshInFlight = false;
 
-    const refreshCurrentDirectory = async () => {
+    const refreshLoadedDirectories = async () => {
       if (cancelled || refreshInFlight) {
         return;
       }
 
       refreshInFlight = true;
       try {
-        const payload = await window.electronAPI.fs.listDirectory(
+        const refreshTargets = [
           currentPath,
-          selectedWorkspaceId ?? null,
+          ...Object.entries(expandedDirectoryPaths)
+            .filter(([, isExpanded]) => isExpanded)
+            .map(([targetPath]) => targetPath),
+        ].filter(
+          (targetPath, index, paths) =>
+            Boolean(targetPath) &&
+            paths.findIndex(
+              (candidatePath) =>
+                normalizeComparablePath(candidatePath) ===
+                normalizeComparablePath(targetPath),
+            ) === index,
         );
-        if (cancelled || payload.currentPath !== currentPath) {
+        const refreshedDirectories = await Promise.allSettled(
+          refreshTargets.map((targetPath) =>
+            window.electronAPI.fs.listDirectory(
+              targetPath,
+              selectedWorkspaceId ?? null,
+            ),
+          ),
+        );
+        if (cancelled) {
           return;
         }
-        setEntries(payload.entries);
-        setDirectoryEntriesByPath((current) => ({
-          ...current,
-          [payload.currentPath]: payload.entries,
-        }));
+
+        let currentDirectoryPayload: LocalDirectoryResponse | null = null;
+        const refreshedEntriesByPath: Record<string, LocalFileEntry[]> = {};
+
+        for (const refreshedDirectory of refreshedDirectories) {
+          if (refreshedDirectory.status !== "fulfilled") {
+            continue;
+          }
+          const payload = refreshedDirectory.value;
+          refreshedEntriesByPath[payload.currentPath] = payload.entries;
+          if (
+            normalizeComparablePath(payload.currentPath) ===
+            normalizeComparablePath(currentPath)
+          ) {
+            currentDirectoryPayload = payload;
+          }
+        }
+
+        if (Object.keys(refreshedEntriesByPath).length > 0) {
+          setDirectoryEntriesByPath((current) => ({
+            ...current,
+            ...refreshedEntriesByPath,
+          }));
+        }
+        if (!currentDirectoryPayload) {
+          return;
+        }
+
+        setEntries(currentDirectoryPayload.entries);
         setSelectedPath((prev) =>
           !prev ||
-          (!payload.entries.some((entry) => entry.absolutePath === prev) &&
-            !isPathWithin(payload.currentPath, prev))
-            ? (payload.entries[0]?.absolutePath ?? "")
+          (!currentDirectoryPayload.entries.some(
+            (entry) => entry.absolutePath === prev,
+          ) &&
+            !isPathWithin(currentDirectoryPayload.currentPath, prev))
+            ? (currentDirectoryPayload.entries[0]?.absolutePath ?? "")
             : prev,
         );
       } catch {
-        // Best-effort background refresh; keep current listing on transient failures.
+        // Best-effort background refresh; keep current listings on transient failures.
       } finally {
         refreshInFlight = false;
       }
     };
 
     const timer = window.setInterval(() => {
-      void refreshCurrentDirectory();
+      void refreshLoadedDirectories();
     }, 1200);
 
     return () => {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [currentPath, selectedWorkspaceId]);
+  }, [currentPath, expandedDirectoryPaths, selectedWorkspaceId]);
 
   useEffect(() => {
     let mounted = true;
@@ -943,6 +989,14 @@ export function FileExplorerPane({
   const isMarkdownPreview = isMarkdownPreviewPayload(preview);
   const isHtmlPreview = isHtmlPreviewPayload(preview);
   const supportsRenderedTextPreview = isMarkdownPreview || isHtmlPreview;
+
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+  }, [isDirty]);
+
+  useEffect(() => {
+    isSavingRef.current = saving;
+  }, [saving]);
 
   const openPreviewLink = useCallback((url: string) => {
     void window.electronAPI.ui.openExternalUrl(url);
@@ -1191,6 +1245,75 @@ export function FileExplorerPane({
     setRenameDraft("");
     setRenameSaving(false);
   }, []);
+
+  useEffect(() => {
+    const watchedPath = preview?.absolutePath?.trim() || "";
+    if (!previewInPane || !watchedPath) {
+      return;
+    }
+
+    let cancelled = false;
+    let subscriptionId = "";
+    let refreshInFlight = false;
+
+    const refreshPreviewFromDisk = async () => {
+      if (
+        cancelled ||
+        refreshInFlight ||
+        isDirtyRef.current ||
+        isSavingRef.current
+      ) {
+        return;
+      }
+
+      refreshInFlight = true;
+      try {
+        const nextPreview = await window.electronAPI.fs.readFilePreview(
+          watchedPath,
+          selectedWorkspaceId ?? null,
+        );
+        if (cancelled) {
+          return;
+        }
+        setPreview(nextPreview);
+        setPreviewDraft(nextPreview.content ?? "");
+        setTablePreviewDraft(cloneTablePreviewSheets(nextPreview.tableSheets));
+      } catch {
+        // The agent may still be writing or replacing the file; wait for the next event.
+      } finally {
+        refreshInFlight = false;
+      }
+    };
+
+    const unsubscribe = window.electronAPI.fs.onFileChange((payload) => {
+      if (
+        normalizeComparablePath(payload.absolutePath) !==
+        normalizeComparablePath(watchedPath)
+      ) {
+        return;
+      }
+      void refreshPreviewFromDisk();
+    });
+
+    void window.electronAPI.fs
+      .watchFile(watchedPath, selectedWorkspaceId ?? null)
+      .then((subscription) => {
+        if (cancelled) {
+          void window.electronAPI.fs.unwatchFile(subscription.subscriptionId);
+          return;
+        }
+        subscriptionId = subscription.subscriptionId;
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      if (subscriptionId) {
+        void window.electronAPI.fs.unwatchFile(subscriptionId);
+      }
+    };
+  }, [preview?.absolutePath, previewInPane, selectedWorkspaceId]);
 
   const startRenamingEntry = useCallback(
     (entry: LocalFileEntry) => {

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -55,6 +55,21 @@ declare global {
     absolutePath: string;
   }
 
+  type ExplorerExternalImportEntryPayload =
+    | {
+        kind: "directory";
+        relativePath: string;
+      }
+    | {
+        kind: "file";
+        relativePath: string;
+        content: Uint8Array;
+      };
+
+  interface ExplorerExternalImportResultPayload {
+    absolutePaths: string[];
+  }
+
   type FileSystemCreateKind = "file" | "directory";
 
   interface FilePreviewWatchSubscriptionPayload {
@@ -1260,6 +1275,11 @@ declare global {
         kind: FileSystemCreateKind,
         workspaceId?: string | null,
       ) => Promise<FileSystemMutationPayload>;
+      importExternalEntries: (
+        destinationDirectoryPath: string,
+        entries: ExplorerExternalImportEntryPayload[],
+        workspaceId?: string | null,
+      ) => Promise<ExplorerExternalImportResultPayload>;
       renamePath: (targetPath: string, nextName: string, workspaceId?: string | null) => Promise<FileSystemMutationPayload>;
       movePath: (
         sourcePath: string,

--- a/website/docs/docs/app-development/applications/first-app.md
+++ b/website/docs/docs/app-development/applications/first-app.md
@@ -142,6 +142,7 @@ Useful runtime surfaces while iterating:
 - `POST /api/v1/apps/:appId/setup`
 - `POST /api/v1/apps/:appId/start`
 - `GET /api/v1/apps/:appId/build-status`
+- `GET /api/v1/apps/:appId/setup-log`
 - `GET /api/v1/apps/ports`
 
 If you install from files or an archive instead of editing the workspace directly, the runtime also exposes:
@@ -149,7 +150,14 @@ If you install from files or an archive instead of editing the workspace directl
 - `POST /api/v1/apps/install`
 - `POST /api/v1/apps/install-archive`
 
-`install-archive` extracts into `apps/my_app/`, requires `app.runtime.yaml` at the archive root, appends the `workspace.yaml` application entry, and tries to reconcile the MCP registry after startup.
+`install-archive` extracts into `apps/my_app/`, requires `app.runtime.yaml` at the archive root, appends the `workspace.yaml` application entry, and tries to reconcile the MCP registry after startup. It now serializes installs per `(workspace_id, app_id)` and returns `409` if another install for that app is already in progress.
+
+When setup fails, pull the latest setup diagnostics:
+
+```bash
+curl \
+  'http://127.0.0.1:5160/api/v1/apps/my_app/setup-log?workspace_id=workspace-1'
+```
 
 ## 9. Verify the End-to-End Loop
 

--- a/website/docs/docs/app-development/applications/mcp-tools.md
+++ b/website/docs/docs/app-development/applications/mcp-tools.md
@@ -49,6 +49,7 @@ mcp_registry:
       url: http://localhost:$MCP_PORT/mcp/sse
       enabled: true
       timeout_ms: 30000
+      started_at: 2026-04-14T11:22:33.000Z
 ```
 
 The allowlist entries are written as `app_id.tool_name`, for example `my_app.create_post`.
@@ -61,6 +62,8 @@ There are two important write paths:
 2. `reconcileAppMcpRegistry()` runs after app start and rewrites the same entries idempotently
 
 That second step matters because it auto-heals stale MCP registry state when app ports or tool lists changed.
+
+On post-start reconciliation, the runtime can bump `mcp_registry.servers.<appId>.started_at` so MCP clients watching `workspace.yaml` can detect app restarts and reconnect SSE sessions.
 
 ## Health Requirements
 

--- a/website/docs/docs/build-on-holaos/agent-harness/internals.md
+++ b/website/docs/docs/build-on-holaos/agent-harness/internals.md
@@ -87,6 +87,34 @@ const settingsManager = SettingsManager.inMemory({
 });
 ```
 
+## Quoted workspace skill expansion
+
+The current prompt path supports leading slash skill references from the composer.
+
+When the request instruction starts with lines like:
+
+```text
+/customer_lookup
+/sales_policy
+
+Review this lead and draft next-step guidance.
+```
+
+`buildPiPromptPayload()` resolves those ids against `workspace_skill_dirs`, injects canonical `<skill ...>` blocks, and leaves the remainder as the instruction body:
+
+```ts
+const quotedSkills = resolveQuotedSkillSections(
+  request.instruction,
+  request.workspace_skill_dirs,
+);
+if (quotedSkills.blocks.length > 0) {
+  sections.push(["Quoted workspace skills:", ...quotedSkills.blocks].join("\n\n"));
+}
+const instruction = quotedSkills.body.trim();
+```
+
+If a quoted skill id is missing, the host appends an explicit warning section rather than silently dropping it. Keep this behavior stable so composer-selected skills remain inspectable in runtime traces and harness prompts.
+
 ## Change the right seam
 
 - If you are changing prompt layers, model selection, or capability projection, start in `runtime/api-server/src/agent-runtime-config.ts`.

--- a/website/docs/docs/build-on-holaos/desktop/internals.md
+++ b/website/docs/docs/build-on-holaos/desktop/internals.md
@@ -16,6 +16,7 @@ That means desktop work is usually spread across four boundaries: React renderer
 ## Main code seams
 
 - `desktop/src/components/layout/AppShell.tsx`: the shell composition and top-level product routing. This is where the agent pane, browser panes, file explorer, app surfaces, operations drawer, notifications, settings overlays, and reported non-browser operator surfaces are coordinated.
+- `desktop/src/components/onboarding/FirstWorkspacePane.tsx`, `ConfigureStep.tsx`, `BrowserProfileStep.tsx`, and `CreatingView.tsx`: first-workspace flow, including empty/template workspace creation and browser-profile bootstrap choices.
 - `desktop/shared/model-catalog.ts`: shipped fallback model metadata for direct providers and Holaboss Proxy model mapping, including reasoning support, allowed thinking values, and input modalities.
 - `desktop/src/lib/workspaceDesktop.tsx` and `desktop/src/lib/workspaceSelection.tsx`: renderer-side workspace state and shell coordination.
 - `desktop/src/components/auth/AuthPanel.tsx`: provider settings, catalog-backed defaults, background-task selection, recall embeddings, and image-generation configuration.
@@ -118,6 +119,30 @@ handleTrustedIpc("workspace:queueSessionInput", ["main"], async (_event, payload
   queueSessionInput(payload),
 );
 ```
+
+## Workspace bootstrap flow
+
+Workspace bootstrap now has two phases:
+
+1. `workspace:createWorkspace` in Electron main materializes template/empty content, writes workspace files, and activates the runtime record.
+2. renderer-side workspace bootstrap in `workspaceDesktop.tsx` can then copy browser profile state from another workspace or import browser data from Chrome/Edge/Arc/Safari.
+
+Representative post-create browser bootstrap calls from the renderer:
+
+```ts
+await window.electronAPI.workspace.copyBrowserWorkspaceProfile({
+  sourceWorkspaceId,
+  targetWorkspaceId: createdWorkspaceId,
+});
+
+await window.electronAPI.workspace.importBrowserProfile({
+  workspaceId: createdWorkspaceId,
+  source: browserImportSource,
+  profileDir: browserImportProfileDir.trim() || undefined,
+});
+```
+
+`createWorkspace()` in `desktop/electron/main.ts` now also emits structured stage logs with the `[holaboss.createWorkspace]` prefix for debugging create failures across materialization, runtime record creation, template apply, and workspace activation.
 
 ## Browser protocol
 
@@ -234,6 +259,26 @@ if (/^claude-/i.test(normalizedModelId)) {
 ```
 
 That is how a managed proxy model like `gpt-5.4` or `claude-sonnet-4-6` can still light up the desktop reasoning selector even if the control plane catalog did not provide explicit `thinking_values`.
+
+## Composer skill entry points
+
+Skill usage is now composer-first rather than a standalone pane:
+
+- slash commands in the composer (`/skill_id`)
+- quoted skill chips attached to the pending message
+- `Use Skills` picker inside composer actions
+
+`ChatPane.tsx` serializes selected skills into a leading slash block before queueing:
+
+```ts
+const serializedPrompt = serializeQuotedSkillPrompt(trimmed, quotedSkillIds);
+await window.electronAPI.workspace.queueSessionInput({
+  text: serializedPrompt,
+  // other fields omitted
+});
+```
+
+If you change skill discoverability or prompt shaping, inspect both the desktop serialization path and the harness-host prompt-expansion path.
 
 ## File explorer contract
 

--- a/website/docs/docs/build-on-holaos/runtime/apis.md
+++ b/website/docs/docs/build-on-holaos/runtime/apis.md
@@ -33,7 +33,7 @@ Use the right port before you assume a route is broken.
 | Agent runs and sessions | `/api/v1/agent-runs`, `/api/v1/agent-runs/stream`, `/api/v1/agent-sessions/*`, `/api/v1/agent-sessions/:sessionId/artifacts`, `/api/v1/agent-sessions/by-workspace/:workspaceId/with-artifacts` | `runner-worker.ts`, `ts-runner.ts`, `turn-result-summary.ts`, and state-store session tables |
 | Integrations and auth flows | `/api/v1/integrations/*`, `/api/v1/integrations/oauth/*`, `/api/v1/integrations/broker/*` | `integrations.ts`, `integration-broker.ts`, `oauth-service.ts`, and `composio-service.ts` |
 | Memory and post-run system state | `/api/v1/memory/*`, `/api/v1/memory-update-proposals*`, `/api/v1/task-proposals*` | `memory.js`, `user-memory-proposals.js`, `turn-memory-writeback.js`, and queue or evolve workers |
-| Apps and resolved-app orchestration | `/api/v1/apps/*`, `/api/v1/internal/workspaces/:workspaceId/resolved-apps/start` | `workspace-apps.ts`, `app-lifecycle-worker.ts`, and `resolved-app-bootstrap.ts` |
+| Apps and resolved-app orchestration | `/api/v1/apps/*`, `/api/v1/apps/:appId/setup-log`, `/api/v1/apps/install-archive`, `/api/v1/internal/workspaces/:workspaceId/resolved-apps/start` | `workspace-apps.ts`, `app-lifecycle-worker.ts`, and `resolved-app-bootstrap.ts` |
 | Outputs, notifications, and cronjobs | `/api/v1/outputs*`, `/api/v1/output-folders*`, `/api/v1/notifications*`, `/api/v1/cronjobs*` | `cron-worker.ts`, state-store output tables, session artifact helpers, and the desktop surfaces that render this state |
 
 ## Runtime-tool request metadata
@@ -118,6 +118,26 @@ If you change a runtime-tool route that creates outputs or artifacts, also inspe
 - `runtime/api-server/src/claimed-input-executor.ts`
 
 That path now matters for report artifacts because the runtime can persist them during the run and the post-turn file capture path must not duplicate them later.
+
+## App install and setup diagnostics
+
+The app install path has two operational contracts worth treating as API behavior, not implementation detail:
+
+- `POST /api/v1/apps/install-archive` serializes installs per `(workspace_id, app_id)` and returns `409` with `app install already in progress for this id` when a second install races the same target.
+- `GET /api/v1/apps/:appId/setup-log?workspace_id=...` returns the latest setup log tail plus recent structured events from `<workspace>/apps/<appId>/.holaboss/logs/`.
+
+Representative setup-log debug call:
+
+```bash
+curl \
+  'http://127.0.0.1:5160/api/v1/apps/my_app/setup-log?workspace_id=workspace-1'
+```
+
+The response includes:
+
+- `log_path` and `log_size_bytes`
+- `log_tail` (bounded tail of `setup.latest.log`)
+- `recent_events` (last lifecycle events from `events.ndjson`)
 
 ## How to change the API safely
 

--- a/website/docs/docs/build-on-holaos/runtime/state-store.md
+++ b/website/docs/docs/build-on-holaos/runtime/state-store.md
@@ -102,7 +102,7 @@ Important distinction:
 The same database also stores:
 
 - output folders and outputs
-- app builds and app port allocation
+- app builds, app restart-attempt counters, and app port allocation
 - app catalog metadata
 - cronjobs
 - runtime notifications
@@ -186,6 +186,7 @@ Current migration seams in `store.ts` include:
 - cronjob instruction migration
 - sandbox run-token table migration
 - queue/runtime-state lease-column migrations
+- app-build `restart_attempts` persistence migration
 
 If you add a new durable record family, you need to think about both schema creation and migration behavior for existing runtimes.
 

--- a/website/docs/docs/build-on-holaos/troubleshooting.md
+++ b/website/docs/docs/build-on-holaos/troubleshooting.md
@@ -96,6 +96,22 @@ Also verify that:
 - `apps/<app-id>/app.runtime.yaml` declares the expected setup and start commands
 - the app manifest points at the expected MCP path, if the app exposes MCP tools
 - the runtime can still resolve the app's assigned ports through `/api/v1/apps/ports`
+- `POST /api/v1/apps/install-archive` is not already running for the same `(workspace_id, app_id)` pair. A concurrent attempt now returns `409` with `app install already in progress for this id`.
+
+When setup still fails, inspect the per-app setup logs first:
+
+```bash
+curl \
+  'http://127.0.0.1:5160/api/v1/apps/my_app/setup-log?workspace_id=workspace-1'
+```
+
+This returns the tail of `<workspace>/apps/my_app/.holaboss/logs/setup.latest.log` and recent lifecycle events from `events.ndjson`.
+
+## Workspace creation fails mid-bootstrap
+
+Workspace creation now emits structured stage logs from Electron main with the `[holaboss.createWorkspace]` prefix.
+
+If first-workspace onboarding appears stuck around template apply, runtime record creation, or activation, inspect those stage lines in desktop logs before changing runtime code.
 
 ## Browser tools are missing during agent runs
 

--- a/website/docs/docs/templates/materialization.md
+++ b/website/docs/docs/templates/materialization.md
@@ -59,6 +59,13 @@ After the template files are materialized, `createWorkspace()`:
 
 That means a template is not finished when it can be downloaded. It is finished when the materialized workspace can be opened and used without repair.
 
+The desktop renderer can then run optional browser bootstrap after workspace creation:
+
+- copy browser profile state from another workspace through `workspace.copyBrowserWorkspaceProfile(...)`
+- import browser data from Chrome, Edge, Arc, or Safari through `workspace.importBrowserProfile(...)`
+
+Those are post-create bootstrap actions. They do not replace template materialization.
+
 ## Applying Templates Through the Runtime API
 
 The runtime exposes two workspace template application routes:

--- a/website/docs/index.test.mjs
+++ b/website/docs/index.test.mjs
@@ -354,6 +354,11 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(desktopInternals, /PROVIDER_MODEL_CATALOG/);
   assert.match(desktopInternals, /catalogConfigShapeForProviderModel/);
   assert.match(desktopInternals, /mappedHolabossProxyProviderModel/);
+  assert.match(desktopInternals, /copyBrowserWorkspaceProfile/);
+  assert.match(desktopInternals, /importBrowserProfile/);
+  assert.match(desktopInternals, /\[holaboss\.createWorkspace\]/);
+  assert.match(desktopInternals, /serializeQuotedSkillPrompt/);
+  assert.match(desktopInternals, /Use Skills/);
 
   assert.match(runtimeApis, /runtime\/api-server\/src\/app\.ts/);
   assert.match(runtimeApis, /\/api\/v1\/agent-runs\/stream/);
@@ -367,6 +372,9 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeApis, /127\.0\.0\.1:5160/);
   assert.match(runtimeApis, /POST \/api\/v1\/agent-sessions\/queue/);
   assert.match(runtimeApis, /curl -X POST http:\/\/127\.0\.0\.1:5160\/api\/v1\/capabilities\/runtime-tools\/reports/);
+  assert.match(runtimeApis, /\/api\/v1\/apps\/:appId\/setup-log/);
+  assert.match(runtimeApis, /app install already in progress for this id/);
+  assert.match(runtimeApis, /\.holaboss\/logs\//);
   assert.match(
     runtimeApis,
     /api\/v1\/agent-sessions\/session-main\/outputs\/stream/
@@ -389,6 +397,7 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(runtimeStateStore, /exclude specific session ids/);
   assert.match(runtimeStateStore, /distinctSessions:\s*true/);
   assert.match(runtimeStateStore, /claim-inputs --request-base64/);
+  assert.match(runtimeStateStore, /restart_attempts/);
 
   assert.match(independentDeploy, /package-metadata\.json/);
   assert.match(independentDeploy, /runtime\/metadata\.json/);
@@ -406,6 +415,8 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(harnessInternals, /instructionWithContextMessages/);
   assert.match(harnessInternals, /tool_execution_start/);
   assert.match(harnessInternals, /defaultThinkingLevel/);
+  assert.match(harnessInternals, /resolveQuotedSkillSections/);
+  assert.match(harnessInternals, /Quoted workspace skills:/);
 
   assert.match(troubleshooting, /desktop\/scripts\/check-runtime-status\.sh/);
   assert.match(troubleshooting, /HOLABOSS_BACKEND_BASE_URL/);
@@ -414,6 +425,9 @@ test("build on holaOS pages expose the real developer seams and validation paths
   assert.match(troubleshooting, /127\.0\.0\.1:5160/);
   assert.match(troubleshooting, /rm -rf desktop\/out\/runtime-<platform>/);
   assert.match(troubleshooting, /\/api\/v1\/runtime\/status/);
+  assert.match(troubleshooting, /\/api\/v1\/apps\/my_app\/setup-log/);
+  assert.match(troubleshooting, /events\.ndjson/);
+  assert.match(troubleshooting, /\[holaboss\.createWorkspace\]/);
 });
 
 test("app development and templates pages expose runtime-true developer contracts", async () => {
@@ -440,6 +454,8 @@ test("app development and templates pages expose runtime-true developer contract
   assert.match(appAnatomy, /HOLABOSS_APP_GRANT/);
 
   assert.match(firstApp, /POST \/api\/v1\/apps\/install-archive/);
+  assert.match(firstApp, /GET \/api\/v1\/apps\/:appId\/setup-log/);
+  assert.match(firstApp, /already in progress/);
   assert.match(firstApp, /workspace\.yaml/);
   assert.match(firstApp, /mcp\.tools/);
 
@@ -449,6 +465,7 @@ test("app development and templates pages expose runtime-true developer contract
 
   assert.match(mcpTools, /writeWorkspaceMcpRegistryEntry/);
   assert.match(mcpTools, /app_id\.tool_name/);
+  assert.match(mcpTools, /started_at/);
   assert.match(mcpTools, /runtime\/api-server\/src\/app\.test\.ts/);
 
   assert.match(publishingOutputs, /publishSessionArtifact/);
@@ -460,6 +477,8 @@ test("app development and templates pages expose runtime-true developer contract
   assert.match(templatesOverview, /@holaboss\/app-sdk/);
 
   assert.match(templatesMaterialization, /apply-template-from-url/);
+  assert.match(templatesMaterialization, /copyBrowserWorkspaceProfile/);
+  assert.match(templatesMaterialization, /importBrowserProfile/);
   assert.match(templatesMaterialization, /replace_existing/);
   assert.match(templatesMaterialization, /GET \/api\/v1\/workspaces\/:workspaceId\/export/);
 


### PR DESCRIPTION
## Summary
- refresh the file explorer tree for the current directory and expanded folders so generated files appear while the agent is still writing them
- reload inline file previews from file watch events without overwriting unsaved local edits
- left-align the compact icon-only thinking trigger and update the related source tests

## Validation
- npm run typecheck
- node --test --test-name-pattern="chat composer switches model and thinking selectors into icon-led compact triggers" src/components/panes/ChatPane.test.mjs
- node --test --test-name-pattern="file explorer refreshes the current directory and expanded folders to surface live file changes|file explorer live-refreshes inline previews from file watch events without overwriting dirty edits" src/components/panes/FileExplorerPane.test.mjs

Closes #156