### PR TITLE
fix: stabilize explorer rename state and MCP discovery config

### DIFF
--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -10,13 +10,32 @@ const sourcePath = path.join(__dirname, "FileExplorerPane.tsx");
 test("file explorer syncs the workspace root only when the selected workspace changes", async () => {
   const source = await readFile(sourcePath, "utf8");
 
+  assert.match(source, /const workspaceSessionKeyRef = useRef\(0\);/);
+  assert.match(source, /const directoryLoadRequestKeyRef = useRef\(0\);/);
+  assert.match(source, /const previewRequestKeyRef = useRef\(0\);/);
   assert.match(
     source,
     /const lastSyncedWorkspaceRootRef = useRef<\{[\s\S]*workspaceId: string;[\s\S]*rootPath: string;[\s\S]*\} \| null>\(null\);/,
   );
   assert.match(
     source,
+    /const resetPreviewState = useCallback\(\(\) => \{\s*previewRequestKeyRef\.current \+= 1;[\s\S]*setPreview\(null\);[\s\S]*setPreviewError\(""\);[\s\S]*setPreviewLoading\(false\);[\s\S]*setSaving\(false\);\s*\}, \[\]\);/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*workspaceSessionKeyRef\.current \+= 1;\s*directoryLoadRequestKeyRef\.current \+= 1;\s*previewRequestKeyRef\.current \+= 1;[\s\S]*setCurrentPath\(""\);[\s\S]*setSelectedPath\(""\);[\s\S]*resetPreviewState\(\);\s*\}, \[resetPreviewState, selectedWorkspaceId\]\);/,
+  );
+  assert.match(
+    source,
     /window\.electronAPI\.fs\.listDirectory\(\s*targetPath \?\? null,\s*selectedWorkspaceId \?\? null,\s*\)/,
+  );
+  assert.match(
+    source,
+    /const workspaceSessionKey = workspaceSessionKeyRef\.current;\s*const requestKey = \+\+directoryLoadRequestKeyRef\.current;/,
+  );
+  assert.match(
+    source,
+    /if \(\s*workspaceSessionKey !== workspaceSessionKeyRef\.current \|\|\s*requestKey !== directoryLoadRequestKeyRef\.current\s*\) \{\s*return;\s*\}/,
   );
   assert.match(
     source,
@@ -127,7 +146,12 @@ test("file explorer adds explicit @ references and keeps drag gestures scoped to
   assert.match(source, /const EXPLORER_INTERNAL_MOVE_DRAG_TYPE =\s*"application\/x-holaboss-file-explorer-move";/);
   assert.match(source, /const rowClassName = `group mb-0\.5 w-full rounded-md px-2 py-1\.5 text-left transition-colors/);
   assert.match(source, /\$\{isRenaming \? "cursor-default" : "cursor-pointer"\}/);
+  assert.match(source, /className="flex min-w-0 flex-1 items-center gap-2"/);
+  assert.match(source, /style=\{\{ paddingLeft: `\$\{depth \* 16\}px` \}\}/);
+  assert.match(source, /className="flex w-full min-w-0 items-center gap-1"/);
   assert.match(source, /className="w-full min-w-0 cursor-pointer text-left"/);
+  assert.match(source, /className="flex min-w-0 flex-1 flex-col gap-0\.5"/);
+  assert.match(source, /className="flex shrink-0 items-center gap-0\.5"/);
   assert.match(source, /draggable=\{!entry\.isDirectory && !entryIsProtected\}/);
   assert.match(source, /event\.dataTransfer\.effectAllowed = "move";/);
   assert.match(
@@ -141,6 +165,9 @@ test("file explorer adds explicit @ references and keeps drag gestures scoped to
   assert.doesNotMatch(source, /event\.dataTransfer\.setData\(\s*"text\/plain"/);
   assert.doesNotMatch(source, /cursor-grab/);
   assert.doesNotMatch(source, /cursor-grabbing/);
+  assert.doesNotMatch(source, /className="flex min-w-0 items-center gap-2"\s*style=\{\{ paddingLeft: `\$\{depth \* 16\}px` \}\}/);
+  assert.doesNotMatch(source, /className="flex min-w-0 items-center gap-2 pl-6 text-\[11px\] text-muted-foreground"/);
+  assert.doesNotMatch(source, /className="mt-0\.5 flex shrink-0 items-center gap-0\.5"/);
 });
 
 test("file explorer groups protected workspace system entries into a dedicated root section", async () => {
@@ -211,6 +238,14 @@ test("file explorer accepts one-shot focus requests for artifact files", async (
 test("file explorer adds a markdown preview mode while keeping text editing inline", async () => {
   const source = await readFile(sourcePath, "utf8");
 
+  assert.match(
+    source,
+    /const hasVisibleEntryRows = useMemo\(\s*\(\) => visibleRows\.some\(\(row\) => row\.type === "entry"\),\s*\[visibleRows\],\s*\);/,
+  );
+  assert.match(
+    source,
+    /if \(loading \|\| error \|\| hasVisibleEntryRows\) \{\s*return;\s*\}\s*resetPreviewState\(\);/,
+  );
   assert.match(source, /import \{ SimpleMarkdown \} from "@\/components\/marketplace\/SimpleMarkdown";/);
   assert.match(source, /const MARKDOWN_PREVIEW_EXTENSIONS = new Set\(\[\s*"\.md",\s*"\.mdx",\s*"\.markdown"\s*\]\);/);
   assert.match(source, /const HTML_PREVIEW_EXTENSIONS = new Set\(\[\s*"\.html",\s*"\.htm"\s*\]\);/);
@@ -226,7 +261,7 @@ test("file explorer adds a markdown preview mode while keeping text editing inli
   );
   assert.match(
     source,
-    /const showInlinePreview =\s*previewInPane && Boolean\(preview \|\| previewLoading \|\| previewError\);/,
+    /const showInlinePreview =\s*previewInPane &&\s*hasVisibleEntryRows &&\s*Boolean\(preview \|\| previewLoading \|\| previewError\);/,
   );
   assert.match(source, /const explorerPane = embedded \? \(\s*content\s*\) : \(/);
   assert.match(source, /title=\{showInlinePreview \? "File" : ""\}/);
@@ -242,6 +277,14 @@ test("file explorer adds a markdown preview mode while keeping text editing inli
   assert.match(
     source,
     /window\.electronAPI\.fs\.readFilePreview\(\s*targetPath,\s*selectedWorkspaceId \?\? null,\s*\)/,
+  );
+  assert.match(
+    source,
+    /const workspaceSessionKey = workspaceSessionKeyRef\.current;\s*const requestKey = \+\+previewRequestKeyRef\.current;/,
+  );
+  assert.match(
+    source,
+    /if \(\s*workspaceSessionKey !== workspaceSessionKeyRef\.current \|\|\s*requestKey !== previewRequestKeyRef\.current\s*\) \{\s*return;\s*\}/,
   );
   assert.match(
     source,
@@ -296,7 +339,7 @@ test("file explorer warns users to save before leaving an unsaved file", async (
     /You have unsaved changes\. Press Cancel to go back and save them, or OK to discard them\./,
   );
   assert.match(source, /if \(!skipConfirm && !confirmDiscardIfDirty\(\)\) \{\s*return;\s*\}/);
-  assert.match(source, /if \(!confirmDiscardIfDirty\(\)\) \{\s*return;\s*\}\s*setPreview\(null\);/);
+  assert.match(source, /if \(!confirmDiscardIfDirty\(\)\) \{\s*return;\s*\}\s*resetPreviewState\(\);/);
 });
 
 test("file explorer assigns richer icons for common file types", async () => {
@@ -322,6 +365,9 @@ test("file explorer exposes right-click rename and delete actions for entries", 
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(source, /type FileExplorerContextMenuState = \{/);
+  assert.match(source, /function remapPathAfterRename\(/);
+  assert.match(source, /function remapExplorerPathRecord<T>\(/);
+  assert.match(source, /function remapDirectoryEntriesByPath\(/);
   assert.match(
     source,
     /const \[contextMenu, setContextMenu\]\s*=\s*useState<FileExplorerContextMenuState \| null>\(null\);/,
@@ -338,6 +384,7 @@ test("file explorer exposes right-click rename and delete actions for entries", 
     source,
     /openEntryContextMenu\(entry,\s*\{\s*anchorRect:\s*event\.currentTarget\.getBoundingClientRect\(\),\s*\}\);/,
   );
+  assert.doesNotMatch(source, /\{entry\.isDirectory \? \(\s*<Button[\s\S]*aria-label=\{`More actions for \$\{entry\.name\}`\}/);
   assert.match(source, /group-hover:pointer-events-auto group-hover:opacity-100/);
   assert.match(
     source,
@@ -347,6 +394,19 @@ test("file explorer exposes right-click rename and delete actions for entries", 
   assert.match(source, /contextMenu\.paneBounds\.bottom - menuHeight - 8/);
   assert.match(source, /setRenamingPath\(entry\.absolutePath\);/);
   assert.match(source, /setRenameDraft\(entry\.name\);/);
+  assert.doesNotMatch(source, /const openEntryFromContextMenu = useCallback\(/);
+  assert.doesNotMatch(
+    source,
+    /createPortal\([\s\S]*Expand folder[\s\S]*New file/,
+  );
+  assert.doesNotMatch(
+    source,
+    /createPortal\([\s\S]*Collapse folder[\s\S]*New file/,
+  );
+  assert.doesNotMatch(
+    source,
+    /createPortal\([\s\S]*Open file[\s\S]*New file/,
+  );
   assert.match(source, /ref=\{renameInputRef\}/);
   assert.match(source, /onBlur=\{\(\) => \{\s*void submitRenameEntry\(\);\s*\}\}/);
   assert.match(source, /if \(event\.key === "Enter"\) \{\s*event\.preventDefault\(\);\s*void submitRenameEntry\(\);/);
@@ -355,12 +415,36 @@ test("file explorer exposes right-click rename and delete actions for entries", 
   assert.match(source, /Delete folder "\$\{entry\.name\}" and all of its contents\? This cannot be undone\./);
   assert.match(
     source,
-    /window\.electronAPI\.fs\.renamePath\(\s*renamingEntry\.absolutePath,\s*nextName,\s*selectedWorkspaceId \?\? null,\s*\)/,
+    /window\.electronAPI\.fs\.renamePath\(\s*sourcePath,\s*nextName,\s*selectedWorkspaceId \?\? null,\s*\)/,
   );
   assert.match(source, /const refreshDirectoryEntries = useCallback\(/);
   assert.match(
     source,
-    /const parentPath =\s*getParentFolderPath\(renamingEntry\.absolutePath\)\s*\?\?\s*currentPathRef\.current;/,
+    /const parentPath =\s*getParentFolderPath\(sourcePath\)\s*\?\?\s*currentPathRef\.current;/,
+  );
+  assert.match(
+    source,
+    /setDirectoryEntriesByPath\(\(current\) =>\s*remapDirectoryEntriesByPath\(current, sourcePath, nextAbsolutePath\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /setExpandedDirectoryPaths\(\(current\) =>\s*remapExplorerPathRecord\(current, sourcePath, nextAbsolutePath\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /await revealPathInTree\(nextAbsolutePath\);/,
+  );
+  assert.match(
+    source,
+    /setPreview\(\(current\) => \{[\s\S]*remapPathAfterRename\(\s*sourcePath,\s*nextAbsolutePath,\s*current\.absolutePath,\s*\)[\s\S]*absolutePath: remappedAbsolutePath,[\s\S]*name: getFolderName\(remappedAbsolutePath\),[\s\S]*\}\);/,
+  );
+  assert.match(
+    source,
+    /const shouldRetargetExternalFile =[\s\S]*!previewInPane &&[\s\S]*Boolean\(onFileOpen\) &&[\s\S]*normalizeComparablePath\(selectedPath\) ===[\s\S]*normalizeComparablePath\(sourcePath\);/,
+  );
+  assert.match(
+    source,
+    /if \(shouldRetargetExternalFile\) \{\s*onFileOpen\?\.\(nextAbsolutePath\);\s*\}/,
   );
   assert.match(
     source,
@@ -396,18 +480,20 @@ test("file explorer blocks renaming deleting and moving protected system entries
   assert.match(source, /function getProtectedWorkspacePathLabel\(/);
   assert.match(source, /function protectedWorkspacePathMessage\(/);
   assert.match(source, /function isProtectedWorkspacePath\(/);
+  assert.match(source, /const comparableRelativePath = relativePath\.toLowerCase\(\);/);
   assert.match(
     source,
-    /if \(relativePath === "workspace\.yaml"\) \{\s*return "workspace\.yaml";\s*\}/,
+    /if \(comparableRelativePath === "workspace\.yaml"\) \{\s*return "workspace\.yaml";\s*\}/,
   );
   assert.match(
     source,
-    /if \(relativePath === "agents\.md"\) \{\s*return "AGENTS\.md";\s*\}/,
+    /if \(comparableRelativePath === "agents\.md"\) \{\s*return "AGENTS\.md";\s*\}/,
   );
   assert.match(
     source,
-    /if \(relativePath === "skills"\) \{\s*return "skills";\s*\}/,
+    /if \(comparableRelativePath === "skills"\) \{\s*return "skills";\s*\}/,
   );
+  assert.doesNotMatch(source, /if \(relativePath === "agents\.md"\)/);
   assert.doesNotMatch(source, /relativePath\.startsWith\("skills\/"\)/);
   assert.match(
     source,
@@ -444,6 +530,7 @@ test("file explorer can move dragged files into folder rows", async () => {
     source,
     /const \[draggedEntryPath, setDraggedEntryPath\] = useState<string \| null>\(null\);/,
   );
+  assert.match(source, /const canMoveDraggedEntryToDirectoryPath = useCallback\(/);
   assert.match(
     source,
     /const \[directoryDropTargetPath, setDirectoryDropTargetPath\] = useState<[\s\S]*string \| null[\s\S]*>\(null\);/,
@@ -472,6 +559,31 @@ test("file explorer can move dragged files into folder rows", async () => {
   assert.match(
     source,
     /await Promise\.all\(\s*refreshTargets\.map\(\(targetPath\) => refreshDirectoryEntries\(targetPath\)\),\s*\);/,
+  );
+});
+
+test("file explorer can move dragged files to the current directory from pane empty space", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const canMoveDraggedEntry = canMoveDraggedEntryToDirectoryPath\(\s*currentPathRef\.current,\s*\);/,
+  );
+  assert.match(
+    source,
+    /const canImportExternalEntries =\s*hasExternalExplorerDropData\(event\.dataTransfer\) &&\s*Boolean\(currentPathRef\.current\);/,
+  );
+  assert.match(
+    source,
+    /if \(!canMoveDraggedEntry && !canImportExternalEntries\) \{\s*return;\s*\}/,
+  );
+  assert.match(
+    source,
+    /event\.dataTransfer\.dropEffect = canMoveDraggedEntry \? "move" : "copy";/,
+  );
+  assert.match(
+    source,
+    /if \(canMoveDraggedEntry && draggedEntryPath\) \{\s*void moveEntryToDirectory\(draggedEntryPath,\s*currentPathRef\.current\);\s*return;\s*\}/,
   );
 });
 

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -595,6 +595,88 @@ function isAbsolutePath(targetPath: string) {
   return /^(?:[a-zA-Z]:[\\/]|\/)/.test(targetPath.trim());
 }
 
+function remapPathAfterRename(
+  sourcePath: string,
+  nextPath: string,
+  candidatePath: string | null | undefined,
+) {
+  const trimmedCandidatePath = (candidatePath ?? "").trim();
+  const trimmedNextPath = nextPath.trim();
+  const normalizedSourcePath = normalizeComparablePath(sourcePath);
+  const normalizedCandidatePath = normalizeComparablePath(trimmedCandidatePath);
+  if (
+    !trimmedCandidatePath ||
+    !trimmedNextPath ||
+    !normalizedSourcePath ||
+    !normalizedCandidatePath ||
+    !isPathWithin(normalizedSourcePath, normalizedCandidatePath)
+  ) {
+    return trimmedCandidatePath;
+  }
+  if (normalizedCandidatePath === normalizedSourcePath) {
+    return trimmedNextPath;
+  }
+  const suffix = normalizedCandidatePath
+    .slice(normalizedSourcePath.length)
+    .replace(/^\/+/, "");
+  if (!suffix) {
+    return trimmedNextPath;
+  }
+  const separator = trimmedNextPath.includes("\\") ? "\\" : "/";
+  return `${trimmedNextPath.replace(/[\\/]+$/, "")}${separator}${suffix.split("/").join(separator)}`;
+}
+
+function remapExplorerPathRecord<T>(
+  record: Record<string, T>,
+  sourcePath: string,
+  nextPath: string,
+) {
+  let changed = false;
+  const nextRecord: Record<string, T> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const remappedKey = remapPathAfterRename(sourcePath, nextPath, key) || key;
+    if (remappedKey !== key) {
+      changed = true;
+    }
+    nextRecord[remappedKey] = value;
+  }
+  return changed ? nextRecord : record;
+}
+
+function remapDirectoryEntriesByPath(
+  directoryEntriesByPath: Record<string, LocalFileEntry[]>,
+  sourcePath: string,
+  nextPath: string,
+) {
+  let changed = false;
+  const nextEntriesByPath: Record<string, LocalFileEntry[]> = {};
+  for (const [directoryPath, entries] of Object.entries(directoryEntriesByPath)) {
+    const remappedDirectoryPath =
+      remapPathAfterRename(sourcePath, nextPath, directoryPath) ||
+      directoryPath;
+    const remappedEntries = entries.map((entry) => {
+      const remappedAbsolutePath = remapPathAfterRename(
+        sourcePath,
+        nextPath,
+        entry.absolutePath,
+      );
+      if (remappedAbsolutePath === entry.absolutePath) {
+        return entry;
+      }
+      changed = true;
+      return {
+        ...entry,
+        absolutePath: remappedAbsolutePath,
+      };
+    });
+    if (remappedDirectoryPath !== directoryPath) {
+      changed = true;
+    }
+    nextEntriesByPath[remappedDirectoryPath] = remappedEntries;
+  }
+  return changed ? nextEntriesByPath : directoryEntriesByPath;
+}
+
 function resolveWorkspaceTargetPath(workspaceRoot: string, targetPath: string) {
   const trimmedRoot = workspaceRoot.trim();
   const trimmedTarget = targetPath.trim();
@@ -655,13 +737,14 @@ function getProtectedWorkspacePathLabel(
   if (!relativePath) {
     return null;
   }
-  if (relativePath === "workspace.yaml") {
+  const comparableRelativePath = relativePath.toLowerCase();
+  if (comparableRelativePath === "workspace.yaml") {
     return "workspace.yaml";
   }
-  if (relativePath === "agents.md") {
+  if (comparableRelativePath === "agents.md") {
     return "AGENTS.md";
   }
-  if (relativePath === "skills") {
+  if (comparableRelativePath === "skills") {
     return "skills";
   }
   return null;
@@ -932,6 +1015,9 @@ export function FileExplorerPane({
     rootPath: string;
   } | null>(null);
   const lastProcessedFocusRequestKeyRef = useRef<number | null>(null);
+  const workspaceSessionKeyRef = useRef(0);
+  const directoryLoadRequestKeyRef = useRef(0);
+  const previewRequestKeyRef = useRef(0);
   const currentPathRef = useRef("");
   const isDirtyRef = useRef(false);
   const isSavingRef = useRef(false);
@@ -983,8 +1069,24 @@ export function FileExplorerPane({
 
   currentPathRef.current = currentPath;
 
+  const resetPreviewState = useCallback(() => {
+    previewRequestKeyRef.current += 1;
+    isDirtyRef.current = false;
+    isSavingRef.current = false;
+    setPreview(null);
+    setPreviewDraft("");
+    setTablePreviewDraft([]);
+    setTextPreviewMode("edit");
+    setActiveTableSheetIndex(0);
+    setPreviewError("");
+    setPreviewLoading(false);
+    setSaving(false);
+  }, []);
+
   const loadDirectory = useCallback(
     async (targetPath?: string | null, pushHistory = true) => {
+      const workspaceSessionKey = workspaceSessionKeyRef.current;
+      const requestKey = ++directoryLoadRequestKeyRef.current;
       setLoading(true);
       setError("");
 
@@ -993,6 +1095,12 @@ export function FileExplorerPane({
           targetPath ?? null,
           selectedWorkspaceId ?? null,
         );
+        if (
+          workspaceSessionKey !== workspaceSessionKeyRef.current ||
+          requestKey !== directoryLoadRequestKeyRef.current
+        ) {
+          return;
+        }
         const previousCurrentPath = currentPathRef.current;
         const shouldResetTree =
           pushHistory ||
@@ -1020,11 +1128,22 @@ export function FileExplorerPane({
             : prev,
         );
       } catch (cause) {
+        if (
+          workspaceSessionKey !== workspaceSessionKeyRef.current ||
+          requestKey !== directoryLoadRequestKeyRef.current
+        ) {
+          return;
+        }
         const message =
           cause instanceof Error ? cause.message : "Failed to open directory.";
         setError(message);
       } finally {
-        setLoading(false);
+        if (
+          workspaceSessionKey === workspaceSessionKeyRef.current &&
+          requestKey === directoryLoadRequestKeyRef.current
+        ) {
+          setLoading(false);
+        }
       }
     },
     [selectedWorkspaceId],
@@ -1035,12 +1154,35 @@ export function FileExplorerPane({
   }, [loadDirectory]);
 
   useEffect(() => {
+    workspaceSessionKeyRef.current += 1;
+    directoryLoadRequestKeyRef.current += 1;
+    previewRequestKeyRef.current += 1;
+    lastSyncedWorkspaceRootRef.current = null;
+    currentPathRef.current = "";
+    setCurrentPath("");
+    setEntries([]);
+    setDirectoryEntriesByPath({});
+    setExpandedDirectoryPaths({});
+    setDirectoryLoadingByPath({});
+    setDirectoryErrorByPath({});
+    setSelectedPath("");
+    setWorkspaceRootPath(null);
+    setLoading(false);
+    setError("");
+    setContextMenu(null);
+    setRenamingPath(null);
+    setRenameDraft("");
+    setRenameSaving(false);
+    setDraggedEntryPath(null);
+    setDirectoryDropTargetPath(null);
+    setPaneExternalDropTarget(false);
+    resetPreviewState();
+  }, [resetPreviewState, selectedWorkspaceId]);
+
+  useEffect(() => {
     if (!selectedWorkspaceId) {
-      lastSyncedWorkspaceRootRef.current = null;
-      setWorkspaceRootPath(null);
       return;
     }
-    setWorkspaceRootPath(null);
 
     let cancelled = false;
 
@@ -1317,6 +1459,10 @@ export function FileExplorerPane({
     () => filteredEntries.flatMap((section) => section.rows),
     [filteredEntries],
   );
+  const hasVisibleEntryRows = useMemo(
+    () => visibleRows.some((row) => row.type === "entry"),
+    [visibleRows],
+  );
 
   const selectedEntry = useMemo(
     () => findLoadedEntry(entries, selectedPath, directoryEntriesByPath),
@@ -1347,6 +1493,14 @@ export function FileExplorerPane({
   useEffect(() => {
     isSavingRef.current = saving;
   }, [saving]);
+
+  useEffect(() => {
+    if (loading || error || hasVisibleEntryRows) {
+      return;
+    }
+
+    resetPreviewState();
+  }, [error, hasVisibleEntryRows, loading, resetPreviewState]);
 
   const openPreviewLink = useCallback((url: string) => {
     if (onOpenLinkInBrowser) {
@@ -1693,6 +1847,8 @@ export function FileExplorerPane({
     targetPath: string,
     options?: { skipConfirm?: boolean; syncDirectory?: boolean },
   ) => {
+    const workspaceSessionKey = workspaceSessionKeyRef.current;
+    const requestKey = ++previewRequestKeyRef.current;
     const skipConfirm = options?.skipConfirm ?? false;
     if (!skipConfirm && !confirmDiscardIfDirty()) {
       return;
@@ -1712,6 +1868,12 @@ export function FileExplorerPane({
         targetPath,
         selectedWorkspaceId ?? null,
       );
+      if (
+        workspaceSessionKey !== workspaceSessionKeyRef.current ||
+        requestKey !== previewRequestKeyRef.current
+      ) {
+        return;
+      }
       setPreview(payload);
       setPreviewDraft(payload.content ?? "");
       setTablePreviewDraft(cloneTablePreviewSheets(payload.tableSheets));
@@ -1719,6 +1881,12 @@ export function FileExplorerPane({
         isMarkdownPreviewPayload(payload) || isHtmlPreviewPayload(payload);
       setTextPreviewMode(prefersRenderedTextPreview ? "preview" : "edit");
     } catch (cause) {
+      if (
+        workspaceSessionKey !== workspaceSessionKeyRef.current ||
+        requestKey !== previewRequestKeyRef.current
+      ) {
+        return;
+      }
       const message =
         cause instanceof Error ? cause.message : "Failed to open file.";
       setPreview(null);
@@ -1726,7 +1894,12 @@ export function FileExplorerPane({
       setTablePreviewDraft([]);
       setPreviewError(message);
     } finally {
-      setPreviewLoading(false);
+      if (
+        workspaceSessionKey === workspaceSessionKeyRef.current &&
+        requestKey === previewRequestKeyRef.current
+      ) {
+        setPreviewLoading(false);
+      }
     }
   };
 
@@ -1750,14 +1923,7 @@ export function FileExplorerPane({
       }
 
       setSelectedPath(targetPath);
-      setPreview(null);
-      setPreviewDraft("");
-      setTablePreviewDraft([]);
-      setTextPreviewMode("edit");
-      setActiveTableSheetIndex(0);
-      setPreviewError("");
-      setPreviewLoading(false);
-      setSaving(false);
+      resetPreviewState();
       onFileOpen(targetPath);
     },
     [
@@ -1765,6 +1931,7 @@ export function FileExplorerPane({
       onFileOpen,
       openFilePreview,
       previewInPane,
+      resetPreviewState,
       revealPathInTree,
     ],
   );
@@ -1774,13 +1941,7 @@ export function FileExplorerPane({
       return;
     }
 
-    setPreview(null);
-    setPreviewDraft("");
-    setTablePreviewDraft([]);
-    setTextPreviewMode("edit");
-    setActiveTableSheetIndex(0);
-    setPreviewError("");
-    setSaving(false);
+    resetPreviewState();
   };
 
   const savePreview = async () => {
@@ -1788,6 +1949,8 @@ export function FileExplorerPane({
       return;
     }
 
+    const workspaceSessionKey = workspaceSessionKeyRef.current;
+    const requestKey = ++previewRequestKeyRef.current;
     setSaving(true);
     setPreviewError("");
 
@@ -1804,16 +1967,33 @@ export function FileExplorerPane({
               previewDraft,
               selectedWorkspaceId ?? null,
             );
+      if (
+        workspaceSessionKey !== workspaceSessionKeyRef.current ||
+        requestKey !== previewRequestKeyRef.current
+      ) {
+        return;
+      }
       setPreview(nextPreview);
       setPreviewDraft(nextPreview.content ?? "");
       setTablePreviewDraft(cloneTablePreviewSheets(nextPreview.tableSheets));
       await loadDirectory(currentPath, false);
     } catch (cause) {
+      if (
+        workspaceSessionKey !== workspaceSessionKeyRef.current ||
+        requestKey !== previewRequestKeyRef.current
+      ) {
+        return;
+      }
       const message =
         cause instanceof Error ? cause.message : "Failed to save file.";
       setPreviewError(message);
     } finally {
-      setSaving(false);
+      if (
+        workspaceSessionKey === workspaceSessionKeyRef.current &&
+        requestKey === previewRequestKeyRef.current
+      ) {
+        setSaving(false);
+      }
     }
   };
 
@@ -1828,7 +2008,9 @@ export function FileExplorerPane({
         ]
       : null;
   const showInlinePreview =
-    previewInPane && Boolean(preview || previewLoading || previewError);
+    previewInPane &&
+    hasVisibleEntryRows &&
+    Boolean(preview || previewLoading || previewError);
   const selectedFileEntry =
     !previewInPane && selectedEntry && !selectedEntry.isDirectory
       ? selectedEntry
@@ -1948,18 +2130,6 @@ export function FileExplorerPane({
     workspaceRootPath,
   ]);
 
-  const openEntryFromContextMenu = useCallback(
-    async (entry: LocalFileEntry) => {
-      closeContextMenu();
-      if (entry.isDirectory) {
-        await toggleDirectoryExpansion(entry);
-        return;
-      }
-      await openFileTarget(entry.absolutePath);
-    },
-    [closeContextMenu, openFileTarget, toggleDirectoryExpansion],
-  );
-
   const referenceEntryInChat = useCallback(
     (entry: LocalFileEntry) => {
       const referenceText = buildChatReferenceText(
@@ -1988,20 +2158,62 @@ export function FileExplorerPane({
       return;
     }
 
+    const sourcePath = renamingEntry.absolutePath;
+    const shouldRetargetExternalFile =
+      !previewInPane &&
+      Boolean(onFileOpen) &&
+      normalizeComparablePath(selectedPath) ===
+        normalizeComparablePath(sourcePath);
+
     setError("");
     renameInFlightRef.current = true;
     setRenameSaving(true);
     try {
       const payload = await window.electronAPI.fs.renamePath(
-        renamingEntry.absolutePath,
+        sourcePath,
         nextName,
         selectedWorkspaceId ?? null,
       );
+      const nextAbsolutePath = payload.absolutePath;
       const parentPath =
-        getParentFolderPath(renamingEntry.absolutePath) ??
+        getParentFolderPath(sourcePath) ??
         currentPathRef.current;
+      setDirectoryEntriesByPath((current) =>
+        remapDirectoryEntriesByPath(current, sourcePath, nextAbsolutePath),
+      );
+      setExpandedDirectoryPaths((current) =>
+        remapExplorerPathRecord(current, sourcePath, nextAbsolutePath),
+      );
+      setDirectoryLoadingByPath((current) =>
+        remapExplorerPathRecord(current, sourcePath, nextAbsolutePath),
+      );
+      setDirectoryErrorByPath((current) =>
+        remapExplorerPathRecord(current, sourcePath, nextAbsolutePath),
+      );
       await refreshDirectoryEntries(parentPath);
-      setSelectedPath(payload.absolutePath);
+      await revealPathInTree(nextAbsolutePath);
+      setSelectedPath(nextAbsolutePath);
+      setPreview((current) => {
+        if (!current) {
+          return current;
+        }
+        const remappedAbsolutePath = remapPathAfterRename(
+          sourcePath,
+          nextAbsolutePath,
+          current.absolutePath,
+        );
+        if (!remappedAbsolutePath || remappedAbsolutePath === current.absolutePath) {
+          return current;
+        }
+        return {
+          ...current,
+          absolutePath: remappedAbsolutePath,
+          name: getFolderName(remappedAbsolutePath),
+        };
+      });
+      if (shouldRetargetExternalFile) {
+        onFileOpen?.(nextAbsolutePath);
+      }
       stopRenamingEntry();
     } catch (cause) {
       const message =
@@ -2016,9 +2228,13 @@ export function FileExplorerPane({
       setRenameSaving(false);
     }
   }, [
+    onFileOpen,
+    previewInPane,
     renameDraft,
     renamingEntry,
+    revealPathInTree,
     refreshDirectoryEntries,
+    selectedPath,
     selectedWorkspaceId,
     stopRenamingEntry,
   ]);
@@ -2261,16 +2477,14 @@ export function FileExplorerPane({
     ],
   );
 
-  const canDropDraggedEntryIntoDirectory = useCallback(
-    (entry: LocalFileEntry) => {
-      if (!entry.isDirectory) {
-        return false;
-      }
-
+  const canMoveDraggedEntryToDirectoryPath = useCallback(
+    (targetDirectoryPath: string | null | undefined) => {
       const normalizedDraggedEntryPath = normalizeComparablePath(
         draggedEntryPath ?? "",
       );
-      const normalizedTargetPath = normalizeComparablePath(entry.absolutePath);
+      const normalizedTargetPath = normalizeComparablePath(
+        targetDirectoryPath ?? "",
+      );
       if (!normalizedDraggedEntryPath || !normalizedTargetPath) {
         return false;
       }
@@ -2293,23 +2507,36 @@ export function FileExplorerPane({
     [draggedEntryPath, workspaceRootPath],
   );
 
+  const canDropDraggedEntryIntoDirectory = useCallback(
+    (entry: LocalFileEntry) => {
+      if (!entry.isDirectory) {
+        return false;
+      }
+      return canMoveDraggedEntryToDirectoryPath(entry.absolutePath);
+    },
+    [canMoveDraggedEntryToDirectoryPath],
+  );
+
   const onPaneDragOver = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (
-        !hasExternalExplorerDropData(event.dataTransfer) ||
-        !currentPathRef.current
-      ) {
+      const canMoveDraggedEntry = canMoveDraggedEntryToDirectoryPath(
+        currentPathRef.current,
+      );
+      const canImportExternalEntries =
+        hasExternalExplorerDropData(event.dataTransfer) &&
+        Boolean(currentPathRef.current);
+      if (!canMoveDraggedEntry && !canImportExternalEntries) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
-      event.dataTransfer.dropEffect = "copy";
+      event.dataTransfer.dropEffect = canMoveDraggedEntry ? "move" : "copy";
       setDirectoryDropTargetPath(null);
       if (!paneExternalDropTarget) {
         setPaneExternalDropTarget(true);
       }
     },
-    [paneExternalDropTarget],
+    [canMoveDraggedEntryToDirectoryPath, paneExternalDropTarget],
   );
 
   const onPaneDragLeave = useCallback(
@@ -2332,20 +2559,32 @@ export function FileExplorerPane({
 
   const onPaneDrop = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (
-        !hasExternalExplorerDropData(event.dataTransfer) ||
-        !currentPathRef.current
-      ) {
+      const canMoveDraggedEntry = canMoveDraggedEntryToDirectoryPath(
+        currentPathRef.current,
+      );
+      const canImportExternalEntries =
+        hasExternalExplorerDropData(event.dataTransfer) &&
+        Boolean(currentPathRef.current);
+      if (!canMoveDraggedEntry && !canImportExternalEntries) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
+      if (canMoveDraggedEntry && draggedEntryPath) {
+        void moveEntryToDirectory(draggedEntryPath, currentPathRef.current);
+        return;
+      }
       void importExternalEntriesToDirectory(
         event.dataTransfer,
         currentPathRef.current,
       );
     },
-    [importExternalEntriesToDirectory],
+    [
+      canMoveDraggedEntryToDirectoryPath,
+      draggedEntryPath,
+      importExternalEntriesToDirectory,
+      moveEntryToDirectory,
+    ],
   );
 
   const deleteEntryFromContextMenu = useCallback(
@@ -2787,27 +3026,26 @@ export function FileExplorerPane({
                   <span className="size-4 shrink-0" />
                 );
                 const rowContent = (
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span
-                      className="flex min-w-0 items-center gap-2"
-                      style={{ paddingLeft: `${depth * 16}px` }}
-                    >
-                      {disclosureControl}
-                      <Icon size={14} className={`shrink-0 ${className}`} />
-                      {nameField}
-                    </span>
-                    <span
-                      className="flex min-w-0 items-center gap-2 pl-6 text-[11px] text-muted-foreground"
-                      style={{ paddingLeft: `${depth * 16 + 24}px` }}
-                    >
-                      <span className="truncate">
-                        {formatModified(entry.modifiedAt)}
+                  <span
+                    className="flex min-w-0 flex-1 items-center gap-2"
+                    style={{ paddingLeft: `${depth * 16}px` }}
+                  >
+                    {disclosureControl}
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="flex min-w-0 items-center gap-2">
+                        <Icon size={14} className={`shrink-0 ${className}`} />
+                        {nameField}
                       </span>
-                      {!entry.isDirectory ? (
-                        <span className="shrink-0">
-                          {formatFileSize(entry.size)}
+                      <span className="flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground">
+                        <span className="truncate">
+                          {formatModified(entry.modifiedAt)}
                         </span>
-                      ) : null}
+                        {!entry.isDirectory ? (
+                          <span className="shrink-0">
+                            {formatFileSize(entry.size)}
+                          </span>
+                        ) : null}
+                      </span>
                     </span>
                   </span>
                 );
@@ -2897,7 +3135,7 @@ export function FileExplorerPane({
                     {isRenaming ? (
                       <div className="w-full">{rowContent}</div>
                     ) : (
-                      <div className="flex w-full min-w-0 items-start gap-1">
+                      <div className="flex w-full min-w-0 items-center gap-1">
                         <button
                           type="button"
                           draggable={!entry.isDirectory && !entryIsProtected}
@@ -2952,7 +3190,7 @@ export function FileExplorerPane({
                         >
                           {rowContent}
                         </button>
-                        <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
+                        <div className="flex shrink-0 items-center gap-0.5">
                           {onReferenceInChat ? (
                             <Button
                               type="button"
@@ -2972,24 +3210,22 @@ export function FileExplorerPane({
                               <AtSign size={12} />
                             </Button>
                           ) : null}
-                          {entry.isDirectory ? (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              aria-label={`More actions for ${entry.name}`}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                openEntryContextMenu(entry, {
-                                  anchorRect:
-                                    event.currentTarget.getBoundingClientRect(),
-                                });
-                              }}
-                              className={`shrink-0 text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
-                            >
-                              <MoreHorizontal size={12} />
-                            </Button>
-                          ) : null}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label={`More actions for ${entry.name}`}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openEntryContextMenu(entry, {
+                                anchorRect:
+                                  event.currentTarget.getBoundingClientRect(),
+                              });
+                            }}
+                            className={`shrink-0 text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
+                          >
+                            <MoreHorizontal size={12} />
+                          </Button>
                         </div>
                       </div>
                     )}
@@ -3102,21 +3338,6 @@ export function FileExplorerPane({
               style={contextMenuPosition}
               className="fixed z-[80] rounded-xl border border-border/70 bg-popover/92 p-1.5 text-popover-foreground shadow-xl ring-1 ring-foreground/10 backdrop-blur-xl"
             >
-              <Button
-                type="button"
-                variant="ghost"
-                size="default"
-                onClick={() => {
-                  void openEntryFromContextMenu(contextMenu.entry);
-                }}
-                className="w-full justify-start"
-              >
-                {contextMenu.entry.isDirectory
-                  ? expandedDirectoryPaths[contextMenu.entry.absolutePath]
-                    ? "Collapse folder"
-                    : "Expand folder"
-                  : "Open file"}
-              </Button>
               <Button
                 type="button"
                 variant="ghost"

--- a/runtime/api-server/src/agent-capability-registry.test.ts
+++ b/runtime/api-server/src/agent-capability-registry.test.ts
@@ -182,6 +182,36 @@ test("buildAgentCapabilityManifest includes native web search as a custom tool",
   assert.equal(buildEnabledToolMapFromManifest(manifest).web_search, true);
 });
 
+test("buildAgentCapabilityManifest marks connected MCP servers as available without pre-enumerated tool refs", () => {
+  const manifest = buildAgentCapabilityManifest({
+    harnessId: "pi",
+    sessionKind: "workspace_session",
+    defaultTools: ["read"],
+    extraTools: [],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    resolvedMcpServerIds: ["context7"],
+  });
+
+  assert.deepEqual(manifest.context, {
+    harness_id: "pi",
+    session_kind: "workspace_session",
+    browser_tools_available: false,
+    browser_tool_ids: [],
+    runtime_tool_ids: [],
+    workspace_command_ids: [],
+    mcp_server_ids: ["context7"],
+    workspace_commands_available: false,
+    workspace_skills_available: false,
+    mcp_tools_available: true,
+  });
+  assert.deepEqual(manifest.mcp_tools, []);
+
+  const section = renderCapabilityPolicyPromptSection(manifest);
+  assert.match(section, /Connected MCP servers available now: context7/);
+  assert.match(section, /Specific MCP tool names may be surfaced dynamically by the runtime/i);
+});
+
 test("buildAgentCapabilityManifest carries browser tool descriptions that emphasize live verification", () => {
   const manifest = buildAgentCapabilityManifest({
     harnessId: "pi",

--- a/runtime/api-server/src/agent-capability-registry.ts
+++ b/runtime/api-server/src/agent-capability-registry.ts
@@ -85,6 +85,7 @@ export interface AgentCapabilityPolicyContext {
   browser_tool_ids: string[];
   runtime_tool_ids: string[];
   workspace_command_ids: string[];
+  mcp_server_ids?: string[];
   workspace_commands_available?: boolean;
   workspace_skills_available?: boolean;
   mcp_tools_available?: boolean;
@@ -170,6 +171,7 @@ export interface BuildAgentCapabilityManifestParams {
   extraTools: string[];
   workspaceSkillIds: string[];
   resolvedMcpToolRefs: AgentCapabilityMcpToolRef[];
+  resolvedMcpServerIds?: string[] | null;
   toolServerIdMap?: Readonly<Record<string, string>> | null;
 }
 
@@ -867,19 +869,25 @@ function buildPolicyContext(
       ? params.runtimeToolIds
       : params.extraTools.filter((toolName) => RUNTIME_TOOL_DEFINITIONS.has(normalizedToken(toolName)))
   );
+  const mcpServerIds = uniqueSorted((params.resolvedMcpServerIds ?? []).map((serverId) => serverId.trim()));
   const workspaceCommands = uniqueSorted((params.workspaceCommandIds ?? []).map((commandId) => commandId.trim()));
   const workspaceSkills = uniqueSorted(params.workspaceSkillIds.map((skillId) => skillId.trim()));
+  const context: AgentCapabilityPolicyContext = {
+    harness_id: (params.harnessId ?? "").trim() || null,
+    session_kind: (params.sessionKind ?? "").trim() || null,
+    browser_tools_available:
+      typeof params.browserToolsAvailable === "boolean" ? params.browserToolsAvailable : null,
+    browser_tool_ids: browserToolIds,
+    runtime_tool_ids: runtimeToolIds,
+    workspace_command_ids: workspaceCommands,
+  };
+
+  if (mcpServerIds.length > 0) {
+    context.mcp_server_ids = mcpServerIds;
+  }
 
   return {
-    context: {
-      harness_id: (params.harnessId ?? "").trim() || null,
-      session_kind: (params.sessionKind ?? "").trim() || null,
-      browser_tools_available:
-        typeof params.browserToolsAvailable === "boolean" ? params.browserToolsAvailable : null,
-      browser_tool_ids: browserToolIds,
-      runtime_tool_ids: runtimeToolIds,
-      workspace_command_ids: workspaceCommands,
-    },
+    context,
     workspaceCommands,
     workspaceSkills,
   };
@@ -1187,7 +1195,8 @@ function projectAgentCapabilityManifest(
         : browserTools.length > 0,
     workspace_commands_available: evaluatedSet.workspace_commands.length > 0,
     workspace_skills_available: evaluatedSet.workspace_skills.length > 0,
-    mcp_tools_available: mcpToolAliases.length > 0,
+    mcp_tools_available:
+      mcpToolAliases.length > 0 || (evaluatedSet.context.mcp_server_ids?.length ?? 0) > 0,
   };
 
   return {
@@ -1283,6 +1292,11 @@ export function renderCapabilityPolicyPromptSection(manifest: AgentCapabilityMan
   if (manifest.mcp_tools.length > 0) {
     lines.push(
       `Connected MCP tools available now: ${summarizeList(manifest.mcp_tools.map((capability) => capability.id), 6)}`
+    );
+  } else if ((manifest.context.mcp_server_ids?.length ?? 0) > 0) {
+    lines.push(`Connected MCP servers available now: ${summarizeList(manifest.context.mcp_server_ids ?? [], 6)}`);
+    lines.push(
+      "Specific MCP tool names may be surfaced dynamically by the runtime even when this prompt section does not pre-enumerate them."
     );
   }
 

--- a/runtime/api-server/src/agent-runtime-config.test.ts
+++ b/runtime/api-server/src/agent-runtime-config.test.ts
@@ -364,6 +364,63 @@ test("projectAgentRuntimeConfig includes current user context as a context messa
   }
 });
 
+test("projectAgentRuntimeConfig surfaces connected MCP servers when no explicit MCP tool refs are pre-enumerated", () => {
+  process.env.HOLABOSS_MODEL_PROXY_BASE_URL = "https://runtime.example/api/v1/model-proxy";
+  process.env.HOLABOSS_USER_ID = "user-1";
+  try {
+    const result = projectAgentRuntimeConfig({
+      session_id: "session-1",
+      workspace_id: "workspace-1",
+      input_id: "input-1",
+      session_kind: "workspace_session",
+      harness_id: "pi",
+      browser_tools_available: false,
+      browser_tool_ids: [],
+      runtime_tool_ids: [],
+      workspace_command_ids: [],
+      runtime_exec_model_proxy_api_key: "hbrt.v1.token",
+      runtime_exec_sandbox_id: "sandbox-1",
+      runtime_exec_run_id: "run-1",
+      selected_model: null,
+      default_provider_id: "openai",
+      session_mode: "code",
+      workspace_config_checksum: "checksum-1",
+      workspace_skill_ids: [],
+      default_tools: ["read"],
+      extra_tools: [],
+      resolved_mcp_tool_refs: [],
+      resolved_mcp_server_ids: ["context7"],
+      resolved_output_schemas: {},
+      agent: {
+        id: "workspace.general",
+        model: "gpt-5.2",
+        prompt: "You are concise."
+      }
+    });
+
+    assert.match(result.system_prompt, /Connected MCP servers available now: context7/);
+    assert.match(
+      result.system_prompt,
+      /When connected MCP servers are available without pre-enumerated tool refs in this prompt, do not assume MCP is unavailable/i
+    );
+    assert.deepEqual(result.workspace_tool_ids, []);
+    assert.deepEqual(result.capability_manifest?.context, {
+      harness_id: "pi",
+      session_kind: "workspace_session",
+      browser_tools_available: false,
+      browser_tool_ids: [],
+      runtime_tool_ids: [],
+      workspace_command_ids: [],
+      mcp_server_ids: ["context7"],
+      workspace_commands_available: false,
+      workspace_skills_available: false,
+      mcp_tools_available: true,
+    });
+  } finally {
+    delete process.env.HOLABOSS_MODEL_PROXY_BASE_URL;
+  }
+});
+
 test("projectAgentRuntimeConfig includes operator surface context as a context message", () => {
   process.env.HOLABOSS_MODEL_PROXY_BASE_URL = "https://runtime.example/api/v1/model-proxy";
   process.env.HOLABOSS_USER_ID = "user-1";

--- a/runtime/api-server/src/agent-runtime-config.ts
+++ b/runtime/api-server/src/agent-runtime-config.ts
@@ -59,6 +59,7 @@ export interface AgentRuntimeConfigCliRequest {
   extra_tools: string[];
   tool_server_id_map?: Record<string, string> | null;
   resolved_mcp_tool_refs: Array<{ tool_id: string; server_id: string; tool_name: string }>;
+  resolved_mcp_server_ids?: string[] | null;
   resolved_output_schemas: Record<string, Record<string, unknown>>;
   agent: AgentRuntimeConfigGeneralMemberPayload;
 }
@@ -1207,6 +1208,7 @@ export function projectAgentRuntimeConfig(
     extraTools: request.extra_tools,
     workspaceSkillIds: request.workspace_skill_ids ?? [],
     resolvedMcpToolRefs: request.resolved_mcp_tool_refs,
+    resolvedMcpServerIds: request.resolved_mcp_server_ids ?? null,
     toolServerIdMap: request.tool_server_id_map ?? null,
   });
   const promptComposition = composeBaseAgentPrompt(request.agent.prompt, {
@@ -1214,6 +1216,7 @@ export function projectAgentRuntimeConfig(
     extraTools: request.extra_tools,
     workspaceSkillIds: request.workspace_skill_ids ?? [],
     resolvedMcpToolRefs: request.resolved_mcp_tool_refs,
+    resolvedMcpServerIds: request.resolved_mcp_server_ids ?? null,
     sessionKind: request.session_kind ?? null,
     sessionMode: request.session_mode,
     harnessId: request.harness_id ?? null,

--- a/runtime/api-server/src/agent-runtime-prompt.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.ts
@@ -122,6 +122,7 @@ export interface ComposeBaseAgentPromptRequest {
   extraTools: string[];
   workspaceSkillIds: string[];
   resolvedMcpToolRefs: unknown[];
+  resolvedMcpServerIds?: string[] | null;
   sessionKind?: string | null;
   sessionMode?: string | null;
   harnessId?: string | null;
@@ -608,6 +609,13 @@ export function buildBaseAgentPromptSections(
   }
   if (request.resolvedMcpToolRefs.length > 0) {
     executionLines.push("When a connected MCP tool is relevant, call it directly instead of only describing what it would do.");
+  } else if (
+    (request.resolvedMcpServerIds?.length ?? 0) > 0 ||
+    (request.capabilityManifest?.context.mcp_server_ids?.length ?? 0) > 0
+  ) {
+    executionLines.push(
+      "When connected MCP servers are available without pre-enumerated tool refs in this prompt, do not assume MCP is unavailable; use the MCP tools surfaced by the runtime when they are relevant."
+    );
   }
   pushPromptLayer(promptSections, {
     id: "execution_policy",

--- a/runtime/api-server/src/runner-prep.test.ts
+++ b/runtime/api-server/src/runner-prep.test.ts
@@ -9,6 +9,7 @@ import {
   encodeWorkspaceMcpCatalog,
   effectiveMcpServerPayloads,
   mergePreparedMcpServerPayloads,
+  mcpServerPayloads,
   mcpServerMappingMetadata,
   mcpServerIdMap,
   readWorkspaceRuntimePlanReferences,
@@ -159,6 +160,58 @@ test("effectiveMcpServerPayloads replaces logical workspace server with sidecar 
         timeout: 7000,
       },
       _holaboss_force_refresh: true,
+    },
+  ]);
+});
+
+test("mcpServerPayloads rejects placeholder-shaped literal secrets in MCP headers", () => {
+  const compiledPlan = {
+    resolved_mcp_servers: [
+      {
+        server_id: "context7",
+        type: "remote",
+        command: [],
+        url: "https://mcp.context7.com/mcp",
+        headers: [["CONTEXT7_API_KEY", "{env:ctx7sk-live-abc123}"]],
+        environment: [],
+        timeout_ms: 15000,
+      },
+    ],
+    workspace_mcp_catalog: [],
+  } as never;
+
+  assert.throws(
+    () => mcpServerPayloads(compiledPlan),
+    /invalid MCP env placeholder '\{env:ctx7sk-live-abc123\}' for 'CONTEXT7_API_KEY'; use '\{env:ENV_VAR_NAME\}' or provide a literal value/,
+  );
+});
+
+test("mcpServerPayloads preserves literal MCP header secrets that are not env placeholders", () => {
+  const compiledPlan = {
+    resolved_mcp_servers: [
+      {
+        server_id: "context7",
+        type: "remote",
+        command: [],
+        url: "https://mcp.context7.com/mcp",
+        headers: [["CONTEXT7_API_KEY", "ctx7sk-live-abc123"]],
+        environment: [],
+        timeout_ms: 15000,
+      },
+    ],
+    workspace_mcp_catalog: [],
+  } as never;
+
+  assert.deepEqual(mcpServerPayloads(compiledPlan), [
+    {
+      name: "context7",
+      config: {
+        type: "remote",
+        enabled: true,
+        url: "https://mcp.context7.com/mcp",
+        headers: { CONTEXT7_API_KEY: "ctx7sk-live-abc123" },
+        timeout: 15000,
+      },
     },
   ]);
 });

--- a/runtime/api-server/src/runner-prep.ts
+++ b/runtime/api-server/src/runner-prep.ts
@@ -114,7 +114,13 @@ function resolveEnvPlaceholders(mapping: Record<string, string>): Record<string,
   const resolved: Record<string, string> = {};
   for (const [key, value] of Object.entries(mapping)) {
     const token = value.trim();
+    const looksLikeEnvPlaceholder = token.startsWith("{env:") && token.endsWith("}");
     const match = token.match(/^\{env:([A-Za-z_][A-Za-z0-9_]*)\}$/);
+    if (looksLikeEnvPlaceholder && !match) {
+      throw new Error(
+        `invalid MCP env placeholder '${token}' for '${key}'; use '{env:ENV_VAR_NAME}' or provide a literal value`,
+      );
+    }
     if (!match) {
       resolved[key] = value;
       continue;

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -2814,6 +2814,110 @@ test("runTsRunnerCli pushes emitted events with retry semantics", async () => {
   assert.equal(stdout.trim().split("\n").length, 3);
 });
 
+test("runTsRunnerCli passes prepared MCP server ids into runtime config when no explicit MCP tool refs are resolved", { concurrency: false }, async () => {
+  const sandboxRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hb-ts-runner-pi-mcp-server-ids-"));
+  process.env.HB_SANDBOX_ROOT = sandboxRoot;
+  const piHarnessAdapter = requireRuntimeHarnessAdapter("pi");
+  const originalBuildRunnerPrepPlan = piHarnessAdapter.buildRunnerPrepPlan;
+  let capturedProjectRequest: Record<string, unknown> | null = null;
+  let capturedHarnessRequest: Record<string, unknown> | null = null;
+
+  piHarnessAdapter.buildRunnerPrepPlan = () => ({
+    stageWorkspaceSkills: true,
+    stageWorkspaceCommands: false,
+    prepareMcpTooling: true,
+    startWorkspaceMcpSidecar: false,
+    bootstrapResolvedApplications: false
+  });
+  try {
+    const exitCode = await runTsRunnerCli(
+      [
+        "--request-base64",
+        encodeRequest({
+          ...baseRequest(),
+          context: {
+            _sandbox_runtime_exec_v1: {
+              harness: "pi"
+            }
+          }
+        })
+      ],
+      {
+        deps: {
+          ...testDeps(),
+          compilePlan: () =>
+            ({
+              ...baseCompiledPlan(),
+              resolved_mcp_servers: [
+                {
+                  server_id: "context7",
+                  type: "remote",
+                  url: "https://mcp.context7.com/mcp",
+                  headers: [],
+                  environment: [],
+                  timeout_ms: 15000,
+                  enabled: true,
+                  command: null
+                }
+              ],
+            }) as never,
+          projectAgentRuntimeConfig: (request) => {
+            capturedProjectRequest = request as unknown as Record<string, unknown>;
+            return {
+              provider_id: "openai",
+              model_id: "gpt-5.4",
+              mode: "code",
+              system_prompt: "You are concise.",
+              model_client: {
+                model_proxy_provider: "openai_compatible",
+                api_key: "token",
+                base_url: "http://127.0.0.1:4000/openai/v1",
+                default_headers: { "X-Test": "1" }
+              },
+              tools: { read: true },
+              workspace_tool_ids: [],
+              workspace_skill_ids: [],
+              output_schema_member_id: null,
+              output_format: null,
+              workspace_config_checksum: "checksum-1"
+            };
+          },
+          runHarnessHost: async ({ requestPayload }) => {
+            capturedHarnessRequest = requestPayload;
+            return {
+              exitCode: 0,
+              stderr: "",
+              sawEvent: false,
+              terminalEmitted: false,
+              lastSequence: 0
+            };
+          }
+        },
+        io: {
+          stdout: { write() { return true; } } as unknown as NodeJS.WritableStream,
+          stderr: { write() { return true; } } as unknown as NodeJS.WritableStream
+        }
+      }
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(
+      (capturedProjectRequest as { resolved_mcp_server_ids: string[] }).resolved_mcp_server_ids,
+      ["context7"]
+    );
+    assert.deepEqual(
+      (capturedProjectRequest as { resolved_mcp_tool_refs: Array<Record<string, string>> }).resolved_mcp_tool_refs,
+      []
+    );
+    assert.deepEqual((capturedHarnessRequest as { mcp_servers: Array<{ name: string }> }).mcp_servers.map((server) => server.name), [
+      "context7"
+    ]);
+    assert.deepEqual((capturedHarnessRequest as { mcp_tool_refs: unknown[] }).mcp_tool_refs, []);
+  } finally {
+    piHarnessAdapter.buildRunnerPrepPlan = originalBuildRunnerPrepPlan;
+  }
+});
+
 test("runTsRunnerCli synthesizes run_failed when harness-host ends without a terminal event", async () => {
   const sandboxRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hb-ts-runner-no-terminal-"));
   process.env.HB_SANDBOX_ROOT = sandboxRoot;

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -2901,6 +2901,7 @@ test("runTsRunnerCli passes prepared MCP server ids into runtime config when no 
     );
 
     assert.equal(exitCode, 0);
+    assert.ok(capturedProjectRequest);
     assert.deepEqual(
       (capturedProjectRequest as { resolved_mcp_server_ids: string[] }).resolved_mcp_server_ids,
       ["context7"]
@@ -2909,6 +2910,7 @@ test("runTsRunnerCli passes prepared MCP server ids into runtime config when no 
       (capturedProjectRequest as { resolved_mcp_tool_refs: Array<Record<string, string>> }).resolved_mcp_tool_refs,
       []
     );
+    assert.ok(capturedHarnessRequest);
     assert.deepEqual((capturedHarnessRequest as { mcp_servers: Array<{ name: string }> }).mcp_servers.map((server) => server.name), [
       "context7"
     ]);

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -1077,6 +1077,7 @@ function buildAgentRuntimeConfigRequest(params: {
   workspaceCommandIds: string[];
   toolServerIdMap: Readonly<Record<string, string>>;
   resolvedMcpToolRefs: CompiledWorkspaceRuntimePlan["resolved_mcp_tool_refs"];
+  resolvedMcpServerIds: string[];
   recentRuntimeContext?: AgentRecentRuntimeContext | null;
   sessionResumeContext?: AgentSessionResumeContext | null;
   recalledMemoryContext?: AgentRecalledMemoryContext | null;
@@ -1119,6 +1120,7 @@ function buildAgentRuntimeConfigRequest(params: {
       server_id: toolRef.server_id,
       tool_name: toolRef.tool_name
     })),
+    resolved_mcp_server_ids: [...params.resolvedMcpServerIds],
     resolved_output_schemas: {}
   };
   return {
@@ -1667,6 +1669,7 @@ export async function executeTsRunnerRequest(
           workspaceCommandIds: stagedCommands.commandIds,
           toolServerIdMap: serverIdMap,
           resolvedMcpToolRefs,
+          resolvedMcpServerIds: effectiveMcpServers.map((server) => server.name),
           recentRuntimeContext,
           sessionResumeContext,
           recalledMemoryContext,

--- a/runtime/api-server/src/workspace-runtime-plan.test.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.test.ts
@@ -77,6 +77,60 @@ mcp_registry:
   assert.deepEqual(plan.resolved_mcp_servers.map((server) => server.server_id), []);
 });
 
+test("compileWorkspaceRuntimePlan exposes configured remote MCP servers when no allowlist is indicated", () => {
+  const plan = compileWorkspaceRuntimePlan({
+    workspace_id: "workspace-remote-mcp",
+    workspace_yaml: `
+agents:
+  id: workspace.general
+  model: openai/gpt-5
+mcp_registry:
+  allowlist:
+    tool_ids: []
+  servers:
+    context7:
+      type: remote
+      url: "https://mcp.context7.com/mcp"
+      enabled: true
+`,
+    references: {}
+  });
+
+  assert.deepEqual(plan.mcp_tool_allowlist, []);
+  assert.deepEqual(plan.resolved_mcp_tool_refs, []);
+  assert.deepEqual(plan.resolved_mcp_servers.map((server) => server.server_id), ["context7"]);
+});
+
+test("compileWorkspaceRuntimePlan exposes workspace catalog tools when no allowlist is indicated", () => {
+  const plan = compileWorkspaceRuntimePlan({
+    workspace_id: "workspace-local-mcp",
+    workspace_yaml: `
+agents:
+  id: workspace.general
+  model: openai/gpt-5
+mcp_registry:
+  servers: {}
+  catalog:
+    workspace.echo:
+      module_path: tools.echo
+      symbol: echo_tool
+`,
+    references: {}
+  });
+
+  assert.deepEqual(plan.mcp_tool_allowlist, []);
+  assert.deepEqual(plan.resolved_mcp_tool_refs, []);
+  assert.deepEqual(plan.resolved_mcp_servers.map((server) => server.server_id), ["workspace"]);
+  assert.deepEqual(plan.workspace_mcp_catalog, [
+    {
+      tool_id: "workspace.echo",
+      tool_name: "echo",
+      module_path: "tools.echo",
+      symbol_name: "echo_tool"
+    }
+  ]);
+});
+
 test("compileWorkspaceRuntimePlan loads prompt and applications", () => {
   const plan = compileWorkspaceRuntimePlan({
     workspace_id: "ws-test",

--- a/runtime/api-server/src/workspace-runtime-plan.test.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.test.ts
@@ -180,6 +180,41 @@ env_contract:
   assert.deepEqual(plan.schema_aliases, {});
 });
 
+test("compileWorkspaceRuntimePlan keeps other enabled remote MCP servers even when some tool ids are explicitly allowlisted", () => {
+  const plan = compileWorkspaceRuntimePlan({
+    workspace_id: "ws-mixed-mcp",
+    workspace_yaml: `
+agents:
+  id: workspace.general
+  model: openai/gpt-5
+mcp_registry:
+  allowlist:
+    tool_ids:
+      - gmail.gmail_search
+  servers:
+    gmail:
+      type: remote
+      url: "http://localhost:3099/mcp"
+      enabled: true
+    context7:
+      type: remote
+      url: "https://mcp.context7.com/mcp"
+      enabled: true
+`,
+    references: {}
+  });
+
+  assert.deepEqual(plan.mcp_tool_allowlist, ["gmail.gmail_search"]);
+  assert.deepEqual(plan.resolved_mcp_tool_refs, [
+    {
+      tool_id: "gmail.gmail_search",
+      server_id: "gmail",
+      tool_name: "gmail_search",
+    },
+  ]);
+  assert.deepEqual(plan.resolved_mcp_servers.map((server) => server.server_id), ["gmail", "context7"]);
+});
+
 test("compileWorkspaceRuntimePlan parses application integrations", () => {
   const plan = compileWorkspaceRuntimePlan({
     workspace_id: "ws-integrations",

--- a/runtime/api-server/src/workspace-runtime-plan.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.ts
@@ -137,6 +137,11 @@ type McpRegistryCompileResult = {
   workspace_catalog: WorkspaceMcpCatalogEntry[];
 };
 
+type AllowlistParseResult = {
+  resolved_tool_refs: ResolvedMcpToolRef[];
+  specified: boolean;
+};
+
 type WorkspaceRuntimePlanReferenceResponse =
   | {
       ok: true;
@@ -429,8 +434,11 @@ function parseStringPairs(value: unknown, path: string): Array<[string, string]>
   return pairs;
 }
 
-function readAllowlist(registry: JsonRecord): ResolvedMcpToolRef[] {
+function readAllowlist(registry: JsonRecord): AllowlistParseResult {
   const allowlist = registry.allowlist;
+  if (allowlist === undefined || allowlist === null) {
+    return { resolved_tool_refs: [], specified: false };
+  }
   if (!isRecord(allowlist)) {
     err({
       code: "workspace_mcp_registry_missing",
@@ -439,12 +447,18 @@ function readAllowlist(registry: JsonRecord): ResolvedMcpToolRef[] {
     });
   }
   const toolIds = allowlist.tool_ids;
+  if (toolIds === undefined || toolIds === null) {
+    return { resolved_tool_refs: [], specified: false };
+  }
   if (!Array.isArray(toolIds)) {
     err({
       code: "workspace_mcp_tool_id_invalid",
       path: "mcp_registry.allowlist.tool_ids",
       message: "expected list field 'tool_ids'"
     });
+  }
+  if (toolIds.length === 0) {
+    return { resolved_tool_refs: [], specified: false };
   }
   const refs: ResolvedMcpToolRef[] = [];
   const seen = new Set<string>();
@@ -479,7 +493,7 @@ function readAllowlist(registry: JsonRecord): ResolvedMcpToolRef[] {
       tool_name: parsed[1]
     });
   }
-  return refs;
+  return { resolved_tool_refs: refs, specified: true };
 }
 
 function readServers(registry: JsonRecord): Record<string, ServerConfig> {
@@ -670,54 +684,83 @@ function resolveMcpRegistry(config: JsonRecord): McpRegistryCompileResult {
     });
   }
 
-  const toolRefs = readAllowlist(registry);
+  const allowlist = readAllowlist(registry);
+  const toolRefs = allowlist.resolved_tool_refs;
   const servers = ensureWorkspaceServerConfig(readServers(registry));
   const catalog = readCatalog(registry);
 
   const referencedServerIds: string[] = [];
   const seenServerIds = new Set<string>();
-  for (const [index, toolRef] of toolRefs.entries()) {
-    const server = servers[toolRef.server_id];
-    if (!server) {
-      err({
-        code: "workspace_mcp_server_unknown",
-        path: `mcp_registry.allowlist.tool_ids[${index}]`,
-        message: `unknown MCP server '${toolRef.server_id}' for tool '${toolRef.tool_id}'`,
-        hint: "add server config under mcp_registry.servers"
-      });
+  if (allowlist.specified) {
+    for (const [index, toolRef] of toolRefs.entries()) {
+      const server = servers[toolRef.server_id];
+      if (!server) {
+        err({
+          code: "workspace_mcp_server_unknown",
+          path: `mcp_registry.allowlist.tool_ids[${index}]`,
+          message: `unknown MCP server '${toolRef.server_id}' for tool '${toolRef.tool_id}'`,
+          hint: "add server config under mcp_registry.servers"
+        });
+      }
+      if (!server.enabled) {
+        err({
+          code: "workspace_mcp_server_unknown",
+          path: `mcp_registry.allowlist.tool_ids[${index}]`,
+          message: `MCP server '${toolRef.server_id}' is disabled for tool '${toolRef.tool_id}'`
+        });
+      }
+      if (!seenServerIds.has(toolRef.server_id)) {
+        seenServerIds.add(toolRef.server_id);
+        referencedServerIds.push(toolRef.server_id);
+      }
     }
-    if (!server.enabled) {
-      err({
-        code: "workspace_mcp_server_unknown",
-        path: `mcp_registry.allowlist.tool_ids[${index}]`,
-        message: `MCP server '${toolRef.server_id}' is disabled for tool '${toolRef.tool_id}'`
-      });
-    }
-    if (!seenServerIds.has(toolRef.server_id)) {
-      seenServerIds.add(toolRef.server_id);
-      referencedServerIds.push(toolRef.server_id);
+  } else {
+    for (const server of Object.values(servers)) {
+      if (!server.enabled || server.server_id === WORKSPACE_SERVER_ID) {
+        continue;
+      }
+      seenServerIds.add(server.server_id);
+      referencedServerIds.push(server.server_id);
     }
   }
 
   const workspaceCatalog: WorkspaceMcpCatalogEntry[] = [];
-  for (const [index, toolRef] of toolRefs.entries()) {
-    if (toolRef.server_id !== WORKSPACE_SERVER_ID) {
-      continue;
-    }
-    const catalogEntry = catalog[toolRef.tool_id];
-    if (!catalogEntry) {
-      err({
-        code: "workspace_mcp_catalog_missing",
-        path: `mcp_registry.allowlist.tool_ids[${index}]`,
-        message: `workspace tool '${toolRef.tool_id}' is missing catalog entry in mcp_registry.catalog`
+  if (allowlist.specified) {
+    for (const [index, toolRef] of toolRefs.entries()) {
+      if (toolRef.server_id !== WORKSPACE_SERVER_ID) {
+        continue;
+      }
+      const catalogEntry = catalog[toolRef.tool_id];
+      if (!catalogEntry) {
+        err({
+          code: "workspace_mcp_catalog_missing",
+          path: `mcp_registry.allowlist.tool_ids[${index}]`,
+          message: `workspace tool '${toolRef.tool_id}' is missing catalog entry in mcp_registry.catalog`
+        });
+      }
+      workspaceCatalog.push({
+        tool_id: toolRef.tool_id,
+        tool_name: toolRef.tool_name,
+        module_path: catalogEntry.module_path,
+        symbol_name: catalogEntry.symbol_name
       });
     }
-    workspaceCatalog.push({
-      tool_id: toolRef.tool_id,
-      tool_name: toolRef.tool_name,
-      module_path: catalogEntry.module_path,
-      symbol_name: catalogEntry.symbol_name
-    });
+  } else {
+    for (const [toolId, catalogEntry] of Object.entries(catalog)) {
+      const parsedToolId = parseToolId(toolId);
+      if (!parsedToolId || parsedToolId[0] !== WORKSPACE_SERVER_ID) {
+        continue;
+      }
+      workspaceCatalog.push({
+        tool_id: toolId,
+        tool_name: parsedToolId[1],
+        module_path: catalogEntry.module_path,
+        symbol_name: catalogEntry.symbol_name
+      });
+    }
+  }
+  if (workspaceCatalog.length > 0 && !seenServerIds.has(WORKSPACE_SERVER_ID)) {
+    referencedServerIds.push(WORKSPACE_SERVER_ID);
   }
 
   return {

--- a/runtime/api-server/src/workspace-runtime-plan.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.ts
@@ -714,6 +714,17 @@ function resolveMcpRegistry(config: JsonRecord): McpRegistryCompileResult {
         referencedServerIds.push(toolRef.server_id);
       }
     }
+    for (const server of Object.values(servers)) {
+      if (
+        !server.enabled ||
+        server.server_id === WORKSPACE_SERVER_ID ||
+        seenServerIds.has(server.server_id)
+      ) {
+        continue;
+      }
+      seenServerIds.add(server.server_id);
+      referencedServerIds.push(server.server_id);
+    }
   } else {
     for (const server of Object.values(servers)) {
       if (!server.enabled || server.server_id === WORKSPACE_SERVER_ID) {

--- a/runtime/harness-host/src/contracts.test.ts
+++ b/runtime/harness-host/src/contracts.test.ts
@@ -235,6 +235,7 @@ test("decodeAgentRuntimeConfigCliRequestBase64 defaults optional arrays and obje
     extra_tools: [],
     tool_server_id_map: null,
     resolved_mcp_tool_refs: [],
+    resolved_mcp_server_ids: [],
     resolved_output_schemas: {},
     agent: {
       id: "agent-1",

--- a/runtime/harness-host/src/contracts.ts
+++ b/runtime/harness-host/src/contracts.ts
@@ -133,6 +133,7 @@ export interface AgentRuntimeConfigCliRequest {
   extra_tools: string[];
   tool_server_id_map?: Record<string, string> | null;
   resolved_mcp_tool_refs: Array<Record<string, string>>;
+  resolved_mcp_server_ids?: string[];
   resolved_output_schemas: Record<string, JsonObject>;
   agent: AgentRuntimeConfigGeneralMemberPayload;
 }
@@ -409,6 +410,7 @@ export function decodeAgentRuntimeConfigCliRequestBase64(encoded: string): Agent
     resolved_mcp_tool_refs: Array.isArray(parsed.resolved_mcp_tool_refs)
       ? parsed.resolved_mcp_tool_refs.filter(isRecord).map((item) => stringRecord(item))
       : [],
+    resolved_mcp_server_ids: stringArray(parsed.resolved_mcp_server_ids),
     resolved_output_schemas: isRecord(parsed.resolved_output_schemas)
       ? Object.fromEntries(
           Object.entries(parsed.resolved_output_schemas)

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -1535,6 +1535,49 @@ test("createPiMcpCustomTools filters discovery to allowlisted tools and forwards
   assert.match(String((result.content[0] as { text: string }).text), /"ok": true/);
 });
 
+test("createPiMcpCustomTools exposes all discovered tools when no MCP allowlist is provided", async () => {
+  const request: HarnessHostPiRequest = {
+    ...baseRequest(),
+    mcp_servers: [
+      {
+        name: "context7",
+        config: {
+          type: "remote",
+          enabled: true,
+          url: "https://mcp.context7.com/mcp",
+          timeout: 12000,
+        },
+      },
+    ],
+    mcp_tool_refs: [],
+  };
+
+  const runtime = {
+    listTools: async () => [
+      {
+        name: "lookup",
+        description: "Look something up",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "search",
+        description: "Search docs",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    callTool: async () => ({ structuredContent: { ok: true } }),
+  };
+
+  const bindings = buildPiMcpServerBindings(request);
+  const toolset = await createPiMcpCustomTools(request, runtime as never, bindings);
+
+  assert.equal(toolset.customTools.length, 2);
+  assert.deepEqual(
+    Array.from(toolset.mcpToolMetadata.values()).map((metadata) => metadata.toolId).sort(),
+    ["context7.lookup", "context7.search"]
+  );
+});
+
 test("createPiMcpCustomTools retries discovery until allowlisted MCP tools appear", async () => {
   const request: HarnessHostPiRequest = {
     ...baseRequest(),

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -1680,6 +1680,86 @@ test("createPiMcpCustomTools exposes all discovered tools when no MCP allowlist 
   );
 });
 
+test("createPiMcpCustomTools keeps unrestricted discovery for servers without explicit tool refs even when other servers are allowlisted", async () => {
+  const request: HarnessHostPiRequest = {
+    ...baseRequest(),
+    mcp_servers: [
+      {
+        name: "gmail",
+        config: {
+          type: "remote",
+          enabled: true,
+          url: "http://127.0.0.1:7000/mcp",
+          timeout: 12000,
+        },
+      },
+      {
+        name: "context7",
+        config: {
+          type: "remote",
+          enabled: true,
+          url: "https://mcp.context7.com/mcp",
+          timeout: 12000,
+        },
+      },
+    ],
+    mcp_tool_refs: [
+      {
+        tool_id: "gmail.gmail_search",
+        server_id: "gmail",
+        tool_name: "gmail_search",
+      },
+    ],
+  };
+
+  const runtime = {
+    listTools: async (serverId: string) => {
+      if (serverId === "gmail") {
+        return [
+          {
+            name: "gmail_search",
+            description: "Search Gmail",
+            inputSchema: { type: "object", properties: {} },
+          },
+          {
+            name: "gmail_delete_thread",
+            description: "Should not be exposed",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ];
+      }
+      return [
+        {
+          name: "lookup",
+          description: "Look something up",
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ];
+    },
+    callTool: async () => ({ structuredContent: { ok: true } }),
+  };
+
+  const toolset = await createPiMcpCustomTools(request, runtime as never, buildPiMcpServerBindings(request));
+
+  assert.deepEqual(
+    toolset.customTools.map((tool) => tool.name).sort(),
+    [
+      buildPiMcpToolName("context7", "lookup"),
+      buildPiMcpToolName("context7", "search"),
+      buildPiMcpToolName("gmail", "gmail_search"),
+    ]
+  );
+  assert.deepEqual(
+    Array.from(toolset.mcpToolMetadata.values()).map((metadata) => metadata.toolId).sort(),
+    ["context7.lookup", "context7.search", "gmail.gmail_search"]
+  );
+});
+
 test("createPiMcpCustomTools retries discovery until allowlisted MCP tools appear", async () => {
   const request: HarnessHostPiRequest = {
     ...baseRequest(),

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3168,15 +3168,11 @@ export async function createPiMcpCustomTools(
   bindings: PiMcpServerBinding[] = buildPiMcpServerBindings(request)
 ): Promise<Omit<PiMcpToolset, "runtime">> {
   const allowlist = mcpToolAllowlist(request);
-  const hasGlobalAllowlist = request.mcp_tool_refs.length > 0;
   const customTools: ToolDefinition[] = [];
   const mcpToolMetadata = new Map<string, PiMcpToolMetadata>();
 
   for (const binding of bindings) {
     const allowedTools = allowlist.get(binding.serverId);
-    if (!allowedTools && hasGlobalAllowlist) {
-      continue;
-    }
     const discoveryDeadline = Date.now() + Math.max(
       PI_MCP_DISCOVERY_RETRY_INTERVAL_MS,
       Math.min(binding.timeoutMs, PI_MCP_DISCOVERY_MAX_WAIT_MS)

--- a/website/docs/docs/build-on-holaos/agent-harness/internals.md
+++ b/website/docs/docs/build-on-holaos/agent-harness/internals.md
@@ -42,7 +42,7 @@ Representative reduced host request from `runtime/harnesses/src/pi.ts`:
 }
 ```
 
-`mcp_tool_refs` may be empty. In that case the host still receives the configured `mcp_servers` and exposes all discovered tools from those servers for the run.
+`mcp_tool_refs` may be empty. In that case the host still receives the configured `mcp_servers` and exposes all discovered tools from those servers for the run. The runtime-config path also carries connected MCP server ids so the prompt/capability manifest can say `connected MCP servers` instead of incorrectly implying MCP is unavailable.
 
 ## Main code seams
 
@@ -50,10 +50,10 @@ Representative reduced host request from `runtime/harnesses/src/pi.ts`:
 - `runtime/harnesses/src/pi.ts`: the current `pi` runtime adapter. This is where the shipped path declares capabilities, chooses its runner prep plan, and builds the reduced host request.
 - `runtime/api-server/src/harness-registry.ts`: runtime-side harness registration. This is where browser tools, runtime tools, skill staging, command staging, readiness, and harness-specific timeouts are coordinated.
 - `runtime/api-server/src/ts-runner.ts`: per-run bootstrap. This is where the runtime applies the default tool set, adds extra tools such as `web_search` and `write_report`, prepares browser/runtime/MCP state, loads operator-surface context, and builds the agent runtime config request.
-- `runtime/api-server/src/agent-runtime-config.ts`: prompt and capability projection. This is where prompt layers, recalled memory, recent runtime context, operator-surface context, response-delivery policy, capability manifests, and tool visibility are composed before the harness runs.
+- `runtime/api-server/src/agent-runtime-config.ts`: prompt and capability projection. This is where prompt layers, recalled memory, recent runtime context, operator-surface context, response-delivery policy, capability manifests, and tool visibility are composed before the harness runs. For MCP, this layer distinguishes pre-enumerated tool refs from connected server ids that still require host-side discovery.
 - `runtime/harness-host/src/contracts.ts`: host-side request and event contracts. This is the source of truth for the decoded host request and the normalized runner event types the host must emit back.
 - `runtime/harness-host/src/index.ts`: harness-host CLI entrypoint that dispatches a registered host plugin by command.
-- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, materializes allowlisted MCP tools or all discovered tools when the MCP allowlist is omitted, and normalizes provider-native `thinking_value` choices onto Pi reasoning levels or budgets.
+- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, materializes per-server allowlisted MCP subsets or full discovered tool catalogs when a configured server has no explicit refs, and normalizes provider-native `thinking_value` choices onto Pi reasoning levels or budgets.
 - `runtime/harness-host/src/pi-browser-tools.ts`: desktop browser bridge used by the current host.
 - `runtime/harness-host/src/pi-runtime-tools.ts`: runtime-managed tool bridge for onboarding, cronjobs, image generation, and `write_report`. This is also where the host attaches workspace/session/input/model headers to runtime-tool calls.
 - `runtime/harness-host/src/pi-web-search.ts`: hosted native web search bridge for the current `web_search` tool.
@@ -140,7 +140,8 @@ If a quoted skill id is missing, the host appends an explicit warning section ra
 
 - The workspace contract stays runtime-owned. A harness should consume it, not redefine it.
 - Memory and continuity stay runtime-owned. A harness can use recalled context, but it should not replace the persistence model.
-- MCP tools stay runtime-projected per run. When the runtime resolved a subset, do not expose whole servers; when the runtime omitted the allowlist, exposing all discovered tools from the configured servers is intentional.
+- MCP tools stay runtime-projected per run. When the runtime resolved a subset for a server, do not expose more than that subset for that server; when a configured server has no explicit refs, exposing all discovered tools from that server is intentional.
+- Prompt-visible capability text must stay derived from the same runtime-owned MCP truth. It is guidance, not the enforcement boundary.
 - Skills stay explicit. If a harness supports skill-driven widening, keep the widening rules inspectable and tied to skill metadata.
 - Runtime-tool mutations should stay turn-aware. If the host creates outputs such as report artifacts, keep workspace/session/input association explicit instead of inferring it later from file capture.
 - The harness should receive a reduced execution package, not uncontrolled access to the whole product state.

--- a/website/docs/docs/build-on-holaos/agent-harness/internals.md
+++ b/website/docs/docs/build-on-holaos/agent-harness/internals.md
@@ -15,7 +15,7 @@ For the shipped `pi` path, a single run currently moves through these seams:
 3. `runtime/api-server/src/harness-registry.ts`: selects the runtime harness plugin, timeout behavior, browser tools, runtime tools, and MCP preparation policy.
 4. `runtime/harnesses/src/pi.ts`: builds the reduced host request that crosses from runtime code into the harness host, including the raw `thinking_value` requested for this run.
 5. `runtime/harness-host/src/index.ts`: dispatches the registered host plugin by command.
-6. `runtime/harness-host/src/pi.ts`: creates the Pi session, loads skills, injects runtime and browser tools, materializes allowlisted MCP tools, enforces workspace boundaries, maps `thinking_value` onto Pi-native reasoning settings, and maps native events back out.
+6. `runtime/harness-host/src/pi.ts`: creates the Pi session, loads skills, injects runtime and browser tools, materializes the resolved MCP tool surface, enforces workspace boundaries, maps `thinking_value` onto Pi-native reasoning settings, and maps native events back out.
 7. `runtime/harness-host/src/contracts.ts`: defines the normalized runner event types that the host emits back to the runtime.
 
 If you are unsure where a behavior belongs, trace this path before you patch anything.
@@ -42,6 +42,8 @@ Representative reduced host request from `runtime/harnesses/src/pi.ts`:
 }
 ```
 
+`mcp_tool_refs` may be empty. In that case the host still receives the configured `mcp_servers` and exposes all discovered tools from those servers for the run.
+
 ## Main code seams
 
 - `runtime/harnesses/src/types.ts`: canonical harness contracts, including adapter capabilities, runner prep plans, prompt-layer payloads, prepared MCP payloads, and host request build parameters.
@@ -51,7 +53,7 @@ Representative reduced host request from `runtime/harnesses/src/pi.ts`:
 - `runtime/api-server/src/agent-runtime-config.ts`: prompt and capability projection. This is where prompt layers, recalled memory, recent runtime context, operator-surface context, response-delivery policy, capability manifests, and tool visibility are composed before the harness runs.
 - `runtime/harness-host/src/contracts.ts`: host-side request and event contracts. This is the source of truth for the decoded host request and the normalized runner event types the host must emit back.
 - `runtime/harness-host/src/index.ts`: harness-host CLI entrypoint that dispatches a registered host plugin by command.
-- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, materializes allowlisted MCP tools, and normalizes provider-native `thinking_value` choices onto Pi reasoning levels or budgets.
+- `runtime/harness-host/src/pi.ts`: the current host implementation. This is where the host loads workspace skills, applies skill widening, enforces workspace-boundary policy, injects browser/runtime/web search tools, materializes allowlisted MCP tools or all discovered tools when the MCP allowlist is omitted, and normalizes provider-native `thinking_value` choices onto Pi reasoning levels or budgets.
 - `runtime/harness-host/src/pi-browser-tools.ts`: desktop browser bridge used by the current host.
 - `runtime/harness-host/src/pi-runtime-tools.ts`: runtime-managed tool bridge for onboarding, cronjobs, image generation, and `write_report`. This is also where the host attaches workspace/session/input/model headers to runtime-tool calls.
 - `runtime/harness-host/src/pi-web-search.ts`: hosted native web search bridge for the current `web_search` tool.
@@ -138,7 +140,7 @@ If a quoted skill id is missing, the host appends an explicit warning section ra
 
 - The workspace contract stays runtime-owned. A harness should consume it, not redefine it.
 - Memory and continuity stay runtime-owned. A harness can use recalled context, but it should not replace the persistence model.
-- MCP tools stay allowlisted per run. Do not expose whole servers when the runtime only resolved a subset of tools.
+- MCP tools stay runtime-projected per run. When the runtime resolved a subset, do not expose whole servers; when the runtime omitted the allowlist, exposing all discovered tools from the configured servers is intentional.
 - Skills stay explicit. If a harness supports skill-driven widening, keep the widening rules inspectable and tied to skill metadata.
 - Runtime-tool mutations should stay turn-aware. If the host creates outputs such as report artifacts, keep workspace/session/input association explicit instead of inferring it later from file capture.
 - The harness should receive a reduced execution package, not uncontrolled access to the whole product state.

--- a/website/docs/docs/build-on-holaos/runtime/run-compilation.md
+++ b/website/docs/docs/build-on-holaos/runtime/run-compilation.md
@@ -101,7 +101,8 @@ This is the runtime-owned interpretation of the authored workspace, not a loose 
 - `mcp_registry` is required
 - `tool_registry` is explicitly unsupported
 - when `mcp_registry.allowlist.tool_ids` is provided and non-empty, MCP tool ids must be `server.tool`
-- when `mcp_registry.allowlist.tool_ids` is omitted or empty, the runtime exposes all enabled configured MCP servers for that run
+- when `mcp_registry.allowlist.tool_ids` is omitted or empty, the runtime keeps all enabled configured MCP servers for that run and lets the host discover all tools from those servers at runtime
+- when some servers have explicit allowlisted tool ids and others do not, the runtime carries both: explicit `resolved_mcp_tool_refs` for the constrained servers and connected server payloads for the still-discoverable servers
 - `mcp_registry.servers.workspace` must be local
 - `applications` must be a list of mappings
 - `applications[].app_id` must be unique
@@ -126,6 +127,31 @@ Before the harness launch it also:
 - bootstraps resolved applications and merges app-provided MCP servers into the prepared MCP payloads
 
 This is where runtime-owned tool visibility stops being a static config file and becomes a run-specific capability surface.
+
+For remote MCP auth values, `runner-prep.ts` also resolves header and environment placeholders of the form `{env:ENV_VAR_NAME}` before the host request is built. That syntax expects an environment variable name, not a literal secret value.
+
+Correct:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "{env:CONTEXT7_API_KEY}"
+```
+
+Also correct:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "ctx7sk-..."
+```
+
+Incorrect:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "{env:ctx7sk-...}"
+```
+
+That last shape is now rejected during runner prep instead of being forwarded as a bogus remote header.
 
 ## Stage 4: Load Runtime Context
 
