### PR TITLE
fix: pin bundled runtime node to 24.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/holaboss-ai/holaOS/actions/workflows/ci.yml"><img src="https://github.com/holaboss-ai/holaOS/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/node-22%2B-43853d" alt="Node 22+" />
+  <img src="https://img.shields.io/badge/node-24.14.1-43853d" alt="Node 24.14.1" />
   <img src="https://img.shields.io/badge/platform-macOS%20supported,%20Windows%20%26%20Linux%20in%20progress-f28c28" alt="macOS supported, Windows and Linux in progress" />
   <img src="https://img.shields.io/badge/desktop-Electron-47848f" alt="Electron desktop" />
   <img src="https://img.shields.io/badge/runtime-TypeScript-3178c6" alt="TypeScript runtime" />
@@ -60,7 +60,7 @@ Quick Start is the shortest path to a working local Holaboss Desktop environment
 - `bash`
 - macOS, Linux, or WSL
 
-The installer bootstraps `git`, Node.js `22`, and `npm` if they are missing. On Linux it may use `sudo` to install `git`.
+The installer bootstraps `git`, Node.js `24.14.1`, and `npm` if they are missing. On Linux it may use `sudo` to install `git`.
 
 
 ### One-Line Install
@@ -74,7 +74,7 @@ curl -fsSL https://raw.githubusercontent.com/holaboss-ai/holaboss-ai/main/script
 That installer:
 
 - installs `git` if it is missing
-- installs Node.js `22` plus `npm` if they are missing
+- installs Node.js `24.14.1` plus `npm` if they are missing
 - clones the repository into `~/holaboss-ai` by default
 - creates `desktop/.env` from `desktop/.env.example` if needed
 - runs `npm run desktop:install`

