### PR TITLE
feat(desktop): add applications explorer and proposal toasts

### DIFF
--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -32,6 +32,23 @@ test("app shell routes file outputs into the explorer and universal display whil
   );
 });
 
+test("app shell routes app outputs into the applications explorer and app surface", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /const handleOpenSpaceApp = useCallback\(/);
+  assert.match(source, /setSpaceExplorerMode\("applications"\);/);
+  assert.match(source, /setSpaceExplorerCollapsed\(false\);/);
+  assert.match(
+    source,
+    /setSpaceDisplayView\(\{\s*type: "app",\s*appId,\s*path: options\?\.path,\s*resourceId: options\?\.resourceId,\s*view: options\?\.view,\s*\}\);/,
+  );
+  assert.match(
+    source,
+    /if \(target\.type === "app"\) \{\s*handleOpenSpaceApp\(target\.appId,\s*\{\s*path: target\.path,\s*resourceId: target\.resourceId,\s*view: target\.view,\s*resetAgentView: true,\s*\}\);/,
+  );
+  assert.doesNotMatch(source, /window\.electronAPI\.appSurface\.resolveUrl/);
+});
+
 test("app shell clears a consumed file explorer focus request", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
@@ -313,6 +330,33 @@ test("app shell requests remote task proposal generation without a separate succ
   assert.doesNotMatch(source, /Pending cloud jobs/);
 });
 