@@ -160,6 +186,17 @@ Important outputs include:
 - `capability_manifest`
 
 This is also where response-delivery guidance and operator surface context become prompt-visible context for the run. If the harness sees the wrong tools, wrong prompt layers, wrong selected model, or wrong output schema, this is usually the page and code seam you wanted.
+
+For MCP, this stage now distinguishes two cases:
+
+- explicit allowlist:
+  `resolved_mcp_tool_refs` contains concrete tool ids, so the capability manifest and prompt can list them directly
+- omitted or empty allowlist:
+  `resolved_mcp_tool_refs` may stay empty while the runtime still carries connected MCP server ids into the runtime config; the prompt can then say which servers are connected even though the host will discover the concrete tool names later
+- mixed mode:
+  `resolved_mcp_tool_refs` can contain concrete tool ids for some servers while other connected servers remain discovery-backed for that run
+
+That keeps the prompt aligned with runtime truth without turning prompt text into the enforcement boundary.
 
 Model selection and reasoning effort split here:
 
@@ -213,6 +250,8 @@ That snapshot is the runtime’s replay and debugging seam. It is how the system
 
 - `workspace_config_checksum` changing unexpectedly usually means the authored workspace input changed, not the harness.
 - Missing MCP tools often come from `mcp_registry` compile rules or server-id mapping, not from the host implementation.
