### PR TITLE
fix: harden desktop runtime recovery, file imports, and live chat trace status

### DIFF
--- a/desktop/electron/auth-protocol-registration.test.mjs
+++ b/desktop/electron/auth-protocol-registration.test.mjs
@@ -33,6 +33,9 @@ test("desktop auth callback recovery reuses the dev server and user-data path fo
     source,
     /const explicit =\s*process\.env\.HOLABOSS_DESKTOP_USER_DATA_PATH\?\.trim\(\)\s*\|\|\s*recoveredDevLaunchContext\?\.userDataPath\?\.trim\(\)\s*\|\|\s*"";/,
   );
-  assert.match(source, /configureStableUserDataPath\(\);\s*persistDevLaunchContext\(\);/);
+  assert.match(
+    source,
+    /configureStableUserDataPath\(\);\s*resolvedRuntimeApiPort = resolveRuntimeApiPort\(\);\s*persistDevLaunchContext\(\);/,
+  );
   assert.match(source, /if \(isDev\) \{\s*void win\.loadURL\(RESOLVED_DEV_SERVER_URL\);\s*\}/);
 });

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -90,6 +90,7 @@ import { ensureWorkspaceGitRepo } from "./workspace-git.js";
 
 const APP_DISPLAY_NAME = "Holaboss";
 const AUTH_CALLBACK_PROTOCOL = "ai.holaboss.app";
+const DESKTOP_LAUNCH_ID = randomUUID();
 const verboseTelemetryEnabled =
   process.env.HOLABOSS_VERBOSE_TELEMETRY?.trim() === "1";
 const chromiumStderrLoggingEnabled =