+test("app shell raises a local toast when fresh task proposals arrive and opens the inbox from it", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /const TASK_PROPOSAL_TOAST_ID_PREFIX = "task-proposal-toast:";/);
+  assert.match(source, /function buildTaskProposalToastNotification\(/);
+  assert.match(
+    source,
+    /const \[taskProposalToastNotifications,\s*setTaskProposalToastNotifications\] =\s*useState<\s*RuntimeNotificationRecordPayload\[\]\s*>\(\[\]\);/,
+  );
+  assert.match(
+    source,
+    /const knownTaskProposalIdsByWorkspaceRef = useRef<Record<string, string\[]>>\(\s*\{\s*\},?\s*\);/,
+  );
+  assert.match(source, /const applyTaskProposals = useCallback\(/);
+  assert.match(source, /const pendingNewProposals = proposals\.filter\(\(proposal\) => \{/);
+  assert.match(
+    source,
+    /return isNew && proposal\.state\.trim\(\)\.toLowerCase\(\) === "pending";/,
+  );
+  assert.match(
+    source,
+    /setTaskProposalToastNotifications\(\(current\) =>\s*\[toast, \.\.\.current\]\.slice\(0, 4\),?\s*\)\s*;/,
+  );
+  assert.match(source, /if \(isTaskProposalToastId\(notificationId\)\) \{/);
+  assert.match(source, /openTaskProposalInbox\(notification\.workspace_id\);/);
+});
+
 test("app shell tracks unread task proposals and badges the inbox control", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
@@ -346,7 +390,7 @@ test("app shell renders a collapsible explorer and universal display in space mo
   assert.doesNotMatch(source, /className="mr-1\.5 flex w-9 shrink-0 flex-col items-center gap-1\.5 py-1"/);
   assert.doesNotMatch(source, /aria-label="Toggle files pane"/);
   assert.doesNotMatch(source, /aria-label="Toggle browser pane"/);
-  assert.match(source, /type SpaceExplorerMode = "files" \| "browser";/);
+  assert.match(source, /type SpaceExplorerMode = "files" \| "browser" \| "applications";/);
   assert.match(source, /const \[spaceExplorerMode, setSpaceExplorerMode\] =\s*useState<SpaceExplorerMode>\("files"\);/);
   assert.match(source, /const \[spaceExplorerCollapsed, setSpaceExplorerCollapsed\] = useState\(false\);/);
   assert.match(source, /const \[spaceDisplayView, setSpaceDisplayView\] = useState<SpaceDisplayView>\(\{\s*type: "browser",\s*\}\);/);
@@ -356,9 +400,11 @@ test("app shell renders a collapsible explorer and universal display in space mo
   );
   assert.match(source, /<FileExplorerPane[\s\S]*focusRequest=\{fileExplorerFocusRequest\}/);
   assert.match(source, /<FileExplorerPane[\s\S]*previewInPane=\{false\}/);
+  assert.match(source, /<SpaceApplicationsExplorerPane[\s\S]*installedApps=\{installedApps\}/);
   assert.match(source, /<SpaceBrowserExplorerPane[\s\S]*browserSpace=\{spaceBrowserSpace\}/);
   assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*layoutSyncKey=\{spaceDisplayLayoutSyncKey\}/);
   assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*embedded/);
+  assert.match(source, /aria-label="Open applications explorer"/);
   assert.match(source, /aria-label="Collapse explorer"/);
   assert.match(source, /aria-label="Expand explorer"/);
   assert.match(source, /aria-label="Resize display pane"/);

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -12,7 +12,6 @@ import { SettingsDialog } from "@/components/layout/SettingsDialog";
 import { TopTabsBar } from "@/components/layout/TopTabsBar";
 import { FirstWorkspacePane } from "@/components/onboarding";
 import { AppSurfacePane } from "@/components/panes/AppSurfacePane";
-import { resolveAppSurfacePath } from "@/components/panes/appSurfaceRoute";
 import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { BrowserPane } from "@/components/panes/BrowserPane";
 import { ChatPane } from "@/components/panes/ChatPane";
@@ -23,6 +22,7 @@ import {
 import { InternalSurfacePane } from "@/components/panes/InternalSurfacePane";
 import { MarketplacePane } from "@/components/panes/MarketplacePane";
 import { OnboardingPane } from "@/components/panes/OnboardingPane";
+import { SpaceApplicationsExplorerPane } from "@/components/panes/SpaceApplicationsExplorerPane";
 import { SpaceBrowserDisplayPane } from "@/components/panes/SpaceBrowserDisplayPane";
 import { SpaceBrowserExplorerPane } from "@/components/panes/SpaceBrowserExplorerPane";
 import { PublishDialog } from "@/components/publish/PublishDialog";
@@ -45,6 +45,7 @@ import {
   Folder,
   Globe,
   Inbox,
+  LayoutGrid,
   Loader2,
   PanelLeftClose,
   PanelLeftOpen,
@@ -64,6 +65,7 @@ const THEME_STORAGE_KEY = "holaboss-theme-v1";
 const DEV_APP_UPDATE_PREVIEW_STORAGE_KEY = "holaboss-dev-app-update-preview-v1";
 const DEV_NOTIFICATION_TOAST_PREVIEW_ID_PREFIX =
   "dev-notification-toast-preview:";
+const TASK_PROPOSAL_TOAST_ID_PREFIX = "task-proposal-toast:";
 const OPERATIONS_DRAWER_OPEN_STORAGE_KEY = "holaboss-operations-drawer-open-v1";
 const OPERATIONS_DRAWER_TAB_STORAGE_KEY = "holaboss-operations-drawer-tab-v1";
 const TASK_PROPOSAL_SEEN_STORAGE_KEY = "holaboss-task-proposal-seen-v1";
@@ -104,7 +106,7 @@ const MAX_SEEN_TASK_PROPOSAL_IDS_PER_WORKSPACE = 200;
 type SpaceComponentId = "agent" | "files" | "browser";
 type UtilityPaneId = "files" | "browser";
 type DevAppUpdatePreviewMode = "off" | "downloading" | "ready";
-type SpaceExplorerMode = "files" | "browser";
+type SpaceExplorerMode = "files" | "browser" | "applications";
 
 type SpaceVisibilityState = Record<SpaceComponentId, boolean>;
 
@@ -168,6 +170,7 @@ type AgentView =
   | {
       type: "app";
       appId: string;
+      path?: string | null;
       resourceId?: string | null;
       view?: string | null;
     }
@@ -183,6 +186,7 @@ type SpaceDisplayView =
   | {
       type: "app";
       appId: string;
+      path?: string | null;
       resourceId?: string | null;
       view?: string | null;
     }
@@ -215,6 +219,7 @@ type WorkspaceOutputNavigationTarget =
   | {
       type: "app";
       appId: string;
+      path?: string | null;
       resourceId?: string | null;
       view?: string | null;
     }
@@ -289,17 +294,18 @@ function buildReportedSurfaceFromAppView(params: {
   view: Extract<AgentView, { type: "app" }> | Extract<SpaceDisplayView, { type: "app" }>;
 }): OperatorSurfacePayload {
   const resourceId = nonEmptySurfaceText(params.view.resourceId);
+  const routePath = nonEmptySurfaceText(params.view.path);
   const viewId = nonEmptySurfaceText(params.view.view);
   const ownerLabel = params.owner === "user" ? "User" : "Agent";
   const mutability: OperatorSurfaceMutability =
     params.owner === "agent" ? "agent_owned" : "inspect_only";
   return {
-    surface_id: `app_surface:${params.owner}:${params.view.appId}:${resourceId || viewId || "current"}`,
+    surface_id: `app_surface:${params.owner}:${params.view.appId}:${resourceId || routePath || viewId || "current"}`,
     surface_type: "app_surface",
     owner: params.owner,
     active: params.active,
     mutability,
-    summary: `${ownerLabel} is currently viewing workspace app \`${params.view.appId}\`${resourceId ? ` resource \`${resourceId}\`` : ""}${viewId ? ` in view \`${viewId}\`` : ""}.`,
+    summary: `${ownerLabel} is currently viewing workspace app \`${params.view.appId}\`${resourceId ? ` resource \`${resourceId}\`` : routePath ? ` route \`${routePath}\`` : ""}${viewId ? ` in view \`${viewId}\`` : ""}.`,
   };
 }
 
@@ -378,6 +384,10 @@ function utilityPaneMinWidth(paneId: UtilityPaneId): number {
 
 function isDevNotificationToastPreviewId(notificationId: string): boolean {
   return notificationId.startsWith(DEV_NOTIFICATION_TOAST_PREVIEW_ID_PREFIX);
+}
+
+function isTaskProposalToastId(notificationId: string): boolean {
+  return notificationId.startsWith(TASK_PROPOSAL_TOAST_ID_PREFIX);
 }
 
 function buildDevNotificationToastPreviewNotifications(
@@ -467,6 +477,43 @@ function appUpdateChangelogUrl(status: AppUpdateStatusPayload): string | null {
     return null;
   }
   return `${APP_UPDATE_CHANGELOG_BASE_URL}/holaboss-${version}`;
+}
+
+function buildTaskProposalToastNotification(params: {
+  workspaceId: string;
+  workspaceName?: string | null;
+  proposals: TaskProposalRecordPayload[];
+}): RuntimeNotificationRecordPayload {
+  const now = new Date().toISOString();
+  const proposalCount = params.proposals.length;
+  const firstProposalName =
+    params.proposals[0]?.task_name?.trim() || "Untitled task";
+  const workspaceName = params.workspaceName?.trim() || "";
+  const workspaceQualifier = workspaceName ? ` in ${workspaceName}` : "";
+
+  return {
+    id: `${TASK_PROPOSAL_TOAST_ID_PREFIX}${crypto.randomUUID()}`,
+    workspace_id: params.workspaceId,
+    cronjob_id: null,
+    source_type: "task_proposal",
+    source_label: "Task proposals",
+    title:
+      proposalCount === 1 ? "Task proposal ready" : "Task proposals ready",
+    message:
+      proposalCount === 1
+        ? `"${firstProposalName}" is ready to review in the inbox${workspaceQualifier}.`
+        : `${proposalCount} task proposals are ready to review in the inbox${workspaceQualifier}.`,
+    level: "info",
+    priority: "high",
+    state: "unread",
+    metadata: {
+      proposal_ids: params.proposals.map((proposal) => proposal.proposal_id),
+    },
+    read_at: null,
+    dismissed_at: null,
+    created_at: now,
+    updated_at: now,
+  };
 }
 
 function notificationMetadataString(
@@ -765,10 +812,8 @@ function workspaceOutputNavigationTarget(
     return {
       type: "app",
       appId: moduleId,
-      resourceId:
-        hasAppPresentation && presentation?.path
-          ? presentation.path
-          : output.module_resource_id || output.artifact_id || output.id,
+      path: hasAppPresentation ? presentation?.path || null : null,
+      resourceId: output.module_resource_id || output.artifact_id || output.id,
       view: hasAppPresentation
         ? presentation.view
         : output.output_type || "home",
@@ -1119,6 +1164,8 @@ function AppShellContent() {
   const [toastNotifications, setToastNotifications] = useState<
     RuntimeNotificationRecordPayload[]
   >([]);
+  const [taskProposalToastNotifications, setTaskProposalToastNotifications] =
+    useState<RuntimeNotificationRecordPayload[]>([]);
   const [devNotificationToastPreview, setDevNotificationToastPreview] =
     useState<RuntimeNotificationRecordPayload[]>([]);
   const utilityPaneHostRef = useRef<HTMLDivElement | null>(null);
@@ -1129,6 +1176,9 @@ function AppShellContent() {
   const spaceVisibilityRef = useRef(spaceVisibility);
   const notificationsHydratedRef = useRef(false);
   const seenNotificationIdsRef = useRef(new Set<string>());
+  const knownTaskProposalIdsByWorkspaceRef = useRef<Record<string, string[]>>(
+    {},
+  );
   const lastRestorableSpaceDisplayViewByWorkspaceRef = useRef<
     Record<string, RestorableSpaceDisplayView>
   >({});
@@ -1189,8 +1239,17 @@ function AppShellContent() {
     () =>
       devNotificationToastPreview.length > 0
         ? devNotificationToastPreview
-        : toastNotifications,
-    [devNotificationToastPreview, toastNotifications],
+        : [...taskProposalToastNotifications, ...toastNotifications]
+            .sort(
+              (left, right) =>
+                Date.parse(right.created_at) - Date.parse(left.created_at),
+            )
+            .slice(0, 4),
+    [
+      devNotificationToastPreview,
+      taskProposalToastNotifications,
+      toastNotifications,
+    ],
   );
   const runtimeNotificationById = useMemo(
     () =>
@@ -1198,6 +1257,16 @@ function AppShellContent() {
         notifications.map((notification) => [notification.id, notification]),
       ),
     [notifications],
+  );
+  const taskProposalToastById = useMemo(
+    () =>
+      new Map(
+        taskProposalToastNotifications.map((notification) => [
+          notification.id,
+          notification,
+        ]),
+      ),
+    [taskProposalToastNotifications],
   );
   const unreadTaskProposalCount = useMemo(() => {
     if (!selectedWorkspaceId || taskProposals.length === 0) {
@@ -1259,6 +1328,100 @@ function AppShellContent() {
       });
     },
     [],
+  );
+
+  const dismissTaskProposalToast = useCallback((notificationId: string) => {
+    setTaskProposalToastNotifications((current) =>
+      current.filter((item) => item.id !== notificationId),
+    );
+  }, []);
+
+  const openTaskProposalInbox = useCallback(
+    (workspaceId?: string | null) => {
+      const normalizedWorkspaceId =
+        workspaceId?.trim() || selectedWorkspaceId || "";
+      if (normalizedWorkspaceId) {
+        setSelectedWorkspaceId(normalizedWorkspaceId);
+      }
+      setActiveLeftRailItem("space");
+      setSpaceVisibility((previous) => ({
+        ...previous,
+        agent: true,
+      }));
+      setAgentView({ type: "inbox" });
+      if (
+        normalizedWorkspaceId &&
+        normalizedWorkspaceId === selectedWorkspaceId &&
+        taskProposals.length > 0
+      ) {
+        markTaskProposalsSeen(normalizedWorkspaceId, taskProposals);
+      }
+    },
+    [
+      markTaskProposalsSeen,
+      selectedWorkspaceId,
+      setSelectedWorkspaceId,
+      taskProposals,
+    ],
+  );
+
+  const applyTaskProposals = useCallback(
+    (
+      workspaceId: string | null | undefined,
+      workspaceName: string | null | undefined,
+      proposals: TaskProposalRecordPayload[],
+      options?: { notify?: boolean },
+    ) => {
+      setTaskProposals(proposals);
+
+      const normalizedWorkspaceId = workspaceId?.trim() || "";
+      if (!normalizedWorkspaceId) {
+        return;
+      }
+
+      const knownProposalIds = new Set(
+        knownTaskProposalIdsByWorkspaceRef.current[normalizedWorkspaceId] ?? [],
+      );
+      const pendingNewProposals = proposals.filter((proposal) => {
+        const proposalId = proposal.proposal_id.trim();
+        if (!proposalId) {
+          return false;
+        }
+        const isNew = !knownProposalIds.has(proposalId);
+        knownProposalIds.add(proposalId);
+        return isNew && proposal.state.trim().toLowerCase() === "pending";
+      });
+      knownTaskProposalIdsByWorkspaceRef.current[normalizedWorkspaceId] =
+        Array.from(knownProposalIds).slice(
+          -MAX_SEEN_TASK_PROPOSAL_IDS_PER_WORKSPACE,
+        );
+
+      if (options?.notify === false || pendingNewProposals.length === 0) {
+        return;
+      }
+
+      const inboxVisible =
+        agentView.type === "inbox" ||
+        (operationsDrawerOpen && activeOperationsTab === "inbox");
+      if (inboxVisible && normalizedWorkspaceId === selectedWorkspaceId) {
+        return;
+      }
+
+      const toast = buildTaskProposalToastNotification({
+        workspaceId: normalizedWorkspaceId,
+        workspaceName,
+        proposals: pendingNewProposals,
+      });
+      setTaskProposalToastNotifications((current) =>
+        [toast, ...current].slice(0, 4),
+      );
+    },
+    [
+      activeOperationsTab,
+      agentView.type,
+      operationsDrawerOpen,
+      selectedWorkspaceId,
+    ],
   );
 
   const clampUtilityPaneWidth = useCallback(
@@ -1765,9 +1928,23 @@ function AppShellContent() {
         );
         return;
       }
+      if (isTaskProposalToastId(notificationId)) {
+        const notification = taskProposalToastById.get(notificationId);
+        if (!notification) {
+          return;
+        }
+        dismissTaskProposalToast(notificationId);
+        openTaskProposalInbox(notification.workspace_id);
+        return;
+      }
       await handleActivateNotification(notificationId);
     },
-    [handleActivateNotification],
+    [
+      dismissTaskProposalToast,
+      handleActivateNotification,
+      openTaskProposalInbox,
+      taskProposalToastById,
+    ],
   );
 
   const handleCloseDisplayedNotification = useCallback(
@@ -1778,9 +1955,13 @@ function AppShellContent() {
         );
         return;
       }
+      if (isTaskProposalToastId(notificationId)) {
+        dismissTaskProposalToast(notificationId);
+        return;
+      }
       await handleDismissNotification(notificationId);
     },
-    [handleDismissNotification],
+    [dismissTaskProposalToast, handleDismissNotification],
   );
 
   useEffect(() => {
@@ -2081,7 +2262,9 @@ function AppShellContent() {
 
   async function refreshTaskProposals() {
     if (!selectedWorkspaceId || !selectedWorkspace) {
-      setTaskProposals([]);
+      applyTaskProposals(selectedWorkspaceId, selectedWorkspace?.name, [], {
+        notify: false,
+      });
       setTaskProposalStatusMessage("");
       return;
     }
@@ -2092,7 +2275,11 @@ function AppShellContent() {
       const response = await window.electronAPI.workspace.listTaskProposals(
         selectedWorkspace.id,
       );
-      setTaskProposals(response.proposals);
+      applyTaskProposals(
+        selectedWorkspace.id,
+        selectedWorkspace.name,
+        response.proposals,
+      );
     } catch (error) {
       setTaskProposalStatusMessage(normalizeErrorMessage(error));
     } finally {
@@ -2202,7 +2389,9 @@ function AppShellContent() {
 
   useEffect(() => {
     if (!selectedWorkspaceId || !selectedWorkspace) {
-      setTaskProposals([]);
+      applyTaskProposals(selectedWorkspaceId, selectedWorkspace?.name, [], {
+        notify: false,
+      });
       setTaskProposalStatusMessage("");
       setIsLoadingTaskProposals(false);
       return;
@@ -2216,7 +2405,11 @@ function AppShellContent() {
           selectedWorkspace.id,
         );
         if (!cancelled) {
-          setTaskProposals(response.proposals);
+          applyTaskProposals(
+            selectedWorkspace.id,
+            selectedWorkspace.name,
+            response.proposals,
+          );
         }
       } catch (error) {
         if (!cancelled) {
@@ -2240,7 +2433,7 @@ function AppShellContent() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [selectedWorkspace, selectedWorkspaceId]);
+  }, [applyTaskProposals, selectedWorkspace, selectedWorkspaceId]);
 
   useEffect(() => {
     if (
@@ -2414,6 +2607,38 @@ function AppShellContent() {
     });
   };
 
+  const handleOpenSpaceApp = useCallback(
+    (
+      appId: string,
+      options?: {
+        path?: string | null;
+        resourceId?: string | null;
+        view?: string | null;
+        resetAgentView?: boolean;
+      },
+    ) => {
+      setActiveLeftRailItem("space");
+      setSpaceExplorerMode("applications");
+      setSpaceExplorerCollapsed(false);
+      setSpaceVisibility((previous) => ({
+        ...previous,
+        agent: true,
+        files: true,
+      }));
+      if (options?.resetAgentView) {
+        setAgentView({ type: "chat" });
+      }
+      setSpaceDisplayView({
+        type: "app",
+        appId,
+        path: options?.path,
+        resourceId: options?.resourceId,
+        view: options?.view,
+      });
+    },
+    [],
+  );
+
   const handleOpenAutomationRunSession = useCallback((sessionId: string) => {
     const normalizedSessionId = sessionId.trim();
     if (!normalizedSessionId) {
@@ -2502,16 +2727,8 @@ function AppShellContent() {
   );
 
   const handleOpenInboxPane = useCallback(() => {
-    setActiveLeftRailItem("space");
-    setSpaceVisibility((previous) => ({
-      ...previous,
-      agent: true,
-    }));
-    setAgentView({ type: "inbox" });
-    if (selectedWorkspaceId && taskProposals.length > 0) {
-      markTaskProposalsSeen(selectedWorkspaceId, taskProposals);
-    }
-  }, [markTaskProposalsSeen, selectedWorkspaceId, taskProposals]);
+    openTaskProposalInbox(selectedWorkspaceId);
+  }, [openTaskProposalInbox, selectedWorkspaceId]);
 
   const handleReturnToChatPane = useCallback(() => {
     setAgentView({ type: "chat" });
@@ -2648,33 +2865,13 @@ function AppShellContent() {
   const handleOpenWorkspaceOutput = useCallback(
     (output: WorkspaceOutputRecordPayload) => {
       const target = workspaceOutputNavigationTarget(output, installedAppIds);
-      if (target.type === "app" && selectedWorkspaceId) {
-        // target.resourceId is already a full route path (e.g. "/drafts/abc")
-        // when derived from presentation.path — pass it as `path` so
-        // resolveAppSurfacePath uses it directly instead of nesting it under view.
-        const routePath = resolveAppSurfacePath({
-          path: target.resourceId,
+      if (target.type === "app") {
+        handleOpenSpaceApp(target.appId, {
+          path: target.path,
+          resourceId: target.resourceId,
           view: target.view,
+          resetAgentView: true,
         });
-        void window.electronAPI.appSurface
-          .resolveUrl(selectedWorkspaceId, target.appId, routePath)
-          .then((url) => {
-            revealBrowserPane("user");
-            void window.electronAPI.browser
-              .setActiveWorkspace(selectedWorkspaceId)
-              .then(() => window.electronAPI.browser.navigate(url))
-              .catch(() => undefined);
-          })
-          .catch(() => {
-            setActiveLeftRailItem("space");
-            setSpaceDisplayView({
-              type: "app",
-              appId: target.appId,
-              resourceId: target.resourceId,
-              view: target.view,
-            });
-            setAgentView({ type: "chat" });
-          });
         return;
       }
 
@@ -2718,7 +2915,7 @@ function AppShellContent() {
         });
       }
     },
-    [installedAppIds, selectedWorkspaceId, revealBrowserPane],
+    [handleOpenSpaceApp, installedAppIds],
   );
 
   const handleOpenRunningSession = (sessionId: string) => {
@@ -2910,6 +3107,7 @@ function AppShellContent() {
               ? activeApp
               : getWorkspaceAppDefinition(agentView.appId, installedApps)
           }
+          path={agentView.path}
           resourceId={agentView.resourceId}
           view={agentView.view}
         />
@@ -2994,6 +3192,7 @@ function AppShellContent() {
                     installedApps,
                   )
             }
+            path={spaceDisplayView.path}
             resourceId={spaceDisplayView.resourceId}
             view={spaceDisplayView.view}
           />
@@ -3497,6 +3696,13 @@ function AppShellContent() {
                                         <Globe />
                                         Browser
                                       </TabsTrigger>
+                                      <TabsTrigger
+                                        value="applications"
+                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                      >
+                                        <LayoutGrid />
+                                        Apps
+                                      </TabsTrigger>
                                     </TabsList>
                                   </Tabs>
                                   <Button
@@ -3532,6 +3738,18 @@ function AppShellContent() {
                                           resourceId: path,
                                         });
                                       }}
+                                    />
+                                  ) : spaceExplorerMode === "applications" ? (
+                                    <SpaceApplicationsExplorerPane
+                                      installedApps={installedApps}
+                                      activeAppId={
+                                        spaceDisplayView.type === "app"
+                                          ? spaceDisplayView.appId
+                                          : null
+                                      }
+                                      onSelectApp={(appId) =>
+                                        handleOpenSpaceApp(appId)
+                                      }
                                     />
                                   ) : spaceExplorerMode === "browser" ? (
                                     <SpaceBrowserExplorerPane
@@ -3571,6 +3789,26 @@ function AppShellContent() {
                                   }
                                 >
                                   <Folder />
+                                </Button>
+                                <Button
+                                  variant={
+                                    spaceExplorerMode === "applications"
+                                      ? "outline"
+                                      : "ghost"
+                                  }
+                                  size="icon"
+                                  onClick={() => {
+                                    setSpaceExplorerMode("applications");
+                                    setSpaceExplorerCollapsed(false);
+                                  }}
+                                  aria-label="Open applications explorer"
+                                  className={
+                                    spaceExplorerMode === "applications"
+                                      ? "border-primary/40 bg-primary/10 text-primary"
+                                      : "text-muted-foreground"
+                                  }
+                                >
+                                  <LayoutGrid />
                                 </Button>
                                 <Button
                                   variant={

--- a/desktop/src/components/panes/AppSurfacePane.test.mjs
+++ b/desktop/src/components/panes/AppSurfacePane.test.mjs
@@ -33,3 +33,13 @@ test("app surface pane resolves a URL instead of navigating a native app surface
     "expected AppSurfacePane to resolve an app surface URL for iframe rendering",
   );
 });
+
+test("app surface pane preserves explicit app routes when present", async () => {
+  const source = await readFile(APP_SURFACE_PANE_PATH, "utf8");
+
+  assert.match(
+    source,
+    /resolveAppSurfacePath\(\{ path, resourceId, view \}\)/,
+    "expected AppSurfacePane to pass explicit app paths through to route resolution",
+  );
+});

--- a/desktop/src/components/panes/AppSurfacePane.tsx
+++ b/desktop/src/components/panes/AppSurfacePane.tsx
@@ -9,11 +9,18 @@ import { resolveAppSurfacePath } from "./appSurfaceRoute";
 interface AppSurfacePaneProps {
   appId: string;
   app?: WorkspaceInstalledAppDefinition | WorkspaceAppDefinition | null;
+  path?: string | null;
   resourceId?: string | null;
   view?: string | null;
 }
 
-export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: AppSurfacePaneProps) {
+export function AppSurfacePane({
+  appId,
+  app: providedApp,
+  path,
+  resourceId,
+  view,
+}: AppSurfacePaneProps) {
   const { refreshInstalledApps, removeInstalledApp } = useWorkspaceDesktop();
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const app = providedApp || getWorkspaceAppDefinition(appId);
@@ -33,8 +40,8 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
   const accentClassName = app && "accentClassName" in app ? app.accentClassName : "bg-muted-foreground/40";
 
   const routePath = useMemo(
-    () => resolveAppSurfacePath({ resourceId, view }),
-    [resourceId, view],
+    () => resolveAppSurfacePath({ path, resourceId, view }),
+    [path, resourceId, view],
   );
 
   // Integration connection status for this app
@@ -224,10 +231,14 @@ export function AppSurfacePane({ appId, app: providedApp, resourceId, view }: Ap
                 Running
               </span>
             </div>
-            {resourceId ? (
+            {resourceId || path ? (
               <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2">
-                <span className="text-xs text-muted-foreground">Resource</span>
-                <span className="max-w-[120px] truncate text-xs font-medium text-foreground">{resourceId}</span>
+                <span className="text-xs text-muted-foreground">
+                  {resourceId ? "Resource" : "Route"}
+                </span>
+                <span className="max-w-[120px] truncate text-xs font-medium text-foreground">
+                  {resourceId || path}
+                </span>
               </div>
             ) : null}
             {integrationStatus ? (

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
@@ -1,0 +1,92 @@
+import { AppWindow, CheckCircle2, LoaderCircle, TriangleAlert } from "lucide-react";
+import { providerIcon } from "@/components/onboarding/constants";
+import { Button } from "@/components/ui/button";
+import type { WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
+
+interface SpaceApplicationsExplorerPaneProps {
+  installedApps: WorkspaceInstalledAppDefinition[];
+  activeAppId?: string | null;
+  onSelectApp: (appId: string) => void;
+}
+
+function appInitials(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return "?";
+  }
+  if (parts.length === 1) {
+    return parts[0].slice(0, 1).toUpperCase();
+  }
+  return `${parts[0].slice(0, 1)}${parts[1].slice(0, 1)}`.toUpperCase();
+}
+
+export function SpaceApplicationsExplorerPane({
+  installedApps,
+  activeAppId = null,
+  onSelectApp,
+}: SpaceApplicationsExplorerPaneProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-transparent">
+      <div className="border-b border-border/45 px-3 py-2.5">
+        <div className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
+          Applications
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+        {installedApps.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/40 px-3 py-3 text-xs leading-5 text-muted-foreground/70">
+            Installed workspace apps will appear here once the selected workspace has applications.
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {installedApps.map((app) => {
+              const isActive = activeAppId === app.id;
+              const hasError = Boolean(app.error?.trim());
+              const isReady = app.ready && !hasError;
+              return (
+                <Button
+                  key={app.id}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onSelectApp(app.id)}
+                  className={`h-auto w-full justify-start rounded-lg px-2.5 py-2 text-left ${
+                    isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <div className="flex min-w-0 flex-1 items-start gap-2.5">
+                    <div className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
+                      {providerIcon(app.id, 16) ?? (
+                        <span className="text-[11px] font-semibold uppercase tracking-wide">
+                          {appInitials(app.label)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate text-xs font-medium text-foreground">
+                          {app.label}
+                        </span>
+                        {hasError ? (
+                          <TriangleAlert size={12} className="shrink-0 text-destructive" />
+                        ) : isReady ? (
+                          <CheckCircle2 size={12} className="shrink-0 text-emerald-500" />
+                        ) : (
+                          <LoaderCircle size={12} className="shrink-0 animate-spin text-sky-500" />
+                        )}
+                      </div>
+                      <div className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+                        {app.summary}
+                      </div>
+                    </div>
+                    <AppWindow size={14} className="mt-0.5 shrink-0 text-muted-foreground/70" />
+                  </div>
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/docs/docs/app-development/applications/publishing-outputs.md
+++ b/website/docs/docs/app-development/applications/publishing-outputs.md
@@ -130,6 +130,8 @@ const presentation = buildAppResourcePresentation({
 
 The helper normalizes `path` so it always starts with `/`.
 
+The desktop uses that presentation shape to reopen the owning app directly inside the shared app surface. If `path` is present, the artifact or output should deep-link to that in-app route instead of opening a generic browser view.
+
 ## Production Rules
 
 - persist your app's canonical local record before publishing

--- a/website/docs/docs/app-development/bridge-sdk.md
+++ b/website/docs/docs/app-development/bridge-sdk.md
@@ -180,6 +180,8 @@ const presentation = buildAppResourcePresentation({
 
 The helper normalizes `path` so it always starts with `/`.
 
+In the current desktop shell, that presentation no longer falls back through the browser. App-linked outputs and artifacts open the owning workspace app inside the embedded app surface, and `path` is used as the in-app deep link when present.
+
 ## Production Rules
 
 - use the bridge for runtime-owned integrations, not direct provider secrets

--- a/website/docs/docs/build-on-holaos/desktop/internals.md
+++ b/website/docs/docs/build-on-holaos/desktop/internals.md
@@ -15,14 +15,15 @@ That means desktop work is usually spread across four boundaries: React renderer
 
 ## Main code seams
 
-- `desktop/src/components/layout/AppShell.tsx`: the shell composition and top-level product routing. This is where the agent pane, browser panes, file explorer, app surfaces, operations drawer, notifications, settings overlays, and reported non-browser operator surfaces are coordinated.
+- `desktop/src/components/layout/AppShell.tsx`: the shell composition and top-level product routing. This is where the agent pane, browser panes, file explorer, applications explorer, app surfaces, operations drawer, task-proposal toasts, settings overlays, and reported non-browser operator surfaces are coordinated.
 - `desktop/src/components/onboarding/FirstWorkspacePane.tsx`, `ConfigureStep.tsx`, `BrowserProfileStep.tsx`, and `CreatingView.tsx`: first-workspace flow, including empty/template workspace creation and browser-profile bootstrap choices.
 - `desktop/shared/model-catalog.ts`: shipped fallback model metadata for direct providers and Holaboss Proxy model mapping, including reasoning support, allowed thinking values, and input modalities.
 - `desktop/src/lib/workspaceDesktop.tsx` and `desktop/src/lib/workspaceSelection.tsx`: renderer-side workspace state and shell coordination.
 - `desktop/src/components/auth/AuthPanel.tsx`: provider settings, catalog-backed defaults, background-task selection, recall embeddings, and image-generation configuration.
 - `desktop/src/components/panes/ChatPane.tsx`: model picker, per-model reasoning-effort selector, queued chat inputs, and stream/timeline rendering.
 - `desktop/src/components/panes/BrowserPane.tsx`, `SpaceBrowserExplorerPane.tsx`, and `SpaceBrowserDisplayPane.tsx`: the browser-space UI for the `user` and `agent` browser surfaces.
-- `desktop/src/components/panes/FileExplorerPane.tsx`: workspace file explorer, previews, editing, bookmarking, and file-watch behavior.
+- `desktop/src/components/panes/FileExplorerPane.tsx`: workspace file explorer, previews, editing, bookmarking, drag-and-drop imports, and file-watch behavior.
+- `desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx`: workspace app list for the space explorer, parallel to files and browser.
 - `desktop/src/components/layout/NotificationToastStack.tsx`: runtime-backed notification rendering and activation behavior.
 - `desktop/electron/preload.ts`: the renderer-to-main bridge exposed on `window.electronAPI`.
 - `desktop/src/types/electron.d.ts`: the typed source of truth for the preload bridge. If the renderer can call it, it should be declared here.
@@ -299,6 +300,14 @@ The current contract includes:
 
 That keeps file access centralized in the main process and makes workspace-relative behavior auditable.
 
+The explorer is also no longer files-only. In space mode the left explorer rail now has three modes:
+
+- `files` for workspace filesystem inspection and editing
+- `browser` for user and agent browser surfaces
+- `applications` for installed workspace apps
+
+App outputs that carry app-resource presentation metadata now route into that applications explorer path and open through `AppSurfacePane` rather than resolving into the browser first.
+
 ## Notification and runtime-backed product state
 
 Desktop notifications are runtime-backed, not purely renderer-local.
@@ -313,12 +322,14 @@ The current path is:
 
 So if you are changing notification behavior, inspect both the desktop shell and the runtime notification model.
 
+Task-proposal toasts are the current exception. The proposals themselves remain runtime-backed and are polled from `workspace:listTaskProposals`, but the "new proposal ready" toast is synthesized in `AppShell` by diffing newly seen pending proposal ids per workspace and feeding that local toast record into the same stack. Activating that toast opens the inbox for the corresponding workspace instead of updating runtime notification state.
+
 ## Display-surface model
 
 The shell maintains a central display surface that can project:
 
 - browser content
-- app content
+- app content, including app-resource deep links from outputs and artifacts
 - internal surfaces
 
 That routing currently lives in `AppShell.tsx` through `spaceDisplayView`. If you are adding a new display mode, start there and trace the corresponding pane/component path.

--- a/website/docs/docs/build-on-holaos/desktop/workspace-experience.md
+++ b/website/docs/docs/build-on-holaos/desktop/workspace-experience.md
@@ -12,6 +12,8 @@ The workspace is the operator's entrypoint into the `holaOS` environment. The UI
 
 At the product level, a workspace is where the operator understands what this environment is for, what capabilities are currently available, what state should persist, and what changed since the last session.
 
+In the current desktop shell that means the left workspace rail cannot just be a file tree. It has to expose the active workspace across files, browser surfaces, and installed applications without forcing the operator to translate everything back into raw paths or URLs.
+
 ## What a workspace represents
 
 A workspace is a stable operating context for one workflow. In the UI, that context includes:
@@ -41,6 +43,7 @@ The workspace UI should make these areas discoverable:
 | Recent session state | What happened most recently? | Helps the operator continue work without starting from scratch. |
 | Durable memory | What should persist beyond one run? | Keeps long-horizon context visible and reviewable. |
 | Outputs | What has this workspace produced? | Gives the operator reviewable results instead of hidden side effects. |
+| Proposed next work | What new task suggestions are waiting for review? | Keeps proactive work discoverable without requiring the operator to poll the inbox manually. |
 
 ## What the UI should help the operator answer quickly
 
@@ -76,6 +79,34 @@ Avoid these failure modes:
 - surfacing raw internals before the operator is oriented
 
 The workspace should feel inspectable and powerful, but still organized around the operator's need to understand and direct work.
+
+## Explorer lanes
+
+The space-mode explorer now has three first-class lanes:
+
+- `Files` for workspace-owned documents and editable local state
+- `Browser` for user and agent browser surfaces
+- `Apps` for installed workspace apps
+
+Those lanes are parallel views into one workspace, not separate products. The operator should be able to switch between them without losing the current display surface unless the lane itself requires a different one.
+
+## App outputs and artifacts
+
+When an output or artifact belongs to a workspace app, the desktop should reopen it inside that app's surface, not by bouncing the operator out into the browser.
+
+The current contract is:
+
+- app-linked outputs should activate the `Apps` explorer lane
+- the corresponding app should open inside the shared display surface
+- if the output or artifact includes a presentation `path`, the app surface should deep-link directly to that route
+
+That keeps app results grounded in the app that owns them instead of degrading them into generic links.
+
+## Proposal visibility
+
+Task proposals should not be discoverable only if the operator happens to have the inbox open. The workspace surface should surface newly generated proposals as a toast-level event and route the operator into the inbox for review.
+
+That behavior matters because proactive work is part of the workspace state, not just a hidden background subsystem.
 
 ## Relationship to the rest of the system
 


### PR DESCRIPTION
## Context

This PR expands the desktop workspace surface so app-owned results stay inside the app experience and newly generated task proposals are surfaced immediately.

## What Changed

- add an `Apps` lane to the space explorer alongside `Files` and `Browser`
- route app-linked outputs and artifacts into the embedded app surface instead of the browser
- preserve app presentation `path` values so outputs and artifacts deep-link to the correct in-app route
- synthesize local task-proposal toasts from newly polled pending proposals and open the inbox when those toasts are activated
- add the new `SpaceApplicationsExplorerPane` and update the app-shell/app-surface source tests

## Docs Updated

- document the new space explorer lane and app-surface routing in `build-on-holaos/desktop/internals`
- document the operator-facing explorer/app/proposal behavior in `build-on-holaos/desktop/workspace-experience`
- document that `buildAppResourcePresentation()` now reopens outputs and artifacts inside the embedded app surface in the app-development docs

## Validation

- `node --test desktop/src/components/layout/AppShell.test.mjs`
- `node --test desktop/src/components/panes/AppSurfacePane.test.mjs desktop/src/components/panes/appSurfaceRoute.test.mjs`
- `npm --prefix desktop run typecheck`

## Screenshots / Notes

- UI-affecting change; no screenshot attached from this CLI session