+- If MCP is configured but the prompt only summarizes connected server ids, that usually means the allowlist was omitted and concrete tool names will be discovered in the host at runtime.
+- If a remote MCP server reports invalid auth and your header value looks like `{env:ctx7sk-...}`, that is a config mistake. Use a literal `ctx7sk-...` value or `{env:CONTEXT7_API_KEY}`.
 - Ambiguous `here`, `this page`, or `what am I looking at` behavior usually comes from operator surface context loading, not from `workspace.yaml`.
 - Wrong prompt context often comes from runtime context loading or `projectAgentRuntimeConfig()`, not from `workspace.yaml`.
 - Wrong reasoning effort usually comes from the queued `thinking_value`, catalog metadata, or harness-host normalization, not from `workspace.yaml`.

--- a/website/docs/docs/build-on-holaos/runtime/run-compilation.md
+++ b/website/docs/docs/build-on-holaos/runtime/run-compilation.md
@@ -100,7 +100,8 @@ This is the runtime-owned interpretation of the authored workspace, not a loose 
 - `workspace.yaml` must parse to a mapping object
 - `mcp_registry` is required
 - `tool_registry` is explicitly unsupported
-- allowlisted MCP tool ids must be `server.tool`
+- when `mcp_registry.allowlist.tool_ids` is provided and non-empty, MCP tool ids must be `server.tool`
+- when `mcp_registry.allowlist.tool_ids` is omitted or empty, the runtime exposes all enabled configured MCP servers for that run
 - `mcp_registry.servers.workspace` must be local
 - `applications` must be a list of mappings
 - `applications[].app_id` must be unique

