### PR TITLE
feat(billing): rich Usage record with session grouping

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -2714,6 +2714,8 @@ interface DesktopBillingTransactionRpcPayload {
   type: string;
   sourceType: string | null;
   reason: string | null;
+  serviceType: string | null;
+  serviceId: string | null;
   amount: number;
   createdAt: string;
 }
@@ -8197,6 +8199,8 @@ async function getDesktopBillingUsage(
         type: transaction.type,
         sourceType: transaction.sourceType,
         reason: transaction.reason,
+        serviceType: transaction.serviceType,
+        serviceId: transaction.serviceId,
         amount,
         absoluteAmount: Math.abs(amount),
         createdAt: transaction.createdAt,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -2716,6 +2716,8 @@ interface DesktopBillingTransactionRpcPayload {
   reason: string | null;
   serviceType: string | null;
   serviceId: string | null;
+  category: string | null;
+  metadata: Record<string, unknown> | null;
   amount: number;
   createdAt: string;
 }
@@ -8201,6 +8203,8 @@ async function getDesktopBillingUsage(
         reason: transaction.reason,
         serviceType: transaction.serviceType,
         serviceId: transaction.serviceId,
+        category: transaction.category,
+        metadata: transaction.metadata,
         amount,
         absoluteAmount: Math.abs(amount),
         createdAt: transaction.createdAt,

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -728,6 +728,8 @@ interface DesktopBillingUsageItemPayload {
   type: string;
   sourceType: string | null;
   reason: string | null;
+  serviceType: string | null;
+  serviceId: string | null;
   amount: number;
   absoluteAmount: number;
   createdAt: string;

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -730,6 +730,8 @@ interface DesktopBillingUsageItemPayload {
   reason: string | null;
   serviceType: string | null;
   serviceId: string | null;
+  category: string | null;
+  metadata: Record<string, unknown> | null;
   amount: number;
   absoluteAmount: number;
   createdAt: string;

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -1,8 +1,22 @@
 import { useMemo, useState } from "react";
-import { AlertCircle, ChevronRight } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowDownLeft,
+  ArrowUpRight,
+  ChevronRight,
+  Gift,
+  ShoppingCart,
+  Sparkles,
+  UserCog,
+  Zap,
+} from "lucide-react";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
 import { Button } from "@/components/ui/button";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
+
+// ============================================================================
+// Helpers
+// ============================================================================
 
 function formatBillingDate(value: string) {
   return new Date(value).toLocaleDateString(undefined, {
@@ -31,40 +45,11 @@ function formatBillingDateTime(value: string) {
   return `${datePart} · ${timePart}`;
 }
 
-// Short time only (no date) for child rows inside a group.
-function formatBillingTime(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return date.toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-}
-
 const CATEGORY_LABELS: Record<string, string> = {
   llm: "Model",
   integration: "Integration",
   proactive: "Background work",
   workspace: "Workspace",
-};
-
-const SERVICE_TYPE_LABELS: Record<string, string> = {
-  workspace: "Workspace chat",
-  "model-proxy": "Model proxy",
-  compose: "Compose",
-  sourcing: "Sourcing",
-  hola_canvas: "Canvas",
-  growth_campaign: "Growth campaign",
-  marketplace: "Marketplace",
-  proactive: "Background work",
-  cronjobs: "Scheduled task",
-  daily_work: "Daily work",
-  campaign: "Campaign",
-  integration: "Integration",
 };
 
 function titleCase(raw: string): string {
@@ -77,10 +62,6 @@ function titleCase(raw: string): string {
 
 function humanizeCategory(raw: string): string {
   return CATEGORY_LABELS[raw] ?? titleCase(raw);
-}
-
-function humanizeServiceType(raw: string): string {
-  return SERVICE_TYPE_LABELS[raw] ?? titleCase(raw);
 }
 
 function readMetadataString(
@@ -112,7 +93,7 @@ function resolveUsageTitle(item: UsageItem): string {
     return humanizeCategory(category);
   }
   if (item.serviceType) {
-    return humanizeServiceType(item.serviceType);
+    return titleCase(item.serviceType);
   }
   if (item.type === "allocate" || item.amount > 0) {
     return "Credits added";
@@ -120,15 +101,34 @@ function resolveUsageTitle(item: UsageItem): string {
   if (
     item.reason &&
     item.reason.trim() &&
-    item.reason !== "Service consumption"
+    item.reason !== "Service consumption" &&
+    !item.reason.startsWith("Service consumption:")
   ) {
     return item.reason;
   }
-  return humanizeServiceType(item.type);
+  return titleCase(item.type);
+}
+
+function resolveUsageSubtitle(item: UsageItem): string | null {
+  const operation = readMetadataString(item.metadata, "operation");
+  const workspaceId = readMetadataString(item.metadata, "workspaceId");
+  const modelId = readMetadataString(item.metadata, "modelId");
+
+  if (operation && operation !== modelId) {
+    return operation;
+  }
+  if (item.category === "llm" && workspaceId) {
+    return `Workspace ${workspaceId.slice(0, 8)}`;
+  }
+  const reason = (item.reason ?? "").trim();
+  if (!reason || reason.startsWith("Service consumption")) {
+    return null;
+  }
+  return reason;
 }
 
 // ============================================================================
-// Session grouping
+// Session Grouping
 // ============================================================================
 
 interface UsageGroup {
@@ -136,7 +136,6 @@ interface UsageGroup {
   items: UsageItem[];
   totalAmount: number;
   firstCreatedAt: string;
-  lastCreatedAt: string;
 }
 
 function groupBySession(items: UsageItem[]): UsageGroup[] {
@@ -150,15 +149,12 @@ function groupBySession(items: UsageItem[]): UsageGroup[] {
     if (sessionId && sessionId === currentSessionId && currentGroup) {
       currentGroup.items.push(item);
       currentGroup.totalAmount += item.amount;
-      // items arrive createdAt DESC so "last" is actually the earliest
-      currentGroup.lastCreatedAt = item.createdAt;
     } else {
       currentGroup = {
         key: sessionId ?? item.id,
         items: [item],
         totalAmount: item.amount,
         firstCreatedAt: item.createdAt,
-        lastCreatedAt: item.createdAt,
       };
       groups.push(currentGroup);
       currentSessionId = sessionId;
@@ -167,29 +163,25 @@ function groupBySession(items: UsageItem[]): UsageGroup[] {
   return groups;
 }
 
-// Group header title: e.g. "Chat · 3 calls" or model name for single items.
 function resolveGroupTitle(group: UsageGroup): string {
   const first = group.items[0];
   if (group.items.length === 1) {
     return resolveUsageTitle(first);
   }
-  const category = first.category ?? null;
   const modelId = readMetadataString(first.metadata, "modelId");
   const provider = readMetadataString(first.metadata, "provider");
 
   let label: string;
-  if (category === "llm" && modelId) {
+  if (first.category === "llm" && modelId) {
     label = provider ? `${provider} · ${modelId}` : modelId;
-  } else if (category) {
-    label = humanizeCategory(category);
+  } else if (first.category) {
+    label = humanizeCategory(first.category);
   } else {
     label = "Chat";
   }
   return `${label} · ${group.items.length} calls`;
 }
 
-// Group subtitle: show session + workspace context so the user can tell
-// sessions apart even when the model is the same.
 function resolveGroupSubtitle(group: UsageGroup): string | null {
   if (group.items.length <= 1) {
     return null;
@@ -205,42 +197,77 @@ function resolveGroupSubtitle(group: UsageGroup): string | null {
   if (workspaceId) {
     parts.push(`Workspace ${workspaceId.slice(0, 8)}`);
   }
-  return parts.length > 0 ? parts.join(" · ") : null;
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+  return null;
 }
 
 // ============================================================================
-// Components
+// Icons
 // ============================================================================
 
-const GRID_COLS = "grid-cols-[minmax(0,1fr)_200px_120px]";
+function UsageIcon({ item }: { item: UsageItem }) {
+  if (item.type === "consume") {
+    return <Zap size={14} />;
+  }
+  switch (item.sourceType) {
+    case "signup":
+      return <Gift size={14} />;
+    case "purchase":
+      return <ShoppingCart size={14} />;
+    case "admin":
+      return <UserCog size={14} />;
+    default:
+      return <Sparkles size={14} />;
+  }
+}
 
-function UsageRow({
-  item,
-  indent = false,
-  compactTime = false,
-}: {
-  item: UsageItem;
-  indent?: boolean;
-  compactTime?: boolean;
-}) {
+// ============================================================================
+// Row Components (matching web style)
+// ============================================================================
+
+function UsageRow({ item }: { item: UsageItem }) {
+  const isCredit = item.amount > 0;
   const title = resolveUsageTitle(item);
+  const subtitle = resolveUsageSubtitle(item);
+
   return (
-    <div
-      className={`grid ${GRID_COLS} items-center gap-3 border-b border-border/30 py-2 text-sm last:border-b-0 ${indent ? "pl-5" : ""}`}
-    >
-      <div className="min-w-0 leading-tight">
-        <div className="truncate text-foreground text-xs">{title}</div>
+    <div className="flex items-center justify-between gap-3 py-2">
+      <div className="flex min-w-0 items-center gap-2.5">
+        <div
+          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${
+            isCredit
+              ? "bg-green-500/10 text-green-600"
+              : "bg-red-500/10 text-red-600"
+          }`}
+        >
+          <UsageIcon item={item} />
+        </div>
+        <div className="min-w-0 leading-tight">
+          <p className="truncate font-medium text-sm text-foreground">
+            {title}
+          </p>
+          <p className="truncate text-muted-foreground text-xs tabular-nums">
+            {subtitle ? `${subtitle} · ` : ""}
+            {formatBillingDateTime(item.createdAt)}
+          </p>
+        </div>
       </div>
-      <div className="text-muted-foreground text-xs tabular-nums">
-        {compactTime
-          ? formatBillingTime(item.createdAt)
-          : formatBillingDateTime(item.createdAt)}
-      </div>
-      <div
-        className={`text-right text-xs tabular-nums ${item.amount > 0 ? "text-foreground" : "text-muted-foreground"}`}
-      >
-        {item.amount > 0 ? "+" : ""}
-        {item.amount.toLocaleString()}
+      <div className="flex shrink-0 items-center gap-1">
+        {isCredit ? (
+          <ArrowDownLeft size={14} className="text-green-600" />
+        ) : (
+          <ArrowUpRight size={14} className="text-red-600" />
+        )}
+        <span
+          className={`font-semibold text-sm tabular-nums ${
+            isCredit ? "text-green-600" : "text-red-600"
+          }`}
+        >
+          {isCredit ? "+" : "-"}
+          {Math.abs(item.amount).toLocaleString()}
+        </span>
       </div>
     </div>
   );
@@ -255,20 +282,19 @@ function UsageGroupRow({
   expanded: boolean;
   onToggle: () => void;
 }) {
-  const collapsible = group.items.length > 1;
-
-  if (!collapsible) {
+  if (group.items.length <= 1) {
     return <UsageRow item={group.items[0]} />;
   }
 
   const title = resolveGroupTitle(group);
   const subtitle = resolveGroupSubtitle(group);
+  const isCredit = group.totalAmount > 0;
 
   return (
-    <div className="border-b border-border/30 last:border-b-0">
+    <div>
       {/* Group header */}
       <div
-        className={`grid ${GRID_COLS} cursor-pointer items-center gap-3 py-2.5 text-sm transition-colors hover:bg-accent/30`}
+        className="flex cursor-pointer items-center justify-between gap-3 py-2 transition-colors hover:bg-accent/30"
         onClick={onToggle}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -279,37 +305,61 @@ function UsageGroupRow({
         role="button"
         tabIndex={0}
       >
-        <div className="flex min-w-0 items-center gap-1.5 leading-tight">
-          <ChevronRight
-            size={14}
-            className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
-          />
-          <div className="min-w-0">
-            <div className="truncate font-medium text-foreground">{title}</div>
-            {subtitle ? (
-              <div className="mt-0.5 truncate text-muted-foreground text-xs">
-                {subtitle}
-              </div>
-            ) : null}
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div
+            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${
+              isCredit
+                ? "bg-green-500/10 text-green-600"
+                : "bg-red-500/10 text-red-600"
+            }`}
+          >
+            <ChevronRight
+              size={14}
+              className={`transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
+            />
+          </div>
+          <div className="min-w-0 leading-tight">
+            <p className="truncate font-medium text-sm text-foreground">
+              {title}
+            </p>
+            <p className="truncate text-muted-foreground text-xs tabular-nums">
+              {subtitle ? `${subtitle} · ` : ""}
+              {formatBillingDateTime(group.firstCreatedAt)}
+            </p>
           </div>
         </div>
-        <div className="text-muted-foreground text-xs tabular-nums">
-          {formatBillingDateTime(group.firstCreatedAt)}
-        </div>
-        <div className="text-right tabular-nums text-muted-foreground">
-          {group.totalAmount > 0 ? "+" : ""}
-          {group.totalAmount.toLocaleString()}
+        <div className="flex shrink-0 items-center gap-1">
+          {isCredit ? (
+            <ArrowDownLeft size={14} className="text-green-600" />
+          ) : (
+            <ArrowUpRight size={14} className="text-red-600" />
+          )}
+          <span
+            className={`font-semibold text-sm tabular-nums ${
+              isCredit ? "text-green-600" : "text-red-600"
+            }`}
+          >
+            {isCredit ? "+" : "-"}
+            {Math.abs(group.totalAmount).toLocaleString()}
+          </span>
         </div>
       </div>
 
       {/* Expanded children */}
-      {expanded &&
-        group.items.map((item) => (
-          <UsageRow key={item.id} item={item} indent compactTime />
-        ))}
+      {expanded && (
+        <div className="ml-9 border-l border-border/30 pl-2">
+          {group.items.map((item) => (
+            <UsageRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
+
+// ============================================================================
+// Main
+// ============================================================================
 
 function openBillingLink(url: string | null | undefined) {
   const normalizedUrl = (url ?? "").trim();
@@ -379,15 +429,7 @@ export function BillingSettingsPanel() {
           Usage record
         </div>
 
-        <div
-          className={`grid ${GRID_COLS} gap-3 border-b border-border/40 pb-2 text-xs text-muted-foreground`}
-        >
-          <div>Channel</div>
-          <div>Time</div>
-          <div className="text-right">Credits change</div>
-        </div>
-
-        <div className="grid gap-0">
+        <div className="divide-y divide-border/30">
           {groups.length === 0 ? (
             <div className="py-3 text-sm text-muted-foreground">
               {isLoading ? "Loading usage..." : "No usage yet."}

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -1,4 +1,5 @@
-import { AlertCircle } from "lucide-react";
+import { useMemo, useState } from "react";
+import { AlertCircle, ChevronRight } from "lucide-react";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
 import { Button } from "@/components/ui/button";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
@@ -11,8 +12,6 @@ function formatBillingDate(value: string) {
   });
 }
 
-// Full timestamp for usage rows: "Apr 15, 2026 · 14:17:06".
-// Uses 24h clock + seconds so rapid successive calls are distinguishable.
 function formatBillingDateTime(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -32,7 +31,20 @@ function formatBillingDateTime(value: string) {
   return `${datePart} · ${timePart}`;
 }
 
-// Friendly labels for known high-level categories from `quota_transactions.category`.
+// Short time only (no date) for child rows inside a group.
+function formatBillingTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
 const CATEGORY_LABELS: Record<string, string> = {
   llm: "Model",
   integration: "Integration",
@@ -40,9 +52,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   workspace: "Workspace",
 };
 
-// Friendly labels for legacy `serviceType` rows (pre-category migration).
-// Keep in sync with `AgentServiceEnum` in
-// `backend/src/core/domain/agent_service_enum.py`.
 const SERVICE_TYPE_LABELS: Record<string, string> = {
   workspace: "Workspace chat",
   "model-proxy": "Model proxy",
@@ -76,7 +85,7 @@ function humanizeServiceType(raw: string): string {
 
 function readMetadataString(
   metadata: Record<string, unknown> | null,
-  key: string
+  key: string,
 ): string | null {
   if (!metadata) {
     return null;
@@ -85,22 +94,9 @@ function readMetadataString(
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-// Primary label for a usage row. Rich shape (category + metadata) wins over
-// legacy shape (serviceType). Priority:
-//   1. LLM calls  → provider/modelId from metadata (e.g. "openai · gpt-5.4")
-//   2. Integration calls → integrationId + operation
-//   3. Category label (Model / Integration / Background work)
-//   4. Legacy serviceType label
-//   5. "Credits added" for positive-amount allocations
-//   6. Reason / transaction type as a last resort
-function resolveUsageTitle(item: {
-  type: string;
-  reason: string | null;
-  serviceType: string | null;
-  category: string | null;
-  metadata: Record<string, unknown> | null;
-  amount: number;
-}): string {
+type UsageItem = DesktopBillingUsageItemPayload;
+
+function resolveUsageTitle(item: UsageItem): string {
   const category = item.category ?? null;
   const provider = readMetadataString(item.metadata, "provider");
   const modelId = readMetadataString(item.metadata, "modelId");
@@ -131,33 +127,160 @@ function resolveUsageTitle(item: {
   return humanizeServiceType(item.type);
 }
 
-// Optional sub-line under the title. Surfaces the most useful detail we have
-// that isn't already in the title — typically the operation name, workspace,
-// or a non-generic reason.
-function resolveUsageSubtitle(item: {
-  reason: string | null;
-  serviceType: string | null;
-  category: string | null;
-  metadata: Record<string, unknown> | null;
-}): string | null {
-  const operation = readMetadataString(item.metadata, "operation");
-  const workspaceId = readMetadataString(item.metadata, "workspaceId");
-  const modelId = readMetadataString(item.metadata, "modelId");
+// ============================================================================
+// Session grouping
+// ============================================================================
 
-  if (operation && operation !== modelId) {
-    return operation;
+interface UsageGroup {
+  key: string;
+  items: UsageItem[];
+  totalAmount: number;
+  firstCreatedAt: string;
+  lastCreatedAt: string;
+}
+
+function groupBySession(items: UsageItem[]): UsageGroup[] {
+  const groups: UsageGroup[] = [];
+  let currentSessionId: string | null = null;
+  let currentGroup: UsageGroup | null = null;
+
+  for (const item of items) {
+    const sessionId = readMetadataString(item.metadata, "sessionId");
+
+    if (sessionId && sessionId === currentSessionId && currentGroup) {
+      currentGroup.items.push(item);
+      currentGroup.totalAmount += item.amount;
+      // items arrive createdAt DESC so "last" is actually the earliest
+      currentGroup.lastCreatedAt = item.createdAt;
+    } else {
+      currentGroup = {
+        key: sessionId ?? item.id,
+        items: [item],
+        totalAmount: item.amount,
+        firstCreatedAt: item.createdAt,
+        lastCreatedAt: item.createdAt,
+      };
+      groups.push(currentGroup);
+      currentSessionId = sessionId;
+    }
   }
-  if (item.category === "llm" && workspaceId) {
-    return `Workspace ${workspaceId.slice(0, 8)}`;
+  return groups;
+}
+
+// Group header title: e.g. "Chat · 3 calls" or model name for single items.
+function resolveGroupTitle(group: UsageGroup): string {
+  const first = group.items[0];
+  if (group.items.length === 1) {
+    return resolveUsageTitle(first);
   }
-  const reason = (item.reason ?? "").trim();
-  if (!reason || reason === "Service consumption") {
-    return null;
+  const category = first.category ?? null;
+  const modelId = readMetadataString(first.metadata, "modelId");
+  const provider = readMetadataString(first.metadata, "provider");
+
+  let label: string;
+  if (category === "llm" && modelId) {
+    label = provider ? `${provider} · ${modelId}` : modelId;
+  } else if (category) {
+    label = humanizeCategory(category);
+  } else {
+    label = "Chat";
   }
-  if (item.serviceType && humanizeServiceType(item.serviceType) === reason) {
-    return null;
+  return `${label} · ${group.items.length} calls`;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const GRID_COLS = "grid-cols-[minmax(0,1fr)_200px_120px]";
+
+function UsageRow({
+  item,
+  indent = false,
+  compactTime = false,
+}: {
+  item: UsageItem;
+  indent?: boolean;
+  compactTime?: boolean;
+}) {
+  const title = resolveUsageTitle(item);
+  return (
+    <div
+      className={`grid ${GRID_COLS} items-center gap-3 border-b border-border/30 py-2 text-sm last:border-b-0 ${indent ? "pl-5" : ""}`}
+    >
+      <div className="min-w-0 leading-tight">
+        <div className="truncate text-foreground text-xs">{title}</div>
+      </div>
+      <div className="text-muted-foreground text-xs tabular-nums">
+        {compactTime
+          ? formatBillingTime(item.createdAt)
+          : formatBillingDateTime(item.createdAt)}
+      </div>
+      <div
+        className={`text-right text-xs tabular-nums ${item.amount > 0 ? "text-foreground" : "text-muted-foreground"}`}
+      >
+        {item.amount > 0 ? "+" : ""}
+        {item.amount.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+function UsageGroupRow({
+  group,
+  expanded,
+  onToggle,
+}: {
+  group: UsageGroup;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const collapsible = group.items.length > 1;
+
+  if (!collapsible) {
+    return <UsageRow item={group.items[0]} />;
   }
-  return reason;
+
+  const title = resolveGroupTitle(group);
+
+  return (
+    <div className="border-b border-border/30 last:border-b-0">
+      {/* Group header */}
+      <div
+        className={`grid ${GRID_COLS} cursor-pointer items-center gap-3 py-2.5 text-sm transition-colors hover:bg-accent/30`}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <div className="flex min-w-0 items-center gap-1.5 leading-tight">
+          <ChevronRight
+            size={14}
+            className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
+          />
+          <span className="truncate font-medium text-foreground">{title}</span>
+        </div>
+        <div className="text-muted-foreground text-xs tabular-nums">
+          {formatBillingDateTime(group.firstCreatedAt)}
+        </div>
+        <div className="text-right tabular-nums text-muted-foreground">
+          {group.totalAmount > 0 ? "+" : ""}
+          {group.totalAmount.toLocaleString()}
+        </div>
+      </div>
+
+      {/* Expanded children */}
+      {expanded &&
+        group.items.map((item) => (
+          <UsageRow key={item.id} item={item} indent compactTime />
+        ))}
+    </div>
+  );
 }
 
 function openBillingLink(url: string | null | undefined) {
@@ -174,6 +297,25 @@ export function BillingSettingsPanel() {
 
   const showExpirationBanner = Boolean(overview?.expiresAt);
   const usageItems = usage?.items ?? [];
+  const groups = useMemo(
+    () => groupBySession(usageItems.slice(0, 30)),
+    [usageItems],
+  );
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleGroup = (key: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
   return (
     <div className="grid max-w-[760px] gap-4">
@@ -209,48 +351,28 @@ export function BillingSettingsPanel() {
           Usage record
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/40 pb-2 text-xs text-muted-foreground">
+        <div
+          className={`grid ${GRID_COLS} gap-3 border-b border-border/40 pb-2 text-xs text-muted-foreground`}
+        >
           <div>Channel</div>
           <div>Time</div>
           <div className="text-right">Credits change</div>
         </div>
 
         <div className="grid gap-0">
-          {usageItems.length === 0 ? (
+          {groups.length === 0 ? (
             <div className="py-3 text-sm text-muted-foreground">
               {isLoading ? "Loading usage..." : "No usage yet."}
             </div>
           ) : (
-            usageItems.slice(0, 8).map((item) => {
-              const title = resolveUsageTitle(item);
-              const subtitle = resolveUsageSubtitle(item);
-              return (
-                <div
-                  key={item.id}
-                  className="grid grid-cols-[minmax(0,1fr)_200px_120px] items-center gap-3 border-b border-border/30 py-2.5 text-sm last:border-b-0"
-                >
-                  <div className="min-w-0 leading-tight">
-                    <div className="truncate font-medium text-foreground">
-                      {title}
-                    </div>
-                    {subtitle ? (
-                      <div className="mt-0.5 truncate text-muted-foreground text-xs">
-                        {subtitle}
-                      </div>
-                    ) : null}
-                  </div>
-                  <div className="text-muted-foreground text-xs tabular-nums">
-                    {formatBillingDateTime(item.createdAt)}
-                  </div>
-                  <div
-                    className={`text-right tabular-nums ${item.amount > 0 ? "text-foreground" : "text-muted-foreground"}`}
-                  >
-                    {item.amount > 0 ? "+" : ""}
-                    {item.amount.toLocaleString()}
-                  </div>
-                </div>
-              );
-            })
+            groups.map((group) => (
+              <UsageGroupRow
+                key={group.key}
+                group={group}
+                expanded={expandedGroups.has(group.key)}
+                onToggle={() => toggleGroup(group.key)}
+              />
+            ))
           )}
         </div>
       </section>

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -11,6 +11,91 @@ function formatBillingDate(value: string) {
   });
 }
 
+// Full timestamp for usage rows: "Apr 15, 2026 · 14:17:06".
+// Uses 24h clock + seconds so rapid successive calls are distinguishable.
+function formatBillingDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const datePart = date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timePart = date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  return `${datePart} · ${timePart}`;
+}
+
+// Friendly labels for known service types emitted by the backend quota
+// transactions. Keep this list in sync with `AgentServiceEnum` in
+// `backend/src/core/domain/agent_service_enum.py` — any unmapped value falls
+// through to a snake_case → Title Case formatter below.
+const SERVICE_TYPE_LABELS: Record<string, string> = {
+  workspace: "Workspace chat",
+  "model-proxy": "Model proxy",
+  compose: "Compose",
+  sourcing: "Sourcing",
+  hola_canvas: "Canvas",
+  growth_campaign: "Growth campaign",
+  marketplace: "Marketplace",
+  proactive: "Background work",
+  cronjobs: "Scheduled task",
+  daily_work: "Daily work",
+  campaign: "Campaign",
+};
+
+function humanizeServiceType(raw: string): string {
+  const mapped = SERVICE_TYPE_LABELS[raw];
+  if (mapped) {
+    return mapped;
+  }
+  // snake_case / kebab-case → Title Case fallback.
+  return raw
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+// Primary label for a usage row. Tries: serviceType label → custom reason →
+// "Credits added" for positive-amount allocations → transaction type as a
+// last resort.
+function resolveUsageTitle(
+  item: { type: string; reason: string | null; serviceType: string | null; amount: number },
+): string {
+  if (item.serviceType) {
+    return humanizeServiceType(item.serviceType);
+  }
+  if (item.type === "allocate" || item.amount > 0) {
+    return "Credits added";
+  }
+  if (item.reason && item.reason.trim() && item.reason !== "Service consumption") {
+    return item.reason;
+  }
+  return humanizeServiceType(item.type);
+}
+
+// Optional sub-line under the title: show `reason` only when it adds info
+// beyond the generic "Service consumption" label or the service type itself.
+function resolveUsageSubtitle(
+  item: { reason: string | null; serviceType: string | null },
+): string | null {
+  const reason = (item.reason ?? "").trim();
+  if (!reason || reason === "Service consumption") {
+    return null;
+  }
+  if (item.serviceType && humanizeServiceType(item.serviceType) === reason) {
+    return null;
+  }
+  return reason;
+}
+
 function openBillingLink(url: string | null | undefined) {
   const normalizedUrl = (url ?? "").trim();
   if (!normalizedUrl) {
@@ -60,9 +145,9 @@ export function BillingSettingsPanel() {
           Usage record
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_140px_120px] gap-3 border-b border-border/40 pb-3 text-sm text-muted-foreground">
-          <div>Details</div>
-          <div>Date</div>
+        <div className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/40 pb-3 text-sm text-muted-foreground">
+          <div>Channel</div>
+          <div>Time</div>
           <div className="text-right">Credits change</div>
         </div>
 
@@ -72,25 +157,36 @@ export function BillingSettingsPanel() {
               {isLoading ? "Loading usage..." : "No usage yet."}
             </div>
           ) : (
-            usageItems.slice(0, 8).map((item) => (
-              <div
-                key={item.id}
-                className="grid grid-cols-[minmax(0,1fr)_140px_120px] gap-3 border-b border-border/30 py-4 text-sm last:border-b-0"
-              >
-                <div className="truncate text-foreground">
-                  {item.reason || item.type}
-                </div>
-                <div className="text-muted-foreground">
-                  {formatBillingDate(item.createdAt)}
-                </div>
+            usageItems.slice(0, 8).map((item) => {
+              const title = resolveUsageTitle(item);
+              const subtitle = resolveUsageSubtitle(item);
+              return (
                 <div
-                  className={`text-right tabular-nums ${item.amount > 0 ? "text-foreground" : "text-muted-foreground"}`}
+                  key={item.id}
+                  className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/30 py-4 text-sm last:border-b-0"
                 >
-                  {item.amount > 0 ? "+" : ""}
-                  {item.amount.toLocaleString()}
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-foreground">
+                      {title}
+                    </div>
+                    {subtitle ? (
+                      <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {subtitle}
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="tabular-nums text-muted-foreground">
+                    {formatBillingDateTime(item.createdAt)}
+                  </div>
+                  <div
+                    className={`text-right tabular-nums ${item.amount > 0 ? "text-foreground" : "text-muted-foreground"}`}
+                  >
+                    {item.amount > 0 ? "+" : ""}
+                    {item.amount.toLocaleString()}
+                  </div>
                 </div>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       </section>

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -32,10 +32,17 @@ function formatBillingDateTime(value: string) {
   return `${datePart} · ${timePart}`;
 }
 
-// Friendly labels for known service types emitted by the backend quota
-// transactions. Keep this list in sync with `AgentServiceEnum` in
-// `backend/src/core/domain/agent_service_enum.py` — any unmapped value falls
-// through to a snake_case → Title Case formatter below.
+// Friendly labels for known high-level categories from `quota_transactions.category`.
+const CATEGORY_LABELS: Record<string, string> = {
+  llm: "Model",
+  integration: "Integration",
+  proactive: "Background work",
+  workspace: "Workspace",
+};
+
+// Friendly labels for legacy `serviceType` rows (pre-category migration).
+// Keep in sync with `AgentServiceEnum` in
+// `backend/src/core/domain/agent_service_enum.py`.
 const SERVICE_TYPE_LABELS: Record<string, string> = {
   workspace: "Workspace chat",
   "model-proxy": "Model proxy",
@@ -48,14 +55,10 @@ const SERVICE_TYPE_LABELS: Record<string, string> = {
   cronjobs: "Scheduled task",
   daily_work: "Daily work",
   campaign: "Campaign",
+  integration: "Integration",
 };
 
-function humanizeServiceType(raw: string): string {
-  const mapped = SERVICE_TYPE_LABELS[raw];
-  if (mapped) {
-    return mapped;
-  }
-  // snake_case / kebab-case → Title Case fallback.
+function titleCase(raw: string): string {
   return raw
     .split(/[_-]+/)
     .filter(Boolean)
@@ -63,29 +66,90 @@ function humanizeServiceType(raw: string): string {
     .join(" ");
 }
 
-// Primary label for a usage row. Tries: serviceType label → custom reason →
-// "Credits added" for positive-amount allocations → transaction type as a
-// last resort.
-function resolveUsageTitle(
-  item: { type: string; reason: string | null; serviceType: string | null; amount: number },
-): string {
+function humanizeCategory(raw: string): string {
+  return CATEGORY_LABELS[raw] ?? titleCase(raw);
+}
+
+function humanizeServiceType(raw: string): string {
+  return SERVICE_TYPE_LABELS[raw] ?? titleCase(raw);
+}
+
+function readMetadataString(
+  metadata: Record<string, unknown> | null,
+  key: string
+): string | null {
+  if (!metadata) {
+    return null;
+  }
+  const value = metadata[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+// Primary label for a usage row. Rich shape (category + metadata) wins over
+// legacy shape (serviceType). Priority:
+//   1. LLM calls  → provider/modelId from metadata (e.g. "openai · gpt-5.4")
+//   2. Integration calls → integrationId + operation
+//   3. Category label (Model / Integration / Background work)
+//   4. Legacy serviceType label
+//   5. "Credits added" for positive-amount allocations
+//   6. Reason / transaction type as a last resort
+function resolveUsageTitle(item: {
+  type: string;
+  reason: string | null;
+  serviceType: string | null;
+  category: string | null;
+  metadata: Record<string, unknown> | null;
+  amount: number;
+}): string {
+  const category = item.category ?? null;
+  const provider = readMetadataString(item.metadata, "provider");
+  const modelId = readMetadataString(item.metadata, "modelId");
+  const integrationId = readMetadataString(item.metadata, "integrationId");
+
+  if (category === "llm" && modelId) {
+    return provider ? `${provider} · ${modelId}` : modelId;
+  }
+  if (category === "integration" && integrationId) {
+    return titleCase(integrationId);
+  }
+  if (category) {
+    return humanizeCategory(category);
+  }
   if (item.serviceType) {
     return humanizeServiceType(item.serviceType);
   }
   if (item.type === "allocate" || item.amount > 0) {
     return "Credits added";
   }
-  if (item.reason && item.reason.trim() && item.reason !== "Service consumption") {
+  if (
+    item.reason &&
+    item.reason.trim() &&
+    item.reason !== "Service consumption"
+  ) {
     return item.reason;
   }
   return humanizeServiceType(item.type);
 }
 
-// Optional sub-line under the title: show `reason` only when it adds info
-// beyond the generic "Service consumption" label or the service type itself.
-function resolveUsageSubtitle(
-  item: { reason: string | null; serviceType: string | null },
-): string | null {
+// Optional sub-line under the title. Surfaces the most useful detail we have
+// that isn't already in the title — typically the operation name, workspace,
+// or a non-generic reason.
+function resolveUsageSubtitle(item: {
+  reason: string | null;
+  serviceType: string | null;
+  category: string | null;
+  metadata: Record<string, unknown> | null;
+}): string | null {
+  const operation = readMetadataString(item.metadata, "operation");
+  const workspaceId = readMetadataString(item.metadata, "workspaceId");
+  const modelId = readMetadataString(item.metadata, "modelId");
+
+  if (operation && operation !== modelId) {
+    return operation;
+  }
+  if (item.category === "llm" && workspaceId) {
+    return `Workspace ${workspaceId.slice(0, 8)}`;
+  }
   const reason = (item.reason ?? "").trim();
   if (!reason || reason === "Service consumption") {
     return null;
@@ -140,12 +204,12 @@ export function BillingSettingsPanel() {
         error={error}
         onRefresh={() => void refresh()}
       />
-      <section className="grid gap-3 rounded-[24px] border border-border/40 bg-card/40 px-4 py-4">
+      <section className="grid gap-2 rounded-[24px] border border-border/40 bg-card/40 px-4 py-3">
         <div className="text-lg font-semibold text-foreground">
           Usage record
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/40 pb-3 text-sm text-muted-foreground">
+        <div className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/40 pb-2 text-xs text-muted-foreground">
           <div>Channel</div>
           <div>Time</div>
           <div className="text-right">Credits change</div>
@@ -153,7 +217,7 @@ export function BillingSettingsPanel() {
 
         <div className="grid gap-0">
           {usageItems.length === 0 ? (
-            <div className="py-4 text-sm text-muted-foreground">
+            <div className="py-3 text-sm text-muted-foreground">
               {isLoading ? "Loading usage..." : "No usage yet."}
             </div>
           ) : (
@@ -163,19 +227,19 @@ export function BillingSettingsPanel() {
               return (
                 <div
                   key={item.id}
-                  className="grid grid-cols-[minmax(0,1fr)_200px_120px] gap-3 border-b border-border/30 py-4 text-sm last:border-b-0"
+                  className="grid grid-cols-[minmax(0,1fr)_200px_120px] items-center gap-3 border-b border-border/30 py-2.5 text-sm last:border-b-0"
                 >
-                  <div className="min-w-0">
+                  <div className="min-w-0 leading-tight">
                     <div className="truncate font-medium text-foreground">
                       {title}
                     </div>
                     {subtitle ? (
-                      <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                      <div className="mt-0.5 truncate text-muted-foreground text-xs">
                         {subtitle}
                       </div>
                     ) : null}
                   </div>
-                  <div className="tabular-nums text-muted-foreground">
+                  <div className="text-muted-foreground text-xs tabular-nums">
                     {formatBillingDateTime(item.createdAt)}
                   </div>
                   <div

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -188,6 +188,26 @@ function resolveGroupTitle(group: UsageGroup): string {
   return `${label} · ${group.items.length} calls`;
 }
 
+// Group subtitle: show session + workspace context so the user can tell
+// sessions apart even when the model is the same.
+function resolveGroupSubtitle(group: UsageGroup): string | null {
+  if (group.items.length <= 1) {
+    return null;
+  }
+  const first = group.items[0];
+  const sessionId = readMetadataString(first.metadata, "sessionId");
+  const workspaceId = readMetadataString(first.metadata, "workspaceId");
+
+  const parts: string[] = [];
+  if (sessionId) {
+    parts.push(`Session ${sessionId.slice(0, 8)}`);
+  }
+  if (workspaceId) {
+    parts.push(`Workspace ${workspaceId.slice(0, 8)}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
 // ============================================================================
 // Components
 // ============================================================================
@@ -242,6 +262,7 @@ function UsageGroupRow({
   }
 
   const title = resolveGroupTitle(group);
+  const subtitle = resolveGroupSubtitle(group);
 
   return (
     <div className="border-b border-border/30 last:border-b-0">
@@ -263,7 +284,14 @@ function UsageGroupRow({
             size={14}
             className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
           />
-          <span className="truncate font-medium text-foreground">{title}</span>
+          <div className="min-w-0">
+            <div className="truncate font-medium text-foreground">{title}</div>
+            {subtitle ? (
+              <div className="mt-0.5 truncate text-muted-foreground text-xs">
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
         </div>
         <div className="text-muted-foreground text-xs tabular-nums">
           {formatBillingDateTime(group.firstCreatedAt)}

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -388,7 +388,7 @@ export function SettingsDialog({
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
-        className="pointer-events-auto relative z-10 grid h-[min(680px,calc(100vh-32px))] w-[min(880px,calc(100vw-24px))] min-w-0 overflow-hidden rounded-2xl border border-border bg-background shadow-lg grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[220px_minmax(0,1fr)] lg:grid-rows-1"
+        className="pointer-events-auto relative z-10 grid h-[min(780px,calc(100vh-32px))] w-[min(980px,calc(100vw-24px))] min-w-0 overflow-hidden rounded-2xl border border-border bg-background shadow-lg grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[220px_minmax(0,1fr)] lg:grid-rows-1"
       >
         <aside className="border-b border-sidebar-border bg-sidebar p-4 text-sidebar-foreground lg:border-b-0 lg:border-r">
           <nav className="mt-6 grid gap-1">

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -830,6 +830,8 @@ declare global {
     type: string;
     sourceType: string | null;
     reason: string | null;
+    serviceType: string | null;
+    serviceId: string | null;
     amount: number;
     absoluteAmount: number;
     createdAt: string;

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -832,6 +832,8 @@ declare global {
     reason: string | null;
     serviceType: string | null;
     serviceId: string | null;
+    category: string | null;
+    metadata: Record<string, unknown> | null;
     amount: number;
     absoluteAmount: number;
     createdAt: string;


### PR DESCRIPTION
## Summary

- **Channel labels**: Usage rows now render `openai · gpt-5.4` (from `quota_transactions.category` + `metadata`) instead of the uniform "Service consumption" label. Falls back gracefully for old data without metadata.
- **Full timestamps**: `Apr 15, 2026 · 14:17:06` (24h, seconds) so rapid successive calls are distinguishable.
- **Session grouping**: Consecutive rows sharing `metadata.sessionId` collapse into a single expandable row showing `openai · gpt-5.4 · 3 calls` with total credits. Click to expand individual calls.
- **Session context**: Group headers show `Session 6079ce39 · Workspace abc12345` subtitle so sessions are identifiable even when the model is the same.
- **Visual parity with web**: Flex layout, colored circle avatars (Zap/Gift/ShoppingCart/Sparkles icons), arrow direction indicators (↗↙), `border-l` indent for expanded children.
- **Settings modal**: Width 880→980px, height 680→780px for more breathing room.
- **IPC threading**: `category`, `metadata` fields threaded through `DesktopBillingTransactionRpcPayload` → preload → renderer type declarations.

## Test plan

- [ ] Open desktop → Settings → Billing → Usage record
- [ ] Recent LLM calls show `openai · gpt-5.4` (or similar) with colored ⚡ avatar
- [ ] Multi-call sessions are collapsed with `· N calls` suffix and chevron
- [ ] Click group → expands to show individual calls with `border-l` indent
- [ ] Group subtitle shows `Session xxxxxxxx · Workspace yyyyyyyy`
- [ ] Allocations show green ↙ arrow + "Credits added" / "Signup bonus"
- [ ] Timestamps include seconds (`· HH:MM:SS`)
- [ ] Settings modal visibly larger than before
- [ ] Old data (no metadata) renders gracefully without errors