--- a/runtime/deploy/build_runtime_root.mjs
+++ b/runtime/deploy/build_runtime_root.mjs
@@ -17,6 +17,11 @@ const runtimeRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(runtimeRoot, "..");
 
 function resolveWindowsNpmCliPath() {
+  const explicitCliPath = process.env.HOLABOSS_RUNTIME_BUILD_NPM_CLI?.trim();
+  if (explicitCliPath && existsSync(explicitCliPath)) {
+    return explicitCliPath;
+  }
+
   const envExecPath = process.env.npm_execpath?.trim();
   if (envExecPath && existsSync(envExecPath)) {
     return envExecPath;
@@ -25,6 +30,18 @@ function resolveWindowsNpmCliPath() {
   const bundledCliPath = path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
   if (existsSync(bundledCliPath)) {
     return bundledCliPath;
+  }
+
+  const siblingCliPath = path.join(
+    path.dirname(process.execPath),
+    "..",
+    "..",
+    "npm",
+    "bin",
+    "npm-cli.js",
+  );
+  if (existsSync(siblingCliPath)) {
+    return siblingCliPath;
   }
 
   throw new Error("failed to resolve npm CLI entrypoint on Windows");

--- a/runtime/deploy/package_linux_runtime.sh
+++ b/runtime/deploy/package_linux_runtime.sh
@@ -37,28 +37,19 @@ resolve_output_root() {
 require_cmd git
 OUTPUT_ROOT="$(resolve_output_root "${OUTPUT_ROOT}")"
 
-"${SCRIPT_DIR}/build_runtime_root.sh" "${STAGING_ROOT}/runtime-root"
-
-rm -rf "${OUTPUT_ROOT}"
-mkdir -p "${OUTPUT_ROOT}"
-cp -R "${STAGING_ROOT}/runtime-root" "${OUTPUT_ROOT}/runtime"
-"${SCRIPT_DIR}/prune_packaged_tree.sh" "${OUTPUT_ROOT}/runtime" "linux"
-
 NODE_RUNTIME_DIR="${OUTPUT_ROOT}/node-runtime"
 PYTHON_RUNTIME_DIR="${OUTPUT_ROOT}/python-runtime"
 BIN_DIR="${OUTPUT_ROOT}/bin"
 PACKAGE_METADATA_PATH="${OUTPUT_ROOT}/package-metadata.json"
 SKIP_NODE_DEPS="${HOLABOSS_SKIP_NODE_DEPS:-0}"
+BUILD_NODE_RUNTIME_DIR="${STAGING_ROOT}/build-node-runtime"
+BUILD_NODE_BIN="${BUILD_NODE_RUNTIME_DIR}/node_modules/node/bin/node"
 LOCAL_NODE_BIN="${NODE_RUNTIME_DIR}/node_modules/node/bin/node"
 LOCAL_NPM_BIN="${NODE_RUNTIME_DIR}/node_modules/.bin/npm"
 LOCAL_PYTHON_BIN="${PYTHON_RUNTIME_DIR}/bin/python"
 
-NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-}"
-if [ -z "${NODE_VERSION}" ]; then
-  require_cmd node
-  NODE_VERSION="$(node --version)"
-  NODE_VERSION="${NODE_VERSION#v}"
-fi
+DEFAULT_RUNTIME_NODE_VERSION="24.14.1"
+NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-${DEFAULT_RUNTIME_NODE_VERSION}}"
 
 NPM_VERSION="${HOLABOSS_RUNTIME_NPM_VERSION:-}"
 if [ -z "${NPM_VERSION}" ]; then
@@ -81,12 +72,28 @@ case "${PYTHON_ARCH_RAW}" in
     ;;
 esac
 
-mkdir -p "${BIN_DIR}"
-
 if [ "${SKIP_NODE_DEPS}" != "1" ]; then
   require_cmd npm
-  mkdir -p "${NODE_RUNTIME_DIR}"
-  npm install --prefix "${NODE_RUNTIME_DIR}" "node@${NODE_VERSION}" "npm@${NPM_VERSION}"
+  mkdir -p "${BUILD_NODE_RUNTIME_DIR}"
+  npm install --prefix "${BUILD_NODE_RUNTIME_DIR}" "node@${NODE_VERSION}" "npm@${NPM_VERSION}"
+fi
+
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
+  PATH="${BUILD_NODE_RUNTIME_DIR}/node_modules/node/bin:${BUILD_NODE_RUNTIME_DIR}/node_modules/.bin:${PATH}" \
+    "${BUILD_NODE_BIN}" "${SCRIPT_DIR}/build_runtime_root.mjs" "${STAGING_ROOT}/runtime-root"
+else
+  require_cmd node
+  node "${SCRIPT_DIR}/build_runtime_root.mjs" "${STAGING_ROOT}/runtime-root"
+fi
+
+rm -rf "${OUTPUT_ROOT}"
+mkdir -p "${OUTPUT_ROOT}"
+mkdir -p "${BIN_DIR}"
+cp -R "${STAGING_ROOT}/runtime-root" "${OUTPUT_ROOT}/runtime"
+"${SCRIPT_DIR}/prune_packaged_tree.sh" "${OUTPUT_ROOT}/runtime" "linux"
+
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
+  cp -R "${BUILD_NODE_RUNTIME_DIR}" "${NODE_RUNTIME_DIR}"
   "${SCRIPT_DIR}/prune_packaged_tree.sh" "${NODE_RUNTIME_DIR}" "linux"
 fi
 

--- a/runtime/deploy/package_macos_runtime.sh
+++ b/runtime/deploy/package_macos_runtime.sh
@@ -37,28 +37,19 @@ resolve_output_root() {
 require_cmd git
 OUTPUT_ROOT="$(resolve_output_root "${OUTPUT_ROOT}")"
 
-"${SCRIPT_DIR}/build_runtime_root.sh" "${STAGING_ROOT}/runtime-root"
-
-rm -rf "${OUTPUT_ROOT}"
-mkdir -p "${OUTPUT_ROOT}"
-cp -R "${STAGING_ROOT}/runtime-root" "${OUTPUT_ROOT}/runtime"
-"${SCRIPT_DIR}/prune_packaged_tree.sh" "${OUTPUT_ROOT}/runtime" "macos"
-
 NODE_RUNTIME_DIR="${OUTPUT_ROOT}/node-runtime"
 PYTHON_RUNTIME_DIR="${OUTPUT_ROOT}/python-runtime"
 BIN_DIR="${OUTPUT_ROOT}/bin"
 PACKAGE_METADATA_PATH="${OUTPUT_ROOT}/package-metadata.json"
 SKIP_NODE_DEPS="${HOLABOSS_SKIP_NODE_DEPS:-0}"
+BUILD_NODE_RUNTIME_DIR="${STAGING_ROOT}/build-node-runtime"
+BUILD_NODE_BIN="${BUILD_NODE_RUNTIME_DIR}/node_modules/node/bin/node"
 LOCAL_NODE_BIN="${NODE_RUNTIME_DIR}/node_modules/node/bin/node"
 LOCAL_NPM_BIN="${NODE_RUNTIME_DIR}/node_modules/.bin/npm"
 LOCAL_PYTHON_BIN="${PYTHON_RUNTIME_DIR}/bin/python"
 
-NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-}"
-if [ -z "${NODE_VERSION}" ]; then
-  require_cmd node
-  NODE_VERSION="$(node --version)"
-  NODE_VERSION="${NODE_VERSION#v}"
-fi
+DEFAULT_RUNTIME_NODE_VERSION="24.14.1"
+NODE_VERSION="${HOLABOSS_RUNTIME_NODE_VERSION:-${DEFAULT_RUNTIME_NODE_VERSION}}"
 
 NPM_VERSION="${HOLABOSS_RUNTIME_NPM_VERSION:-}"
 if [ -z "${NPM_VERSION}" ]; then
@@ -81,12 +72,28 @@ case "${PYTHON_ARCH_RAW}" in
     ;;
 esac
 
-mkdir -p "${BIN_DIR}"
-
 if [ "${SKIP_NODE_DEPS}" != "1" ]; then
   require_cmd npm
-  mkdir -p "${NODE_RUNTIME_DIR}"
-  npm install --prefix "${NODE_RUNTIME_DIR}" "node@${NODE_VERSION}" "npm@${NPM_VERSION}"
+  mkdir -p "${BUILD_NODE_RUNTIME_DIR}"
+  npm install --prefix "${BUILD_NODE_RUNTIME_DIR}" "node@${NODE_VERSION}" "npm@${NPM_VERSION}"
+fi
+
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
+  PATH="${BUILD_NODE_RUNTIME_DIR}/node_modules/node/bin:${BUILD_NODE_RUNTIME_DIR}/node_modules/.bin:${PATH}" \
+    "${BUILD_NODE_BIN}" "${SCRIPT_DIR}/build_runtime_root.mjs" "${STAGING_ROOT}/runtime-root"
+else
+  require_cmd node
+  node "${SCRIPT_DIR}/build_runtime_root.mjs" "${STAGING_ROOT}/runtime-root"
+fi
+
+rm -rf "${OUTPUT_ROOT}"
+mkdir -p "${OUTPUT_ROOT}"
+mkdir -p "${BIN_DIR}"
+cp -R "${STAGING_ROOT}/runtime-root" "${OUTPUT_ROOT}/runtime"
+"${SCRIPT_DIR}/prune_packaged_tree.sh" "${OUTPUT_ROOT}/runtime" "macos"
+
+if [ "${SKIP_NODE_DEPS}" != "1" ]; then
+  cp -R "${BUILD_NODE_RUNTIME_DIR}" "${NODE_RUNTIME_DIR}"
   "${SCRIPT_DIR}/prune_packaged_tree.sh" "${NODE_RUNTIME_DIR}" "macos"
 fi
 

--- a/runtime/deploy/package_runtime_node_bundle.test.mjs
+++ b/runtime/deploy/package_runtime_node_bundle.test.mjs
@@ -19,7 +19,12 @@ for (const targetPath of [macosPackagerPath, linuxPackagerPath]) {
     const source = await readFile(targetPath, "utf8");
     const targetPlatform = path.basename(targetPath).includes("macos") ? "macos" : "linux";
 
-    assert.match(source, /npm install --prefix "\$\{NODE_RUNTIME_DIR\}" "node@\$\{NODE_VERSION\}" "npm@\$\{NPM_VERSION\}"/);
+    assert.match(source, /npm install --prefix "\$\{BUILD_NODE_RUNTIME_DIR\}" "node@\$\{NODE_VERSION\}" "npm@\$\{NPM_VERSION\}"/);
+    assert.match(source, /DEFAULT_RUNTIME_NODE_VERSION="24\.14\.1"/);
+    assert.match(source, /NODE_VERSION="\$\{HOLABOSS_RUNTIME_NODE_VERSION:-\$\{DEFAULT_RUNTIME_NODE_VERSION\}\}"/);
+    assert.match(source, /BUILD_NODE_RUNTIME_DIR="\$\{STAGING_ROOT\}\/build-node-runtime"/);
+    assert.match(source, /build_runtime_root\.mjs/);
+    assert.match(source, /cp -R "\$\{BUILD_NODE_RUNTIME_DIR\}" "\$\{NODE_RUNTIME_DIR\}"/);
     assert.match(source, new RegExp(`node "\\$\\{SCRIPT_DIR\\}/stage_python_runtime\\.mjs" "\\$\\{OUTPUT_ROOT\\}" "${targetPlatform}"`));
     assert.match(source, /BUNDLED_NODE_BIN="\$\{BUNDLE_ROOT\}\/node-runtime\/node_modules\/node\/bin\/node"/);
     assert.match(source, /export PATH="\$\{BUNDLE_ROOT\}\/python-runtime\/bin:\$\{BUNDLE_ROOT\}\/python-runtime\/python\/bin:\$\{BUNDLE_ROOT\}\/node-runtime\/node_modules\/node\/bin:\$\{BUNDLE_ROOT\}\/node-runtime\/node_modules\/\.bin:\$\{PATH\}"/);
@@ -40,7 +45,11 @@ test("package_windows_runtime.mjs writes launchers that use the bundled node run
   const cmdLauncherSource = buildWindowsRuntimeCmdLauncherSource();
 
   assert.match(source, /import \{ stagePythonRuntime \} from "\.\/stage_python_runtime\.mjs";/);
-  assert.match(source, /runNpm\(\["install", "--prefix", nodeRuntimeDir, `node@\$\{nodeVersion\}`, `npm@\$\{npmVersion\}`\]/);
+  assert.match(source, /const DEFAULT_RUNTIME_NODE_VERSION = "24\.14\.1";/);
+  assert.match(source, /const buildNodeRuntimeDir = path\.join\(stagingRoot, "build-node-runtime"\);/);
+  assert.match(source, /HOLABOSS_RUNTIME_BUILD_NPM_CLI: buildNpmCli/);
+  assert.match(source, /runNpm\(\["install", "--prefix", buildNodeRuntimeDir, `node@\$\{nodeVersion\}`, `npm@\$\{npmVersion\}`\]/);
+  assert.match(source, /cpSync\(buildNodeRuntimeDir, nodeRuntimeDir, \{ recursive: true, dereference: true \}\)/);
   assert.match(source, /prunePackagedTree\(nodeRuntimeDir, "windows"\)/);
   assert.match(source, /const pythonStageResult = await stagePythonRuntime\(outputRoot, "windows"\);/);
   assert.match(source, /bundled_npm_bin: Boolean\(bundledNpmBin\)/);

--- a/runtime/deploy/package_windows_runtime.mjs
+++ b/runtime/deploy/package_windows_runtime.mjs
@@ -20,6 +20,7 @@ import { stagePythonRuntime } from "./stage_python_runtime.mjs";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const runtimeRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(runtimeRoot, "..");
+const DEFAULT_RUNTIME_NODE_VERSION = "24.14.1";
 
 function resolveWindowsNpmCliPath() {
   const envExecPath = process.env.npm_execpath?.trim();
@@ -101,7 +102,7 @@ function bundledPythonCandidates(outputRoot) {
 }
 
 function resolveNodeVersion() {
-  return process.env.HOLABOSS_RUNTIME_NODE_VERSION?.trim() || process.versions.node;
+  return process.env.HOLABOSS_RUNTIME_NODE_VERSION?.trim() || DEFAULT_RUNTIME_NODE_VERSION;
 }
 
 function resolveNpmVersion() {
@@ -208,6 +209,14 @@ export async function packageWindowsRuntime(
 
   const outputRoot = path.resolve(outputRootArg);
   const stagingRoot = mkdtempSync(path.join(os.tmpdir(), "holaboss-runtime-windows."));
+  const buildNodeRuntimeDir = path.join(stagingRoot, "build-node-runtime");
+  const buildNodeExe = path.join(buildNodeRuntimeDir, "node_modules", "node", "bin", "node.exe");
+  const buildNpmCli = path.join(buildNodeRuntimeDir, "node_modules", "npm", "bin", "npm-cli.js");
+  const buildPathEntries = [
+    path.join(buildNodeRuntimeDir, "node_modules", "node", "bin"),
+    path.join(buildNodeRuntimeDir, "node_modules", ".bin"),
+    process.env.PATH ?? ""
+  ].filter((value) => value.length > 0);
   const runtimeStagingRoot = path.join(stagingRoot, "runtime-root");
   const runtimeOutputRoot = path.join(outputRoot, "runtime");
   const nodeRuntimeDir = path.join(outputRoot, "node-runtime");
@@ -218,7 +227,22 @@ export async function packageWindowsRuntime(
   const npmVersion = resolveNpmVersion();
 
   try {
-    buildRuntimeRoot(runtimeStagingRoot);
+    if (!skipNodeDeps) {
+      mkdirSync(buildNodeRuntimeDir, { recursive: true });
+      runNpm(["install", "--prefix", buildNodeRuntimeDir, `node@${nodeVersion}`, `npm@${npmVersion}`], {
+        stdio: "inherit",
+        env: process.env
+      });
+      runCommand(buildNodeExe, [path.join(scriptDir, "build_runtime_root.mjs"), runtimeStagingRoot], {
+        env: {
+          ...process.env,
+          HOLABOSS_RUNTIME_BUILD_NPM_CLI: buildNpmCli,
+          PATH: buildPathEntries.join(path.delimiter),
+        }
+      });
+    } else {
+      buildRuntimeRoot(runtimeStagingRoot);
+    }
 
     rmSync(outputRoot, { recursive: true, force: true });
     mkdirSync(outputRoot, { recursive: true });
@@ -227,11 +251,7 @@ export async function packageWindowsRuntime(
 
     mkdirSync(binDir, { recursive: true });
     if (!skipNodeDeps) {
-      mkdirSync(nodeRuntimeDir, { recursive: true });
-      runNpm(["install", "--prefix", nodeRuntimeDir, `node@${nodeVersion}`, `npm@${npmVersion}`], {
-        stdio: "inherit",
-        env: process.env
-      });
+      cpSync(buildNodeRuntimeDir, nodeRuntimeDir, { recursive: true, dereference: true });
       prunePackagedTree(nodeRuntimeDir, "windows");
       stageWindowsNodeCommandLaunchers(outputRoot);
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ DEFAULT_INSTALL_DIR="${HOLABOSS_INSTALL_DIR:-$HOME/holaboss-ai}"
 HOLABOSS_HOME="${HOLABOSS_HOME:-$HOME/.holaboss}"
 MANAGED_NODE_DIR="${HOLABOSS_HOME}/node"
 LOCAL_BIN_DIR="${HOME}/.local/bin"
+MANAGED_NODE_VERSION="24.14.1"
 
 INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
 REF="${HOLABOSS_INSTALL_REF:-main}"
@@ -261,12 +262,12 @@ install_managed_node() {
     *) fail "Unsupported architecture for managed Node.js install: $(uname -m)" ;;
   esac
 
-  shasums_url="https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
-  log_info "Installing managed Node.js 22 and npm"
+  shasums_url="https://nodejs.org/dist/v${MANAGED_NODE_VERSION}/SHASUMS256.txt"
+  log_info "Installing managed Node.js ${MANAGED_NODE_VERSION} and npm"
 
   tarball_name="$(
     curl -fsSL "${shasums_url}" \
-      | grep -E " node-v22\\.[0-9]+\\.[0-9]+-${node_os}-${node_arch}\\.tar\\.gz$" \
+      | grep -E " node-v${MANAGED_NODE_VERSION//./\\.}-${node_os}-${node_arch}\\.tar\\.gz$" \
       | awk '{print $2}' \
       | head -1
   )"
@@ -274,15 +275,15 @@ install_managed_node() {
   if [[ -z "${tarball_name}" ]]; then
     tarball_name="$(
       curl -fsSL "${shasums_url}" \
-        | grep -E " node-v22\\.[0-9]+\\.[0-9]+-${node_os}-${node_arch}\\.tar\\.xz$" \
+        | grep -E " node-v${MANAGED_NODE_VERSION//./\\.}-${node_os}-${node_arch}\\.tar\\.xz$" \
         | awk '{print $2}' \
         | head -1
     )"
   fi
 
-  [[ -n "${tarball_name}" ]] || fail "Could not resolve a Node.js 22 binary for ${node_os}-${node_arch}"
+  [[ -n "${tarball_name}" ]] || fail "Could not resolve a Node.js ${MANAGED_NODE_VERSION} binary for ${node_os}-${node_arch}"
 
-  archive_url="https://nodejs.org/dist/latest-v22.x/${tarball_name}"
+  archive_url="https://nodejs.org/dist/v${MANAGED_NODE_VERSION}/${tarball_name}"
   tmp_dir="$(mktemp -d)"
 
   curl -fsSL "${archive_url}" -o "${tmp_dir}/${tarball_name}"
@@ -293,7 +294,7 @@ install_managed_node() {
     tar -xJf "${tmp_dir}/${tarball_name}" -C "${tmp_dir}"
   fi
 
-  extracted_dir="$(find "${tmp_dir}" -maxdepth 1 -type d -name 'node-v22*' | head -1)"
+  extracted_dir="$(find "${tmp_dir}" -maxdepth 1 -type d -name "node-v${MANAGED_NODE_VERSION}*" | head -1)"
   [[ -n "${extracted_dir}" ]] || fail "Node.js archive extracted but no runtime directory was found"
 
   mkdir -p "${HOLABOSS_HOME}"
@@ -319,15 +320,15 @@ ensure_node_and_npm() {
   if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
     node_version="$(node --version 2>/dev/null || true)"
     node_major="$(printf '%s' "${node_version}" | sed -E 's/^v([0-9]+).*/\1/')"
-    if [[ "${node_major}" =~ ^[0-9]+$ ]] && (( node_major >= 22 )); then
+    if [[ "${node_major}" =~ ^[0-9]+$ ]] && (( node_major >= 24 )); then
       log_success "Node.js found (${node_version})"
       log_success "npm found ($(npm --version))"
       return
     fi
 
-    log_warn "Node.js 22+ is required. Found ${node_version:-unknown}; installing managed Node.js 22."
+    log_warn "Node.js 24+ is required. Found ${node_version:-unknown}; installing managed Node.js ${MANAGED_NODE_VERSION}."
   else
-    log_info "Node.js 22 and npm are missing; installing managed Node.js 22"
+    log_info "Node.js 24 and npm are missing; installing managed Node.js ${MANAGED_NODE_VERSION}"
   fi
 
   install_managed_node

--- a/scripts/quick-install-mac.sh
+++ b/scripts/quick-install-mac.sh
@@ -39,8 +39,8 @@ require_cmd npm
 
 NODE_VERSION="$(node -v)"
 NODE_MAJOR="$(echo "$NODE_VERSION" | sed -E 's/^v([0-9]+).*/\1/')"
-if (( NODE_MAJOR < 22 )); then
-  echo "Node.js 22+ is required. Found: $NODE_VERSION"
+if (( NODE_MAJOR < 24 )); then
+  echo "Node.js 24+ is required. Found: $NODE_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
## Context
- pin the packaged runtime to the exact Node 24.14.1 LTS release
- ensure the runtime root is built with the same bundled Node that ships in the bundle
- avoid ABI mismatches where native modules are compiled against the developer machine Node instead of the embedded runtime Node

## Changes
- pin macOS, Linux, and Windows runtime packaging defaults to `24.14.1`
- build the runtime root with the staged bundled Node runtime before finalizing the output bundle
- update install scripts and README expectations to match the pinned LTS runtime
- extend runtime bundle tests for the staged bundled-node build flow

## Validation
- `node --test runtime/deploy/package_runtime_node_bundle.test.mjs`
- `bash -n runtime/deploy/package_macos_runtime.sh runtime/deploy/package_linux_runtime.sh scripts/install.sh scripts/quick-install-mac.sh`
- `npm --prefix desktop run prepare:runtime:local:macos`
- direct `better-sqlite3` load/query under `desktop/out/runtime-macos/node-runtime/node_modules/node/bin/node`