--- a/website/docs/docs/holaos/agent-harness/mcp-support.md
+++ b/website/docs/docs/holaos/agent-harness/mcp-support.md
@@ -1,6 +1,9 @@
 # MCP Support
 
-MCP support is part of the current harness path, but it is projected from `workspace.yaml` rather than discovered by the harness on its own.
+MCP support is part of the current harness path, but two different layers matter:
+
+- `workspace.yaml` defines the MCP policy boundary for the run
+- the harness host may still discover concrete tool catalogs from the connected MCP servers at runtime
 
 ## Where Workspace-Level MCP Lives
 
@@ -17,12 +20,28 @@ mcp_registry:
       enabled: true
       timeout_ms: 30000
       headers:
-        Authorization: "{env:CONTEXT7_AUTHORIZATION}"
+        CONTEXT7_API_KEY: "{env:CONTEXT7_API_KEY}"
   allowlist:
     tool_ids:
       - context7.lookup
       - context7.search
 ```
+
+For Context7, the header value must be either:
+
+- a literal API key such as `ctx7sk-...`
+- or an environment placeholder whose contents are the environment variable name, such as `{env:CONTEXT7_API_KEY}`
+
+Do not wrap the literal key in placeholder syntax. This is invalid:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "{env:ctx7sk-...}"
+```
+
+That shape does not reference an environment variable. It sends a placeholder-shaped string to the remote MCP server instead of the actual API key.
+
+Explicit tool ids apply to the servers named by those ids. Other enabled configured servers can still remain discoverable for the run when they have no explicit tool refs.
 
 Remote server example that allows all discovered tools from the configured server:
 
