### PR TITLE
feat(desktop): polish app detail, sidebar rail, and marketplace apps loading

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1024,6 +1024,8 @@ function AppShellContent() {
   ] = useState("");
   const [activeLeftRailItem, setActiveLeftRailItem] =
     useState<LeftRailItem>("space");
+  const [marketplaceInitialTab, setMarketplaceInitialTab] =
+    useState<"templates" | "apps">("templates");
   const [spaceLeftRailVisible, setSpaceLeftRailVisible] = useState(false);
   const [agentView, setAgentView] = useState<AgentView>({ type: "chat" });
   const [chatFocusRequestKey, setChatFocusRequestKey] = useState(1);
@@ -2403,7 +2405,15 @@ function AppShellContent() {
       setChatFocusRequestKey((current) => current + 1);
       return;
     }
+    if (item === "marketplace") {
+      setMarketplaceInitialTab("templates");
+    }
     setActiveLeftRailItem(item);
+  };
+
+  const handleAddApp = () => {
+    setMarketplaceInitialTab("apps");
+    setActiveLeftRailItem("marketplace");
   };
 
   const handleOpenInstalledApp = (appId: string) => {
@@ -3430,6 +3440,7 @@ function AppShellContent() {
                   <LeftNavigationRail
                     activeItem={activeLeftRailItem}
                     onSelectItem={handleLeftRailSelect}
+                    onAddApp={handleAddApp}
                     installedApps={installedApps}
                     activeAppId={activeAppId}
                     onSelectApp={handleOpenInstalledApp}
@@ -3441,6 +3452,7 @@ function AppShellContent() {
               <LeftNavigationRail
                 activeItem={activeLeftRailItem}
                 onSelectItem={handleLeftRailSelect}
+                onAddApp={handleAddApp}
                 installedApps={installedApps}
                 activeAppId={activeAppId}
                 onSelectApp={handleOpenInstalledApp}
@@ -3678,7 +3690,7 @@ function AppShellContent() {
                   </div>
                 ) : (
                   <div className="h-full min-h-0 overflow-hidden rounded-xl">
-                    <MarketplacePane />
+                    <MarketplacePane initialTab={marketplaceInitialTab} />
                   </div>
                 )}
               </div>

--- a/desktop/src/components/layout/LeftNavigationRail.tsx
+++ b/desktop/src/components/layout/LeftNavigationRail.tsx
@@ -1,4 +1,4 @@
-import { MessageSquareText, Workflow } from "lucide-react";
+import { MessageSquareText, Plus, Workflow } from "lucide-react";
 import type { WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
 import { providerIcon } from "@/components/onboarding/constants";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
@@ -12,6 +12,7 @@ export type LeftRailItem =
 interface LeftNavigationRailProps {
   activeItem: LeftRailItem;
   onSelectItem: (item: LeftRailItem) => void;
+  onAddApp?: () => void;
   installedApps?: WorkspaceInstalledAppDefinition[];
   activeAppId?: string | null;
   onSelectApp?: (appId: string) => void;
@@ -41,6 +42,7 @@ function appInitials(label: string): string {
 export function LeftNavigationRail({
   activeItem,
   onSelectItem,
+  onAddApp,
   installedApps = [],
   activeAppId = null,
   onSelectApp,
@@ -81,54 +83,73 @@ export function LeftNavigationRail({
           })}
         </nav>
 
-        {installedApps.length > 0 ? (
-          <>
-            <div className="h-px w-7 bg-border" />
-            <nav className="chat-scrollbar-hidden flex min-h-0 w-full flex-1 flex-col items-center gap-0.5 overflow-x-hidden overflow-y-auto pb-1">
-              {installedApps.map((app) => {
-                const isActive = activeAppId === app.id;
-                const isReady = "ready" in app && app.ready;
-                const hasError =
-                  "error" in app && typeof app.error === "string" && app.error;
-                return (
-                  <div key={app.id} className="group relative">
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <button
-                            type="button"
-                            aria-label={app.label}
-                            title={app.label}
-                            onClick={() => onSelectApp?.(app.id)}
-                            className={`relative flex size-10 items-center justify-center rounded-md transition-colors ${
-                              isActive
-                                ? "bg-primary/12 text-accent-foreground"
-                                : "bg-muted/80 text-muted-foreground hover:bg-accent/36"
-                            }`}
-                          >
-                            {providerIcon(app.id, 18) ?? (
-                              <span className="text-xs font-semibold uppercase tracking-wide">
-                                {appInitials(app.label)}
-                              </span>
-                            )}
-                            {hasError ? (
-                              <span className="absolute -right-0.5 -top-0.5 size-2.5 rounded-full border-2 border-card bg-destructive" />
-                            ) : !isReady ? (
-                              <span className="absolute -right-0.5 -top-0.5 size-2.5 animate-pulse rounded-full border-2 border-card bg-sky-400" />
-                            ) : null}
-                          </button>
-                        }
-                      />
-                      <TooltipContent side="right" align="center">
-                        {app.label}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                );
-              })}
-            </nav>
-          </>
-        ) : null}
+        <div className="h-px w-7 bg-border" />
+        <nav className="chat-scrollbar-hidden flex min-h-0 w-full flex-1 flex-col items-center gap-1 overflow-x-hidden overflow-y-auto pb-1">
+          <div className="group relative">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-label="Add app"
+                    title="Add app"
+                    onClick={() => onAddApp?.()}
+                    className="flex size-10 items-center justify-center rounded-md border border-dashed border-border/60 text-muted-foreground/70 transition-colors hover:border-border hover:bg-accent/36 hover:text-foreground"
+                  >
+                    <Plus size={16} />
+                  </button>
+                }
+              />
+              <TooltipContent side="right" align="center">
+                Add app
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          {installedApps.map((app) => {
+            const isActive = activeAppId === app.id;
+            const isReady = "ready" in app && app.ready;
+            const hasError =
+              "error" in app && typeof app.error === "string" && app.error;
+            return (
+              <div key={app.id} className="group relative">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label={app.label}
+                        title={app.label}
+                        onClick={() => onSelectApp?.(app.id)}
+                        className={`relative flex size-10 items-center justify-center rounded-md transition-colors ${
+                          isActive
+                            ? "bg-primary/12 text-foreground"
+                            : "text-muted-foreground hover:bg-accent/36 hover:text-foreground"
+                        }`}
+                      >
+                        {isActive ? (
+                          <span className="absolute -left-2 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-full bg-primary" />
+                        ) : null}
+                        {providerIcon(app.id, 20) ?? (
+                          <span className="text-xs font-semibold uppercase tracking-wide">
+                            {appInitials(app.label)}
+                          </span>
+                        )}
+                        {hasError ? (
+                          <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full border-2 border-card bg-destructive" />
+                        ) : !isReady ? (
+                          <span className="absolute -bottom-0.5 -right-0.5 size-2 animate-pulse rounded-full border-2 border-card bg-sky-400" />
+                        ) : null}
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="right" align="center">
+                    {app.label}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            );
+          })}
+        </nav>
       </div>
       {appVersionLabel ? (
         <div className="mt-2 flex w-full justify-center pt-1">

--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -2,8 +2,37 @@ import { useEffect, useMemo } from "react";
 import { ExternalLink, LoaderCircle, RotateCw } from "lucide-react";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
 import { AppCatalogCard } from "./AppCatalogCard";
+
+function AppCatalogCardSkeleton() {
+  return (
+    <Card size="sm" className="animate-pulse">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="size-9 shrink-0 rounded-lg bg-muted-foreground/15" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-3.5 w-24 rounded bg-muted-foreground/15" />
+            <div className="h-2.5 w-10 rounded bg-muted-foreground/10" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 space-y-1.5">
+        <div className="h-2 w-full rounded bg-muted-foreground/15" />
+        <div className="h-2 w-[92%] rounded bg-muted-foreground/15" />
+        <div className="h-2 w-[70%] rounded bg-muted-foreground/15" />
+      </CardContent>
+      <CardFooter className="justify-end">
+        <div className="h-7 w-20 rounded-md bg-muted-foreground/15" />
+      </CardFooter>
+    </Card>
+  );
+}
 
 const PROVIDER_DISPLAY: Record<string, string> = {
   twitter: "Twitter / X",
@@ -114,11 +143,11 @@ export function AppsGallery() {
       ) : null}
 
       {isLoadingAppCatalog && appCatalog.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center">
-          <LoaderCircle
-            size={16}
-            className="animate-spin text-muted-foreground"
-          />
+        <div className="mt-4 grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton count
+            <AppCatalogCardSkeleton key={i} />
+          ))}
         </div>
       ) : appCatalog.length === 0 ? (
         <div className="mt-8 text-center text-xs text-muted-foreground">

--- a/desktop/src/components/panes/AppSurfacePane.tsx
+++ b/desktop/src/components/panes/AppSurfacePane.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Activity, LoaderCircle, Plug, RefreshCw, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { providerIcon } from "@/components/onboarding/constants";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import { getWorkspaceAppDefinition, type WorkspaceAppDefinition, type WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
@@ -30,7 +31,8 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
   const ready = app && "ready" in app ? app.ready : false;
   const error = app && "error" in app && typeof app.error === "string" ? app.error : null;
   const summary = app?.summary ?? "";
-  const accentClassName = app && "accentClassName" in app ? app.accentClassName : "bg-muted-foreground/40";
+  const brandIcon = providerIcon(appId, 22);
+  const iconFallback = label.slice(0, 2).toUpperCase();
 
   const routePath = useMemo(
     () => resolveAppSurfacePath({ resourceId, view }),
@@ -141,7 +143,7 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
   if (!ready && !error) {
     return (
       <div className="flex h-full min-h-0 gap-2">
-        <section className="flex w-[260px] shrink-0 items-center justify-center rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+        <section className="flex w-[260px] shrink-0 items-center justify-center rounded-xl border border-border bg-card/80 shadow-xs backdrop-blur-sm">
           <div className="max-w-[200px] text-center">
             <LoaderCircle size={20} className="mx-auto animate-spin text-muted-foreground" />
             <div className="mt-3 text-sm font-medium text-foreground">{label}</div>
@@ -150,7 +152,7 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
             </div>
           </div>
         </section>
-        <section className="flex min-w-0 flex-1 items-center justify-center rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+        <section className="flex min-w-0 flex-1 items-center justify-center rounded-xl border border-border bg-card/80 shadow-xs backdrop-blur-sm">
           <div className="text-center">
             <LoaderCircle size={16} className="mx-auto animate-spin text-muted-foreground" />
             <div className="mt-2 text-xs text-muted-foreground">Waiting for app...</div>
@@ -164,7 +166,7 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
   if (!ready && error) {
     return (
       <div className="flex h-full min-h-0 gap-2">
-        <section className="flex w-[260px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 p-4 shadow-md backdrop-blur-sm">
+        <section className="flex w-[260px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 p-4 shadow-xs backdrop-blur-sm">
           <div className="flex items-center gap-2 text-destructive">
             <Activity size={14} />
             <span className="text-[10px] uppercase tracking-widest">App error</span>
@@ -191,7 +193,7 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
             </div>
           ) : null}
         </section>
-        <section className="flex min-w-0 flex-1 items-center justify-center rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+        <section className="flex min-w-0 flex-1 items-center justify-center rounded-xl border border-border bg-card/80 shadow-xs backdrop-blur-sm">
           <div className="text-center">
             <Activity size={18} className="mx-auto text-destructive" />
             <div className="mt-2 text-xs text-muted-foreground">App failed to start</div>
@@ -205,33 +207,38 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
   return (
     <div className="flex h-full min-h-0 gap-2">
       {/* Left: App info card */}
-      <section className="flex w-[260px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+      <section className="flex w-[260px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 shadow-xs backdrop-blur-sm">
         <div className="chat-scrollbar-hidden flex-1 overflow-y-auto p-4">
-          <div className="flex items-center gap-2.5">
-            <span className={`size-2.5 shrink-0 rounded-full ${accentClassName}`} />
-            <span className="text-sm font-semibold text-foreground">{label}</span>
+          <div className="flex items-center gap-3">
+            <span className="grid size-10 shrink-0 place-items-center rounded-lg border border-border bg-muted/40 text-[11px] font-semibold uppercase text-muted-foreground">
+              {brandIcon ?? iconFallback}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-semibold text-foreground">{label}</div>
+              <div className="mt-0.5 flex items-center gap-1.5 text-[11px] font-medium text-emerald-500">
+                <span className="size-1.5 rounded-full bg-emerald-500" />
+                Running
+              </div>
+            </div>
           </div>
 
           {summary ? (
-            <p className="mt-2.5 text-xs leading-5 text-muted-foreground">{summary}</p>
+            <p className="mt-3 text-xs leading-5 text-muted-foreground">{summary}</p>
           ) : null}
 
-          <div className="mt-4 space-y-1.5">
-            <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
-              <span className="text-xs text-muted-foreground">Status</span>
-              <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-500">
-                <span className="size-1.5 rounded-full bg-emerald-500" />
-                Running
-              </span>
+          {resourceId ? (
+            <div className="mt-4 flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
+              <span className="text-xs text-muted-foreground">Resource</span>
+              <span className="max-w-[120px] truncate text-xs font-medium text-foreground">{resourceId}</span>
             </div>
-            {resourceId ? (
-              <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
-                <span className="text-xs text-muted-foreground">Resource</span>
-                <span className="max-w-[120px] truncate text-xs font-medium text-foreground">{resourceId}</span>
+          ) : null}
+
+          {integrationStatus ? (
+            <div className="mt-4">
+              <div className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+                Integrations
               </div>
-            ) : null}
-            {integrationStatus ? (
-              <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
+              <div className="mt-2 flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
                 <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <Plug size={11} />
                   {integrationStatus.providerName}
@@ -241,8 +248,8 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
                   {integrationStatus.connected ? "Connected" : "Not connected"}
                 </span>
               </div>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
 
           {app && "tools" in app && app.tools && app.tools.length > 0 ? (
             <div className="mt-4">
@@ -319,8 +326,8 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
       </section>
 
       {/* Right: App iframe */}
-      <section className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-md shadow-black/5">
-        <div className="relative min-h-0 flex-1 ring-1 ring-inset ring-border/50 shadow-[inset_0_2px_6px_rgba(0,0,0,0.08)]" style={{ borderRadius: "inherit" }}>
+      <section className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-xs">
+        <div className="relative min-h-0 flex-1" style={{ borderRadius: "inherit" }}>
           {frameUrl ? (
             <iframe
               key={`${frameUrl}:${reloadKey}`}

--- a/desktop/src/components/panes/MarketplacePane.tsx
+++ b/desktop/src/components/panes/MarketplacePane.tsx
@@ -23,7 +23,11 @@ function providerDisplayName(provider: string): string {
   return PROVIDER_DISPLAY_NAMES[provider] ?? provider;
 }
 
-export function MarketplacePane() {
+interface MarketplacePaneProps {
+  initialTab?: "templates" | "apps";
+}
+
+export function MarketplacePane({ initialTab = "templates" }: MarketplacePaneProps = {}) {
   const {
     marketplaceTemplates,
     isLoadingMarketplaceTemplates,
@@ -122,7 +126,7 @@ export function MarketplacePane() {
 
   return (
     <Tabs
-      defaultValue="templates"
+      defaultValue={initialTab}
       className="flex h-full min-h-0 p-6 min-w-0 flex-col overflow-hidden bg-muted/50 shadow-xs border border-border rounded-xl"
     >
       <div className="max-w-4xl mx-auto w-full">


### PR DESCRIPTION
## Summary

Four coordinated desktop UI changes that came out of the same pass:

- **App detail pane (`AppSurfacePane`)** — header now shows the brand icon in a 40px tile next to the label, with a compact "Running" pill replacing the old status row. The Integrations block is promoted to its own group heading so it matches the existing Tools section. Shadows come down from `shadow-md` to `shadow-xs` across ready / initializing / error states, and the iframe's old inset ring + inset box-shadow are removed so the preview sits flush against the card.
- **Left navigation rail (`LeftNavigationRail`)** — added an "Add app" button at the top of the installed-app list. It's always visible (dashed border, subtle muted text), and a new `onAddApp` prop routes the click to the Marketplace's **Apps** tab instead of the generic Templates default. Existing installed-app buttons are redesigned: transparent background by default, icons bumped from 18→20px, active state uses `bg-primary/12` plus a 2px vertical accent bar that sits on the rail's left edge, and the running/error status dot moved to the bottom-right corner so it stops clipping the icon.
- **Marketplace pane (`MarketplacePane`)** — accepts an optional `initialTab` prop. `AppShell` tracks a `marketplaceInitialTab` state; a generic marketplace navigation resets it to `templates`, while `handleAddApp` sets it to `apps` before activating the pane.
- **Apps gallery loading (`AppsGallery`)** — replaced the single centered spinner with six skeleton cards that mirror `AppCatalogCard`'s layout (Card + Header/Content/Footer, same grid). The grid no longer reflows when the real data arrives.

## Test plan
- [x] `npm run typecheck` in `desktop/`
- [x] Click "Add app" → Marketplace opens directly on the Apps tab
- [x] Click the Marketplace nav entry the normal way → opens on Templates
- [x] Sidebar app buttons: hover, active, error and initializing states all render correctly
- [x] App detail header shows the brand icon + Running pill, Integrations group heading is visible
- [x] Marketplace Apps tab shows six skeleton cards while loading, then swaps in real cards without layout shift