### PR TITLE
fix: harden session output history loading for oversized native events

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -13117,6 +13117,7 @@ async function getSessionOutputEvents(
     params: {
       include_history: true,
       after_event_id: 0,
+      include_native: false,
     },
   });
 }
@@ -13346,6 +13347,7 @@ async function openSessionOutputStream(
           payload.includeHistory ? "true" : "false",
         );
       }
+      url.searchParams.set("include_native", "false");
       if (payload.stopOnTerminal !== undefined) {
         url.searchParams.set(
           "stop_on_terminal",

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -377,6 +377,10 @@ function normalizeErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Request failed.";
 }
 
+function optionalHistoryLoadErrorMessage(label: string, error: unknown) {
+  return `${label} unavailable: ${normalizeErrorMessage(error)}`;
+}
+
 function openExternalUrl(url: string | null | undefined) {
   const normalizedUrl = (url ?? "").trim();
   if (!normalizedUrl) {
@@ -2778,28 +2782,71 @@ export function ChatPane({
       return;
     }
 
-    const [history, outputEventHistory, outputList, memoryProposalList] =
-      await Promise.all([
-        window.electronAPI.workspace.getSessionHistory({
-          sessionId: nextSessionId,
-          workspaceId,
-        }),
-        window.electronAPI.workspace.getSessionOutputEvents({
-          sessionId: nextSessionId,
-        }),
-        window.electronAPI.workspace.listOutputs({
-          workspaceId,
-          sessionId: nextSessionId,
-          limit: 200,
-        }),
-        window.electronAPI.workspace.listMemoryUpdateProposals({
-          workspaceId,
-          sessionId: nextSessionId,
-          limit: 200,
-        }),
-      ]);
+    const [
+      historyResult,
+      outputEventHistoryResult,
+      outputListResult,
+      memoryProposalListResult,
+    ] = await Promise.allSettled([
+      window.electronAPI.workspace.getSessionHistory({
+        sessionId: nextSessionId,
+        workspaceId,
+      }),
+      window.electronAPI.workspace.getSessionOutputEvents({
+        sessionId: nextSessionId,
+      }),
+      window.electronAPI.workspace.listOutputs({
+        workspaceId,
+        sessionId: nextSessionId,
+        limit: 200,
+      }),
+      window.electronAPI.workspace.listMemoryUpdateProposals({
+        workspaceId,
+        sessionId: nextSessionId,
+        limit: 200,
+      }),
+    ]);
+    if (historyResult.status !== "fulfilled") {
+      throw historyResult.reason;
+    }
     if (cancelled()) {
       return;
+    }
+
+    const auxiliaryHistoryWarnings: string[] = [];
+    const history = historyResult.value;
+    const outputEventHistory =
+      outputEventHistoryResult.status === "fulfilled"
+        ? outputEventHistoryResult.value
+        : { items: [], count: 0, last_event_id: 0 };
+    if (outputEventHistoryResult.status !== "fulfilled") {
+      auxiliaryHistoryWarnings.push(
+        optionalHistoryLoadErrorMessage(
+          "Execution history",
+          outputEventHistoryResult.reason,
+        ),
+      );
+    }
+    const outputList =
+      outputListResult.status === "fulfilled"
+        ? outputListResult.value
+        : { items: [], count: 0 };
+    if (outputListResult.status !== "fulfilled") {
+      auxiliaryHistoryWarnings.push(
+        optionalHistoryLoadErrorMessage("Artifacts", outputListResult.reason),
+      );
+    }
+    const memoryProposalList =
+      memoryProposalListResult.status === "fulfilled"
+        ? memoryProposalListResult.value
+        : { proposals: [] };
+    if (memoryProposalListResult.status !== "fulfilled") {
+      auxiliaryHistoryWarnings.push(
+        optionalHistoryLoadErrorMessage(
+          "Memory proposals",
+          memoryProposalListResult.reason,
+        ),
+      );
     }
 
     const nextOutputs = sortOutputs(outputList.items);
@@ -2812,6 +2859,7 @@ export function ChatPane({
     setSessionOutputs(nextOutputs);
     setCurrentTodoPlan(todoPlanFromOutputEvents(outputEventHistory.items));
     setMessages(nextMessages);
+    setChatErrorMessage(auxiliaryHistoryWarnings.join(" "));
     resetLiveTurn();
     requestHistoryViewportRestore();
 

--- a/desktop/src/components/panes/ChatPaneHistoryLoading.test.mjs
+++ b/desktop/src/components/panes/ChatPaneHistoryLoading.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const sourcePath = path.join(process.cwd(), "src/components/panes/ChatPane.tsx");
+
+test("chat pane preserves message history when auxiliary session history fetches fail", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /await Promise\.allSettled\(\[/);
+  assert.match(
+    source,
+    /if \(historyResult\.status !== "fulfilled"\) \{\s*throw historyResult\.reason;\s*\}/,
+  );
+  assert.match(
+    source,
+    /outputEventHistoryResult\.status === "fulfilled"[\s\S]*\{\s*items: \[\],\s*count: 0,\s*last_event_id: 0\s*\}/,
+  );
+  assert.match(
+    source,
+    /auxiliaryHistoryWarnings\.push\(\s*optionalHistoryLoadErrorMessage\(\s*"Execution history"/,
+  );
+  assert.match(
+    source,
+    /setChatErrorMessage\(auxiliaryHistoryWarnings\.join\(" "\)\);/,
+  );
+});

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -1802,6 +1802,14 @@ test("output events endpoint supports incremental fetches and tail mode", async 
     sessionId: "session-main",
     inputId: "input-1",
     sequence: 2,
+    eventType: "pi_native_event",
+    payload: { native_type: "message_update", native_event: { type: "message_update" } }
+  });
+  store.appendOutputEvent({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: "input-1",
+    sequence: 3,
     eventType: "output_delta",
     payload: { delta: "hi" }
   });
@@ -1814,6 +1822,10 @@ test("output events endpoint supports incremental fetches and tail mode", async 
     method: "GET",
     url: "/api/v1/agent-sessions/session-main/outputs/events?input_id=input-1&include_history=false"
   });
+  const withNative = await app.inject({
+    method: "GET",
+    url: "/api/v1/agent-sessions/session-main/outputs/events?input_id=input-1&after_event_id=0&include_native=true"
+  });
 
   assert.equal(incremental.statusCode, 200);
   assert.equal(incremental.json().count, 1);
@@ -1822,7 +1834,15 @@ test("output events endpoint supports incremental fetches and tail mode", async 
 
   assert.equal(tailed.statusCode, 200);
   assert.equal(tailed.json().count, 0);
-  assert.ok(tailed.json().last_event_id >= 2);
+  assert.ok(tailed.json().last_event_id >= 3);
+
+  assert.equal(withNative.statusCode, 200);
+  assert.deepEqual(
+    withNative
+      .json()
+      .items.map((item: { event_type: string }) => item.event_type),
+    ["run_started", "pi_native_event", "output_delta"]
+  );
 
   await app.close();
   store.close();
@@ -1855,6 +1875,14 @@ test("output stream endpoint emits SSE events and stops on terminal", async () =
     sessionId: "session-main",
     inputId: "input-1",
     sequence: 2,
+    eventType: "pi_native_event",
+    payload: { native_type: "message_update", native_event: { type: "message_update" } }
+  });
+  store.appendOutputEvent({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: "input-1",
+    sequence: 3,
     eventType: "run_completed",
     payload: { status: "success" }
   });
@@ -1868,6 +1896,15 @@ test("output stream endpoint emits SSE events and stops on terminal", async () =
   assert.equal(response.statusCode, 200);
   assert.match(body, /event: run_started/);
   assert.match(body, /event: run_completed/);
+  assert.doesNotMatch(body, /event: pi_native_event/);
+
+  const responseWithNative = await app.inject({
+    method: "GET",
+    url: "/api/v1/agent-sessions/session-main/outputs/stream?input_id=input-1&include_native=true"
+  });
+
+  assert.equal(responseWithNative.statusCode, 200);
+  assert.match(responseWithNative.body, /event: pi_native_event/);
 
   await app.close();
   store.close();

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -138,6 +138,7 @@ const DEFAULT_POLL_INTERVAL_MS = 50;
 const DEFAULT_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
 const DEFAULT_APP_SETUP_TIMEOUT_MS = 900_000;
 const TERMINAL_EVENT_TYPES = new Set(["run_completed", "run_failed"]);
+const DEFAULT_EXCLUDED_SESSION_OUTPUT_EVENT_TYPES = ["pi_native_event"];
 export interface BuildRuntimeApiServerOptions {
   logger?: boolean;
   store?: RuntimeStateStore;
@@ -6050,9 +6051,15 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const query = isRecord(request.query) ? request.query : {};
     const inputId = optionalString(query.input_id);
     const includeHistory = optionalBoolean(query.include_history, true);
+    const includeNative = optionalBoolean(query.include_native, false);
+    const excludedEventTypes = includeNative ? [] : DEFAULT_EXCLUDED_SESSION_OUTPUT_EVENT_TYPES;
     let afterEventId = Math.max(0, optionalInteger(query.after_event_id, 0));
     if (!includeHistory && afterEventId <= 0) {
-      afterEventId = store.latestOutputEventId({ sessionId: params.sessionId, inputId });
+      afterEventId = store.latestOutputEventId({
+        sessionId: params.sessionId,
+        inputId,
+        excludedEventTypes
+      });
     }
 
     const items = store
@@ -6060,7 +6067,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         sessionId: params.sessionId,
         inputId,
         includeHistory: true,
-        afterEventId
+        afterEventId,
+        excludedEventTypes
       })
       .map((item: OutputEventRecord) => outputEventPayload(item));
     return {
@@ -6078,6 +6086,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const query = isRecord(request.query) ? request.query : {};
     const inputId = optionalString(query.input_id);
     const includeHistory = optionalBoolean(query.include_history, true);
+    const includeNative = optionalBoolean(query.include_native, false);
+    const excludedEventTypes = includeNative ? [] : DEFAULT_EXCLUDED_SESSION_OUTPUT_EVENT_TYPES;
     const stopOnTerminal = optionalBoolean(query.stop_on_terminal, true);
 
     reply.header("Cache-Control", "no-cache");
@@ -6087,7 +6097,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
     const stream = Readable.from(
       (async function* () {
-        let lastEventId = includeHistory ? 0 : store.latestOutputEventId({ sessionId: params.sessionId, inputId });
+        let lastEventId = includeHistory
+          ? 0
+          : store.latestOutputEventId({
+              sessionId: params.sessionId,
+              inputId,
+              excludedEventTypes
+            });
         yield sseComment("connected");
 
         while (true) {
@@ -6095,7 +6111,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
             sessionId: params.sessionId,
             inputId,
             includeHistory: true,
-            afterEventId: lastEventId
+            afterEventId: lastEventId,
+            excludedEventTypes
           });
 
           if (events.length > 0) {

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -144,7 +144,7 @@ test("mapPiSessionEvent extracts nested Gemini provider error messages", () => {
   );
 });
 
-test("mapPiSessionEvent emits a pi_native_event passthrough for native Pi session events", () => {
+test("mapPiSessionEvent emits a pi_native_event passthrough for non-streaming Pi session events", () => {
   const sessionFile = "/tmp/pi-session.jsonl";
   const cases = [
     {
@@ -165,19 +165,6 @@ test("mapPiSessionEvent emits a pi_native_event passthrough for native Pi sessio
         },
       } as const,
       nativeType: "message_start",
-    },
-    {
-      event: {
-        type: "message_update",
-        message: {} as never,
-        assistantMessageEvent: {
-          type: "text_delta",
-          contentIndex: 0,
-          delta: "Hello",
-          partial: {} as never,
-        },
-      } as const,
-      nativeType: "message_update",
     },
     {
       event: {
@@ -232,6 +219,51 @@ test("mapPiSessionEvent emits a pi_native_event passthrough for native Pi sessio
       },
     });
   }
+});
+
+test("mapPiSessionEvent trims cumulative partial state from message_update pi_native_event payloads", () => {
+  const sessionFile = "/tmp/pi-session.jsonl";
+  const nativeEvents = onlyPiNativeEvents(
+    mapPiSessionEvent(
+      {
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world" }],
+        } as never,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Hello",
+          partial: {
+            content: [{ type: "text", text: "Hello world" }],
+          } as never,
+        },
+      } as never,
+      sessionFile,
+      createPiEventMapperState()
+    )
+  );
+
+  assert.deepEqual(nativeEvents, [
+    {
+      event_type: "pi_native_event",
+      payload: {
+        native_type: "message_update",
+        native_event: {
+          type: "message_update",
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "Hello",
+          },
+        },
+        event: "message_update",
+        source: "pi",
+        harness_session_id: sessionFile,
+      },
+    },
+  ]);
 });
 
 async function createDocxBuffer(lines: string[]): Promise<Buffer> {

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3999,11 +3999,22 @@ function maybeMapAssistantTerminalFailure(
 }
 
 function mapNativePiEvent(event: AgentSessionEvent, sessionFile: string): PiMappedEvent {
+  const nativeEventPayload =
+    event.type === "message_update"
+      ? jsonValue({
+          type: event.type,
+          assistantMessageEvent: Object.fromEntries(
+            Object.entries(isRecord(event.assistantMessageEvent) ? event.assistantMessageEvent : {}).filter(
+              ([key]) => key !== "partial"
+            )
+          ),
+        })
+      : jsonValue(event);
   return {
     event_type: "pi_native_event",
     payload: {
       native_type: event.type,
-      native_event: jsonValue(event),
+      native_event: nativeEventPayload,
       event: event.type,
       source: "pi",
       harness_session_id: sessionFile,

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -2054,7 +2054,7 @@ export class RuntimeStateStore {
       );
   }
 
-  latestOutputEventId(params: { sessionId: string; inputId?: string }): number {
+  latestOutputEventId(params: { sessionId: string; inputId?: string; excludedEventTypes?: string[] }): number {
     let query = `
       SELECT MAX(id) AS max_id
       FROM session_output_events
@@ -2065,6 +2065,11 @@ export class RuntimeStateStore {
       query += " AND input_id = ?";
       values.push(params.inputId);
     }
+    const excludedEventTypes = (params.excludedEventTypes ?? []).filter((value) => Boolean(value && value.trim()));
+    if (excludedEventTypes.length > 0) {
+      query += ` AND event_type NOT IN (${excludedEventTypes.map(() => "?").join(", ")})`;
+      values.push(...excludedEventTypes);
+    }
     const row = this.db().prepare(query).get(...values) as { max_id: number | null } | undefined;
     return row?.max_id ?? 0;
   }
@@ -2074,6 +2079,7 @@ export class RuntimeStateStore {
     inputId?: string;
     includeHistory?: boolean;
     afterEventId?: number;
+    excludedEventTypes?: string[];
   }): OutputEventRecord[] {
     let query = `
       SELECT id, workspace_id, session_id, input_id, sequence, event_type, payload, created_at
@@ -2085,6 +2091,11 @@ export class RuntimeStateStore {
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
+    }
+    const excludedEventTypes = (params.excludedEventTypes ?? []).filter((value) => Boolean(value && value.trim()));
+    if (excludedEventTypes.length > 0) {
+      query += ` AND event_type NOT IN (${excludedEventTypes.map(() => "?").join(", ")})`;
+      values.push(...excludedEventTypes);
     }
     if (params.includeHistory === false) {
       query += " AND 1 = 0";


### PR DESCRIPTION
## Context
- importing the tester runtime.db reproduces the desktop failure on `/agent-sessions/:sessionId/outputs/events`
- the immediate server-side failure is `RangeError: Invalid string length` while serializing very large `pi_native_event` histories
- the desktop pane also blanked past chats because it cleared the view and then failed the entire load on a single `getSessionOutputEvents` error

## What changed
- exclude `pi_native_event` rows from session output history and stream endpoints by default, with `include_native=true` as an explicit opt-in
- push the event-type exclusion into the state-store query so oversized native payloads are not loaded or serialized on the default path
- make the desktop history loader resilient to auxiliary history failures so message history still renders even if execution-history or artifact loading fails
- trim persisted `message_update` native payloads to drop the cumulative `partial` state that was ballooning `runtime.db`
- add runtime API, harness-host, and desktop coverage for the new filtering and fallback behavior

## Validation
- `npm test -- --test-name-pattern="message_update pi_native_event payloads|runPi emits run_started and terminal success when the session completes|mapPiSessionEvent emits a pi_native_event passthrough for non-streaming Pi session events"` in `runtime/harness-host`
- `npm test -- --test-name-pattern="output events endpoint supports incremental fetches and tail mode|output stream endpoint emits SSE events and stops on terminal"` in `runtime/api-server`
- `node --test src/components/panes/ChatPaneHistoryLoading.test.mjs` in `desktop`