@@ -54,9 +73,12 @@ mcp_registry:
 Before the harness runs, the runtime:
 
 - prepares MCP server payloads
+- resolves `{env:ENV_VAR_NAME}` placeholders in remote MCP headers and environment values
+- rejects placeholder-shaped literals such as `{env:ctx7sk-...}` with a config error before the run starts
 - starts the workspace MCP sidecar when needed
 - resolves MCP tool refs when `mcp_registry.allowlist.tool_ids` is present and non-empty
 - passes the prepared `mcp_servers` and any resolved `mcp_tool_refs` into the host request
+- carries connected MCP server ids into the runtime config so prompt and capability projection can distinguish `no MCP server` from `connected server with runtime discovery`
 
 That means the runtime decides which part of the MCP graph is visible for this run.
 
@@ -66,9 +88,28 @@ The harness host then:
 
 - builds MCP bindings from the prepared server payloads
 - discovers tools from those configured servers
-- exposes either the allowlisted subset or all discovered tools when no MCP allowlist was indicated
+- restricts servers that have explicit `mcp_tool_refs` to that subset
+- exposes all discovered tools for configured servers that do not have explicit `mcp_tool_refs`
 
-This keeps MCP visibility policy inside the runtime while still allowing a workspace to opt into “all tools from this configured server” by leaving the allowlist empty.
+This keeps MCP visibility policy inside the runtime while still allowing a workspace to mix both modes in one run: explicitly constrained servers and unrestricted discovered servers.
+
+## What the Agent Sees
+
+There are two valid MCP shapes at run start:
+
+- explicit allowlist present:
+  the runtime resolves concrete `mcp_tool_refs`, so the capability manifest and prompt can name those tools directly
+- allowlist omitted or empty:
+  the runtime still passes the connected `mcp_servers`, but concrete remote tool names may not be pre-enumerated yet; the host discovers them at runtime and exposes all discovered tools from those servers
+
+A mixed workspace is also valid:
+
+- some servers have explicit `mcp_tool_refs` and stay constrained to those tools
+- other configured servers have no explicit refs and stay discoverable-all for that run
+
+In the second case, the prompt should not claim MCP is unavailable. It may summarize connected MCP server ids even when concrete tool names are discovered later in the host.
+
+The enforcement boundary is still the actual tool registry materialized by the host for that run, not the prose in the prompt.
 
 ## When Changes Take Effect
 
