### PR TITLE
feat(desktop): collapse inactive space explorer tabs to icon-only

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -3684,24 +3684,30 @@ function AppShellContent() {
                                     <TabsList className="w-full">
                                       <TabsTrigger
                                         value="files"
-                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                        className="group min-w-0 grow-0 basis-9 gap-0 px-0 duration-200 ease-out data-active:grow data-active:basis-0 data-active:justify-start data-active:gap-1.5 data-active:px-3"
                                       >
                                         <Folder />
-                                        Files
+                                        <span className="ml-0 inline-block max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-200 ease-out group-data-active:max-w-[120px] group-data-active:opacity-100">
+                                          Files
+                                        </span>
                                       </TabsTrigger>
                                       <TabsTrigger
                                         value="browser"
-                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                        className="group min-w-0 grow-0 basis-9 gap-0 px-0 duration-200 ease-out data-active:grow data-active:basis-0 data-active:justify-start data-active:gap-1.5 data-active:px-3"
                                       >
                                         <Globe />
-                                        Browser
+                                        <span className="ml-0 inline-block max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-200 ease-out group-data-active:max-w-[120px] group-data-active:opacity-100">
+                                          Browser
+                                        </span>
                                       </TabsTrigger>
                                       <TabsTrigger
                                         value="applications"
-                                        className="min-w-0 flex-1 basis-0 gap-1.5"
+                                        className="group min-w-0 grow-0 basis-9 gap-0 px-0 duration-200 ease-out data-active:grow data-active:basis-0 data-active:justify-start data-active:gap-1.5 data-active:px-3"
                                       >
                                         <LayoutGrid />
-                                        Apps
+                                        <span className="ml-0 inline-block max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-200 ease-out group-data-active:max-w-[120px] group-data-active:opacity-100">
+                                          Apps
+                                        </span>
                                       </TabsTrigger>
                                     </TabsList>
                                   </Tabs>


### PR DESCRIPTION
## Summary
The Files / Browser / Apps tabs in the space explorer header now render the label only for the active tab. Inactive tabs shrink to a 36px icon-only square, freeing enough horizontal space that all three fit comfortably without wrapping or truncating.

Width, padding, gap, and the label's max-width/opacity all animate together over 200ms ease-out — the button reuses the base TabsTrigger's existing \`transition-all\` and the wrapping label span has a matching transition so the reveal/collapse looks unified.

## Implementation notes
- Inactive defaults: \`grow-0 basis-9 gap-0 px-0\` (36px icon-only)
- Active overrides (via \`data-active:\`): \`grow basis-0 justify-start gap-1.5 px-3\`
- Label wrapped in a \`<span>\` that animates \`max-w-0 opacity-0\` → \`group-data-active:max-w-[120px] group-data-active:opacity-100\`
- Uses \`data-active\` / \`group-data-active\` to match \`@base-ui/react\` tabs (not \`data-state="active"\`)

## Test plan
- [x] \`npm run typecheck\` in \`desktop/\`
- [ ] Switch between Files, Browser, and Apps — label reveals/collapses smoothly
- [ ] Resize the space explorer panel — inactive tabs stay at 36px, active tab fills the remainder
- [ ] Active tab's indicator, hover, and focus ring still render correctly