### PR TITLE
fix: polish desktop workspace and settings flows

### DIFF
--- a/desktop/electron/authPopupPreload.ts
+++ b/desktop/electron/authPopupPreload.ts
@@ -79,7 +79,7 @@ interface WorkspaceListResponsePayload {
   offset: number;
 }
 
-type UiSettingsPaneSection = "account" | "billing" | "providers" | "settings" | "about";
+type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
 
 const INTERNAL_DEV_BACKEND_OVERRIDES_ENABLED =
   Boolean(process.env.VITE_DEV_SERVER_URL) || process.env.HOLABOSS_INTERNAL_DEV?.trim() === "1";

--- a/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
+++ b/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
@@ -92,6 +92,11 @@ test("desktop file explorer enforces the selected workspace root as a filesystem
   assert.match(source, /await nextAvailableExplorerCreatePath\(\s*destinationAbsolutePath,\s*rootName,\s*\)/);
   assert.match(source, /await fs\.mkdir\(absolutePath, \{ recursive: true \}\);/);
   assert.match(source, /await fs\.writeFile\(absolutePath, Buffer\.from\(fileEntry\.content\)\);/);
+  assert.match(source, /const hideWorkspaceManagedRootEntries = normalizedCurrent === normalizedRoot;/);
+  assert.match(
+    source,
+    /if \(\s*hideWorkspaceManagedRootEntries &&\s*\(\(dirEntry\.isDirectory\(\) && dirEntry\.name === "apps"\) \|\|\s*\(!dirEntry\.isDirectory\(\) && dirEntry\.name === "workspace\.yaml"\)\s*\)\s*\) \{\s*continue;\s*\}/,
+  );
   assert.match(
     source,
     /"fs:importExternalEntries"[\s\S]*destinationDirectoryPath: string,[\s\S]*entries: ExplorerExternalImportEntryPayload\[\],[\s\S]*importExternalExplorerEntries\(\s*destinationDirectoryPath,\s*entries,\s*workspaceId,\s*\)/,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -552,7 +552,10 @@ type UiSettingsPaneSection =
   | "account"
   | "billing"
   | "providers"
+  | "integrations"
+  | "submissions"
   | "settings"
+  | "automations"
   | "about";
 
 interface AddressSuggestionPayload {
@@ -2624,7 +2627,6 @@ interface WorkspaceSkillRecordPayload {
   skill_file_path: string;
   title: string;
   summary: string;
-  enabled: boolean;
   modified_at: string;
 }
 
@@ -2632,8 +2634,6 @@ interface WorkspaceSkillListResponsePayload {
   workspace_id: string;
   workspace_root: string;
   skills_path: string;
-  enabled_skill_ids: string[];
-  missing_enabled_skill_ids: string[];
   skills: WorkspaceSkillRecordPayload[];
 }
 
@@ -12146,78 +12146,6 @@ function sanitizeYamlScalar(rawValue: string): string {
   return trimmed;
 }
 
-function parseInlineYamlStringArray(rawValue: string): string[] {
-  const trimmed = rawValue.trim();
-  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
-    return [];
-  }
-  return trimmed
-    .slice(1, -1)
-    .split(",")
-    .map((item) => normalizeWorkspaceSkillId(sanitizeYamlScalar(item)))
-    .filter((item): item is string => Boolean(item));
-}
-
-function parseWorkspaceSkillsConfig(workspaceYaml: string | null): {
-  enabledSkillIds: string[];
-} {
-  const result = {
-    enabledSkillIds: [] as string[],
-  };
-  if (!workspaceYaml) {
-    return result;
-  }
-
-  const stack: Array<{ key: string; indent: number }> = [];
-  for (const rawLine of workspaceYaml.replace(/\t/g, "  ").split(/\r?\n/)) {
-    const trimmed = rawLine.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const indent = rawLine.match(/^\s*/)?.[0].length ?? 0;
-    while (stack.length && indent <= stack[stack.length - 1].indent) {
-      stack.pop();
-    }
-
-    if (trimmed.startsWith("- ")) {
-      const currentScope = stack.map((entry) => entry.key).join(".");
-      if (currentScope === "skills.enabled") {
-        const skillId = normalizeWorkspaceSkillId(
-          sanitizeYamlScalar(trimmed.slice(2)),
-        );
-        if (skillId && !result.enabledSkillIds.includes(skillId)) {
-          result.enabledSkillIds.push(skillId);
-        }
-      }
-      continue;
-    }
-
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex < 0) {
-      continue;
-    }
-
-    const key = trimmed.slice(0, separatorIndex).trim();
-    const rawValue = trimmed.slice(separatorIndex + 1).trim();
-    const scope = [...stack.map((entry) => entry.key), key].join(".");
-
-    if (scope === "skills.enabled" && rawValue) {
-      for (const skillId of parseInlineYamlStringArray(rawValue)) {
-        if (!result.enabledSkillIds.includes(skillId)) {
-          result.enabledSkillIds.push(skillId);
-        }
-      }
-    }
-
-    if (!rawValue) {
-      stack.push({ key, indent });
-    }
-  }
-
-  return result;
-}
-
 function humanizeSkillId(skillId: string): string {
   return skillId
     .split(/[-_]/)
@@ -12283,7 +12211,6 @@ function extractSkillMetadata(
 
 async function readSkillCatalogFromRoot(params: {
   skillsRoot: string;
-  enabledSkillIds: string[];
 }): Promise<WorkspaceSkillRecordPayload[]> {
   let directoryEntries;
   try {
@@ -12317,10 +12244,6 @@ async function readSkillCatalogFromRoot(params: {
               skill_file_path: skillFilePath,
               title: metadata.title,
               summary: metadata.summary,
-              enabled:
-                params.enabledSkillIds.length === 0
-                  ? true
-                  : params.enabledSkillIds.includes(skillId),
               modified_at: stats.mtime.toISOString(),
             } satisfies WorkspaceSkillRecordPayload;
           } catch {
@@ -12335,69 +12258,20 @@ async function listWorkspaceSkills(
   workspaceId: string,
 ): Promise<WorkspaceSkillListResponsePayload> {
   const workspaceRoot = workspaceDirectoryPath(workspaceId);
-  const workspaceYamlPath = path.join(workspaceRoot, "workspace.yaml");
-  let workspaceYamlContent: string | null = null;
-  try {
-    workspaceYamlContent = await fs.readFile(workspaceYamlPath, "utf-8");
-  } catch {
-    workspaceYamlContent = null;
-  }
-
-  const config = parseWorkspaceSkillsConfig(workspaceYamlContent);
   const skillsPath = path.resolve(workspaceRoot, "skills");
 
-  const workspaceSkills = await readSkillCatalogFromRoot({
-    skillsRoot: skillsPath,
-    enabledSkillIds: config.enabledSkillIds,
-  });
+  const workspaceSkills = await readSkillCatalogFromRoot({ skillsRoot: skillsPath });
 
-  const skillById = new Map(
-    workspaceSkills.map((skill) => [skill.skill_id, skill] as const),
-  );
-  const orderedSkillIds =
-    config.enabledSkillIds.length > 0
-      ? config.enabledSkillIds
-      : workspaceSkills.map((skill) => skill.skill_id);
-
-  const skills = orderedSkillIds
-    .map((skillId) => skillById.get(skillId) ?? null)
-    .filter((skill): skill is WorkspaceSkillRecordPayload => Boolean(skill));
-
-  const configuredOrder = new Map(
-    config.enabledSkillIds.map((skillId, index) => [skillId, index] as const),
-  );
-  if (config.enabledSkillIds.length === 0) {
-    skills.sort((left, right) => {
-      return left.title.localeCompare(right.title, undefined, {
-        sensitivity: "base",
-      });
-    });
-  } else {
-    skills.sort((left, right) => {
-      const leftRank =
-        configuredOrder.get(left.skill_id) ?? Number.MAX_SAFE_INTEGER;
-      const rightRank =
-        configuredOrder.get(right.skill_id) ?? Number.MAX_SAFE_INTEGER;
-      if (leftRank !== rightRank) {
-        return leftRank - rightRank;
-      }
-      return left.title.localeCompare(right.title, undefined, {
-        sensitivity: "base",
-      });
-    });
-  }
-
-  const discoveredIds = new Set(workspaceSkills.map((skill) => skill.skill_id));
-  const missingEnabledSkillIds = config.enabledSkillIds.filter(
-    (skillId) => !discoveredIds.has(skillId),
+  const skills = [...workspaceSkills].sort((left, right) =>
+    left.title.localeCompare(right.title, undefined, {
+      sensitivity: "base",
+    }),
   );
 
   return {
     workspace_id: workspaceId,
     workspace_root: workspaceRoot,
     skills_path: skillsPath,
-    enabled_skill_ids: config.enabledSkillIds,
-    missing_enabled_skill_ids: missingEnabledSkillIds,
     skills,
   };
 }
@@ -15512,11 +15386,23 @@ async function listDirectory(
     throw new Error("Target path is not a directory.");
   }
 
+  const normalizedCurrent = path.normalize(resolvedPath);
+  const normalizedRoot = path.normalize(
+    workspaceRoot ? workspaceRoot : path.parse(resolvedPath).root,
+  );
+  const hideWorkspaceManagedRootEntries = normalizedCurrent === normalizedRoot;
   const dirEntries = await fs.readdir(resolvedPath, { withFileTypes: true });
   const entries: DirectoryEntryPayload[] = [];
 
   for (const dirEntry of dirEntries) {
     if (dirEntry.name.startsWith(".")) {
+      continue;
+    }
+    if (
+      hideWorkspaceManagedRootEntries &&
+      ((dirEntry.isDirectory() && dirEntry.name === "apps") ||
+        (!dirEntry.isDirectory() && dirEntry.name === "workspace.yaml"))
+    ) {
       continue;
     }
     const absolutePath = path.join(resolvedPath, dirEntry.name);
@@ -15541,10 +15427,6 @@ async function listDirectory(
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   });
 
-  const normalizedCurrent = path.normalize(resolvedPath);
-  const normalizedRoot = path.normalize(
-    workspaceRoot ? workspaceRoot : path.parse(resolvedPath).root,
-  );
   const parentPath =
     normalizedCurrent === normalizedRoot
       ? null

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -90,7 +90,7 @@ interface BrowserAnchorBoundsPayload {
   height: number;
 }
 
-type UiSettingsPaneSection = "account" | "billing" | "providers" | "settings" | "about";
+type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
 
 interface DesktopWindowStatePayload {
   isFullScreen: boolean;

--- a/desktop/electron/settings-pane-routing.test.mjs
+++ b/desktop/electron/settings-pane-routing.test.mjs
@@ -7,7 +7,7 @@ const AUTH_POPUP_PRELOAD_PATH = new URL("./authPopupPreload.ts", import.meta.url
 const MAIN_PATH = new URL("./main.ts", import.meta.url);
 const APP_SHELL_PATH = new URL("../src/components/layout/AppShell.tsx", import.meta.url);
 
-test("settings pane routing keeps the providers section available across Electron bridges", async () => {
+test("settings pane routing keeps the full settings section list available across Electron bridges", async () => {
   const [preloadSource, authPopupPreloadSource, mainSource, appShellSource] = await Promise.all([
     readFile(PRELOAD_PATH, "utf8"),
     readFile(AUTH_POPUP_PRELOAD_PATH, "utf8"),
@@ -15,8 +15,8 @@ test("settings pane routing keeps the providers section available across Electro
     readFile(APP_SHELL_PATH, "utf8")
   ]);
 
-  assert.match(preloadSource, /type UiSettingsPaneSection = "account" \| "billing" \| "providers" \| "settings" \| "about";/);
-  assert.match(authPopupPreloadSource, /type UiSettingsPaneSection = "account" \| "billing" \| "providers" \| "settings" \| "about";/);
-  assert.match(mainSource, /type UiSettingsPaneSection =[\s\S]*"account"[\s\S]*"billing"[\s\S]*"providers"[\s\S]*"settings"[\s\S]*"about";/);
-  assert.match(appShellSource, /return \([\s\S]*value === "account"[\s\S]*value === "billing"[\s\S]*value === "providers"[\s\S]*value === "settings"[\s\S]*value === "about"[\s\S]*\);/);
+  assert.match(preloadSource, /type UiSettingsPaneSection = "account" \| "billing" \| "providers" \| "integrations" \| "submissions" \| "settings" \| "automations" \| "about";/);
+  assert.match(authPopupPreloadSource, /type UiSettingsPaneSection = "account" \| "billing" \| "providers" \| "integrations" \| "submissions" \| "settings" \| "automations" \| "about";/);
+  assert.match(mainSource, /type UiSettingsPaneSection =[\s\S]*"account"[\s\S]*"billing"[\s\S]*"providers"[\s\S]*"integrations"[\s\S]*"submissions"[\s\S]*"settings"[\s\S]*"automations"[\s\S]*"about";/);
+  assert.match(appShellSource, /return \([\s\S]*value === "account"[\s\S]*value === "billing"[\s\S]*value === "providers"[\s\S]*value === "integrations"[\s\S]*value === "submissions"[\s\S]*value === "settings"[\s\S]*value === "automations"[\s\S]*value === "about"[\s\S]*\);/);
 });

--- a/desktop/electron/workspace-skills-autodiscovery.test.mjs
+++ b/desktop/electron/workspace-skills-autodiscovery.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop workspace skill discovery comes directly from the fixed skills folder without workspace.yaml skill allowlists", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /async function readSkillCatalogFromRoot\(params: \{\s*skillsRoot: string;\s*\}\)/);
+  assert.match(source, /summary: metadata\.summary,[\s\S]*modified_at: stats\.mtime\.toISOString\(\),/);
+  assert.match(source, /const skills = \[\.\.\.workspaceSkills\]\.sort/);
+  assert.doesNotMatch(source, /parseWorkspaceSkillsConfig/);
+  assert.doesNotMatch(source, /enabled_skill_ids/);
+});

--- a/desktop/src/components/billing/CreditsPill.test.mjs
+++ b/desktop/src/components/billing/CreditsPill.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const CREDITS_PILL_PATH = new URL("./CreditsPill.tsx", import.meta.url);
+
+test("credits pill uses the shared compact top bar control height", async () => {
+  const source = await readFile(CREDITS_PILL_PATH, "utf8");
+
+  assert.match(source, /size="default"/);
+  assert.match(source, /className=\{`inline-flex shrink-0 items-center rounded-lg border px-2\.5 text-xs transition \$\{/);
+  assert.doesNotMatch(source, /h-9/);
+});

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -17,10 +17,10 @@ export function CreditsPill({
   return (
     <Button
       type="button"
-      size="sm"
+      size="default"
       variant="outline"
       onClick={onClick}
-      className={`inline-flex h-7 shrink-0 items-center rounded-lg border px-2.5 text-xs transition ${
+      className={`inline-flex shrink-0 items-center rounded-lg border px-2.5 text-xs transition ${
         isLowBalance
           ? "border-amber-300/40 bg-amber-400/10 text-amber-200 hover:bg-amber-400/14"
           : "border-border/55"

--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -66,15 +66,49 @@ test("app shell restores the last app surface when returning to the applications
   );
   assert.match(
     source,
-    /const restoreLastSpaceAppDisplayView = useCallback\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const lastAppDisplayView =\s*lastRestorableSpaceAppDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*if \(lastAppDisplayView\) \{\s*setSpaceDisplayView\(lastAppDisplayView\);\s*return;\s*\}\s*restoreLastSpaceDisplayView\(\);\s*\}, \[restoreLastSpaceDisplayView, selectedWorkspaceId\]\);/,
+    /const restoreLastSpaceAppDisplayView = useCallback\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const lastAppDisplayView =\s*lastRestorableSpaceAppDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*if \(lastAppDisplayView\) \{\s*setSpaceDisplayView\(lastAppDisplayView\);\s*return;\s*\}\s*setSpaceDisplayView\(spaceDisplayView\);\s*\}, \[selectedWorkspaceId, spaceDisplayView\]\);/,
   );
   assert.match(
     source,
-    /if \(mode === "browser"\) \{\s*setSpaceDisplayView\(\{\s*type: "browser",\s*\}\);\s*\} else if \(mode === "applications"\) \{\s*restoreLastSpaceAppDisplayView\(\);\s*\} else \{\s*restoreLastSpaceDisplayView\(\);\s*\}/,
+    /if \(mode === "browser"\) \{\s*setSpaceDisplayView\(\{\s*type: "browser",\s*\}\);\s*\} else if \(mode === "applications"\) \{\s*restoreLastSpaceAppDisplayView\(\);\s*\} else \{\s*restoreLastSpaceFileDisplayView\(\);\s*\}/,
   );
   assert.match(
     source,
     /onClick=\{\(\) => \{\s*setSpaceExplorerMode\("applications"\);\s*restoreLastSpaceAppDisplayView\(\);\s*setSpaceExplorerCollapsed\(false\);\s*\}\}/,
+  );
+});
+
+test("app shell opens the centered add apps dialog from the applications explorer", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /import \{ WorkspaceAppsDialog \} from "@\/components\/layout\/WorkspaceAppsDialog";/);
+  assert.match(
+    source,
+    /const \[workspaceAppsDialogOpen, setWorkspaceAppsDialogOpen\] =\s*useState\(false\);/,
+  );
+  assert.match(
+    source,
+    /const handleAddApp = \(\) => \{\s*setWorkspaceAppsDialogOpen\(true\);\s*\};/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*if \(selectedWorkspaceId\) \{\s*return;\s*\}\s*setWorkspaceAppsDialogOpen\(false\);\s*\}, \[selectedWorkspaceId\]\);/,
+  );
+  assert.match(
+    source,
+    /<SpaceApplicationsExplorerPane[\s\S]*onAddApp=\{handleAddApp\}/,
+  );
+  assert.match(
+    source,
+    /<WorkspaceAppsDialog[\s\S]*open=\{workspaceAppsDialogOpen\}[\s\S]*onClose=\{\(\) => setWorkspaceAppsDialogOpen\(false\)\}/,
+  );
+  assert.match(
+    source,
+    /const shouldSuspendBrowserNativeView =\s*[\s\S]*workspaceAppsDialogOpen[\s\S]*createWorkspacePanelOpen[\s\S]*publishOpen;/,
+  );
+  assert.doesNotMatch(
+    source,
+    /const handleAddApp = \(\) => \{\s*handleOpenMarketplace\("apps"\);\s*\};/,
   );
 });
 
@@ -93,16 +127,16 @@ test("app shell clears a consumed file explorer focus request", async () => {
   );
 });
 
-test("app shell restores the last non-browser display when returning to files mode", async () => {
+test("app shell restores the last internal display and otherwise keeps the current display when returning to files mode", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(
     source,
-    /type RestorableSpaceDisplayView = Exclude<\s*SpaceDisplayView,\s*\{ type: "browser" \} \| \{ type: "empty" \}\s*>;/,
+    /type RestorableSpaceFileDisplayView = Extract<\s*SpaceDisplayView,\s*\{ type: "internal" \}\s*>;/,
   );
   assert.match(
     source,
-    /const lastRestorableSpaceDisplayViewByWorkspaceRef =\s*useRef<\s*Record<string, RestorableSpaceDisplayView>\s*>\(\{\}\);/,
+    /const lastRestorableSpaceFileDisplayViewByWorkspaceRef =\s*useRef<\s*Record<string, RestorableSpaceFileDisplayView>\s*>\(\{\}\);/,
   );
   assert.match(
     source,
@@ -126,23 +160,23 @@ test("app shell restores the last non-browser display when returning to files mo
   );
   assert.match(
     source,
-    /if \(\s*!selectedWorkspaceId \|\|\s*spaceDisplayView\.type === "browser" \|\|\s*spaceDisplayView\.type === "empty"\s*\) \{\s*return;\s*\}\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[selectedWorkspaceId\] =\s*spaceDisplayView;/,
+    /if \(!selectedWorkspaceId \|\| spaceDisplayView\.type !== "internal"\) \{\s*return;\s*\}\s*lastRestorableSpaceFileDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\]\s*=\s*spaceDisplayView;/,
   );
   assert.match(
     source,
-    /const restoreLastSpaceDisplayView = useCallback\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const lastDisplayView =\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*const nextDisplayView = lastDisplayView \?\? \{ type: "browser" \};\s*setSpaceDisplayView\(nextDisplayView\);\s*syncFileExplorerFocusWithDisplayView\(nextDisplayView\);\s*\}, \[selectedWorkspaceId, syncFileExplorerFocusWithDisplayView\]\);/,
+    /const restoreLastSpaceFileDisplayView = useCallback\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const lastDisplayView =\s*lastRestorableSpaceFileDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*const nextDisplayView = lastDisplayView \?\? spaceDisplayView;\s*setSpaceDisplayView\(nextDisplayView\);\s*syncFileExplorerFocusWithDisplayView\(nextDisplayView\);\s*\}, \[selectedWorkspaceId, spaceDisplayView, syncFileExplorerFocusWithDisplayView\]\);/,
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const nextDisplayView =\s*lastRestorableSpaceDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*if \(!nextDisplayView\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*setSpaceDisplayView\(nextDisplayView\);\s*syncFileExplorerFocusWithDisplayView\(nextDisplayView\);\s*\}, \[selectedWorkspaceId, syncFileExplorerFocusWithDisplayView\]\);/,
+    /useEffect\(\(\) => \{\s*if \(!selectedWorkspaceId\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*const nextDisplayView =\s*lastRestorableSpaceFileDisplayViewByWorkspaceRef\.current\[\s*selectedWorkspaceId\s*\];\s*if \(!nextDisplayView\) \{\s*setSpaceExplorerMode\("browser"\);\s*setSpaceDisplayView\(\{ type: "browser" \}\);\s*return;\s*\}\s*setSpaceDisplayView\(nextDisplayView\);\s*syncFileExplorerFocusWithDisplayView\(nextDisplayView\);\s*\}, \[selectedWorkspaceId, syncFileExplorerFocusWithDisplayView\]\);/,
   );
   assert.match(
     source,
-    /onValueChange=\{\(value\) => \{\s*const mode = value as SpaceExplorerMode;\s*setSpaceExplorerMode\(mode\);\s*if \(mode === "browser"\) \{\s*setSpaceDisplayView\(\{\s*type: "browser",\s*\}\);\s*\} else if \(mode === "applications"\) \{\s*restoreLastSpaceAppDisplayView\(\);\s*\} else \{\s*restoreLastSpaceDisplayView\(\);\s*\}\s*\}\}/,
+    /onValueChange=\{\(value\) => \{\s*const mode = value as SpaceExplorerMode;\s*setSpaceExplorerMode\(mode\);\s*if \(mode === "browser"\) \{\s*setSpaceDisplayView\(\{\s*type: "browser",\s*\}\);\s*\} else if \(mode === "applications"\) \{\s*restoreLastSpaceAppDisplayView\(\);\s*\} else \{\s*restoreLastSpaceFileDisplayView\(\);\s*\}\s*\}\}/,
   );
   assert.match(
     source,
-    /onClick=\{\(\) => \{\s*setSpaceExplorerMode\("files"\);\s*restoreLastSpaceDisplayView\(\);\s*setSpaceExplorerCollapsed\(false\);\s*\}\}/,
+    /onClick=\{\(\) => \{\s*setSpaceExplorerMode\("files"\);\s*restoreLastSpaceFileDisplayView\(\);\s*setSpaceExplorerCollapsed\(false\);\s*\}\}/,
   );
 });
 
@@ -329,22 +363,22 @@ test("app shell always opens the file explorer at minimum width", async () => {
 test("app shell uses the top toolbar for shell navigation and removes the left rail", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
-  assert.match(source, /type ShellView = "space" \| "automations" \| "marketplace";/);
+  assert.match(source, /type ShellView = "space";/);
   assert.match(source, /const \[activeShellView, setActiveShellView\] = useState<ShellView>\("space"\);/);
-  assert.match(source, /const handleOpenSpace = useCallback\(\(\) => \{/);
-  assert.match(source, /const handleOpenMarketplace = useCallback\(/);
-  assert.match(source, /const handleOpenAutomations = useCallback\(\(\) => \{/);
-  assert.match(source, /<TopTabsBar[\s\S]*onOpenSpace=\{handleOpenSpace\}/);
-  assert.match(source, /<TopTabsBar[\s\S]*isSpaceActive=\{spaceMode\}/);
-  assert.match(source, /<TopTabsBar[\s\S]*onOpenAutomations=\{handleOpenAutomations\}/);
-  assert.match(
-    source,
-    /<TopTabsBar[\s\S]*isAutomationsActive=\{activeShellView === "automations"\}/,
-  );
-  assert.match(
-    source,
-    /<TopTabsBar[\s\S]*onOpenMarketplace=\{\(\) => handleOpenMarketplace\("templates"\)\}/,
-  );
+  assert.match(source, /<SettingsDialog[\s\S]*onOpenAutomationRunSession=\{\(workspaceId, sessionId\) => \{/);
+  assert.match(source, /<SettingsDialog[\s\S]*onCreateAutomationSchedule=\{\(workspaceId\) => \{/);
+  assert.match(source, /<SettingsDialog[\s\S]*onEditAutomationSchedule=\{\(workspaceId, job\) => \{/);
+  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleOpenAutomationRunSession\(sessionId, workspaceId\);/);
+  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleCreateScheduleInChat\(workspaceId\);/);
+  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleEditScheduleInChat\(job, workspaceId\);/);
+  assert.doesNotMatch(source, /handleOpenMarketplace/);
+  assert.doesNotMatch(source, /MarketplacePane/);
+  assert.doesNotMatch(source, /activeShellView === "marketplace"/);
+  assert.doesNotMatch(source, /handleOpenSpace = useCallback/);
+  assert.doesNotMatch(source, /onOpenSpace=\{handleOpenSpace\}/);
+  assert.doesNotMatch(source, /isSpaceActive=\{spaceMode\}/);
+  assert.doesNotMatch(source, /handleOpenAutomations/);
+  assert.doesNotMatch(source, /activeShellView === "automations"/);
   assert.doesNotMatch(source, /LeftNavigationRail/);
 });
 
@@ -527,16 +561,31 @@ test("app shell can route new schedule creation into a prefilled workspace chat"
   assert.match(source, /const chatComposerPrefillRequestKeyRef = useRef\(0\);/);
   assert.match(source, /const nextChatSessionOpenRequestKey = useCallback\(\(\) => \{\s*chatSessionOpenRequestKeyRef\.current \+= 1;\s*return chatSessionOpenRequestKeyRef\.current;\s*\}, \[\]\);/);
   assert.match(source, /const nextChatComposerPrefillRequestKey = useCallback\(\(\) => \{\s*chatComposerPrefillRequestKeyRef\.current \+= 1;\s*return chatComposerPrefillRequestKeyRef\.current;\s*\}, \[\]\);/);
-  assert.match(source, /const handleCreateScheduleInChat = useCallback\(\(\) => \{/);
+  assert.match(source, /const handleCreateScheduleInChat = useCallback\(\(\s*workspaceId\?: string \| null\) => \{/);
+  assert.match(source, /const normalizedWorkspaceId =\s*workspaceId\?\.trim\(\) \|\| selectedWorkspaceId\?\.trim\(\) \|\| "";/);
+  assert.match(source, /if \(normalizedWorkspaceId !== \(selectedWorkspaceId\?\.trim\(\) \|\| ""\)\) \{\s*setSelectedWorkspaceId\(normalizedWorkspaceId\);\s*\}/);
   assert.match(source, /setActiveShellView\("space"\);/);
   assert.match(source, /setSpaceVisibility\(\(previous\) => \(\{\s*\.\.\.previous,\s*agent: true,\s*\}\)\);/);
   assert.match(source, /setAgentView\(\{ type: "chat" \}\);/);
   assert.match(source, /setChatSessionJumpRequest\(null\);/);
-  assert.match(source, /setChatSessionOpenRequest\(\s*activeChatSessionId\s*\?\s*\{\s*sessionId: activeChatSessionId,\s*requestKey: nextChatSessionOpenRequestKey\(\),\s*\}\s*:\s*null,\s*\);/);
+  assert.match(source, /setChatSessionOpenRequest\(\{\s*sessionId: "",\s*mode: "draft",\s*parentSessionId: null,\s*requestKey: nextChatSessionOpenRequestKey\(\),\s*\}\);/);
   assert.match(source, /setChatComposerPrefillRequest\(\{\s*text: "Create a cronjob for ",\s*requestKey: nextChatComposerPrefillRequestKey\(\),\s*\}\);/);
   assert.match(source, /composerPrefillRequest=\{chatComposerPrefillRequest\}/);
   assert.match(source, /onComposerPrefillConsumed=\{handleChatComposerPrefillConsumed\}/);
-  assert.match(source, /onCreateSchedule=\{handleCreateScheduleInChat\}/);
+  assert.match(source, /onCreateAutomationSchedule=\{\(workspaceId\) => \{/);
+  assert.match(source, /handleCreateScheduleInChat\(workspaceId\);/);
+});
+
+test("app shell can route schedule edits into a prefilled workspace chat", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /const handleEditScheduleInChat = useCallback\(\(\s*job: CronjobRecordPayload,\s*workspaceId\?: string \| null,\s*\) => \{/);
+  assert.match(source, /const jobName =\s*job\.name\?\.trim\(\) \|\| job\.description\?\.trim\(\) \|\| "Untitled schedule";/);
+  assert.match(source, /const instruction = job\.instruction\?\.trim\(\) \|\| job\.description\?\.trim\(\) \|\| "";/);
+  assert.match(source, /Edit cronjob "\$\{jobName\}" \(id: \$\{job\.id\}\)\. Current cron: \$\{job\.cron\}\./);
+  assert.match(source, /Current instruction: \$\{instruction\}\\n\\nUpdate it to:/);
+  assert.match(source, /onEditAutomationSchedule=\{\(workspaceId, job\) => \{/);
+  assert.match(source, /handleEditScheduleInChat\(job, workspaceId\);/);
 });
 
 test("app shell passes new session requests into the chat pane selector", async () => {

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -6,9 +6,9 @@ import {
 } from "@/components/layout/OperationsDrawer";
 import { SettingsDialog } from "@/components/layout/SettingsDialog";
 import { TopTabsBar } from "@/components/layout/TopTabsBar";
+import { WorkspaceAppsDialog } from "@/components/layout/WorkspaceAppsDialog";
 import { FirstWorkspacePane } from "@/components/onboarding";
 import { AppSurfacePane } from "@/components/panes/AppSurfacePane";
-import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { BrowserPane } from "@/components/panes/BrowserPane";
 import { ChatPane } from "@/components/panes/ChatPane";
 import {
@@ -16,7 +16,6 @@ import {
   type FileExplorerFocusRequest,
 } from "@/components/panes/FileExplorerPane";
 import { InternalSurfacePane } from "@/components/panes/InternalSurfacePane";
-import { MarketplacePane } from "@/components/panes/MarketplacePane";
 import { OnboardingPane } from "@/components/panes/OnboardingPane";
 import { SpaceApplicationsExplorerPane } from "@/components/panes/SpaceApplicationsExplorerPane";
 import { SpaceBrowserDisplayPane } from "@/components/panes/SpaceBrowserDisplayPane";
@@ -103,7 +102,7 @@ type SpaceComponentId = "agent" | "files" | "browser";
 type UtilityPaneId = "files" | "browser";
 type DevAppUpdatePreviewMode = "off" | "downloading" | "ready";
 type SpaceExplorerMode = "files" | "browser" | "applications";
-type ShellView = "space" | "automations" | "marketplace";
+type ShellView = "space";
 
 type SpaceVisibilityState = Record<SpaceComponentId, boolean>;
 
@@ -156,7 +155,10 @@ function isSettingsPaneSection(value: string): value is UiSettingsPaneSection {
     value === "account" ||
     value === "billing" ||
     value === "providers" ||
+    value === "integrations" ||
+    value === "submissions" ||
     value === "settings" ||
+    value === "automations" ||
     value === "about"
   );
 }
@@ -195,9 +197,9 @@ type SpaceDisplayView =
     }
   | { type: "empty" };
 
-type RestorableSpaceDisplayView = Exclude<
+type RestorableSpaceFileDisplayView = Extract<
   SpaceDisplayView,
-  { type: "browser" } | { type: "empty" }
+  { type: "internal" }
 >;
 type RestorableSpaceAppDisplayView = Extract<SpaceDisplayView, { type: "app" }>;
 
@@ -1040,13 +1042,13 @@ function AppShellContent() {
   const [publishOpen, setPublishOpen] = useState(false);
   const [createWorkspacePanelOpen, setCreateWorkspacePanelOpen] =
     useState(false);
+  const [workspaceAppsDialogOpen, setWorkspaceAppsDialogOpen] =
+    useState(false);
   const [
     createWorkspacePanelAnchorWorkspaceId,
     setCreateWorkspacePanelAnchorWorkspaceId,
   ] = useState("");
   const [activeShellView, setActiveShellView] = useState<ShellView>("space");
-  const [marketplaceInitialTab, setMarketplaceInitialTab] =
-    useState<"templates" | "apps">("templates");
   const [agentView, setAgentView] = useState<AgentView>({ type: "chat" });
   const [chatFocusRequestKey, setChatFocusRequestKey] = useState(1);
   const [chatSessionJumpRequest, setChatSessionJumpRequest] = useState<{
@@ -1156,8 +1158,8 @@ function AppShellContent() {
   const knownTaskProposalIdsByWorkspaceRef = useRef<Record<string, string[]>>(
     {},
   );
-  const lastRestorableSpaceDisplayViewByWorkspaceRef = useRef<
-    Record<string, RestorableSpaceDisplayView>
+  const lastRestorableSpaceFileDisplayViewByWorkspaceRef = useRef<
+    Record<string, RestorableSpaceFileDisplayView>
   >({});
   const lastRestorableSpaceAppDisplayViewByWorkspaceRef = useRef<
     Record<string, RestorableSpaceAppDisplayView>
@@ -2024,6 +2026,13 @@ function AppShellContent() {
   ]);
 
   useEffect(() => {
+    if (selectedWorkspaceId) {
+      return;
+    }
+    setWorkspaceAppsDialogOpen(false);
+  }, [selectedWorkspaceId]);
+
+  useEffect(() => {
     setChatSessionJumpRequest(null);
   }, [selectedWorkspaceId]);
 
@@ -2567,28 +2576,8 @@ function AppShellContent() {
     [installedApps],
   );
 
-  const handleOpenSpace = useCallback(() => {
-    setActiveShellView("space");
-    if (agentView.type === "app") {
-      setAgentView({ type: "chat" });
-    }
-    setChatFocusRequestKey((current) => current + 1);
-  }, [agentView.type]);
-
-  const handleOpenMarketplace = useCallback(
-    (initialTab: "templates" | "apps" = "templates") => {
-      setMarketplaceInitialTab(initialTab);
-      setActiveShellView("marketplace");
-    },
-    [],
-  );
-
-  const handleOpenAutomations = useCallback(() => {
-    setActiveShellView("automations");
-  }, []);
-
   const handleAddApp = () => {
-    handleOpenMarketplace("apps");
+    setWorkspaceAppsDialogOpen(true);
   };
 
   const handleOpenSpaceApp = useCallback(
@@ -2623,10 +2612,22 @@ function AppShellContent() {
     [],
   );
 
-  const handleOpenAutomationRunSession = useCallback((sessionId: string) => {
+  const handleOpenAutomationRunSession = useCallback((
+    sessionId: string,
+    workspaceId?: string | null,
+  ) => {
     const normalizedSessionId = sessionId.trim();
+    const normalizedWorkspaceId =
+      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
     if (!normalizedSessionId) {
       return;
+    }
+    if (!normalizedWorkspaceId) {
+      return;
+    }
+
+    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+      setSelectedWorkspaceId(normalizedWorkspaceId);
     }
 
     setActiveShellView("space");
@@ -2640,7 +2641,7 @@ function AppShellContent() {
       requestKey: Date.now(),
     });
     setChatFocusRequestKey((current) => current + 1);
-  }, []);
+  }, [selectedWorkspaceId, setSelectedWorkspaceId]);
 
   const nextChatSessionOpenRequestKey = useCallback(() => {
     chatSessionOpenRequestKeyRef.current += 1;
@@ -2652,7 +2653,17 @@ function AppShellContent() {
     return chatComposerPrefillRequestKeyRef.current;
   }, []);
 
-  const handleCreateScheduleInChat = useCallback(() => {
+  const handleCreateScheduleInChat = useCallback((workspaceId?: string | null) => {
+    const normalizedWorkspaceId =
+      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
+    if (!normalizedWorkspaceId) {
+      return;
+    }
+
+    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+      setSelectedWorkspaceId(normalizedWorkspaceId);
+    }
+
     setActiveShellView("space");
     setSpaceVisibility((previous) => ({
       ...previous,
@@ -2660,23 +2671,66 @@ function AppShellContent() {
     }));
     setAgentView({ type: "chat" });
     setChatSessionJumpRequest(null);
-    setChatSessionOpenRequest(
-      activeChatSessionId
-        ? {
-            sessionId: activeChatSessionId,
-            requestKey: nextChatSessionOpenRequestKey(),
-          }
-        : null,
-    );
+    setChatSessionOpenRequest({
+      sessionId: "",
+      mode: "draft",
+      parentSessionId: null,
+      requestKey: nextChatSessionOpenRequestKey(),
+    });
     setChatComposerPrefillRequest({
       text: "Create a cronjob for ",
       requestKey: nextChatComposerPrefillRequestKey(),
     });
     setChatFocusRequestKey((current) => current + 1);
   }, [
-    activeChatSessionId,
     nextChatComposerPrefillRequestKey,
     nextChatSessionOpenRequestKey,
+    selectedWorkspaceId,
+    setSelectedWorkspaceId,
+  ]);
+
+  const handleEditScheduleInChat = useCallback((
+    job: CronjobRecordPayload,
+    workspaceId?: string | null,
+  ) => {
+    const normalizedWorkspaceId =
+      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
+    if (!normalizedWorkspaceId) {
+      return;
+    }
+
+    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+      setSelectedWorkspaceId(normalizedWorkspaceId);
+    }
+
+    const jobName =
+      job.name?.trim() || job.description?.trim() || "Untitled schedule";
+    const instruction = job.instruction?.trim() || job.description?.trim() || "";
+    setActiveShellView("space");
+    setSpaceVisibility((previous) => ({
+      ...previous,
+      agent: true,
+    }));
+    setAgentView({ type: "chat" });
+    setChatSessionJumpRequest(null);
+    setChatSessionOpenRequest({
+      sessionId: "",
+      mode: "draft",
+      parentSessionId: null,
+      requestKey: nextChatSessionOpenRequestKey(),
+    });
+    setChatComposerPrefillRequest({
+      text:
+        `Edit cronjob "${jobName}" (id: ${job.id}). Current cron: ${job.cron}. ` +
+        `Current instruction: ${instruction}\n\nUpdate it to: `,
+      requestKey: nextChatComposerPrefillRequestKey(),
+    });
+    setChatFocusRequestKey((current) => current + 1);
+  }, [
+    nextChatComposerPrefillRequestKey,
+    nextChatSessionOpenRequestKey,
+    selectedWorkspaceId,
+    setSelectedWorkspaceId,
   ]);
 
   const handleCreateSession = useCallback(
@@ -2766,15 +2820,12 @@ function AppShellContent() {
   );
 
   useEffect(() => {
-    if (
-      !selectedWorkspaceId ||
-      spaceDisplayView.type === "browser" ||
-      spaceDisplayView.type === "empty"
-    ) {
+    if (!selectedWorkspaceId || spaceDisplayView.type !== "internal") {
       return;
     }
-    lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId] =
-      spaceDisplayView;
+    lastRestorableSpaceFileDisplayViewByWorkspaceRef.current[
+      selectedWorkspaceId
+    ] = spaceDisplayView;
   }, [selectedWorkspaceId, spaceDisplayView]);
 
   useEffect(() => {
@@ -2786,18 +2837,20 @@ function AppShellContent() {
     ] = spaceDisplayView;
   }, [selectedWorkspaceId, spaceDisplayView]);
 
-  const restoreLastSpaceDisplayView = useCallback(() => {
+  const restoreLastSpaceFileDisplayView = useCallback(() => {
     if (!selectedWorkspaceId) {
       setSpaceDisplayView({ type: "browser" });
       return;
     }
 
     const lastDisplayView =
-      lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId];
-    const nextDisplayView = lastDisplayView ?? { type: "browser" };
+      lastRestorableSpaceFileDisplayViewByWorkspaceRef.current[
+        selectedWorkspaceId
+      ];
+    const nextDisplayView = lastDisplayView ?? spaceDisplayView;
     setSpaceDisplayView(nextDisplayView);
     syncFileExplorerFocusWithDisplayView(nextDisplayView);
-  }, [selectedWorkspaceId, syncFileExplorerFocusWithDisplayView]);
+  }, [selectedWorkspaceId, spaceDisplayView, syncFileExplorerFocusWithDisplayView]);
 
   const restoreLastSpaceAppDisplayView = useCallback(() => {
     if (!selectedWorkspaceId) {
@@ -2814,8 +2867,8 @@ function AppShellContent() {
       return;
     }
 
-    restoreLastSpaceDisplayView();
-  }, [restoreLastSpaceDisplayView, selectedWorkspaceId]);
+    setSpaceDisplayView(spaceDisplayView);
+  }, [selectedWorkspaceId, spaceDisplayView]);
 
   useEffect(() => {
     if (!selectedWorkspaceId) {
@@ -2825,7 +2878,9 @@ function AppShellContent() {
     }
 
     const nextDisplayView =
-      lastRestorableSpaceDisplayViewByWorkspaceRef.current[selectedWorkspaceId];
+      lastRestorableSpaceFileDisplayViewByWorkspaceRef.current[
+        selectedWorkspaceId
+      ];
     if (!nextDisplayView) {
       setSpaceExplorerMode("browser");
       setSpaceDisplayView({ type: "browser" });
@@ -2975,6 +3030,7 @@ function AppShellContent() {
     isUtilityPaneResizing ||
     workspaceSwitcherOpen ||
     settingsDialogOpen ||
+    workspaceAppsDialogOpen ||
     createWorkspacePanelOpen ||
     publishOpen;
   const runtimeStartupBlockedDetail = runtimeStartupBlockedMessage(
@@ -3575,12 +3631,6 @@ function AppShellContent() {
               integratedTitleBar={hasIntegratedTitleBar}
               desktopPlatform={desktopPlatform}
               onWorkspaceSwitcherVisibilityChange={setWorkspaceSwitcherOpen}
-              onOpenSpace={handleOpenSpace}
-              isSpaceActive={spaceMode}
-              onOpenAutomations={handleOpenAutomations}
-              isAutomationsActive={activeShellView === "automations"}
-              onOpenMarketplace={() => handleOpenMarketplace("templates")}
-              isMarketplaceActive={activeShellView === "marketplace"}
               onOpenWorkspaceCreatePanel={handleOpenCreateWorkspacePanel}
               onOpenSettings={() => {
                 setSettingsDialogSection("settings");
@@ -3644,7 +3694,7 @@ function AppShellContent() {
                                       } else if (mode === "applications") {
                                         restoreLastSpaceAppDisplayView();
                                       } else {
-                                        restoreLastSpaceDisplayView();
+                                        restoreLastSpaceFileDisplayView();
                                       }
                                     }}
                                     className="min-w-0 flex-1"
@@ -3750,7 +3800,7 @@ function AppShellContent() {
                                 size="icon"
                                 onClick={() => {
                                   setSpaceExplorerMode("files");
-                                  restoreLastSpaceDisplayView();
+                                  restoreLastSpaceFileDisplayView();
                                   setSpaceExplorerCollapsed(false);
                                 }}
                                 aria-label="Open file explorer"
@@ -3848,18 +3898,7 @@ function AppShellContent() {
                     </div>
                   </div>
                 </div>
-              ) : activeShellView === "automations" ? (
-                <div className="h-full min-h-0 overflow-hidden rounded-xl">
-                  <AutomationsPane
-                    onOpenRunSession={handleOpenAutomationRunSession}
-                    onCreateSchedule={handleCreateScheduleInChat}
-                  />
-                </div>
-              ) : (
-                <div className="h-full min-h-0 overflow-hidden rounded-xl">
-                  <MarketplacePane initialTab={marketplaceInitialTab} />
-                </div>
-              )}
+              ) : null}
             </div>
           </div>
         )}
@@ -3871,6 +3910,10 @@ function AppShellContent() {
           onClose={handleCloseCreateWorkspacePanel}
         />
       ) : null}
+      <WorkspaceAppsDialog
+        open={workspaceAppsDialogOpen}
+        onClose={() => setWorkspaceAppsDialogOpen(false)}
+      />
 
       <SettingsDialog
         open={settingsDialogOpen}
@@ -3881,6 +3924,18 @@ function AppShellContent() {
         themes={THEMES}
         onThemeChange={handleThemeChange}
         onOpenExternalUrl={handleOpenExternalUrl}
+        onOpenAutomationRunSession={(workspaceId, sessionId) => {
+          setSettingsDialogOpen(false);
+          handleOpenAutomationRunSession(sessionId, workspaceId);
+        }}
+        onCreateAutomationSchedule={(workspaceId) => {
+          setSettingsDialogOpen(false);
+          handleCreateScheduleInChat(workspaceId);
+        }}
+        onEditAutomationSchedule={(workspaceId, job) => {
+          setSettingsDialogOpen(false);
+          handleEditScheduleInChat(job, workspaceId);
+        }}
       />
       {selectedWorkspaceId && (
         <PublishDialog

--- a/desktop/src/components/layout/SettingsDialog.test.mjs
+++ b/desktop/src/components/layout/SettingsDialog.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const SETTINGS_DIALOG_PATH = new URL("./SettingsDialog.tsx", import.meta.url);
+
+test("settings dialog includes an automations section with a workspace selector", async () => {
+  const source = await readFile(SETTINGS_DIALOG_PATH, "utf8");
+
+  assert.match(source, /import \{ AutomationsPane \} from "@\/components\/panes\/AutomationsPane";/);
+  assert.match(source, /import \{ useWorkspaceDesktop \} from "@\/lib\/workspaceDesktop";/);
+  assert.match(source, /import \{\s*Select,\s*SelectContent,\s*SelectItem,\s*SelectTrigger,\s*SelectValue,\s*\} from "@\/components\/ui\/select";/);
+  assert.match(source, /\{ id: "automations", label: "Automations", icon: Workflow \}/);
+  assert.match(source, /case "automations":\s*return "Automations";/);
+  assert.match(source, /const \{ workspaces, selectedWorkspace \} = useWorkspaceDesktop\(\);/);
+  assert.match(source, /const \[automationsWorkspaceId, setAutomationsWorkspaceId\] = useState\(""\);/);
+  assert.match(source, /activeSection === "automations" \? \(/);
+  assert.match(source, /toolbarLeading=\{/);
+  assert.match(source, /<Select\s+value=\{automationsWorkspaceId \|\| undefined\}/);
+  assert.match(source, /onValueChange=\{\(value\) =>\s*setAutomationsWorkspaceId\(value \?\? ""\)\s*\}/);
+  assert.match(source, /<SelectTrigger className="min-w-\[220px\] rounded-full border-border\/40 bg-background\/80 px-3\.5 text-sm shadow-none sm:w-\[280px\]">/);
+  assert.match(source, /<SelectValue placeholder="Select workspace">/);
+  assert.match(source, /\{\(value: string \| null\) =>/);
+  assert.match(source, /workspaces\.find\(\(workspace\) => workspace\.id === value\)\?\.name/);
+  assert.match(source, /<AutomationsPane[\s\S]*workspaceId=\{automationsWorkspaceId \|\| null\}[\s\S]*showHeader=\{false\}[\s\S]*toolbarLeading=\{/);
+  assert.match(source, /onEditSchedule=\{\(job\) => \{/);
+  assert.match(source, /onEditAutomationSchedule\(automationsWorkspaceId, job\);/);
+});
+
+test("settings nav lists automations below model providers", async () => {
+  const source = await readFile(SETTINGS_DIALOG_PATH, "utf8");
+
+  const providersIndex = source.indexOf('{ id: "providers", label: "Model Providers", icon: Waypoints }');
+  const automationsIndex = source.indexOf('{ id: "automations", label: "Automations", icon: Workflow }');
+
+  assert.notEqual(providersIndex, -1);
+  assert.notEqual(automationsIndex, -1);
+  assert.ok(providersIndex < automationsIndex);
+});

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -11,15 +11,25 @@ import {
   Settings2,
   User2,
   Waypoints,
+  Workflow,
   X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AuthPanel } from "@/components/auth/AuthPanel";
 import { BillingSettingsPanel } from "@/components/billing/BillingSettingsPanel";
+import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { IntegrationsPane } from "@/components/panes/IntegrationsPane";
 import { SubmissionsPanel } from "@/components/settings/SubmissionsPanel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 const THEME_SWATCHES: Record<string, [string, string, string]> = {
   "amber-minimal-dark": ["#1a1814", "#e8853a", "#2e2920"],
@@ -47,6 +57,12 @@ interface SettingsDialogProps {
   themes: readonly string[];
   onThemeChange: (theme: string) => void;
   onOpenExternalUrl: (url: string) => void;
+  onOpenAutomationRunSession: (workspaceId: string, sessionId: string) => void;
+  onCreateAutomationSchedule: (workspaceId: string) => void;
+  onEditAutomationSchedule: (
+    workspaceId: string,
+    job: CronjobRecordPayload,
+  ) => void;
 }
 
 const SETTINGS_SECTIONS: Array<{
@@ -58,6 +74,7 @@ const SETTINGS_SECTIONS: Array<{
   { id: "settings", label: "Settings", icon: Settings2 },
   { id: "billing", label: "Billing", icon: CreditCard },
   { id: "providers", label: "Model Providers", icon: Waypoints },
+  { id: "automations", label: "Automations", icon: Workflow },
   { id: "integrations", label: "Integrations", icon: Plug },
   { id: "submissions", label: "Submissions", icon: Send },
   { id: "about", label: "About", icon: Info },
@@ -95,6 +112,8 @@ function titleForSection(section: UiSettingsPaneSection): string {
       return "Account";
     case "billing":
       return "Billing";
+    case "automations":
+      return "Automations";
     case "providers":
       return "Model Providers";
     case "integrations":
@@ -128,7 +147,12 @@ export function SettingsDialog({
   themes,
   onThemeChange,
   onOpenExternalUrl,
+  onOpenAutomationRunSession,
+  onCreateAutomationSchedule,
+  onEditAutomationSchedule,
 }: SettingsDialogProps) {
+  const { workspaces, selectedWorkspace } = useWorkspaceDesktop();
+  const [automationsWorkspaceId, setAutomationsWorkspaceId] = useState("");
   const [diagnosticsExportState, setDiagnosticsExportState] = useState<{
     status: "idle" | "exporting" | "success" | "error";
     message: string;
@@ -155,6 +179,14 @@ export function SettingsDialog({
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setAutomationsWorkspaceId(selectedWorkspace?.id ?? workspaces[0]?.id ?? "");
+  }, [open, selectedWorkspace?.id, workspaces]);
 
   async function handleExportDiagnosticsBundle() {
     setDiagnosticsExportState({
@@ -332,6 +364,61 @@ export function SettingsDialog({
                     })}
                   </div>
                 </section>
+              </div>
+            ) : null}
+
+            {activeSection === "automations" ? (
+              <div>
+                <AutomationsPane
+                  workspaceId={automationsWorkspaceId || null}
+                  showHeader={false}
+                  emptyWorkspaceMessage="Choose a workspace to view and manage automations."
+                  toolbarLeading={
+                    <Select
+                      value={automationsWorkspaceId || undefined}
+                      onValueChange={(value) =>
+                        setAutomationsWorkspaceId(value ?? "")
+                      }
+                      disabled={workspaces.length === 0}
+                    >
+                      <SelectTrigger className="min-w-[220px] rounded-full border-border/40 bg-background/80 px-3.5 text-sm shadow-none sm:w-[280px]">
+                        <SelectValue placeholder="Select workspace">
+                          {(value: string | null) =>
+                            value
+                              ? workspaces.find((workspace) => workspace.id === value)?.name ??
+                                "Select workspace"
+                              : "Select workspace"
+                          }
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent align="end">
+                        {workspaces.map((workspace) => (
+                          <SelectItem key={workspace.id} value={workspace.id}>
+                            {workspace.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  }
+                  onOpenRunSession={(sessionId) => {
+                    if (!automationsWorkspaceId) {
+                      return;
+                    }
+                    onOpenAutomationRunSession(automationsWorkspaceId, sessionId);
+                  }}
+                  onCreateSchedule={() => {
+                    if (!automationsWorkspaceId) {
+                      return;
+                    }
+                    onCreateAutomationSchedule(automationsWorkspaceId);
+                  }}
+                  onEditSchedule={(job) => {
+                    if (!automationsWorkspaceId) {
+                      return;
+                    }
+                    onEditAutomationSchedule(automationsWorkspaceId, job);
+                  }}
+                />
               </div>
             ) : null}
 

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -18,10 +18,6 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   const source = await readFile(TOP_TABS_BAR_PATH, "utf8");
 
   assert.match(source, /desktopPlatform\?: string \| null;/);
-  assert.match(source, /onOpenSpace\?: \(\) => void;/);
-  assert.match(source, /isSpaceActive\?: boolean;/);
-  assert.match(source, /onOpenAutomations\?: \(\) => void;/);
-  assert.match(source, /isAutomationsActive\?: boolean;/);
   assert.match(
     source,
     /const isWindowsIntegratedTitleBar =\s*integratedTitleBar && desktopPlatform === "win32";/,
@@ -40,7 +36,7 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   );
   assert.match(
     source,
-    /const workspaceSwitcherButtonClassName =\s*"h-7 w-full justify-start gap-1\.5 px-2 rounded-lg text-xs";/,
+    /const workspaceSwitcherButtonClassName =\s*"h-8 w-full justify-start gap-1\.5 px-2\.5 rounded-lg text-xs";/,
   );
   assert.match(
     source,
@@ -49,14 +45,19 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   assert.match(source, /className="size-7 shrink-0 rounded-\[9px\] border border-border overflow-hidden"/);
   assert.match(source, /<FolderKanban size=\{13\} className="shrink-0 text-primary" \/>/);
   assert.match(source, /<ChevronDown\s+size=\{12\}/);
-  assert.match(source, /size="sm"\s+aria-label="Space"/);
-  assert.match(source, /<MessageSquareText size=\{12\} \/>/);
-  assert.match(source, /size="sm"\s+aria-label="Automations"/);
-  assert.match(source, /<Workflow size=\{12\} \/>/);
-  assert.match(source, /size="sm"\s+aria-label="Marketplace"/);
-  assert.match(source, /className="h-7 gap-1\.5 px-2 rounded-lg text-xs"/);
-  assert.match(source, /<LayoutGrid size=\{12\} \/>/);
-  assert.match(source, /render=\{<Button variant="outline" size="icon-sm" className="relative rounded-lg" \/>\}/);
+  assert.doesNotMatch(source, /onOpenSpace\?: \(\) => void;/);
+  assert.doesNotMatch(source, /isSpaceActive\?: boolean;/);
+  assert.doesNotMatch(source, /aria-label="Space"/);
+  assert.doesNotMatch(source, /MessageSquareText/);
+  assert.doesNotMatch(source, /aria-label="Automations"/);
+  assert.doesNotMatch(source, /onOpenAutomations\?: \(\) => void;/);
+  assert.doesNotMatch(source, /isAutomationsActive\?: boolean;/);
+  assert.doesNotMatch(source, /Workflow/);
+  assert.doesNotMatch(source, /aria-label="Marketplace"/);
+  assert.doesNotMatch(source, /onOpenMarketplace\?: \(\) => void;/);
+  assert.doesNotMatch(source, /isMarketplaceActive\?: boolean;/);
+  assert.doesNotMatch(source, /LayoutGrid/);
+  assert.match(source, /render=\{<Button variant="outline" size="icon" className="relative rounded-lg" \/>\}/);
   assert.match(source, /window\.electronAPI\.ui\.getWindowState\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.minimizeWindow\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.closeWindow\(\)/);

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -4,9 +4,7 @@ import {
   Copy,
   FolderKanban,
   Home,
-  LayoutGrid,
   Loader2,
-  MessageSquareText,
   Minus,
   Plus,
   Search,
@@ -15,7 +13,6 @@ import {
   Trash2,
   Upload,
   User2,
-  Workflow,
   X,
 } from "lucide-react";
 import {
@@ -48,12 +45,6 @@ interface TopTabsBarProps {
   integratedTitleBar?: boolean;
   desktopPlatform?: string | null;
   onWorkspaceSwitcherVisibilityChange?: (open: boolean) => void;
-  onOpenSpace?: () => void;
-  isSpaceActive?: boolean;
-  onOpenAutomations?: () => void;
-  isAutomationsActive?: boolean;
-  onOpenMarketplace?: () => void;
-  isMarketplaceActive?: boolean;
   onOpenWorkspaceCreatePanel?: () => void;
   onOpenSettings?: () => void;
   onOpenAccount?: () => void;
@@ -66,12 +57,6 @@ export function TopTabsBar({
   integratedTitleBar = false,
   desktopPlatform = null,
   onWorkspaceSwitcherVisibilityChange,
-  onOpenSpace,
-  isSpaceActive = false,
-  onOpenAutomations,
-  isAutomationsActive = false,
-  onOpenMarketplace,
-  isMarketplaceActive = false,
   onOpenWorkspaceCreatePanel,
   onOpenSettings,
   onOpenAccount,
@@ -270,7 +255,7 @@ export function TopTabsBar({
     "window-no-drag flex h-5 w-5 items-center justify-center rounded-[7px] border border-transparent text-muted-foreground/72 transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative min-w-55 max-w-full`;
   const workspaceSwitcherButtonClassName =
-    "h-7 w-full justify-start gap-1.5 px-2 rounded-lg text-xs";
+    "h-8 w-full justify-start gap-1.5 px-2.5 rounded-lg text-xs";
 
   return (
     <header
@@ -371,42 +356,6 @@ export function TopTabsBar({
         <div
           className={`${integratedTitleBar ? "window-no-drag " : ""}flex items-center justify-self-end gap-1.5`}
         >
-          {onOpenSpace ? (
-            <Button
-              variant={isSpaceActive ? "secondary" : "outline"}
-              size="sm"
-              aria-label="Space"
-              onClick={onOpenSpace}
-              className="h-7 gap-1.5 px-2 rounded-lg text-xs"
-            >
-              <MessageSquareText size={12} />
-              <span className="hidden sm:inline">Space</span>
-            </Button>
-          ) : null}
-          {onOpenAutomations ? (
-            <Button
-              variant={isAutomationsActive ? "secondary" : "outline"}
-              size="sm"
-              aria-label="Automations"
-              onClick={onOpenAutomations}
-              className="h-7 gap-1.5 px-2 rounded-lg text-xs"
-            >
-              <Workflow size={12} />
-              <span className="hidden sm:inline">Automations</span>
-            </Button>
-          ) : null}
-          {onOpenMarketplace ? (
-            <Button
-              variant={isMarketplaceActive ? "secondary" : "outline"}
-              size="sm"
-              aria-label="Marketplace"
-              onClick={onOpenMarketplace}
-              className="h-7 gap-1.5 px-2 rounded-lg text-xs"
-            >
-              <LayoutGrid size={12} />
-              <span className="hidden sm:inline">Marketplace</span>
-            </Button>
-          ) : null}
           {isBillingAvailable ? (
             <CreditsPill
               balance={overview?.creditsBalance ?? 0}
@@ -418,7 +367,7 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon-sm" className="relative rounded-lg" />}
+              render={<Button variant="outline" size="icon" className="relative rounded-lg" />}
             >
               <User2 />
               <span

--- a/desktop/src/components/layout/WorkspaceAppsDialog.test.mjs
+++ b/desktop/src/components/layout/WorkspaceAppsDialog.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_APPS_DIALOG_PATH = new URL(
+  "./WorkspaceAppsDialog.tsx",
+  import.meta.url,
+);
+
+test("workspace apps dialog wraps the apps gallery in a centered modal window", async () => {
+  const source = await readFile(WORKSPACE_APPS_DIALOG_PATH, "utf8");
+
+  assert.match(source, /import \{ LayoutGrid, X \} from "lucide-react";/);
+  assert.match(source, /import \{ AppsGallery \} from "@\/components\/marketplace\/AppsGallery";/);
+  assert.match(source, /interface WorkspaceAppsDialogProps \{\s*open: boolean;\s*onClose: \(\) => void;\s*\}/);
+  assert.match(source, /if \(!open\) \{\s*return null;\s*\}/);
+  assert.match(source, /document\.body\.style\.overflow = "hidden";/);
+  assert.match(source, /document\.body\.style\.overflow = "";/);
+  assert.match(source, /if \(event\.key === "Escape"\) \{\s*onClose\(\);\s*\}/);
+  assert.match(source, /role="dialog"/);
+  assert.match(source, /aria-modal="true"/);
+  assert.match(source, /aria-label="Add apps"/);
+  assert.match(source, /aria-label="Close add apps"/);
+  assert.doesNotMatch(source, /Install available apps into/);
+  assert.doesNotMatch(source, /Marketplace catalog/);
+  assert.doesNotMatch(source, /Local catalog/);
+  assert.doesNotMatch(source, /useWorkspaceDesktop/);
+  assert.match(source, /<AppsGallery \/>/);
+});

--- a/desktop/src/components/layout/WorkspaceAppsDialog.tsx
+++ b/desktop/src/components/layout/WorkspaceAppsDialog.tsx
@@ -1,0 +1,79 @@
+import { LayoutGrid, X } from "lucide-react";
+import { useEffect } from "react";
+import { AppsGallery } from "@/components/marketplace/AppsGallery";
+import { Button } from "@/components/ui/button";
+
+interface WorkspaceAppsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function WorkspaceAppsDialog({
+  open,
+  onClose,
+}: WorkspaceAppsDialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-50 grid place-items-center px-4 py-6">
+      <button
+        type="button"
+        aria-label="Close add apps"
+        onClick={onClose}
+        className="pointer-events-auto absolute inset-0 bg-[rgba(7,10,14,0.46)] backdrop-blur-sm"
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add apps"
+        className="pointer-events-auto relative z-10 flex h-[min(820px,calc(100vh-36px))] w-[min(1120px,calc(100vw-32px))] min-w-0 flex-col overflow-hidden rounded-[28px] border border-border/55 bg-background shadow-2xl"
+      >
+        <header className="flex items-center justify-between gap-4 border-b border-border/35 px-6 py-5">
+          <div className="inline-flex min-w-0 items-center gap-2 text-[17px] font-semibold tracking-[-0.02em] text-foreground">
+            <LayoutGrid size={16} className="shrink-0 text-muted-foreground" />
+            <span className="truncate">Add apps</span>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={onClose}
+              aria-label="Close add apps"
+              className="rounded-full"
+            >
+              <X size={16} />
+            </Button>
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5 [scrollbar-gutter:stable]">
+          <AppsGallery />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -75,9 +75,6 @@ export function AppsGallery() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          Install apps into your workspace.
-        </p>
         <Button
           variant="ghost"
           size="sm"

--- a/desktop/src/components/panes/AutomationsPane.test.mjs
+++ b/desktop/src/components/panes/AutomationsPane.test.mjs
@@ -12,9 +12,10 @@ test("automations pane keeps scheduled tasks and completed runs as distinct data
 
   assert.match(source, /const \[cronjobs, setCronjobs\] = useState<CronjobRecordPayload\[]>\(\[\]\);/);
   assert.match(source, /const \[completedRuns, setCompletedRuns\] = useState<CompletedAutomationRun\[]>\(/);
-  assert.match(source, /window\.electronAPI\.workspace\.listCronjobs\(selectedWorkspaceId\)/);
-  assert.match(source, /window\.electronAPI\.workspace\.listAgentSessions\(selectedWorkspaceId\)/);
-  assert.match(source, /window\.electronAPI\.workspace\.listRuntimeStates\(selectedWorkspaceId\)/);
+  assert.match(source, /const activeWorkspaceId = workspaceId \?\? selectedWorkspaceId;/);
+  assert.match(source, /window\.electronAPI\.workspace\.listCronjobs\(activeWorkspaceId\)/);
+  assert.match(source, /window\.electronAPI\.workspace\.listAgentSessions\(activeWorkspaceId\)/);
+  assert.match(source, /window\.electronAPI\.workspace\.listRuntimeStates\(activeWorkspaceId\)/);
   assert.match(source, /session\.kind\.trim\(\)\.toLowerCase\(\) === "cronjob"/);
 });
 
@@ -33,7 +34,7 @@ test("scheduled rows expose a run-now action for each automation", async () => {
   assert.match(source, /await window\.electronAPI\.workspace\.runCronjobNow\(job\.id\);/);
   assert.match(source, /item\.id === response\.cronjob\.id \? response\.cronjob : item/);
   assert.match(source, /Run now/);
-  assert.match(source, /<Play size=\{14\} \/>/);
+  assert.match(source, /<Play size=\{16\} \/>/);
 });
 
 test("post-action refresh preserves the current banner and suppresses transient refresh errors", async () => {
@@ -59,7 +60,7 @@ test("scheduled rows label whether an automation is a notification or task run",
 test("new schedule button can route creation into the workspace chat", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /interface AutomationsPaneProps \{\s*onOpenRunSession\?: \(sessionId: string\) => void;\s*onCreateSchedule\?: \(\) => void;\s*\}/);
+  assert.match(source, /interface AutomationsPaneProps \{\s*workspaceId\?: string \| null;\s*showHeader\?: boolean;\s*emptyWorkspaceMessage\?: string;\s*toolbarLeading\?: ReactNode;\s*onOpenRunSession\?: \(sessionId: string\) => void;\s*onCreateSchedule\?: \(\) => void;\s*onEditSchedule\?: \(job: CronjobRecordPayload\) => void;\s*\}/);
   assert.match(source, /if \(onCreateSchedule\) \{\s*onCreateSchedule\(\);\s*return;\s*\}/);
   assert.match(source, /onClick=\{handleNewSchedule\}/);
 });
@@ -67,6 +68,55 @@ test("new schedule button can route creation into the workspace chat", async () 
 test("completed runs open the corresponding sub-session when clicked", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /interface AutomationsPaneProps \{\s*onOpenRunSession\?: \(sessionId: string\) => void;/);
+  assert.match(source, /interface AutomationsPaneProps \{\s*workspaceId\?: string \| null;[\s\S]*onOpenRunSession\?: \(sessionId: string\) => void;/);
   assert.match(source, /onClick=\{\(\) => onOpenRunSession\?\.\(run\.sessionId\)\}/);
+});
+
+test("automations pane can embed inside settings and hide its standalone header", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /showHeader = true/);
+  assert.match(source, /emptyWorkspaceMessage = "Choose a workspace from the top bar to view and manage automations\."/);
+  assert.match(source, /toolbarLeading\?: ReactNode/);
+  assert.match(source, /const content = \(/);
+  assert.match(source, /if \(!showHeader\) \{\s*return content;\s*\}/);
+  assert.match(source, /return <PaneCard className="shadow-md">\{content\}<\/PaneCard>;/);
+  assert.match(source, /showHeader \? \(/);
+  assert.match(source, /toolbarLeading \? \(/);
+  assert.match(source, /!activeWorkspaceId \? \(\s*<EmptyState message=\{emptyWorkspaceMessage\} \/>/);
+});
+
+test("scheduled rows use a kebab menu for run, edit, and delete actions", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const handleEdit = \(job: CronjobRecordPayload\) => \{/);
+  assert.match(source, /if \(onEditSchedule\) \{\s*onEditSchedule\(job\);\s*return;\s*\}/);
+  assert.match(source, /Actions for \$\{jobTitle\(job\)\}/);
+  assert.match(source, /<MoreHorizontal size=\{20\} \/>/);
+  assert.match(source, /<Pencil size=\{16\} \/>/);
+  assert.match(source, /Run now/);
+  assert.match(source, /Edit/);
+  assert.match(source, /Delete/);
+});
+
+test("new schedule button uses the shared primary button style", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /<Button\s+type="button"\s+size="default"\s+onClick=\{handleNewSchedule\}\s+className="rounded-full px-4"/);
+  assert.doesNotMatch(source, /bg-foreground/);
+});
+
+test("embedded automations toolbar uses the shared compact control height", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /theme-subtle-surface mt-5 inline-flex items-center rounded-full border border-border\/45 bg-muted\/40 p-1/);
+  assert.match(source, /min-w-\[124px\] rounded-full px-4 text-sm font-semibold/);
+  assert.doesNotMatch(source, /h-9 min-w-\[132px\]/);
+});
+
+test("automation tabs keep a distinct hover state instead of blending into the track", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground/);
+  assert.match(source, /text-muted-foreground hover:bg-background\/70 hover:text-foreground/);
 });

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Clock3, Loader2, MoreHorizontal, Play, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Clock3, Loader2, MoreHorizontal, Pencil, Play, Plus, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PaneCard } from "@/components/ui/PaneCard";
@@ -20,8 +20,13 @@ interface CompletedAutomationRun {
 }
 
 interface AutomationsPaneProps {
+  workspaceId?: string | null;
+  showHeader?: boolean;
+  emptyWorkspaceMessage?: string;
+  toolbarLeading?: ReactNode;
   onOpenRunSession?: (sessionId: string) => void;
   onCreateSchedule?: () => void;
+  onEditSchedule?: (job: CronjobRecordPayload) => void;
 }
 
 interface RefreshDataOptions {
@@ -162,13 +167,19 @@ function completedStatusClassName(status: string): string {
 }
 
 export function AutomationsPane({
+  workspaceId,
+  showHeader = true,
+  emptyWorkspaceMessage = "Choose a workspace from the top bar to view and manage automations.",
+  toolbarLeading,
   onOpenRunSession,
   onCreateSchedule,
+  onEditSchedule,
 }: AutomationsPaneProps) {
   const [activeTab, setActiveTab] = useState<"scheduled" | "completed">(
     "scheduled",
   );
   const { selectedWorkspaceId } = useWorkspaceSelection();
+  const activeWorkspaceId = workspaceId ?? selectedWorkspaceId;
   const [cronjobs, setCronjobs] = useState<CronjobRecordPayload[]>([]);
   const [completedRuns, setCompletedRuns] = useState<CompletedAutomationRun[]>(
     [],
@@ -208,7 +219,7 @@ export function AutomationsPane({
     const preserveStatusMessage = options?.preserveStatusMessage ?? false;
     const suppressErrors = options?.suppressErrors ?? false;
 
-    if (!selectedWorkspaceId) {
+    if (!activeWorkspaceId) {
       setCronjobs([]);
       setCompletedRuns([]);
       return;
@@ -218,9 +229,9 @@ export function AutomationsPane({
     try {
       const [cronjobsResponse, sessionsResponse, runtimeStatesResponse] =
         await Promise.all([
-          window.electronAPI.workspace.listCronjobs(selectedWorkspaceId),
-          window.electronAPI.workspace.listAgentSessions(selectedWorkspaceId),
-          window.electronAPI.workspace.listRuntimeStates(selectedWorkspaceId),
+          window.electronAPI.workspace.listCronjobs(activeWorkspaceId),
+          window.electronAPI.workspace.listAgentSessions(activeWorkspaceId),
+          window.electronAPI.workspace.listRuntimeStates(activeWorkspaceId),
         ]);
 
       setCronjobs(cronjobsResponse.jobs);
@@ -265,7 +276,7 @@ export function AutomationsPane({
     } finally {
       setIsLoading(false);
     }
-  }, [selectedWorkspaceId]);
+  }, [activeWorkspaceId]);
 
   useEffect(() => {
     void refreshData();
@@ -351,40 +362,61 @@ export function AutomationsPane({
     );
   };
 
-  return (
-    <PaneCard className="shadow-md">
+  const handleEdit = (job: CronjobRecordPayload) => {
+    if (onEditSchedule) {
+      onEditSchedule(job);
+      return;
+    }
+    setInfoMessage(
+      "Editing isn't wired in this pane yet. Open the schedule in chat to update it.",
+    );
+  };
+
+  const content = (
+    <>
       <div className="relative min-h-0 flex-1 overflow-auto">
         <div className="mx-auto flex min-h-full max-w-5xl flex-col px-6 py-6">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">
-                Automations
-              </h1>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Manage recurring schedules and review completed automation runs.
-              </p>
+          <div
+            className="flex flex-wrap items-center justify-between gap-4"
+          >
+            <div className="min-w-0">
+              {showHeader ? (
+                <div>
+                  <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                    Automations
+                  </h1>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Manage recurring schedules and review completed automation runs.
+                  </p>
+                </div>
+              ) : toolbarLeading ? (
+                toolbarLeading
+              ) : null}
             </div>
 
             <Button
               type="button"
-              variant="outline"
               size="default"
               onClick={handleNewSchedule}
-              className="h-9 rounded-xl px-4 text-sm font-semibold"
+              className="rounded-full px-4"
             >
-              <Plus size={16} />
+              <Plus size={14} />
               New schedule
             </Button>
           </div>
 
-          <div className="theme-subtle-surface mt-5 inline-flex items-center rounded-xl border border-border/45 p-1">
+          <div className="theme-subtle-surface mt-5 inline-flex items-center rounded-full border border-border/45 bg-muted/40 p-1">
             <div className="inline-flex items-center gap-1">
               <Button
                 type="button"
                 variant={activeTab === "scheduled" ? "secondary" : "ghost"}
                 size="default"
                 onClick={() => setActiveTab("scheduled")}
-                className={activeTab === "scheduled" ? "shadow-sm" : ""}
+                className={`min-w-[124px] rounded-full px-4 text-sm font-semibold ${
+                  activeTab === "scheduled"
+                    ? "bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground"
+                    : "text-muted-foreground hover:bg-background/70 hover:text-foreground"
+                }`}
               >
                 Scheduled
               </Button>
@@ -393,7 +425,11 @@ export function AutomationsPane({
                 variant={activeTab === "completed" ? "secondary" : "ghost"}
                 size="default"
                 onClick={() => setActiveTab("completed")}
-                className={activeTab === "completed" ? "shadow-sm" : ""}
+                className={`min-w-[124px] rounded-full px-4 text-sm font-semibold ${
+                  activeTab === "completed"
+                    ? "bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground"
+                    : "text-muted-foreground hover:bg-background/70 hover:text-foreground"
+                }`}
               >
                 Completed
               </Button>
@@ -408,9 +444,9 @@ export function AutomationsPane({
             </div>
           ) : null}
 
-          <div className="mt-4 min-h-0 flex-1 overflow-hidden rounded-xl border border-border/45 bg-card/70">
-            {!selectedWorkspaceId ? (
-              <EmptyState message="Choose a workspace from the top bar to view and manage automations." />
+          <div className="mt-5 min-h-0 flex-1 overflow-hidden rounded-[24px] border border-border/40 bg-background/70">
+            {!activeWorkspaceId ? (
+              <EmptyState message={emptyWorkspaceMessage} />
             ) : isLoading && scheduledJobs.length === 0 && completedRuns.length === 0 ? (
               <EmptyState message="Loading automations..." />
             ) : activeTab === "scheduled" ? (
@@ -418,12 +454,11 @@ export function AutomationsPane({
                 <EmptyState message="No scheduled tasks in this workspace." />
               ) : (
                 <div className="flex h-full min-h-0 flex-col">
-                  <div className="shrink-0 border-b border-border/35 bg-muted/35 px-4 py-2.5">
-                    <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1.4fr)_120px_132px_48px] items-center gap-4 text-[11px] font-medium uppercase tracking-widest text-muted-foreground/75">
+                  <div className="shrink-0 border-b border-border/30 px-4 py-4 sm:px-5">
+                    <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/75">
                       <span>Title</span>
                       <span>Schedule at</span>
                       <span>Status</span>
-                      <span>Run</span>
                       <span />
                     </div>
                   </div>
@@ -434,23 +469,30 @@ export function AutomationsPane({
                       return (
                         <div
                           key={job.id}
-                          className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1.4fr)_120px_132px_48px] items-center gap-4 border-b border-border/25 px-4 py-3 transition-colors hover:bg-accent/45"
+                          className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border/20 px-4 py-4 transition-colors hover:bg-accent/20 sm:px-5"
                         >
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium text-foreground">
+                          <div className="min-w-0 pr-2">
+                            <div className="truncate text-[18px] font-medium tracking-[-0.02em] text-foreground">
                               {jobTitle(job)}
                             </div>
-                            <div className="mt-1">
-                              <Badge
-                                variant="outline"
-                                className={`uppercase tracking-[0.12em] ${jobKindClassName(job)}`}
-                              >
-                                {jobKindLabel(job)}
-                              </Badge>
-                            </div>
+                            {jobKindLabel(job) !== "Automation" ? (
+                              <div className="mt-1">
+                                <Badge
+                                  variant="outline"
+                                  className={`uppercase tracking-[0.12em] ${jobKindClassName(job)}`}
+                                >
+                                  {jobKindLabel(job)}
+                                </Badge>
+                              </div>
+                            ) : null}
+                            {job.last_error ? (
+                              <div className="mt-1 truncate text-xs text-destructive/85">
+                                {job.last_error}
+                              </div>
+                            ) : null}
                           </div>
 
-                          <div className="truncate text-sm text-muted-foreground">
+                          <div className="truncate text-[18px] tracking-[-0.02em] text-muted-foreground">
                             {scheduleAtLabel(job)}
                           </div>
 
@@ -460,16 +502,16 @@ export function AutomationsPane({
                               disabled={isBusy}
                               onClick={() => void handleToggleEnabled(job)}
                               aria-label={job.enabled ? "Disable schedule" : "Enable schedule"}
-                              className={`relative inline-flex h-7 w-12 items-center rounded-full border transition-colors ${
+                              className={`relative inline-flex h-[34px] w-[52px] items-center rounded-full border transition-colors ${
                                 job.enabled
-                                  ? "border-[rgba(247,90,84,0.95)] bg-[rgba(247,90,84,0.9)]"
-                                  : "border-border/60 bg-muted/70"
+                                  ? "border-primary/40 bg-primary/85"
+                                  : "border-border/60 bg-muted/75"
                               } disabled:cursor-not-allowed disabled:opacity-45`}
                             >
                               <span
                                 className={`size-5 rounded-full bg-background shadow-sm transition-transform ${
                                   job.enabled
-                                    ? "translate-x-6 ring-1 ring-[rgba(247,90,84,0.6)]"
+                                    ? "translate-x-7"
                                     : "translate-x-1"
                                 }`}
                               />
@@ -481,40 +523,39 @@ export function AutomationsPane({
                             </button>
                           </div>
 
-                          <div>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              disabled={isBusy}
-                              onClick={() => void handleRunNow(job)}
-                              className="h-8 rounded-lg px-3"
-                            >
-                              {isBusy ? (
-                                <Loader2 size={14} className="animate-spin" />
-                              ) : (
-                                <Play size={14} />
-                              )}
-                              Run now
-                            </Button>
-                          </div>
-
                           <div className="flex justify-end">
                             <DropdownMenu>
                               <DropdownMenuTrigger
                                 aria-label={`Actions for ${jobTitle(job)}`}
-                                className="grid size-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                className="grid size-10 place-items-center rounded-2xl border border-border/30 bg-muted/30 text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
                               >
-                                <MoreHorizontal size={16} />
+                                <MoreHorizontal size={20} />
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" sideOffset={6} className="w-40">
+                              <DropdownMenuContent align="end" sideOffset={8} className="w-48 rounded-[20px] p-1.5">
+                                <DropdownMenuItem
+                                  onClick={() => void handleRunNow(job)}
+                                  disabled={isBusy}
+                                  className="min-h-11 rounded-[14px] text-base"
+                                >
+                                  <Play size={16} />
+                                  Run now
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => handleEdit(job)}
+                                  disabled={isBusy}
+                                  className="min-h-11 rounded-[14px] text-base"
+                                >
+                                  <Pencil size={16} />
+                                  Edit
+                                </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onClick={() => void handleDelete(job)}
                                   disabled={isBusy}
                                   variant="destructive"
+                                  className="min-h-11 rounded-[14px] text-base"
                                 >
-                                  <Trash2 size={14} />
-                                  Delete schedule
+                                  <Trash2 size={16} />
+                                  Delete
                                 </DropdownMenuItem>
                               </DropdownMenuContent>
                             </DropdownMenu>
@@ -529,8 +570,8 @@ export function AutomationsPane({
               <EmptyState message="No completed automation runs yet." />
             ) : (
               <div className="flex h-full min-h-0 flex-col">
-                <div className="shrink-0 border-b border-border/35 bg-muted/35 px-4 py-2.5">
-                  <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_120px] items-center gap-4 text-[11px] font-medium uppercase tracking-widest text-muted-foreground/75">
+                <div className="shrink-0 border-b border-border/30 px-4 py-4 sm:px-5">
+                  <div className="grid grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/75">
                     <span>Title</span>
                     <span>Completed at</span>
                     <span>Status</span>
@@ -544,10 +585,10 @@ export function AutomationsPane({
                       type="button"
                       disabled={!onOpenRunSession}
                       onClick={() => onOpenRunSession?.(run.sessionId)}
-                      className="grid w-full grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_120px] items-center gap-4 border-b border-border/25 px-4 py-3 text-left transition-colors hover:bg-accent/45 disabled:cursor-default disabled:hover:bg-transparent"
+                      className="grid w-full grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 border-b border-border/20 px-4 py-4 text-left transition-colors hover:bg-accent/20 disabled:cursor-default disabled:hover:bg-transparent sm:px-5"
                     >
                       <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-foreground">
+                        <div className="truncate text-[18px] font-medium tracking-[-0.02em] text-foreground">
                           {run.title}
                         </div>
                         {run.errorDetail ? (
@@ -557,7 +598,7 @@ export function AutomationsPane({
                         ) : null}
                       </div>
 
-                      <div className="truncate text-sm text-muted-foreground">
+                      <div className="truncate text-[18px] tracking-[-0.02em] text-muted-foreground">
                         {formatAbsoluteTimestamp(run.completedAt)}
                       </div>
 
@@ -577,8 +618,14 @@ export function AutomationsPane({
           </div>
         </div>
       </div>
-    </PaneCard>
+    </>
   );
+
+  if (!showHeader) {
+    return content;
+  }
+
+  return <PaneCard className="shadow-md">{content}</PaneCard>;
 }
 
 function EmptyState({ message }: { message: string }) {

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -194,7 +194,6 @@ interface ChatComposerSlashCommandOption {
 interface ChatComposerQuotedSkillItem {
   skillId: string;
   title: string;
-  enabled: boolean;
 }
 
 interface StreamTelemetryEntry {
@@ -229,7 +228,7 @@ const COMPOSER_FULL_THINKING_CONTROL_WIDTH_PX = 88;
 const COMPOSER_FULL_PROVIDER_SETUP_WIDTH_PX = 320;
 const COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX = 168;
 const COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX = 56;
-const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 56;
+const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 124;
 const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
 const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
@@ -499,7 +498,6 @@ function buildComposerSlashCommandOptions(
   skills: WorkspaceSkillRecordPayload[],
 ): ChatComposerSlashCommandOption[] {
   return skills
-    .filter((skill) => skill.enabled)
     .map((skill) => ({
       key: `skill:${skill.skill_id}`,
       kind: "skill" as const,
@@ -3105,34 +3103,66 @@ export function ChatPane({
   useEffect(() => {
     if (!selectedWorkspaceId) {
       setAvailableWorkspaceSkills([]);
+      setQuotedSkillIds([]);
       return;
     }
 
     let cancelled = false;
-    void window.electronAPI.workspace
-      .listSkills(selectedWorkspaceId)
-      .then((result) => {
+    let requestInFlight = false;
+
+    const loadAvailableWorkspaceSkills = async () => {
+      if (requestInFlight) {
+        return;
+      }
+      requestInFlight = true;
+      try {
+        const result = await window.electronAPI.workspace.listSkills(
+          selectedWorkspaceId,
+        );
         if (cancelled) {
           return;
         }
         setAvailableWorkspaceSkills(result.skills);
         setQuotedSkillIds((current) =>
           current.filter((skillId) =>
-            result.skills.some(
-              (skill) => skill.enabled && skill.skill_id === skillId,
-            ),
+            result.skills.some((skill) => skill.skill_id === skillId),
           ),
         );
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) {
           setAvailableWorkspaceSkills([]);
           setQuotedSkillIds([]);
         }
-      });
+      } finally {
+        requestInFlight = false;
+      }
+    };
+
+    const refreshVisibleWorkspaceSkills = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      void loadAvailableWorkspaceSkills();
+    };
+
+    void loadAvailableWorkspaceSkills();
+    const intervalId = window.setInterval(() => {
+      refreshVisibleWorkspaceSkills();
+    }, 1200);
+    window.addEventListener("focus", refreshVisibleWorkspaceSkills);
+    document.addEventListener(
+      "visibilitychange",
+      refreshVisibleWorkspaceSkills,
+    );
 
     return () => {
       cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshVisibleWorkspaceSkills);
+      document.removeEventListener(
+        "visibilitychange",
+        refreshVisibleWorkspaceSkills,
+      );
     };
   }, [selectedWorkspaceId]);
 
@@ -4558,7 +4588,6 @@ export function ChatPane({
         return {
           skillId,
           title: skill?.title ?? skillId,
-          enabled: skill?.enabled ?? false,
         };
       }),
     [availableWorkspaceSkillMap, quotedSkillIds],
@@ -7102,9 +7131,11 @@ function Composer({
   >("menu");
   const [skillPickerQuery, setSkillPickerQuery] = useState("");
   const [caretIndex, setCaretIndex] = useState(0);
+  const [dismissedSlashCommandKey, setDismissedSlashCommandKey] = useState("");
   const [highlightedSlashIndex, setHighlightedSlashIndex] = useState(0);
   const composerFooterRef = useRef<HTMLDivElement | null>(null);
   const composerActionsRef = useRef<HTMLDivElement | null>(null);
+  const slashCommandMenuRef = useRef<HTMLDivElement | null>(null);
   const [composerFooterLayout, setComposerFooterLayout] = useState({
     width: 0,
     actionsWidth: 0,
@@ -7119,7 +7150,13 @@ function Composer({
     () => findActiveSlashCommandRange(input, caretIndex),
     [caretIndex, input],
   );
-  const showSlashCommandMenu = !inputDisabled && activeSlashRange !== null;
+  const activeSlashCommandKey = activeSlashRange
+    ? `${activeSlashRange.start}:${activeSlashRange.end}:${activeSlashRange.query}`
+    : "";
+  const showSlashCommandMenu =
+    !inputDisabled &&
+    activeSlashRange !== null &&
+    activeSlashCommandKey !== dismissedSlashCommandKey;
   const filteredSlashCommands = useMemo(() => {
     if (inputDisabled || !activeSlashRange) {
       return [];
@@ -7233,12 +7270,44 @@ function Composer({
     setHighlightedSlashIndex(0);
   }, [activeSlashRange?.query, filteredSlashCommands.length]);
   useEffect(() => {
+    if (!dismissedSlashCommandKey) {
+      return;
+    }
+    if (!activeSlashCommandKey) {
+      setDismissedSlashCommandKey("");
+      return;
+    }
+    if (dismissedSlashCommandKey !== activeSlashCommandKey) {
+      setDismissedSlashCommandKey("");
+    }
+  }, [activeSlashCommandKey, dismissedSlashCommandKey]);
+  useEffect(() => {
     if (inputDisabled) {
       setComposerActionsMenuOpen(false);
       setComposerActionsView("menu");
       setSkillPickerQuery("");
+      setDismissedSlashCommandKey("");
     }
   }, [inputDisabled]);
+  useEffect(() => {
+    if (!showSlashCommandMenu) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const menu = slashCommandMenuRef.current;
+      const target = event.target;
+      if (!menu || !(target instanceof Node) || menu.contains(target)) {
+        return;
+      }
+      setDismissedSlashCommandKey(activeSlashCommandKey);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [activeSlashCommandKey, showSlashCommandMenu]);
   const visibleFooterControlCount =
     1 + (showThinkingValueSelector ? 1 : 0) + 1;
   const fullPrimaryControlWidth = showModelSelector
@@ -7460,10 +7529,10 @@ function Composer({
     <div className="relative">
       {showSlashCommandMenu ? (
         <div className="pointer-events-none absolute left-3 right-3 top-4 z-20 -translate-y-[calc(100%+2px)]">
-          <div className="pointer-events-auto overflow-hidden rounded-[24px] border border-border/55 bg-popover shadow-2xl ring-1 ring-foreground/5">
-            <div className="border-b border-border/30 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/75">
-              Slash commands
-            </div>
+          <div
+            ref={slashCommandMenuRef}
+            className="pointer-events-auto overflow-hidden rounded-[24px] border border-border/55 bg-popover shadow-2xl ring-1 ring-foreground/5"
+          >
             {filteredSlashCommands.length > 0 ? (
               <div className="max-h-[280px] overflow-y-auto py-1.5">
                 {filteredSlashCommands.map((command, index) => (
@@ -7484,12 +7553,6 @@ function Composer({
                     <span className="min-w-0 flex-1">
                       <span className="block truncate font-medium">
                         {command.label}
-                      </span>
-                      <span className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
-                        <span className="truncate">{command.command}</span>
-                        {command.description ? (
-                          <span className="truncate">{command.description}</span>
-                        ) : null}
                       </span>
                     </span>
                   </button>
@@ -7535,15 +7598,11 @@ function Composer({
               {quotedSkills.map((skill) => (
                 <div
                   key={skill.skillId}
-                  className={`inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] ${
-                    skill.enabled
-                      ? "border-primary/20 bg-primary/8 text-foreground/88"
-                      : "border-destructive/25 bg-destructive/8 text-destructive"
-                  }`}
+                  className="inline-flex max-w-full items-center gap-2 rounded-full border border-primary/20 bg-primary/8 px-3 py-1.5 text-[11px] text-foreground/88"
                 >
                   <Sparkles
                     size={12}
-                    className={skill.enabled ? "text-primary/80" : "text-destructive"}
+                    className="text-primary/80"
                   />
                   <span className="truncate">{skill.title}</span>
                   <button
@@ -7722,11 +7781,11 @@ function Composer({
               >
                 {composerActionsView === "skills" ? (
                   <div className="flex flex-col">
-                    <div className="border-b border-border/30 px-3 py-3">
-                      <div className="relative rounded-lg bg-transparent">
+                    <div className="border-b border-border/40 p-2">
+                      <div className="relative flex items-center rounded-[10px] border border-border/40 bg-muted/35 px-2.5 transition-colors focus-within:border-border/55 focus-within:bg-background/70">
                         <Search
-                          size={14}
-                          className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                          size={13}
+                          className="shrink-0 text-muted-foreground"
                         />
                         <input
                           value={skillPickerQuery}
@@ -7734,7 +7793,7 @@ function Composer({
                             setSkillPickerQuery(event.target.value)
                           }
                           placeholder="Search skills..."
-                          className="h-9 w-full border-0 bg-transparent pl-9 text-xs text-foreground outline-none placeholder:text-muted-foreground"
+                          className="embedded-input h-8 w-full bg-transparent pl-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/60"
                           autoFocus
                         />
                       </div>
@@ -7774,9 +7833,6 @@ function Composer({
                                       Added
                                     </span>
                                   ) : null}
-                                </span>
-                                <span className="mt-1 block truncate text-[11px] text-muted-foreground">
-                                  {command.description || command.command}
                                 </span>
                               </span>
                               {isSelected ? (

--- a/desktop/src/components/panes/ChatPaneReasoningControl.test.mjs
+++ b/desktop/src/components/panes/ChatPaneReasoningControl.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "ChatPane.tsx");
+
+test("chat composer compact reasoning control can expand past icon-only width", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX = 56;/,
+  );
+  assert.match(
+    source,
+    /const COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX = 124;/,
+  );
+  assert.match(
+    source,
+    /const showCompactLabel =\s*!compact \|\|\s*typeof compactWidth !== "number" \|\|\s*compactWidth >= compactLabelMinWidth;/,
+  );
+  assert.match(
+    source,
+    /const compactThinkingControlWidth = showThinkingValueSelector[\s\S]*Math\.min\(\s*COMPOSER_COMPACT_THINKING_CONTROL_MAX_WIDTH_PX,\s*compactFooterControlWidth - compactModelControlWidth,\s*\)/,
+  );
+});

--- a/desktop/src/components/panes/ChatPaneSlashCommands.test.mjs
+++ b/desktop/src/components/panes/ChatPaneSlashCommands.test.mjs
@@ -26,10 +26,19 @@ test("chat pane loads workspace skills into slash commands and quoted skill chip
 
   assert.match(source, /const \[quotedSkillIds, setQuotedSkillIds\] = useState<string\[\]>\(\[\]\);/);
   assert.match(source, /const \[availableWorkspaceSkills, setAvailableWorkspaceSkills\] = useState</);
-  assert.match(source, /window\.electronAPI\.workspace\s*\.listSkills\(selectedWorkspaceId\)/);
+  assert.match(source, /const loadAvailableWorkspaceSkills = async \(\) => \{/);
+  assert.match(source, /window\.electronAPI\.workspace\.listSkills\(\s*selectedWorkspaceId,\s*\)/);
+  assert.match(source, /let requestInFlight = false;/);
+  assert.match(source, /const refreshVisibleWorkspaceSkills = \(\) => \{/);
+  assert.match(source, /if \(document\.visibilityState !== "visible"\) \{\s*return;\s*\}/);
+  assert.match(source, /const intervalId = window\.setInterval\(\(\) => \{\s*refreshVisibleWorkspaceSkills\(\);\s*\}, 1200\);/);
+  assert.match(source, /window\.addEventListener\("focus", refreshVisibleWorkspaceSkills\);/);
+  assert.match(source, /document\.addEventListener\(\s*"visibilitychange",\s*refreshVisibleWorkspaceSkills,\s*\);/);
+  assert.match(source, /window\.clearInterval\(intervalId\);/);
   assert.match(source, /const slashCommandOptions = useMemo\(\s*\(\) => buildComposerSlashCommandOptions\(availableWorkspaceSkills\),/);
   assert.match(source, /quotedSkills=\{quotedSkills\}/);
   assert.match(source, /slashCommands=\{slashCommandOptions\}/);
+  assert.doesNotMatch(source, /enabled: skill\?\.enabled \?\? false/);
 });
 
 test("chat composer renders a slash-triggered skill menu and removes the typed token on selection", async () => {
@@ -37,9 +46,11 @@ test("chat composer renders a slash-triggered skill menu and removes the typed t
 
   assert.match(source, /function findActiveSlashCommandRange\(/);
   assert.match(source, /function removeSlashCommandText\(/);
+  assert.doesNotMatch(source, /\.filter\(\(skill\) => skill\.enabled\)/);
   assert.match(source, /const \[composerActionsMenuOpen, setComposerActionsMenuOpen\] = useState\(false\);/);
   assert.match(source, /const \[composerActionsView, setComposerActionsView\] = useState</);
   assert.match(source, /const \[skillPickerQuery, setSkillPickerQuery\] = useState\(""\);/);
+  assert.match(source, /const \[dismissedSlashCommandKey, setDismissedSlashCommandKey\] = useState\(""\);/);
   assert.match(source, /const filteredSlashCommands = useMemo\(\(\) => \{/);
   assert.match(source, /const filteredSkillCommands = useMemo\(\(\) => \{/);
   assert.match(source, /const applySlashCommand = \(command: ChatComposerSlashCommandOption\) => \{/);
@@ -49,9 +60,20 @@ test("chat composer renders a slash-triggered skill menu and removes the typed t
   assert.match(source, /Attach a file/);
   assert.match(source, /Use Skills/);
   assert.match(source, /Search skills\.\.\./);
+  assert.match(source, /rounded-\[10px\] border border-border\/40 bg-muted\/35 px-2\.5 transition-colors focus-within:border-border\/55 focus-within:bg-background\/70/);
+  assert.match(source, /className="embedded-input h-8 w-full bg-transparent pl-2 text-xs text-foreground outline-none placeholder:text-muted-foreground\/60"/);
   assert.match(source, /onKeyDown=\{handleTextareaKeyDown\}/);
+  assert.match(source, /activeSlashCommandKey !== dismissedSlashCommandKey/);
+  assert.match(source, /document\.addEventListener\("pointerdown", handlePointerDown\);/);
+  assert.match(source, /menu\.contains\(target\)/);
+  assert.match(source, /setDismissedSlashCommandKey\(activeSlashCommandKey\);/);
+  assert.match(source, /ref=\{slashCommandMenuRef\}/);
   assert.match(source, /pointer-events-none absolute left-3 right-3 top-4 z-20 -translate-y-\[calc\(100%\+2px\)\]/);
-  assert.match(source, /Slash commands/);
+  assert.doesNotMatch(source, /<span className="mt-1 block truncate text-\[11px\] text-muted-foreground">\s*\{command\.command\}\s*<\/span>/);
+  assert.doesNotMatch(source, /<span className="mt-0\.5 block truncate text-\[11px\] text-muted-foreground">\s*<span className="truncate">\{command\.command\}<\/span>\s*<\/span>/);
+  assert.doesNotMatch(source, /command\.description \|\| command\.command/);
+  assert.doesNotMatch(source, /command\.description \? \(/);
+  assert.doesNotMatch(source, /Slash commands/);
   assert.match(source, /No slash commands match\./);
   assert.match(source, /No skills match this search\./);
   assert.match(source, /Remove quoted skill/);

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.test.mjs
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.test.mjs
@@ -16,5 +16,5 @@ test("space applications explorer renders the add app action in the header", asy
     /<div className="flex items-center justify-between gap-3 border-b border-border\/45 px-3 py-2\.5">/,
   );
   assert.match(source, /onClick=\{onAddApp\}/);
-  assert.match(source, /Add app/);
+  assert.match(source, /Add apps/);
 });

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
@@ -41,7 +41,7 @@ export function SpaceApplicationsExplorerPane({
           className="h-7 gap-1.5 rounded-md px-2.5 text-[11px]"
         >
           <Plus size={12} />
-          Add app
+          Add apps
         </Button>
       </div>
 

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -102,7 +102,7 @@ declare global {
     height: number;
   }
 
-  type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "about";
+  type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
 
   interface BrowserStatePayload {
     id: string;
@@ -979,7 +979,6 @@ declare global {
     skill_file_path: string;
     title: string;
     summary: string;
-    enabled: boolean;
     modified_at: string;
   }
 
@@ -987,8 +986,6 @@ declare global {
     workspace_id: string;
     workspace_root: string;
     skills_path: string;
-    enabled_skill_ids: string[];
-    missing_enabled_skill_ids: string[];
     skills: WorkspaceSkillRecordPayload[];
   }
 

--- a/runtime/api-server/src/evolve-skill-review.ts
+++ b/runtime/api-server/src/evolve-skill-review.ts
@@ -8,7 +8,6 @@ import type {
   RuntimeStateStore,
   TurnResultRecord,
 } from "@holaboss/runtime-state-store";
-import yaml from "js-yaml";
 
 import type { MemoryModelClientConfig } from "./memory-model-client.js";
 import { queryMemoryModelJson } from "./memory-model-client.js";
@@ -209,44 +208,6 @@ async function upsertWorkspaceMemoryFileIfChanged(params: {
 
 function activeCandidate(records: EvolveSkillCandidateRecord[]): EvolveSkillCandidateRecord[] {
   return records.filter((record) => !["dismissed", "discarded"].includes(record.status));
-}
-
-function readWorkspaceYamlDocument(workspaceDir: string): Record<string, unknown> | null {
-  const workspaceYamlPath = path.join(workspaceDir, "workspace.yaml");
-  if (!fs.existsSync(workspaceYamlPath)) {
-    return null;
-  }
-  try {
-    const parsed = yaml.load(fs.readFileSync(workspaceYamlPath, "utf8"));
-    return isRecord(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeWorkspaceYamlDocument(workspaceDir: string, document: Record<string, unknown>): void {
-  const workspaceYamlPath = path.join(workspaceDir, "workspace.yaml");
-  fs.writeFileSync(workspaceYamlPath, yaml.dump(document, { sortKeys: false, noRefs: true }), "utf8");
-}
-
-function ensureWorkspaceSkillEnabled(workspaceDir: string, slug: string): void {
-  const document = readWorkspaceYamlDocument(workspaceDir);
-  if (!document) {
-    return;
-  }
-  const skills = isRecord(document.skills) ? { ...document.skills } : null;
-  if (!skills || !Array.isArray(skills.enabled)) {
-    return;
-  }
-  const enabled = skills.enabled
-    .map((item) => (typeof item === "string" ? item.trim() : ""))
-    .filter(Boolean);
-  if (enabled.includes(slug)) {
-    return;
-  }
-  skills.enabled = [...enabled, slug];
-  document.skills = skills;
-  writeWorkspaceYamlDocument(workspaceDir, document);
 }
 
 function liveWorkspaceSkillExists(workspaceDir: string, slug: string): boolean {
@@ -551,7 +512,6 @@ export async function promoteAcceptedSkillCandidate(params: {
   }
 
   const workspaceDir = params.store.workspaceDir(candidate.workspaceId);
-  ensureWorkspaceSkillEnabled(workspaceDir, candidate.slug);
   if (liveWorkspaceSkillExists(workspaceDir, candidate.slug)) {
     params.store.updateEvolveSkillCandidate({
       candidateId: candidate.candidateId,
@@ -578,7 +538,6 @@ export async function promoteAcceptedSkillCandidate(params: {
   if (existing !== draftMarkdown) {
     fs.writeFileSync(targetFilePath, draftMarkdown, "utf8");
   }
-  ensureWorkspaceSkillEnabled(workspaceDir, candidate.slug);
   if (!liveWorkspaceSkillExists(workspaceDir, candidate.slug)) {
     return { status: "invalid_live_skill", targetSkillPath };
   }

--- a/runtime/api-server/src/evolve.test.ts
+++ b/runtime/api-server/src/evolve.test.ts
@@ -414,11 +414,6 @@ test("processClaimedInput promotes accepted evolve skill candidates into live wo
   const { store, memoryService } = makeRuntimeState("hb-evolve-skill-promotion-");
   seedWorkspace(store);
   const workspaceDir = store.workspaceDir("workspace-1");
-  fs.writeFileSync(
-    path.join(workspaceDir, "workspace.yaml"),
-    ["skills:", "  enabled:", "    - skill-creator", ""].join("\n"),
-    "utf8"
-  );
   store.ensureSession({
     workspaceId: "workspace-1",
     sessionId: "session-review",
@@ -536,7 +531,6 @@ test("processClaimedInput promotes accepted evolve skill candidates into live wo
   assert.equal(fs.readFileSync(liveSkillPath, "utf8"), draftMarkdown);
   assert.equal(store.getEvolveSkillCandidate("evolve-skill-input-10")?.status, "promoted");
   assert.ok(store.getEvolveSkillCandidate("evolve-skill-input-10")?.promotedAt);
-  assert.match(fs.readFileSync(path.join(workspaceDir, "workspace.yaml"), "utf8"), /release-verification/);
   store.close();
 });
 

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -2348,11 +2348,6 @@ test("runTsRunnerCli keeps embedded skills authoritative when a workspace skill 
     "---\nname: holaboss-runtime\ndescription: Workspace override\n---\n# Workspace Override\n",
     "utf8"
   );
-  fs.writeFileSync(
-    path.join(workspaceDir, "workspace.yaml"),
-    ['skills:', '  path: "skills"', '  enabled:', '    - "holaboss-runtime"'].join("\n"),
-    "utf8"
-  );
   const embeddedSkillDir = path.join(embeddedSkillsRoot, "holaboss-runtime");
   fs.mkdirSync(embeddedSkillDir, { recursive: true });
   fs.writeFileSync(
@@ -2438,11 +2433,6 @@ test("runTsRunnerCli resolves workspace skill ids and source directories for the
   const skillDir = path.join(workspaceDir, "skills", "alpha");
   fs.mkdirSync(skillDir, { recursive: true });
   fs.writeFileSync(path.join(skillDir, "SKILL.md"), "---\nname: alpha\ndescription: Alpha skill\n---\n# Alpha\n", "utf8");
-  fs.writeFileSync(
-    path.join(workspaceDir, "workspace.yaml"),
-    ['skills:', '  path: "skills"', '  enabled:', '    - "alpha"'].join("\n"),
-    "utf8"
-  );
 
   let capturedProjectRequest: Record<string, unknown> | null = null;
   let capturedHarnessRequest: Record<string, unknown> | null = null;
@@ -2504,9 +2494,15 @@ test("runTsRunnerCli resolves workspace skill ids and source directories for the
   assert.equal(exitCode, 0);
   assert.ok(capturedProjectRequest);
   assert.equal((capturedProjectRequest as { harness_id: string | null }).harness_id, "pi");
-  assert.deepEqual((capturedProjectRequest as { workspace_skill_ids: string[] }).workspace_skill_ids, ["alpha"]);
+  assert.deepEqual(
+    (capturedProjectRequest as { workspace_skill_ids: string[] }).workspace_skill_ids,
+    ["skill-creator", "skill-installer", "alpha"]
+  );
   assert.ok(capturedHarnessRequest);
-  assert.deepEqual((capturedHarnessRequest as { workspace_skill_dirs: string[] }).workspace_skill_dirs, [fs.realpathSync(skillDir)]);
+  assert.deepEqual(
+    (capturedHarnessRequest as { workspace_skill_dirs: string[] }).workspace_skill_dirs.map((dir) => path.basename(dir)),
+    ["skill-creator", "skill-installer", "alpha"]
+  );
 });
 
 test("runTsRunnerCli skips workspace command staging for harnesses that do not support it", async () => {

--- a/runtime/api-server/src/workspace-skills.test.ts
+++ b/runtime/api-server/src/workspace-skills.test.ts
@@ -79,7 +79,7 @@ test("resolveWorkspaceSkills keeps embedded defaults authoritative when workspac
   assert.equal(resolved[0]?.source_dir, fs.realpathSync(path.join(embeddedRoot, "alpha")));
 });
 
-test("resolveWorkspaceSkills follows explicit enabled ordering across embedded and workspace skills", () => {
+test("resolveWorkspaceSkills includes workspace-local skills without requiring workspace.yaml skill allowlists", () => {
   const embeddedRoot = makeTempDir("hb-embedded-skills-");
   process.env.HOLABOSS_EMBEDDED_SKILLS_DIR = embeddedRoot;
   writeSkill(embeddedRoot, "holaboss-runtime");
@@ -88,18 +88,16 @@ test("resolveWorkspaceSkills follows explicit enabled ordering across embedded a
   const workspaceDir = makeTempDir("hb-workspace-enabled-skills-");
   const workspaceSkillsRoot = path.join(workspaceDir, "skills");
   writeSkill(workspaceSkillsRoot, "alpha");
-  fs.writeFileSync(
-    path.join(workspaceDir, "workspace.yaml"),
-    ['skills:', '  enabled:', '    - "alpha"', '    - "holaboss-runtime"', '    - "missing"'].join("\n"),
-    "utf8"
-  );
+  writeSkill(workspaceSkillsRoot, "gamma");
 
   const resolved = resolveWorkspaceSkills(workspaceDir);
   assert.deepEqual(
     resolved.map((skill) => ({ skill_id: skill.skill_id, origin: skill.origin })),
     [
+      { skill_id: "beta", origin: "embedded" },
+      { skill_id: "holaboss-runtime", origin: "embedded" },
       { skill_id: "alpha", origin: "workspace" },
-      { skill_id: "holaboss-runtime", origin: "embedded" }
+      { skill_id: "gamma", origin: "workspace" }
     ]
   );
 });

--- a/runtime/api-server/src/workspace-skills.ts
+++ b/runtime/api-server/src/workspace-skills.ts
@@ -49,41 +49,6 @@ function embeddedSkillsRoot(): string {
   return path.join(runtimeRootDir(), "harnesses", "src", "embedded-skills");
 }
 
-function readWorkspaceYamlMapping(workspaceDir: string): Record<string, unknown> {
-  const workspaceYamlPath = path.join(path.resolve(workspaceDir), "workspace.yaml");
-  if (!fs.existsSync(workspaceYamlPath)) {
-    return {};
-  }
-  try {
-    const loaded = yaml.load(fs.readFileSync(workspaceYamlPath, "utf8"));
-    return loaded && typeof loaded === "object" && !Array.isArray(loaded) ? (loaded as Record<string, unknown>) : {};
-  } catch {
-    return {};
-  }
-}
-
-function workspaceEnabledSkillIds(payload: Record<string, unknown>): string[] {
-  const skills = payload.skills;
-  if (!skills || typeof skills !== "object" || Array.isArray(skills)) {
-    return [];
-  }
-  const enabled = (skills as Record<string, unknown>).enabled;
-  if (!Array.isArray(enabled)) {
-    return [];
-  }
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  for (const item of enabled) {
-    const skillId = normalizeSkillId(item);
-    if (!skillId || seen.has(skillId)) {
-      continue;
-    }
-    seen.add(skillId);
-    ordered.push(skillId);
-  }
-  return ordered;
-}
-
 function skillFrontmatter(content: string): Record<string, unknown> | null {
   const normalized = content.replace(/^\uFEFF/, "");
   const match = normalized.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
@@ -195,8 +160,6 @@ function resolveWorkspaceLocalSkills(workspaceDirInput: string): ResolvedWorkspa
 }
 
 export function resolveWorkspaceSkills(workspaceDirInput: string): ResolvedWorkspaceSkill[] {
-  const payload = readWorkspaceYamlMapping(workspaceDirInput);
-  const enabledSkillIds = workspaceEnabledSkillIds(payload);
   const embeddedSkills = listSkillsInRoot(embeddedSkillsRoot(), "embedded");
   const workspaceSkills = resolveWorkspaceLocalSkills(workspaceDirInput);
 
@@ -208,21 +171,18 @@ export function resolveWorkspaceSkills(workspaceDirInput: string): ResolvedWorks
     resolvedById.set(skill.skill_id, skill);
   }
 
-  const orderedSkillIds =
-    enabledSkillIds.length > 0
-      ? enabledSkillIds
-      : (() => {
-          const ordered: string[] = [];
-          const seen = new Set<string>();
-          for (const skill of [...embeddedSkills, ...workspaceSkills]) {
-            if (seen.has(skill.skill_id)) {
-              continue;
-            }
-            seen.add(skill.skill_id);
-            ordered.push(skill.skill_id);
-          }
-          return ordered;
-        })();
+  const orderedSkillIds = (() => {
+    const ordered: string[] = [];
+    const seen = new Set<string>();
+    for (const skill of [...embeddedSkills, ...workspaceSkills]) {
+      if (seen.has(skill.skill_id)) {
+        continue;
+      }
+      seen.add(skill.skill_id);
+      ordered.push(skill.skill_id);
+    }
+    return ordered;
+  })();
 
   return orderedSkillIds
     .map((skillId) => {


### PR DESCRIPTION
## Context
This PR rolls up the desktop UX and settings work from the current session into one branch. It focuses on workspace navigation, chat composer polish, app installation flow, and the new settings-hosted automations experience.

## Changes
- tighten the chat composer reasoning control and slash/use-skills menus, including title-only skill rows and outside-click dismissal
- remove `skills.enabled`, auto-discover workspace skills, and keep new skill additions visible without workspace switching
- restore file/app explorer displays correctly, hide workspace-only root entries, and move app installation into a dedicated dialog
- move automations under Settings, add workspace-scoped automation management, and align the top-bar and automations controls with the current desktop UI
- remove redundant marketplace/space top-bar navigation and add focused regression coverage for the updated flows

## Validation
- `node --test desktop/src/components/layout/SettingsDialog.test.mjs desktop/src/components/panes/AutomationsPane.test.mjs desktop/src/components/billing/CreditsPill.test.mjs desktop/src/components/layout/TopTabsBar.test.mjs`
- `npm run typecheck` in `desktop`

## Linked Issues
- none

## Screenshots
- UI changes were iterated directly in-app during this session; no static screenshots attached to the PR body