@@ -79,8 +120,9 @@ The runtime compiles `workspace.yaml` at run start. If you add or edit a remote 
 MCP is one of the most important capability surfaces in `holaOS`, so it needs a stable policy boundary:
 
 - runtime resolves configured MCP servers for the run
-- runtime resolves explicit MCP tool refs when an allowlist is present
-- host materializes the resolved subset or all discovered tools when no allowlist was indicated
+- runtime resolves explicit MCP tool refs when allowlisted tool ids exist for a server
+- runtime may carry only MCP server ids, not pre-enumerated tool ids, when the allowlist is omitted
+- host materializes the resolved subset for servers with explicit refs and all discovered tools for servers without them
 - harness consumes the projected tool surface
 
 That split is what keeps MCP support compatible with multiple harnesses later.

--- a/website/docs/docs/holaos/agent-harness/mcp-support.md
+++ b/website/docs/docs/holaos/agent-harness/mcp-support.md
@@ -1,34 +1,86 @@
 # MCP Support
 
-MCP support is part of the current harness path, but it is explicitly projected rather than implicitly discovered.
+MCP support is part of the current harness path, but it is projected from `workspace.yaml` rather than discovered by the harness on its own.
 
-## What the runtime does first
+## Where Workspace-Level MCP Lives
+
+Workspace-level MCP servers are authored in `workspace.yaml` under `mcp_registry`.
+
+Remote server example with an explicit allowlist:
+
+```yaml
+mcp_registry:
+  servers:
+    context7:
+      type: remote
+      url: https://mcp.context7.com/mcp
+      enabled: true
+      timeout_ms: 30000
+      headers:
+        Authorization: "{env:CONTEXT7_AUTHORIZATION}"
+  allowlist:
+    tool_ids:
+      - context7.lookup
+      - context7.search
+```
+
+Remote server example that allows all discovered tools from the configured server:
+
+```yaml
+mcp_registry:
+  servers:
+    context7:
+      type: remote
+      url: https://mcp.context7.com/mcp
+      enabled: true
+      timeout_ms: 30000
+```
+
+An empty allowlist has the same meaning:
+
+```yaml
+mcp_registry:
+  servers:
+    context7:
+      type: remote
+      url: https://mcp.context7.com/mcp
+      enabled: true
+  allowlist:
+    tool_ids: []
+```
+
+## What the Runtime Does First
 
 Before the harness runs, the runtime:
 
 - prepares MCP server payloads
 - starts the workspace MCP sidecar when needed