@@ -4929,6 +4930,23 @@ function migrateRuntimeInstallationStateTable(database: Database.Database) {
   `);
 }
 
+function migrateRuntimeProcessStateTable(database: Database.Database) {
+  const tableInfo = database
+    .prepare("PRAGMA table_info(runtime_process_state)")
+    .all() as Array<{ name: string }>;
+  if (!tableInfo.length) {
+    return;
+  }
+
+  const columns = new Set(tableInfo.map((column) => column.name));
+  if (!columns.has("launch_id")) {
+    database.exec("ALTER TABLE runtime_process_state ADD COLUMN launch_id TEXT;");
+  }
+  if (!columns.has("sandbox_root")) {
+    database.exec("ALTER TABLE runtime_process_state ADD COLUMN sandbox_root TEXT;");
+  }
+}
+
 async function bootstrapRuntimeDatabase() {
   await fs.mkdir(path.dirname(runtimeDatabasePath()), { recursive: true });
 
@@ -4936,6 +4954,7 @@ async function bootstrapRuntimeDatabase() {
   try {
     migrateLocalWorkspacesTable(database);
     migrateRuntimeInstallationStateTable(database);
+    migrateRuntimeProcessStateTable(database);
     database.exec(`
       CREATE TABLE IF NOT EXISTS runtime_installation_state (
         installation_key TEXT PRIMARY KEY,
@@ -5074,6 +5093,8 @@ async function bootstrapRuntimeDatabase() {
         bind_host TEXT,
         bind_port INTEGER,
         base_url TEXT,
+        launch_id TEXT,
+        sandbox_root TEXT,
         last_started_at TEXT,
         last_stopped_at TEXT,
         last_healthy_at TEXT,
@@ -5170,6 +5191,8 @@ function persistRuntimeProcessState(update: {
           bind_host,
           bind_port,
           base_url,
+          launch_id,
+          sandbox_root,
           last_started_at,
           last_stopped_at,
           last_healthy_at,
@@ -5182,6 +5205,8 @@ function persistRuntimeProcessState(update: {
           @bind_host,
           @bind_port,
           @base_url,
+          @launch_id,
+          @sandbox_root,
           @last_started_at,
           @last_stopped_at,
           @last_healthy_at,
@@ -5194,6 +5219,8 @@ function persistRuntimeProcessState(update: {
           bind_host = excluded.bind_host,
           bind_port = excluded.bind_port,
           base_url = excluded.base_url,
+          launch_id = excluded.launch_id,
+          sandbox_root = excluded.sandbox_root,
           last_started_at = COALESCE(excluded.last_started_at, runtime_process_state.last_started_at),
           last_stopped_at = COALESCE(excluded.last_stopped_at, runtime_process_state.last_stopped_at),
           last_healthy_at = COALESCE(excluded.last_healthy_at, runtime_process_state.last_healthy_at),
@@ -5208,12 +5235,93 @@ function persistRuntimeProcessState(update: {
         bind_host: "127.0.0.1",
         bind_port: runtimeApiPort(),
         base_url: runtimeBaseUrl(),
+        launch_id: DESKTOP_LAUNCH_ID,
+        sandbox_root: runtimeSandboxRoot(),
         last_started_at: update.lastStartedAt ?? null,
         last_stopped_at: update.lastStoppedAt ?? null,
         last_healthy_at: update.lastHealthyAt ?? null,
         last_error: update.lastError ?? null,
         updated_at: utcNowIso(),
       });
+  } finally {
+    database.close();
+  }
+}
+
+type PersistedRuntimeProcessStateRecord = {
+  pid: number | null;
+  status: string;
+  bindHost: string | null;
+  bindPort: number | null;
+  baseUrl: string | null;
+  launchId: string | null;
+  sandboxRoot: string | null;
+  lastStartedAt: string | null;
+  lastStoppedAt: string | null;
+  lastHealthyAt: string | null;
+  lastError: string | null;
+  updatedAt: string;
+};
+
+function readPersistedRuntimeProcessState(): PersistedRuntimeProcessStateRecord | null {
+  const database = openRuntimeDatabase();
+  try {
+    const row = database
+      .prepare(
+        `
+        SELECT
+          pid,
+          status,
+          bind_host,
+          bind_port,
+          base_url,
+          launch_id,
+          sandbox_root,
+          last_started_at,
+          last_stopped_at,
+          last_healthy_at,
+          last_error,
+          updated_at
+        FROM runtime_process_state
+        WHERE process_key = ?
+        LIMIT 1
+      `,
+      )
+      .get("embedded-runtime") as
+      | {
+          pid: number | null;
+          status: string;
+          bind_host: string | null;
+          bind_port: number | null;
+          base_url: string | null;
+          launch_id: string | null;
+          sandbox_root: string | null;
+          last_started_at: string | null;
+          last_stopped_at: string | null;
+          last_healthy_at: string | null;
+          last_error: string | null;
+          updated_at: string;
+        }
+      | undefined;
+    if (!row) {
+      return null;
+    }
+    return {
+      pid: typeof row.pid === "number" ? row.pid : null,
+      status: row.status,
+      bindHost: row.bind_host,
+      bindPort: typeof row.bind_port === "number" ? row.bind_port : null,
+      baseUrl: row.base_url,
+      launchId: row.launch_id,
+      sandboxRoot: row.sandbox_root,
+      lastStartedAt: row.last_started_at,
+      lastStoppedAt: row.last_stopped_at,
+      lastHealthyAt: row.last_healthy_at,
+      lastError: row.last_error,
+      updatedAt: row.updated_at,
+    };
+  } catch {
+    return null;
   } finally {
     database.close();
   }
@@ -13653,6 +13761,199 @@ async function isRuntimeHealthy(url: string) {
   });
 }
 
+function persistedRuntimeMatchesCurrentLaunch(
+  record: PersistedRuntimeProcessStateRecord | null,
+  sandboxRoot: string,
+) {
+  return (
+    record?.launchId === DESKTOP_LAUNCH_ID &&
+    record?.sandboxRoot === sandboxRoot
+  );
+}
+
+function processExists(pid: number) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | undefined)?.code !== "ESRCH";
+  }
+}
+
+async function killRuntimeProcessByPid(pid: number) {
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) {
+    return false;
+  }
+
+  if (process.platform === "win32") {
+    await killWindowsProcessTree(pid);
+    return !processExists(pid);
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return !processExists(pid);
+  }
+
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    if (!processExists(pid)) {
+      return true;
+    }
+    await sleep(100);
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    return !processExists(pid);
+  }
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (!processExists(pid)) {
+      return true;
+    }
+    await sleep(100);
+  }
+
+  return !processExists(pid);
+}
+
+function windowsPowerShellPath() {
+  const systemRoot = (process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows").trim();
+  if (!systemRoot) {
+    return "powershell.exe";
+  }
+  return path.win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+function killRuntimePortListener(port: number) {
+  if (!Number.isInteger(port) || port <= 0) {
+    return;
+  }
+
+  try {
+    if (process.platform === "win32") {
+      execFileSync(
+        windowsPowerShellPath(),
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          [
+            `$port = ${port};`,
+            "Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue |",
+            "  Where-Object { $_.State -eq 'Listen' } |",
+            "  Select-Object -ExpandProperty OwningProcess -Unique |",
+            "  ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }",
+          ].join(" "),
+        ],
+        {
+          stdio: "ignore",
+          windowsHide: true,
+        },
+      );
+      return;
+    }
+
+    // Restrict to LISTEN state so health-check sockets do not kill the caller.
+    execFileSync(
+      "/bin/bash",
+      [
+        "-lc",
+        `command -v lsof >/dev/null 2>&1 && kill $(lsof -nP -iTCP:${port} -sTCP:LISTEN -t 2>/dev/null) 2>/dev/null || true`,
+      ],
+      {
+        stdio: "ignore",
+      },
+    );
+  } catch {
+    // Ignore best-effort stale-port cleanup failures.
+  }
+}
+
+async function waitForRuntimeShutdown(
+  url: string,
+  attempts = 20,
+  delayMs = 150,
+) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (!(await isRuntimeHealthy(url))) {
+      return true;
+    }
+    await sleep(delayMs);
+  }
+  return !(await isRuntimeHealthy(url));
+}
+
+async function terminateDetachedRuntime(params: {
+  reason: string;
+  url: string;
+  sandboxRoot: string;
+}) {
+  const persisted = readPersistedRuntimeProcessState();
+  const pid = persisted?.pid ?? null;
+  if (pid !== null) {
+    await killRuntimeProcessByPid(pid);
+  }
+  let stopped = await waitForRuntimeShutdown(params.url, 10, 150);
+  if (!stopped) {
+    killRuntimePortListener(runtimeApiPort());
+    stopped = await waitForRuntimeShutdown(params.url, 20, 150);
+  }
+
+  appendRuntimeEventLog({
+    category: "runtime",
+    event: "embedded_runtime.detached_cleanup",
+    outcome: stopped ? "success" : "error",
+    detail: `reason=${params.reason} launch_id=${persisted?.launchId ?? "unknown"} pid=${pid ?? "null"} sandbox_root=${persisted?.sandboxRoot ?? params.sandboxRoot}`,
+  });
+
+  if (stopped) {
+    persistRuntimeProcessState({
+      pid: null,
+      status: "stopped",
+      lastStoppedAt: utcNowIso(),
+      lastError: "",
+    });
+  }
+
+  return {
+    stopped,
+    persisted,
+  };
+}
+
+async function ensureRuntimePortAvailable(params: {
+  url: string;
+  sandboxRoot: string;
+  reason: string;
+}) {
+  if (!(await isRuntimeHealthy(params.url))) {
+    return "available" as const;
+  }
+
+  const persisted = readPersistedRuntimeProcessState();
+  if (persistedRuntimeMatchesCurrentLaunch(persisted, params.sandboxRoot)) {
+    return "reused" as const;
+  }
+
+  const { stopped } = await terminateDetachedRuntime(params);
+  return stopped ? ("available" as const) : ("blocked" as const);
+}
+
 function runtimeUnavailableStatus(hasBundle: boolean): RuntimeStatus {
   if (runtimeStartupInFlight && hasBundle) {
     return "starting";
@@ -13677,6 +13978,13 @@ async function refreshRuntimeStatus() {
     ? await resolveRuntimeExecutablePath(runtimeRoot)
     : null;
   const sandboxRoot = runtimeSandboxRoot();
+  const persisted = readPersistedRuntimeProcessState();
+  const persistedPid = persistedRuntimeMatchesCurrentLaunch(
+    persisted,
+    sandboxRoot,
+  )
+    ? persisted?.pid ?? null
+    : null;
   const harness = process.env.HOLABOSS_RUNTIME_HARNESS || "pi";
   const workflowBackend =
     process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND || "remote_api";
@@ -13686,7 +13994,7 @@ async function refreshRuntimeStatus() {
 
   if (healthy) {
     persistRuntimeProcessState({
-      pid: runtimeProcess?.pid ?? null,
+      pid: runtimeProcess?.pid ?? persistedPid,
       status: "running",
       lastHealthyAt: utcNowIso(),
       lastError: "",
@@ -13698,7 +14006,7 @@ async function refreshRuntimeStatus() {
       sandboxRoot,
       executablePath,
       url,
-      pid: runtimeProcess?.pid ?? null,
+      pid: runtimeProcess?.pid ?? persistedPid,
       harness,
       lastError: "",
     });
@@ -13732,6 +14040,34 @@ async function stopEmbeddedRuntime() {
     const running = runtimeProcess;
     runtimeProcess = null;
     if (!running) {
+      const url = runtimeBaseUrl();
+      if (await isRuntimeHealthy(url)) {
+        const { stopped } = await terminateDetachedRuntime({
+          reason: "quit_without_child_handle",
+          url,
+          sandboxRoot: runtimeSandboxRoot(),
+        });
+        const nextStatus = stopped ? "stopped" : "error";
+        const nextError = stopped
+          ? ""
+          : "Runtime is still responding after detached cleanup.";
+        runtimeStatus = withDesktopBrowserStatus({
+          ...runtimeStatus,
+          status: nextStatus,
+          pid: null,
+          lastError: nextError,
+        });
+        if (!stopped) {
+          persistRuntimeProcessState({
+            pid: null,
+            status: "error",
+            lastStoppedAt: utcNowIso(),
+            lastError: nextError,
+          });
+        }
+        emitRuntimeState();
+        return;
+      }
       if (
         runtimeStatus.status === "running" ||
         runtimeStatus.status === "starting"
@@ -13848,12 +14184,39 @@ async function startEmbeddedRuntime() {
         process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND || "remote_api";
       const url = runtimeBaseUrl();
 
-      // A previous Electron process can leave the embedded runtime alive across
-      // an app restart or upgrade. Reuse that healthy process without emitting a
-      // synthetic "starting" state that would bounce the renderer back into
-      // workspace activation.
-      if (await isRuntimeHealthy(url)) {
+      await fs.mkdir(sandboxRoot, { recursive: true });
+      await bootstrapRuntimeDatabase();
+
+      const preflightRuntimePort = await ensureRuntimePortAvailable({
+        url,
+        sandboxRoot,
+        reason: "startup_preflight",
+      });
+      if (preflightRuntimePort === "reused") {
         return refreshRuntimeStatus();
+      }
+      if (preflightRuntimePort === "blocked") {
+        const portCleanupError =
+          "A stale runtime is still bound to the profile runtime port. Quit the other desktop instance or kill the orphaned runtime process.";
+        runtimeStatus = withDesktopBrowserStatus({
+          ...runtimeStatus,
+          status: "error",
+          available: Boolean(runtimeRoot && executablePath),
+          runtimeRoot,
+          sandboxRoot,
+          executablePath,
+          url,
+          pid: null,
+          harness,
+          lastError: portCleanupError,
+        });
+        persistRuntimeProcessState({
+          pid: null,
+          status: "error",
+          lastError: portCleanupError,
+        });
+        emitRuntimeState();
+        return runtimeStatus;
       }
 
       runtimeStatus = withDesktopBrowserStatus({
@@ -13907,11 +14270,36 @@ async function startEmbeddedRuntime() {
         return runtimeStatus;
       }
 
-      await fs.mkdir(sandboxRoot, { recursive: true });
-      await bootstrapRuntimeDatabase();
-
-      if (await isRuntimeHealthy(url)) {
+      const launchRuntimePort = await ensureRuntimePortAvailable({
+        url,
+        sandboxRoot,
+        reason: "startup_before_spawn",
+      });
+      if (launchRuntimePort === "reused") {
         return refreshRuntimeStatus();
+      }
+      if (launchRuntimePort === "blocked") {
+        const launchBlockedError =
+          "A stale runtime reclaimed the profile runtime port before startup completed.";
+        runtimeStatus = withDesktopBrowserStatus({
+          ...runtimeStatus,
+          status: "error",
+          pid: null,
+          lastError: launchBlockedError,
+        });
+        persistRuntimeProcessState({
+          pid: null,
+          status: "error",
+          lastError: launchBlockedError,
+        });
+        appendRuntimeEventLog({
+          category: "runtime",
+          event: "embedded_runtime.launch_blocked",
+          outcome: "error",
+          detail: launchBlockedError,
+        });
+        emitRuntimeState();
+        return runtimeStatus;
       }
 
       const launchSpec = await resolveRuntimeLaunchSpec(

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -800,7 +800,50 @@ let appUpdateStatus: AppUpdateStatusPayload = {
 };
 
 // Port 5060 is SIP — blocked by Node.js fetch (undici "bad port").
-const RUNTIME_API_PORT = 5160;
+const RUNTIME_API_PORT_FALLBACK = 5160;
+const RUNTIME_API_PORT_RANGE_START = 39160;
+const RUNTIME_API_PORT_RANGE_SIZE = 2000;
+let resolvedRuntimeApiPort = RUNTIME_API_PORT_FALLBACK;
+
+function parseRuntimeApiPort(value: string): number | null {
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1024 || parsed > 65535) {
+    return null;
+  }
+  if (parsed === 5060) {
+    return null;
+  }
+  return parsed;
+}
+
+function runtimeApiPortForUserDataPath(userDataPath: string): number {
+  const hash = Number.parseInt(
+    createHash("sha256")
+      .update(path.resolve(userDataPath), "utf8")
+      .digest("hex")
+      .slice(0, 8),
+    16,
+  );
+  return RUNTIME_API_PORT_RANGE_START + (hash % RUNTIME_API_PORT_RANGE_SIZE);
+}
+
+function resolveRuntimeApiPort(): number {
+  const explicit = parseRuntimeApiPort(
+    process.env.HOLABOSS_RUNTIME_API_PORT?.trim() || "",
+  );
+  if (explicit !== null) {
+    return explicit;
+  }
+  return runtimeApiPortForUserDataPath(app.getPath("userData"));
+}
+
+function runtimeApiPort(): number {
+  return resolvedRuntimeApiPort;
+}
+
 function runtimePlatformFromProcessPlatform(
   platform: NodeJS.Platform = process.platform,
 ): "macos" | "linux" | "windows" {
@@ -1644,6 +1687,7 @@ function emitOpenSettingsPane(section: UiSettingsPaneSection = "settings") {
 }
 
 configureStableUserDataPath();
+resolvedRuntimeApiPort = resolveRuntimeApiPort();
 persistDevLaunchContext();
 appUpdatePreferences = loadAppUpdatePreferences();
 runtimeModelCatalogState = loadRuntimeModelCatalogCache();
@@ -5156,14 +5200,14 @@ function persistRuntimeProcessState(update: {
           last_error = excluded.last_error,
           updated_at = excluded.updated_at
       `,
-      )
+        )
       .run({
         process_key: "embedded-runtime",
         pid: update.pid ?? null,
         status: update.status,
         bind_host: "127.0.0.1",
-        bind_port: RUNTIME_API_PORT,
-        base_url: `http://127.0.0.1:${RUNTIME_API_PORT}`,
+        bind_port: runtimeApiPort(),
+        base_url: runtimeBaseUrl(),
         last_started_at: update.lastStartedAt ?? null,
         last_stopped_at: update.lastStoppedAt ?? null,
         last_healthy_at: update.lastHealthyAt ?? null,
@@ -11069,7 +11113,7 @@ async function pickTemplateFolder(): Promise<TemplateFolderSelectionPayload> {
 }
 
 function runtimeBaseUrl() {
-  return `http://127.0.0.1:${RUNTIME_API_PORT}`;
+  return `http://127.0.0.1:${runtimeApiPort()}`;
 }
 
 async function ensureRuntimeReady() {
@@ -13636,7 +13680,7 @@ async function refreshRuntimeStatus() {
   const harness = process.env.HOLABOSS_RUNTIME_HARNESS || "pi";
   const workflowBackend =
     process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND || "remote_api";
-  const url = `http://127.0.0.1:${RUNTIME_API_PORT}`;
+  const url = runtimeBaseUrl();
   const healthy = await isRuntimeHealthy(url);
   const hasBundle = Boolean(runtimeRoot && executablePath);
 
@@ -13802,7 +13846,7 @@ async function startEmbeddedRuntime() {
       const harness = process.env.HOLABOSS_RUNTIME_HARNESS || "pi";
       const workflowBackend =
         process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND || "remote_api";
-      const url = `http://127.0.0.1:${RUNTIME_API_PORT}`;
+      const url = runtimeBaseUrl();
 
       // A previous Electron process can leave the embedded runtime alive across
       // an app restart or upgrade. Reuse that healthy process without emitting a
@@ -13904,7 +13948,7 @@ async function startEmbeddedRuntime() {
           ...process.env,
           HB_SANDBOX_ROOT: sandboxRoot,
           SANDBOX_AGENT_BIND_HOST: "127.0.0.1",
-          SANDBOX_AGENT_BIND_PORT: String(RUNTIME_API_PORT),
+          SANDBOX_AGENT_BIND_PORT: String(runtimeApiPort()),
           HOLABOSS_EMBEDDED_RUNTIME: "1",
           SANDBOX_AGENT_HARNESS: harness,
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
@@ -19992,7 +20036,7 @@ app.whenReady().then(async () => {
   runtimeStatus = withDesktopBrowserStatus({
     ...runtimeStatus,
     status: "starting",
-    url: `http://127.0.0.1:${RUNTIME_API_PORT}`,
+    url: runtimeBaseUrl(),
     sandboxRoot: runtimeSandboxRoot(),
     harness: process.env.HOLABOSS_RUNTIME_HARNESS || "pi",
     lastError: "",

--- a/desktop/electron/runtime-healthy-reuse.test.mjs
+++ b/desktop/electron/runtime-healthy-reuse.test.mjs
@@ -4,11 +4,11 @@ import { readFile } from "node:fs/promises";
 
 const MAIN_PATH = new URL("./main.ts", import.meta.url);
 
-test("startEmbeddedRuntime reuses an already-healthy runtime before emitting starting", async () => {
+test("startEmbeddedRuntime only reuses a healthy runtime when it matches the current launch", async () => {
   const source = await readFile(MAIN_PATH, "utf8");
 
   assert.match(
     source,
-    /async function startEmbeddedRuntime\(\) \{[\s\S]*const url = runtimeBaseUrl\(\);[\s\S]*if \(await isRuntimeHealthy\(url\)\) \{\s*return refreshRuntimeStatus\(\);\s*\}[\s\S]*runtimeStatus = withDesktopBrowserStatus\(\{\s*\.\.\.runtimeStatus,\s*status: runtimeRoot && executablePath \? "starting" : "missing",/,
+    /async function startEmbeddedRuntime\(\) \{[\s\S]*await bootstrapRuntimeDatabase\(\);[\s\S]*const preflightRuntimePort = await ensureRuntimePortAvailable\(\{\s*url,\s*sandboxRoot,\s*reason: "startup_preflight",\s*\}\);[\s\S]*if \(preflightRuntimePort === "reused"\) \{\s*return refreshRuntimeStatus\(\);\s*\}[\s\S]*if \(preflightRuntimePort === "blocked"\) \{[\s\S]*runtimeStatus = withDesktopBrowserStatus\(\{/,
   );
 });

--- a/desktop/electron/runtime-healthy-reuse.test.mjs
+++ b/desktop/electron/runtime-healthy-reuse.test.mjs
@@ -9,6 +9,6 @@ test("startEmbeddedRuntime reuses an already-healthy runtime before emitting sta
 
   assert.match(
     source,
-    /async function startEmbeddedRuntime\(\) \{[\s\S]*const url = `http:\/\/127\.0\.0\.1:\$\{RUNTIME_API_PORT\}`;[\s\S]*if \(await isRuntimeHealthy\(url\)\) \{\s*return refreshRuntimeStatus\(\);\s*\}[\s\S]*runtimeStatus = withDesktopBrowserStatus\(\{\s*\.\.\.runtimeStatus,\s*status: runtimeRoot && executablePath \? "starting" : "missing",/,
+    /async function startEmbeddedRuntime\(\) \{[\s\S]*const url = runtimeBaseUrl\(\);[\s\S]*if \(await isRuntimeHealthy\(url\)\) \{\s*return refreshRuntimeStatus\(\);\s*\}[\s\S]*runtimeStatus = withDesktopBrowserStatus\(\{\s*\.\.\.runtimeStatus,\s*status: runtimeRoot && executablePath \? "starting" : "missing",/,
   );
 });

--- a/desktop/electron/runtime-orphan-recovery.test.mjs
+++ b/desktop/electron/runtime-orphan-recovery.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop runtime process state persists launch ownership for orphan recovery", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /const DESKTOP_LAUNCH_ID = randomUUID\(\);/);
+  assert.match(source, /function migrateRuntimeProcessStateTable\(database: Database\.Database\) \{/);
+  assert.match(source, /ALTER TABLE runtime_process_state ADD COLUMN launch_id TEXT;/);
+  assert.match(source, /ALTER TABLE runtime_process_state ADD COLUMN sandbox_root TEXT;/);
+  assert.match(
+    source,
+    /CREATE TABLE IF NOT EXISTS runtime_process_state \([\s\S]*launch_id TEXT,[\s\S]*sandbox_root TEXT,[\s\S]*updated_at TEXT NOT NULL[\s\S]*\);/,
+  );
+  assert.match(source, /launch_id: DESKTOP_LAUNCH_ID,/);
+  assert.match(source, /sandbox_root: runtimeSandboxRoot\(\),/);
+  assert.match(
+    source,
+    /function persistedRuntimeMatchesCurrentLaunch\([\s\S]*record\?\.launchId === DESKTOP_LAUNCH_ID[\s\S]*record\?\.sandboxRoot === sandboxRoot[\s\S]*\)/,
+  );
+});
+
+test("desktop runtime orphan cleanup kills persisted pids and falls back to the runtime port listener", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /async function killRuntimeProcessByPid\(pid: number\)/);
+  assert.match(source, /function killRuntimePortListener\(port: number\)/);
+  assert.match(
+    source,
+    /async function terminateDetachedRuntime\(params: \{[\s\S]*const persisted = readPersistedRuntimeProcessState\(\);[\s\S]*const pid = persisted\?\.pid \?\? null;[\s\S]*if \(pid !== null\) \{[\s\S]*await killRuntimeProcessByPid\(pid\);[\s\S]*\}[\s\S]*killRuntimePortListener\(runtimeApiPort\(\)\);[\s\S]*event: "embedded_runtime.detached_cleanup",/,
+  );
+});

--- a/desktop/electron/runtime-port-isolation.test.mjs
+++ b/desktop/electron/runtime-port-isolation.test.mjs
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop runtime port is derived from the resolved userData path with an explicit override", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /const RUNTIME_API_PORT_FALLBACK = 5160;/);
+  assert.match(source, /const RUNTIME_API_PORT_RANGE_START = 39160;/);
+  assert.match(source, /const RUNTIME_API_PORT_RANGE_SIZE = 2000;/);
+  assert.match(source, /let resolvedRuntimeApiPort = RUNTIME_API_PORT_FALLBACK;/);
+  assert.match(source, /function parseRuntimeApiPort\(value: string\): number \| null \{/);
+  assert.match(source, /if \(parsed === 5060\) \{\s*return null;\s*\}/);
+  assert.match(
+    source,
+    /function runtimeApiPortForUserDataPath\(userDataPath: string\): number \{[\s\S]*createHash\("sha256"\)[\s\S]*update\(path\.resolve\(userDataPath\), "utf8"\)[\s\S]*RUNTIME_API_PORT_RANGE_START \+ \(hash % RUNTIME_API_PORT_RANGE_SIZE\);[\s\S]*\}/,
+  );
+  assert.match(
+    source,
+    /function resolveRuntimeApiPort\(\): number \{[\s\S]*process\.env\.HOLABOSS_RUNTIME_API_PORT\?\.trim\(\) \|\| ""[\s\S]*return runtimeApiPortForUserDataPath\(app\.getPath\("userData"\)\);[\s\S]*\}/,
+  );
+  assert.match(
+    source,
+    /configureStableUserDataPath\(\);\s*resolvedRuntimeApiPort = resolveRuntimeApiPort\(\);\s*persistDevLaunchContext\(\);/,
+  );
+  assert.match(
+    source,
+    /function runtimeBaseUrl\(\) \{\s*return `http:\/\/127\.0\.0\.1:\$\{runtimeApiPort\(\)\}`;\s*\}/,
+  );
+  assert.match(source, /SANDBOX_AGENT_BIND_PORT: String\(runtimeApiPort\(\)\),/);
+});

--- a/desktop/electron/runtime-quit-cleanup.test.mjs
+++ b/desktop/electron/runtime-quit-cleanup.test.mjs
@@ -21,3 +21,12 @@ test("before-quit waits for embedded runtime cleanup before allowing Electron to
     /app\.on\("before-quit", \(event\) => \{[\s\S]*if \(appQuitCleanupFinished\) \{\s*return;\s*\}[\s\S]*event\.preventDefault\(\);[\s\S]*void ensureAppQuitCleanup\(\)\.finally\(\(\) => \{\s*app\.quit\(\);\s*\}\);[\s\S]*\}\);/,
   );
 });
+
+test("stopEmbeddedRuntime tears down a healthy detached runtime when the child handle is missing", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /async function stopEmbeddedRuntime\(\) \{[\s\S]*const running = runtimeProcess;[\s\S]*if \(!running\) \{[\s\S]*const url = runtimeBaseUrl\(\);[\s\S]*if \(await isRuntimeHealthy\(url\)\) \{[\s\S]*await terminateDetachedRuntime\(\{\s*reason: "quit_without_child_handle",\s*url,\s*sandboxRoot: runtimeSandboxRoot\(\),\s*\}\);[\s\S]*runtimeStatus = withDesktopBrowserStatus\(\{/,
+  );
+});

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -198,7 +198,11 @@ test("chat trace summary only surfaces terminal run failures in the summary labe
   );
   assert.match(
     source,
-    /groupHasTerminalError[\s\S]*groupIsLive \|\| runningCount > 0[\s\S]*<Check size=\{13\} className="text-emerald-500" \/>/,
+    /const showLiveSummarySpinner =[\s\S]*\(groupIsLive \|\| runningCount > 0\) && !groupExpanded;/,
+  );
+  assert.match(
+    source,
+    /groupHasTerminalError[\s\S]*showLiveSummarySpinner[\s\S]*groupIsLive \|\| runningCount > 0[\s\S]*<Clock3 size=\{13\} className="mt-0\.5 shrink-0 text-muted-foreground" \/>[\s\S]*<Check size=\{13\} className="mt-0\.5 shrink-0 text-emerald-500" \/>/,
   );
 });
 
@@ -234,7 +238,7 @@ test("chat trace collapsed summary surfaces the current active step", async () =
   );
   assert.match(
     source,
-    /className="flex w-full items-start gap-2 rounded-lg px-2\.5 py-1\.5 -ml-2\.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted\/60"/,
+    /className="flex w-full items-center gap-2 rounded-lg px-2\.5 py-1\.5 -ml-2\.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted\/60"/,
   );
   assert.match(source, /<span className="min-w-0 flex-1 leading-5">/);
 });
@@ -256,9 +260,11 @@ test("chat pane renders live placeholder status as faint text with animated trai
 
   assert.match(source, /aria-live="polite"/);
   assert.match(source, /const normalizedStatus = status\.replace\(\/\\\.\+\$\/, ""\)\.trim\(\);/);
+  assert.match(source, /function LiveStatusLine\(/);
+  assert.match(source, /const normalizedLabel = label\.replace\(\/\\\.\+\$\/, ""\)\.trim\(\);/);
   assert.match(
     source,
-    /className="inline-flex items-baseline gap-0\.5 text-\[12px\] leading-6 text-muted-foreground\/72"/,
+    /className=\{`inline-flex items-baseline gap-0\.5 text-\[12px\] leading-6 text-muted-foreground\/72 \$\{className\}`\.trim\(\)\}/,
   );
   assert.match(source, /function LiveStatusEllipsis\(\)/);
   assert.match(source, /@keyframes status-dot-wave/);
@@ -269,6 +275,23 @@ test("chat pane renders live placeholder status as faint text with animated trai
   assert.doesNotMatch(source, /Queued\.\.\./);
   assert.doesNotMatch(source, /Working\.\.\./);
   assert.doesNotMatch(source, /Checking workspace context\.\.\./);
+});
+
+test("chat pane keeps a persistent working line visible once the live run has streamed content", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const showWorkingStatusLine =\s*live &&\s*\(executionItems\.length > 0 \|\| Boolean\(text\)\);/,
+  );
+  assert.match(
+    source,
+    /showStatusPlaceholder =[\s\S]*live &&[\s\S]*Boolean\(normalizedStatus\) &&[\s\S]*!text &&[\s\S]*executionItems\.length === 0;/,
+  );
+  assert.match(
+    source,
+    /{showWorkingStatusLine \? \(\s*<LiveStatusLine[\s\S]*label="Working"[\s\S]*className=\{executionItems\.length > 0 \? "mt-1" : ""\}/,
+  );
 });
 
 test("chat pane renders an execution timeline that interleaves thinking segments with trace entries", async () => {
@@ -797,6 +820,10 @@ test("live trace auto-expands during the run and collapses when output starts", 
   assert.match(
     source,
     /if \(live && liveOutputStarted && !previousLiveOutputStartedRef\.current\) \{\s*setGroupExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /const showLiveSummarySpinner =[\s\S]*\(groupIsLive \|\| runningCount > 0\) && !groupExpanded;/,
   );
   assert.match(
     source,

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -6220,23 +6220,20 @@ function AssistantTurn({
   live?: boolean;
 }) {
   const normalizedStatus = status.replace(/\.+$/, "").trim();
-  const traceSteps = traceStepsFromExecutionItems(executionItems);
   const showStatusPlaceholder =
+    live &&
     Boolean(normalizedStatus) &&
     !text &&
     executionItems.length === 0;
+  const showWorkingStatusLine =
+    live &&
+    (executionItems.length > 0 || Boolean(text));
 
   return (
     <div className="flex min-w-0 justify-start">
       <article className="min-w-0 flex-1">
         {showStatusPlaceholder ? (
-          <div
-            aria-live="polite"
-            className="inline-flex items-baseline gap-0.5 text-[12px] leading-6 text-muted-foreground/72"
-          >
-            <span>{normalizedStatus}</span>
-            <LiveStatusEllipsis />
-          </div>
+          <LiveStatusLine label={normalizedStatus} />
         ) : null}
 
         {executionItems.length > 0 ? (
@@ -6247,6 +6244,13 @@ function AssistantTurn({
             live={live}
             liveOutputStarted={live && Boolean(text)}
             onLinkClick={onLinkClick}
+          />
+        ) : null}
+
+        {showWorkingStatusLine ? (
+          <LiveStatusLine
+            label="Working"
+            className={executionItems.length > 0 ? "mt-1" : ""}
           />
         ) : null}
 
@@ -6811,6 +6815,29 @@ function LiveStatusEllipsis() {
   );
 }
 
+function LiveStatusLine({
+  label,
+  className = "",
+}: {
+  label: string;
+  className?: string;
+}) {
+  const normalizedLabel = label.replace(/\.+$/, "").trim();
+  if (!normalizedLabel) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-live="polite"
+      className={`inline-flex items-baseline gap-0.5 text-[12px] leading-6 text-muted-foreground/72 ${className}`.trim()}
+    >
+      <span>{normalizedLabel}</span>
+      <LiveStatusEllipsis />
+    </div>
+  );
+}
+
 function summarizeThinking(text: string) {
   const firstContentLine =
     text
@@ -6959,6 +6986,8 @@ function TraceStepGroup({
   const summarySuffix = groupHasTerminalError
     ? ` (${terminalErrorCount} failed)`
     : "";
+  const showLiveSummarySpinner =
+    (groupIsLive || runningCount > 0) && !groupExpanded;
   const summaryLabel = summaryStep
     ? summaryStep === activeStep || summaryStep.status === "waiting"
       ? `${traceStatusLabel(summaryStep.status)}: ${summaryStep.title}`
@@ -6984,17 +7013,19 @@ function TraceStepGroup({
       <button
         type="button"
         onClick={() => setGroupExpanded((v) => !v)}
-        className="flex w-full items-start gap-2 rounded-lg px-2.5 py-1.5 -ml-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60"
+        className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 -ml-2.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60"
       >
         {groupHasTerminalError ? (
-          <AlertTriangle size={13} className="mt-0.5 shrink-0 text-destructive" />
-        ) : groupIsLive || runningCount > 0 ? (
+          <AlertTriangle size={13} className="shrink-0 text-destructive" />
+        ) : showLiveSummarySpinner ? (
           <Loader2
             size={13}
-            className="mt-0.5 shrink-0 animate-spin text-muted-foreground"
+            className="shrink-0 animate-spin text-muted-foreground"
           />
+        ) : groupIsLive || runningCount > 0 ? (
+          <Clock3 size={13} className="shrink-0 text-muted-foreground" />
         ) : (
-          <Check size={13} className="mt-0.5 shrink-0 text-emerald-500" />
+          <Check size={13} className="shrink-0 text-emerald-500" />
         )}
         <span className="min-w-0 flex-1 leading-5">
           {summaryLabel}
@@ -7002,7 +7033,7 @@ function TraceStepGroup({
         </span>
         <ChevronDown
           size={12}
-          className={`mt-0.5 shrink-0 transition-transform ${groupExpanded ? "rotate-180" : ""}`}
+          className={`shrink-0 transition-transform ${groupExpanded ? "rotate-180" : ""}`}
         />
       </button>
 

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -393,6 +393,35 @@ test("file explorer imports dragged external files and folders into the tree", a
   assert.match(source, /onDrop=\{onPaneDrop\}/);
 });
 
+test("file explorer preserves multi-file external drops when entry-backed items are incomplete", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /if \(importedEntries\.length === 0\) \{\s*return dedupeExplorerExternalImportEntries\(fileEntries\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /const hasImportedDirectories = importedEntries\.some\(\s*\(entry\) => entry\.kind === "directory",\s*\);/,
+  );
+  assert.match(
+    source,
+    /if \(hasImportedDirectories\) \{\s*return dedupeExplorerExternalImportEntries\(importedEntries\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /const importedFilePaths = new Set\(\s*importedEntries[\s\S]*\.map\(\(entry\) => entry\.relativePath\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /const hasUnmatchedDroppedFiles = fileEntries\.some\(\s*\(entry\) => !importedFilePaths\.has\(entry\.relativePath\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /return dedupeExplorerExternalImportEntries\(\[\s*\.\.\.importedEntries,\s*\.\.\.fileEntries,\s*\]\);/,
+  );
+});
+
 test("file explorer does not expose a pane-level close action", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -335,10 +335,6 @@ async function collectDroppedExternalEntries(dataTransfer: DataTransfer | null) 
     );
   }
 
-  if (importedEntries.length > 0) {
-    return dedupeExplorerExternalImportEntries(importedEntries);
-  }
-
   const fileEntries = await Promise.all(
     Array.from(dataTransfer.files ?? []).map(async (file) => ({
       kind: "file" as const,
@@ -346,7 +342,38 @@ async function collectDroppedExternalEntries(dataTransfer: DataTransfer | null) 
       content: new Uint8Array(await file.arrayBuffer()),
     })),
   );
-  return dedupeExplorerExternalImportEntries(fileEntries);
+  if (importedEntries.length === 0) {
+    return dedupeExplorerExternalImportEntries(fileEntries);
+  }
+
+  const hasImportedDirectories = importedEntries.some(
+    (entry) => entry.kind === "directory",
+  );
+  if (hasImportedDirectories) {
+    return dedupeExplorerExternalImportEntries(importedEntries);
+  }
+
+  const importedFilePaths = new Set(
+    importedEntries
+      .filter(
+        (
+          entry,
+        ): entry is Extract<ExplorerExternalImportEntry, { kind: "file" }> =>
+          entry.kind === "file",
+      )
+      .map((entry) => entry.relativePath),
+  );
+  const hasUnmatchedDroppedFiles = fileEntries.some(
+    (entry) => !importedFilePaths.has(entry.relativePath),
+  );
+  if (!hasUnmatchedDroppedFiles) {
+    return dedupeExplorerExternalImportEntries(importedEntries);
+  }
+
+  return dedupeExplorerExternalImportEntries([
+    ...importedEntries,
+    ...fileEntries,
+  ]);
 }
 
 function getComparableFileName(targetName: string) {

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -719,6 +719,66 @@ test("claimed input renews its claim lease while the runner is still healthy", a
   store.close();
 });
 
+test("claimed input treats streamed runner events as lease activity", async () => {
+  const store = makeStore("hb-claimed-input-event-lease-renewal-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" }
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 1
+  });
+  const claimedUntilBefore = claimed[0]?.claimedUntil ?? null;
+  let claimedUntilDuringRun: string | null = null;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 1,
+        event_type: "run_started",
+        payload: {}
+      });
+      claimedUntilDuringRun = store.getInput(String(payload.input_id))?.claimedUntil ?? null;
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 2,
+        event_type: "run_completed",
+        payload: { status: "ok" }
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true
+      };
+    }
+  });
+
+  assert.ok(claimedUntilBefore);
+  assert.ok(claimedUntilDuringRun);
+  assert.notEqual(claimedUntilDuringRun, claimedUntilBefore);
+  assert.ok(Date.parse(claimedUntilDuringRun) > Date.parse(claimedUntilBefore));
+
+  store.close();
+});
+
 test("claimed input honors a persisted failure terminal after claim recovery aborts the runner", async () => {
   const store = makeStore("hb-claimed-input-persisted-terminal-");
   const workspace = store.createWorkspace({

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -842,6 +842,7 @@ export async function processClaimedInput(params: {
   let stopReason: string | null = null;
   let tokenUsage: Record<string, unknown> | null = null;
   let activeLeaseUntil = record.claimedUntil ?? claimLeaseUntilIso(leaseSeconds);
+  let lastClaimRenewalAtMs = 0;
   let promptSectionIds: string[] = [];
   let capabilityManifestFingerprint: string | null = null;
   let requestSnapshotFingerprint: string | null = null;
@@ -863,30 +864,45 @@ export async function processClaimedInput(params: {
     workspaceFileManifestBefore = null;
   }
 
+  const EVENT_CLAIM_RENEWAL_MIN_INTERVAL_MS = 250;
+  const renewClaimLease = (source: "heartbeat" | "event") => {
+    const nowMs = Date.now();
+    if (
+      source === "event" &&
+      nowMs - lastClaimRenewalAtMs < EVENT_CLAIM_RENEWAL_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    const renewedClaim = store.renewInputClaim({
+      inputId: record.inputId,
+      claimedBy,
+      leaseSeconds,
+    });
+    if (renewedClaim?.claimedUntil) {
+      activeLeaseUntil = renewedClaim.claimedUntil;
+    }
+    lastClaimRenewalAtMs = nowMs;
+    store.updateRuntimeState({
+      workspaceId: record.workspaceId,
+      sessionId: record.sessionId,
+      status: "BUSY",
+      currentInputId: record.inputId,
+      currentWorkerId: claimedBy,
+      leaseUntil: activeLeaseUntil,
+      lastError: null
+    });
+  };
+
   try {
     const executeRunner = params.executeRunnerRequestFn ?? executeRunnerRequest;
     const execution = await executeRunner(payload, {
       signal: params.abortSignal,
       onHeartbeat: () => {
-        const renewedClaim = store.renewInputClaim({
-          inputId: record.inputId,
-          claimedBy,
-          leaseSeconds,
-        });
-        if (renewedClaim?.claimedUntil) {
-          activeLeaseUntil = renewedClaim.claimedUntil;
-        }
-        store.updateRuntimeState({
-          workspaceId: record.workspaceId,
-          sessionId: record.sessionId,
-          status: "BUSY",
-          currentInputId: record.inputId,
-          currentWorkerId: claimedBy,
-          leaseUntil: activeLeaseUntil,
-          lastError: null
-        });
+        renewClaimLease("heartbeat");
       },
       onEvent: async (event) => {
+        renewClaimLease("event");
         const sequence = typeof event.sequence === "number" ? event.sequence : 0;
         lastSequence = Math.max(lastSequence, sequence);
         const eventPayload = payloadForEvent(event);


### PR DESCRIPTION
## Context

This branch addresses a few related desktop/runtime rough edges that showed up together during local desktop debugging:
- the desktop could reuse or attach to a stale embedded runtime after crashes or detached child loss
- file explorer external drops could miss files in multi-file drag flows
- active runs could fail if claim renewal depended only on heartbeat timing
- the live chat trace looked idle or visually off during long-running turns

## What Changed

- persist launch ownership metadata for the embedded runtime, clean up detached/orphaned runtimes on startup and quit, and block reuse when a stale process still owns the profile port
- derive the embedded runtime port from the resolved profile path, with env override support, so separate profiles do not share a backend accidentally
- merge external drag entries with `FileList` fallback handling so multi-file drops import every selected file while still preserving directory-backed drops
- renew claimed input leases from streamed runner events so active runs do not fail when heartbeat renewals are delayed
- refine live chat trace presentation so expanded traces keep a persistent `Working...` line, collapsed live traces keep the spinner in the summary only, and the summary icon/chevron stay visually centered
- add regression coverage for runtime ownership/recovery, port isolation, quit cleanup, auth callback recovery, file drop handling, event-driven claim renewal, and the updated chat trace presentation

## UI Excerpt

- Expanded live trace: static in-progress icon in the trace header plus a persistent animated `Working...` line under the trace while the run is active.
- Collapsed live trace: spinner remains in the summary only while the run is still active.

## Validation

- `git diff --check`
- `node --test desktop/electron/auth-protocol-registration.test.mjs desktop/electron/runtime-healthy-reuse.test.mjs desktop/electron/runtime-port-isolation.test.mjs`
- `node --test desktop/electron/auth-protocol-registration.test.mjs desktop/electron/runtime-healthy-reuse.test.mjs desktop/electron/runtime-quit-cleanup.test.mjs desktop/electron/runtime-port-isolation.test.mjs desktop/electron/runtime-orphan-recovery.test.mjs`
- `node --test desktop/src/components/panes/FileExplorerPane.test.mjs` (4 pre-existing unrelated failures remain; the new multi-file drop assertion passes)
- `npm --prefix desktop run typecheck`

## Linked Issues

- None provided.

## Supabase / Migrations

- None.

## Env Tweaks

- None.
