### PR TITLE
fix: keep silent runner executions alive with invisible heartbeats

### DIFF
--- a/runtime/api-server/src/runner-worker.test.ts
+++ b/runtime/api-server/src/runner-worker.test.ts
@@ -19,6 +19,7 @@ const ORIGINAL_ENV = {
   SANDBOX_AGENT_TASK_PROPOSAL_RUN_TIMEOUT_S: process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_TIMEOUT_S,
   SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S: process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S,
   SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S: process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S,
+  SANDBOX_AGENT_RUNNER_HEARTBEAT_MS: process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS,
   SANDBOX_RUNTIME_API_URL: process.env.SANDBOX_RUNTIME_API_URL,
   SANDBOX_RUNTIME_API_HOST: process.env.SANDBOX_RUNTIME_API_HOST,
   SANDBOX_RUNTIME_API_PORT: process.env.SANDBOX_RUNTIME_API_PORT,
@@ -56,6 +57,11 @@ afterEach(() => {
     delete process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S;
   } else {
     process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S = ORIGINAL_ENV.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S;
+  }
+  if (ORIGINAL_ENV.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS === undefined) {
+    delete process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS;
+  } else {
+    process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS = ORIGINAL_ENV.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS;
   }
   if (ORIGINAL_ENV.SANDBOX_RUNTIME_API_URL === undefined) {
     delete process.env.SANDBOX_RUNTIME_API_URL;
@@ -323,6 +329,28 @@ test("native runner executor gives task proposal runs a longer idle timeout budg
 
   const executor = new NativeRunnerExecutor();
   const response = await executor.run(payload({ session_kind: "task_proposal" }));
+  const events = response.events as Array<Record<string, unknown>>;
+
+  assert.deepEqual(
+    events.map((event) => event.event_type),
+    ["run_started", "run_completed"]
+  );
+});
+
+test("native runner executor keeps silent runs alive with invisible runner heartbeats", async () => {
+  process.env.SANDBOX_AGENT_RUN_TIMEOUT_S = "10";
+  process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S = "1";
+  process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS = "50";
+
+  setNodeRunnerTemplate([
+    "setTimeout(() => {",
+    "  process.stdout.write(JSON.stringify({ session_id: 'session-1', input_id: 'input-1', sequence: 1, event_type: 'run_started', payload: { instruction_preview: 'hello' } }) + '\\n');",
+    "  process.stdout.write(JSON.stringify({ session_id: 'session-1', input_id: 'input-1', sequence: 2, event_type: 'run_completed', payload: { status: 'success' } }) + '\\n');",
+    "}, 1500);"
+  ]);
+
+  const executor = new NativeRunnerExecutor();
+  const response = await executor.run(payload());
   const events = response.events as Array<Record<string, unknown>>;
 
   assert.deepEqual(

--- a/runtime/api-server/src/runner-worker.ts
+++ b/runtime/api-server/src/runner-worker.ts
@@ -12,7 +12,7 @@ import {
 } from "./runtime-shell.js";
 
 const TERMINAL_EVENT_TYPES = new Set(["run_completed", "run_failed"]);
-const HEARTBEAT_INTERVAL_MS = 5000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 5000;
 const DEFAULT_RUN_TIMEOUT_SECONDS = 1800;
 const DEFAULT_IDLE_TIMEOUT_SECONDS = 900;
 const DEFAULT_TASK_PROPOSAL_RUN_TIMEOUT_SECONDS = 7200;
@@ -132,6 +132,19 @@ function secondsFromEnv(
   return Math.max(options.min, Math.min(parsed, options.max));
 }
 
+function millisecondsFromEnv(
+  envName: string,
+  defaultValue: number,
+  options: { min: number; max: number }
+): number {
+  const raw = (process.env[envName] ?? String(defaultValue)).trim();
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return defaultValue;
+  }
+  return Math.max(options.min, Math.min(parsed, options.max));
+}
+
 function runnerTimeoutSeconds(payload: Record<string, unknown>): number {
   const baseTimeoutSeconds = secondsFromEnv("SANDBOX_AGENT_RUN_TIMEOUT_S", DEFAULT_RUN_TIMEOUT_SECONDS, {
     min: 1,
@@ -160,6 +173,13 @@ function runnerIdleTimeoutSeconds(payload: Record<string, unknown>): number {
     runnerTimeoutSeconds(payload),
     { min: 1, max: 7200 }
   );
+}
+
+function runnerHeartbeatIntervalMs(): number {
+  return millisecondsFromEnv("SANDBOX_AGENT_RUNNER_HEARTBEAT_MS", DEFAULT_HEARTBEAT_INTERVAL_MS, {
+    min: 50,
+    max: 60_000,
+  });
 }
 
 function normalizeRuntimeApiHost(value: string): string {
@@ -435,8 +455,11 @@ export async function executeRunnerRequest(
   };
   resetIdleTimeout();
   const heartbeat = setInterval(() => {
+    // Keep silent-but-alive runs from tripping the idle watchdog while still
+    // letting the hard timeout cap total wall-clock execution.
+    resetIdleTimeout();
     void options.onHeartbeat?.();
-  }, HEARTBEAT_INTERVAL_MS);
+  }, runnerHeartbeatIntervalMs());
   const abortChild = () => {
     if (sawTerminal || timedOut || idleTimedOut || aborted) {
       return;
@@ -580,7 +603,7 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
       heartbeat = setTimeout(() => {
         stream.push(": ping\n\n");
         resetHeartbeat();
-      }, HEARTBEAT_INTERVAL_MS);
+      }, runnerHeartbeatIntervalMs());
     };
 
     resetHeartbeat();


### PR DESCRIPTION
## Context

Silent but still-alive runs could fail with `runner command became idle ... without a terminal event` before the first visible event arrived. This showed up for long model/tool gaps where the runner process was healthy but nothing had been forwarded yet.

## Changes

- reset the runner idle watchdog on the internal runner heartbeat so alive-but-silent executions stay active
- add `SANDBOX_AGENT_RUNNER_HEARTBEAT_MS` for tuning and focused regression coverage
- add a regression test for a silent run that only emits visible events after the old idle window

## Validation

- `cd runtime/api-server && node --import /Users/jeffrey/Desktop/holaboss/holaOS/runtime/api-server/node_modules/tsx/dist/loader.mjs --test /Users/jeffrey/Desktop/holaboss/holaOS-feat-terminal-sessions-plan/runtime/api-server/src/runner-worker.test.ts`