-- resolves the allowed MCP tool refs for the run
-- passes the allowlisted `mcp_tool_refs` into the host request
+- resolves MCP tool refs when `mcp_registry.allowlist.tool_ids` is present and non-empty
+- passes the prepared `mcp_servers` and any resolved `mcp_tool_refs` into the host request
 
 That means the runtime decides which part of the MCP graph is visible for this run.
 
-## What the host does next
+## What the Host Does Next
 
 The harness host then:
 
 - builds MCP bindings from the prepared server payloads
-- discovers the allowed tools
-- exposes only the resolved tool subset to the harness
+- discovers tools from those configured servers
+- exposes either the allowlisted subset or all discovered tools when no MCP allowlist was indicated
 
-This is why MCP visibility is explicit per run rather than a blanket “everything on the server is available” rule.
+This keeps MCP visibility policy inside the runtime while still allowing a workspace to opt into “all tools from this configured server” by leaving the allowlist empty.
 
-## Current boundary
+## When Changes Take Effect
+
+The runtime compiles `workspace.yaml` at run start. If you add or edit a remote MCP server during one run, the updated server configuration is ready on the next run, not retroactively inside the already running harness session.
+
+## Current Boundary
 
 MCP is one of the most important capability surfaces in `holaOS`, so it needs a stable policy boundary:
 
-- runtime resolves and allowlists
-- host materializes the allowed tools
+- runtime resolves configured MCP servers for the run
+- runtime resolves explicit MCP tool refs when an allowlist is present
+- host materializes the resolved subset or all discovered tools when no allowlist was indicated
 - harness consumes the projected tool surface
 
 That split is what keeps MCP support compatible with multiple harnesses later.

--- a/website/docs/docs/holaos/workspace-model.md
+++ b/website/docs/docs/holaos/workspace-model.md
@@ -162,8 +162,33 @@ For app development, two fields matter immediately:
 For workspace-level MCP, the main authored surface is `mcp_registry`:
 
 - `mcp_registry.servers.<server-id>` declares local or remote MCP servers
-- `mcp_registry.allowlist.tool_ids` optionally narrows visibility to explicit `server.tool` ids
+- `mcp_registry.allowlist.tool_ids` optionally provides explicit `server.tool` refs for servers that should be constrained to a known subset
 - when `mcp_registry.allowlist.tool_ids` is omitted or empty, the runtime exposes all discovered tools from the enabled configured MCP servers for that run
+- when some servers have explicit tool ids and others do not, the runtime keeps the explicit subset for the referenced servers and still allows discovery for the other enabled configured servers
+- remote MCP headers and environment values may use `{env:ENV_VAR_NAME}` placeholders, but the contents must be an environment variable name, not a literal secret
+
+For remote MCP servers, `workspace.yaml` usually declares the server and policy boundary, not the full raw tool catalog. The concrete remote tool list may still be discovered at run time.
+
+For example, this is valid:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "{env:CONTEXT7_API_KEY}"
+```
+
+and this is also valid:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "ctx7sk-..."
+```
+
+This is invalid:
+
+```yaml
+headers:
+  CONTEXT7_API_KEY: "{env:ctx7sk-...}"
+```
 
 Those entries are how the runtime finds each app manifest under `apps/`.
 

--- a/website/docs/docs/holaos/workspace-model.md
+++ b/website/docs/docs/holaos/workspace-model.md
@@ -159,6 +159,12 @@ For app development, two fields matter immediately:
 - `applications[].app_id`
 - `applications[].config_path`
 
+For workspace-level MCP, the main authored surface is `mcp_registry`:
+
+- `mcp_registry.servers.<server-id>` declares local or remote MCP servers
+- `mcp_registry.allowlist.tool_ids` optionally narrows visibility to explicit `server.tool` ids
+- when `mcp_registry.allowlist.tool_ids` is omitted or empty, the runtime exposes all discovered tools from the enabled configured MCP servers for that run
+
 Those entries are how the runtime finds each app manifest under `apps/`.
 
 ### `.git/`


### PR DESCRIPTION
## Context

This branch carries two related fixes that were validated together in the current desktop/runtime flow:

- file explorer rename could leave stale tree, selection, and preview state after a path change
- MCP runtime behavior around unrestricted server discovery and Context7 auth configuration needed to match the actual host behavior and be documented clearly

## What Changed

- remap cached file explorer paths after rename, reveal the renamed entry in the tree, and retarget preview/open-file state when the active path changes
- keep unrestricted remote MCP servers discoverable even when other servers have explicit allowlisted tool refs
- carry connected MCP server ids through runtime capability projection so prompt-visible MCP state matches host-side discovery behavior
- reject placeholder-shaped literal MCP secrets such as `{env:ctx7sk-...}` and document the correct Context7 header forms in the docs site
- update MCP docs to explain omitted allowlist behavior, mixed constrained/unrestricted discovery, and correct env placeholder usage

## Validation

- `node --test desktop/src/components/panes/FileExplorerPane.test.mjs`
- `npm run typecheck` in `desktop`
- `node --import tsx --test src/runner-prep.test.ts` in `runtime/api-server`
- `npm run build` in `website/docs`

## Notes

- Screenshots: not attached; the UI-facing change is limited to file explorer rename state handling.
- Supabase or migration impact: none.
