### PR TITLE
feat: improve agent browser surfaces and file preview interactions

### DIFF
--- a/desktop/electron/browser-context-menu.test.mjs
+++ b/desktop/electron/browser-context-menu.test.mjs
@@ -16,7 +16,7 @@ test("browser tabs register a native context menu for BrowserView content", asyn
   assert.match(source, /const popupY = browserBounds\.y \+ context\.y;/);
   assert.match(
     source,
-    /view\.webContents\.on\("context-menu", \(_event, params\) => \{\s*showBrowserViewContextMenu\(\{\s*workspaceId,\s*view,\s*context: params,/,
+    /view\.webContents\.on\("context-menu", \(_event, params\) => \{\s*showBrowserViewContextMenu\(\{\s*workspaceId,\s*space: browserSpace,\s*sessionId: normalizedSessionId,\s*view,\s*context: params,/,
   );
   assert.match(source, /label: "Open Link in New Tab"/);
   assert.match(source, /label: "Open Link Externally"/);

--- a/desktop/electron/browser-navigation-abort.test.mjs
+++ b/desktop/electron/browser-navigation-abort.test.mjs
@@ -25,11 +25,11 @@ test("desktop browser ignores aborted loadURL rejections during active navigatio
   );
   assert.match(
     source,
-    /async function navigateActiveBrowserTab\([\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\(workspaceId, space\);\s*\}/,
+    /async function navigateActiveBrowserTab\([\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\(workspaceId, space, sessionId,[\s\S]*?\);\s*\}/,
   );
   assert.match(
     source,
-    /"browser:openHistoryUrl"[\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\(workspace\.workspaceId, activeBrowserSpaceId\);\s*\}/,
+    /"browser:openHistoryUrl"[\s\S]*?await activeTab\.view\.webContents\.loadURL\(targetUrl\);[\s\S]*?if \(isAbortedBrowserLoadError\(error\)\) \{\s*return browserWorkspaceSnapshot\([\s\S]*workspace\.workspaceId,[\s\S]*activeBrowserSpaceId,[\s\S]*activeBrowserSessionId[\s\S]*\);\s*\}/,
   );
 });
 

--- a/desktop/electron/browser-operator-surface-context.test.mjs
+++ b/desktop/electron/browser-operator-surface-context.test.mjs
@@ -22,6 +22,7 @@ test("desktop browser exposes operator surface context for user and agent spaces
   assert.match(source, /surface_id: `browser:\$\{space\}`/);
   assert.match(source, /surface_type: "browser"/);
   assert.match(source, /owner: space === "user" \? "user" : "agent"/);
-  assert.match(source, /mutability: space === "agent" \? "agent_owned" : "inspect_only"/);
+  assert.match(source, /mutability: space === "agent" \? "agent_owned" : "takeover_allowed"/);
+  assert.match(source, /Exclusive control is currently held by agent session/);
   assert.match(source, /It shares the workspace browser session and auth state with the other browser surface\./);
 });

--- a/desktop/electron/browser-session-lifecycle.test.mjs
+++ b/desktop/electron/browser-session-lifecycle.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop browser can suspend and rehydrate session-owned agent browser surfaces", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /type BrowserSurfaceLifecycleState = "active" \| "suspended";/);
+  assert.match(source, /persistedTabs: BrowserWorkspaceTabPersistencePayload\[\];/);
+  assert.match(source, /lifecycleState: BrowserSurfaceLifecycleState;/);
+  assert.match(source, /suspendTimer: ReturnType<typeof setTimeout> \| null;/);
+  assert.match(source, /function browserTabSpacePersistencePayload\(/);
+  assert.match(source, /function browserTabSpaceStates\(/);
+  assert.match(source, /function hydrateAgentSessionBrowserSpace\(/);
+  assert.match(source, /function suspendAgentSessionBrowserSpace\(/);
+  assert.match(source, /function scheduleAgentSessionBrowserLifecycleCheck\(/);
+  assert.match(source, /function reconcileAgentSessionBrowserSpace\(/);
+  assert.match(source, /status === "WAITING_USER" \|\| status === "PAUSED"/);
+  assert.match(source, /SESSION_BROWSER_WARM_TTL_MS/);
+  assert.match(source, /SESSION_BROWSER_COMPLETED_GRACE_MS/);
+  assert.match(source, /agentTabSpace\.persistedTabs = persistedTabs;/);
+  assert.match(source, /agentTabSpace\.lifecycleState =\s*persistedTabs\.length > 0 \? "suspended" : "active";/);
+  assert.match(source, /hydrateAgentSessionBrowserSpace\(normalizedWorkspaceId, normalizedSessionId\);/);
+  assert.match(source, /scheduleAgentSessionBrowserLifecycleCheck\(workspaceId, normalizedSessionId\);/);
+});

--- a/desktop/electron/browser-space-routing.test.mjs
+++ b/desktop/electron/browser-space-routing.test.mjs
@@ -12,12 +12,21 @@ test("desktop browser tracks separate user and agent browser spaces and routes t
 
   assert.match(source, /const BROWSER_SPACE_IDS = \["user", "agent"\] as const;/);
   assert.match(source, /let activeBrowserSpaceId: BrowserSpaceId = "user";/);
+  assert.match(source, /let activeBrowserSessionId = "";/);
   assert.match(source, /spaces: \{\s*user: createBrowserTabSpaceState\(\),\s*agent: createBrowserTabSpaceState\(\),\s*\}/);
+  assert.match(source, /activeAgentSessionId: null,/);
+  assert.match(source, /agentSessionSpaces: new Map<string, BrowserTabSpaceState>\(\),/);
+  assert.match(source, /function browserAgentSessionSpaceState\(/);
+  assert.match(source, /function seedVisibleAgentBrowserSession\(/);
+  assert.match(source, /function desktopBrowserSpaceFromRequest\(/);
   assert.match(source, /function oppositeBrowserSpaceId\(space: BrowserSpaceId\): BrowserSpaceId \{/);
-  assert.match(source, /function initialBrowserTabSeed\(\s*workspaceId: string,\s*space: BrowserSpaceId,\s*\): \{/);
+  assert.match(source, /function hydrateAgentSessionBrowserSpace\(/);
+  assert.match(source, /function suspendAgentSessionBrowserSpace\(/);
+  assert.match(source, /function reconcileAgentSessionBrowserSpace\(/);
+  assert.match(source, /function initialBrowserTabSeed\(\s*workspaceId: string,\s*space: BrowserSpaceId,\s*sessionId\?: string \| null,\s*\): \{/);
   assert.match(
     source,
-    /const sourceSpace = browserTabSpaceState\(\s*workspace,\s*oppositeBrowserSpaceId\(space\),\s*\);/,
+    /const sourceSpaceId = oppositeBrowserSpaceId\(space\);[\s\S]*const sourceSpace = browserTabSpaceState\(/,
   );
   assert.match(
     source,
@@ -25,9 +34,26 @@ test("desktop browser tracks separate user and agent browser spaces and routes t
   );
   assert.match(
     source,
-    /const seed = initialBrowserTabSeed\(workspaceId, space\);\s*const initialTabId = createBrowserTab\(workspaceId, \{\s*\.\.\.seed,\s*browserSpace: space,\s*\}\);/,
+    /const seed = initialBrowserTabSeed\(workspaceId, space, normalizedSessionId\);[\s\S]*createBrowserTab\(workspaceId, \{[\s\S]*browserSpace: space,[\s\S]*sessionId: normalizedSessionId,/,
   );
-  assert.match(source, /emitWorkbenchOpenBrowser\(\{\s*workspaceId: targetWorkspaceId,\s*url: targetUrl,\s*space: "agent",\s*\}\);/);
-  assert.match(source, /await ensureBrowserWorkspace\(targetWorkspaceId, "agent"\);/);
-  assert.match(source, /browserWorkspaceSnapshot\(targetWorkspaceId, "agent"\)/);
+  assert.match(
+    source,
+    /if \(space === "agent" && normalizedSessionId\) \{\s*seedVisibleAgentBrowserSession\(workspace, normalizedSessionId\);\s*\}/,
+  );
+  assert.match(source, /const requestedSessionId = desktopBrowserSessionIdFromRequest\(request\);/);
+  assert.match(source, /const targetSpace = desktopBrowserSpaceFromRequest\(request\);/);
+  assert.match(
+    source,
+    /if \(browserSpace === "agent" && normalizedSessionId\) \{[\s\S]*seedVisibleAgentBrowserSession\(existing, normalizedSessionId\);[\s\S]*touchAgentSessionBrowserSpace\(normalizedWorkspaceId, normalizedSessionId\);[\s\S]*return existing;/,
+  );
+  assert.match(
+    source,
+    /else if \(requestedSessionId\) \{\s*touchAgentSessionBrowserSpace\(targetWorkspaceId, requestedSessionId\);\s*\}/,
+  );
+  assert.doesNotMatch(
+    source,
+    /else if \(requestedSessionId\) \{[\s\S]*setVisibleAgentBrowserSession\(workspace, requestedSessionId\)/,
+  );
+  assert.match(source, /emitWorkbenchOpenBrowser\(\{\s*workspaceId: targetWorkspaceId,\s*url: targetUrl,\s*space: targetSpace,\s*sessionId: requestedSessionId \|\| null,\s*\}\);/);
+  assert.match(source, /browserWorkspaceSnapshot\(targetWorkspaceId, targetSpace, ensuredSessionId,/);
 });

--- a/desktop/electron/browser-user-lock.test.mjs
+++ b/desktop/electron/browser-user-lock.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop browser protects shared and session-owned browser control with a confirmed interrupt flow", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /const USER_BROWSER_LOCK_TIMEOUT_MS = 15_000;/);
+  assert.match(source, /interface BrowserUserLockState \{/);
+  assert.match(source, /userBrowserLock: BrowserUserLockState \| null;/);
+  assert.match(source, /const sessionRuntimeStateCache = new Map<\s*string,\s*Map<string, SessionRuntimeRecordPayload>\s*>\(\);/);
+  assert.match(source, /function ensureUserBrowserLock\(/);
+  assert.match(source, /function releaseUserBrowserLock\(/);
+  assert.match(source, /function cacheRuntimeStateRecords\(/);
+  assert.match(source, /function upsertCachedRuntimeStateRecord\(/);
+  assert.match(source, /function getCachedRuntimeStateRecord\(/);
+  assert.match(source, /function confirmBrowserInterrupt\(/);
+  assert.match(source, /buttons: \["Let agent continue", "Interrupt and take over"\]/);
+  assert.match(source, /The agent is currently controlling this browser\./);
+  assert.match(source, /await pauseSessionRun\(\{\s*workspace_id: workspaceId,\s*session_id: sessionId,\s*\}\);/);
+  assert.match(source, /const items = cacheRuntimeStateRecords\(workspaceId, response\.items \?\? \[\]\);/);
+  assert.match(source, /upsertCachedRuntimeStateRecord\(\{\s*workspace_id: payload\.workspace_id,\s*session_id: response\.session_id,/s);
+  assert.match(source, /upsertCachedRuntimeStateRecord\(\{\s*workspace_id: payload\.workspace_id,\s*session_id: response\.session_id \|\| payload\.session_id,/s);
+  assert.match(source, /browserSessionId\(sessionId\)\s*\|\|\s*browserSessionId\(browserWorkspaceFromMap\(workspaceId\)\?\.activeAgentSessionId\)/);
+  assert.match(source, /return status === "BUSY" \|\| status === "QUEUED" \|\| status === "PAUSING";/);
+  assert.match(source, /view\.webContents\.on\("before-input-event", \(event, input\) => \{/);
+  assert.match(source, /view\.webContents\.on\("before-mouse-event", \(event, mouse\) => \{/);
+  assert.match(source, /maybePromptBrowserInterrupt\(\s*workspaceId,\s*browserSpace,\s*normalizedSessionId,\s*\)/);
+  assert.match(source, /const targetSpace = desktopBrowserSpaceFromRequest\(request\);/);
+  assert.match(source, /Header 'x-holaboss-session-id' is required when targeting the user browser\./);
+  assert.match(source, /code: "user_browser_locked"/);
+  assert.match(source, /maybePromptBrowserInterrupt\(\s*activeBrowserWorkspaceId,\s*activeBrowserSpaceId,\s*activeBrowserSpaceId === "agent" \? activeBrowserSessionId : null,\s*\)/);
+  assert.doesNotMatch(source, /maybePromptUserBrowserInterrupt/);
+});

--- a/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
+++ b/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
@@ -32,7 +32,12 @@ test("desktop file preview supports tabular spreadsheet kinds", async () => {
     /if \(kind === "table"\) \{[\s\S]*const tableSheets = await buildTablePreviewSheets\(buffer, extension\);/,
   );
   assert.match(source, /hasHeaderRow: boolean;/);
+  assert.match(source, /links\?: \(string \| null\)\[\]\[\];/);
   assert.match(source, /const hasHeaderRow =/);
+  assert.match(source, /function normalizePreviewTableLinkTarget\(/);
+  assert.match(source, /typeof cell\.hyperlink === "string" \? cell\.hyperlink : cell\.text/);
+  assert.match(source, /links,\s*totalRows: allRows\.length,/);
+  assert.match(source, /worksheetRow\.getCell\(columnIndex \+ 1\)\.value = hyperlink[\s\S]*\? \{ text: value, hyperlink \}[\s\S]*: value;/);
   assert.match(source, /async function writeTableFile\(/);
   assert.match(source, /async function writeCsvTablePreview\(/);
   assert.match(source, /async function writeWorkbookTablePreview\(/);
@@ -158,6 +163,7 @@ test("desktop preload exposes file preview watch subscriptions and change events
   const source = await readFile(preloadSourcePath, "utf8");
 
   assert.match(source, /hasHeaderRow: boolean;/);
+  assert.match(source, /links\?: \(string \| null\)\[\]\[\];/);
   assert.match(
     source,
     /createPath: \(\s*parentPath: string \| null \| undefined,\s*kind: "file" \| "directory",\s*workspaceId\?: string \| null,\s*\) =>[\s\S]*ipcRenderer\.invoke\("fs:createPath", parentPath, kind, workspaceId\) as Promise<FileSystemMutationPayload>/,
@@ -206,6 +212,6 @@ test("file explorer renders spreadsheet previews with the shared table editor", 
   );
   assert.match(
     source,
-    /<SpreadsheetEditor[\s\S]*sheets=\{previewTableSheets\}[\s\S]*onChange=\{setTablePreviewDraft\}/,
+    /<SpreadsheetEditor[\s\S]*sheets=\{previewTableSheets\}[\s\S]*onChange=\{setTablePreviewDraft\}[\s\S]*onOpenLinkInBrowser=\{openPreviewLink\}/,
   );
 });

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -278,6 +278,7 @@ interface FilePreviewTableSheetPayload {
   index: number;
   columns: string[];
   rows: string[][];
+  links?: (string | null)[][];
   totalRows: number;
   totalColumns: number;
   truncated: boolean;
@@ -15878,22 +15879,73 @@ function trimTrailingEmptyTableCells(row: string[]): string[] {
   return row.slice(0, lastNonEmptyIndex + 1);
 }
 
-function worksheetPreviewRows(worksheet: ExcelJS.Worksheet): string[][] {
+function normalizePreviewTableLinkTarget(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("#")) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^localhost(?::\d+)?(?:[/?#]|$)/i.test(trimmed)) {
+    return `http://${trimmed}`;
+  }
+
+  if (
+    /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?:[/?#]|$)/.test(trimmed) ||
+    /^(?:www\.)?(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d+)?(?:[/?#]|$)/.test(
+      trimmed,
+    )
+  ) {
+    return /^www\./i.test(trimmed) ? `https://${trimmed}` : `https://${trimmed}`;
+  }
+
+  return null;
+}
+
+function trimTrailingEmptyTableLinkRow(
+  row: (string | null)[],
+  targetLength: number,
+): (string | null)[] {
+  return Array.from(
+    { length: targetLength },
+    (_unused, columnIndex) => row[columnIndex] ?? null,
+  );
+}
+
+function worksheetPreviewRows(worksheet: ExcelJS.Worksheet): {
+  rows: string[][];
+  links: (string | null)[][];
+} {
   const rows: string[][] = [];
+  const links: (string | null)[][] = [];
   worksheet.eachRow({ includeEmpty: false }, (row) => {
     const values: string[] = [];
+    const rowLinks: (string | null)[] = [];
     row.eachCell({ includeEmpty: true }, (cell, columnNumber) => {
       values[columnNumber - 1] = toPreviewTableCellValue(cell.text);
+      rowLinks[columnNumber - 1] = normalizePreviewTableLinkTarget(
+        typeof cell.hyperlink === "string" ? cell.hyperlink : cell.text,
+      );
     });
-    rows.push(trimTrailingEmptyTableCells(values));
+    const trimmedValues = trimTrailingEmptyTableCells(values);
+    rows.push(trimmedValues);
+    links.push(trimTrailingEmptyTableLinkRow(rowLinks, trimmedValues.length));
   });
-  return rows;
+  return { rows, links };
 }
 
 function tablePreviewSheetFromRows(
   sheetName: string,
   sheetIndex: number,
   rawRows: string[][],
+  rawLinks: (string | null)[][],
   totalSheetCount: number,
 ): FilePreviewTableSheetPayload {
   const totalColumns = rawRows.reduce(
@@ -15910,6 +15962,12 @@ function tablePreviewSheetFromRows(
       (_unused, columnIndex) => row[columnIndex] ?? "",
     ),
   );
+  const paddedLinks = rawLinks.map((row) =>
+    Array.from(
+      { length: visibleColumnCount },
+      (_unused, columnIndex) => row[columnIndex] ?? null,
+    ),
+  );
   const hasHeaderRow =
     paddedRows.length > 0 &&
     paddedRows[0].some((cell) => cell.trim().length > 0);
@@ -15922,7 +15980,9 @@ function tablePreviewSheetFromRows(
         (_unused, columnIndex) => `Column ${columnIndex + 1}`,
       );
   const allRows = hasHeaderRow ? paddedRows.slice(1) : paddedRows;
+  const allLinks = hasHeaderRow ? paddedLinks.slice(1) : paddedLinks;
   const rows = allRows.slice(0, MAX_TABLE_PREVIEW_ROWS);
+  const links = allLinks.slice(0, MAX_TABLE_PREVIEW_ROWS);
   const truncated =
     allRows.length > rows.length ||
     totalColumns > visibleColumnCount ||
@@ -15933,6 +15993,7 @@ function tablePreviewSheetFromRows(
     index: sheetIndex,
     columns,
     rows,
+    links,
     totalRows: allRows.length,
     totalColumns,
     truncated,
@@ -15958,7 +16019,7 @@ function normalizeWritableTableSheets(
   }
 
   return value
-    .map((sheet, sheetIndex) => {
+    .map<FilePreviewTableSheetPayload | null>((sheet, sheetIndex) => {
       if (!sheet || typeof sheet !== "object") {
         return null;
       }
@@ -15976,6 +16037,13 @@ function normalizeWritableTableSheets(
               : [],
           )
         : [];
+      const links = Array.isArray(candidate.links)
+        ? candidate.links.map((row) =>
+            Array.isArray(row)
+              ? row.map((cell) => normalizePreviewTableLinkTarget(cell))
+              : [],
+          )
+        : rows.map((row) => row.map(() => null));
       const normalizedName =
         typeof candidate.name === "string" && candidate.name.trim()
           ? candidate.name.trim()
@@ -15990,6 +16058,7 @@ function normalizeWritableTableSheets(
             : sheetIndex,
         columns,
         rows,
+        links,
         totalRows:
           typeof candidate.totalRows === "number" &&
           Number.isFinite(candidate.totalRows)
@@ -16002,7 +16071,7 @@ function normalizeWritableTableSheets(
             : columns.length,
         truncated: Boolean(candidate.truncated),
         hasHeaderRow: candidate.hasHeaderRow !== false,
-      } satisfies FilePreviewTableSheetPayload;
+      };
     })
     .filter((sheet): sheet is FilePreviewTableSheetPayload => sheet !== null);
 }
@@ -16022,15 +16091,38 @@ function sourceRowsFromTablePreviewSheet(
   );
 }
 
+function sourceLinksFromTablePreviewSheet(
+  sheet: FilePreviewTableSheetPayload,
+): (string | null)[][] {
+  const visibleColumnCount = Math.max(sheet.columns.length, 1);
+  const bodyLinks = (sheet.links ?? []).map((row) =>
+    Array.from(
+      { length: visibleColumnCount },
+      (_unused, columnIndex) =>
+        normalizePreviewTableLinkTarget(row[columnIndex]) ?? null,
+    ),
+  );
+
+  if (sheet.hasHeaderRow) {
+    return [Array.from({ length: visibleColumnCount }, () => null), ...bodyLinks];
+  }
+
+  return bodyLinks;
+}
+
 function applyPreviewSheetEditsToWorksheet(
   worksheet: ExcelJS.Worksheet,
   sheet: FilePreviewTableSheetPayload,
 ) {
   const sourceRows = sourceRowsFromTablePreviewSheet(sheet);
+  const sourceLinks = sourceLinksFromTablePreviewSheet(sheet);
   for (const [rowIndex, row] of sourceRows.entries()) {
     const worksheetRow = worksheet.getRow(rowIndex + 1);
     for (const [columnIndex, value] of row.entries()) {
-      worksheetRow.getCell(columnIndex + 1).value = value;
+      const hyperlink = sourceLinks[rowIndex]?.[columnIndex] ?? null;
+      worksheetRow.getCell(columnIndex + 1).value = hyperlink
+        ? { text: value, hyperlink }
+        : value;
     }
     worksheetRow.commit();
   }
@@ -16090,12 +16182,16 @@ async function buildWorkbookPreviewSheets(
 
   const worksheets = workbook.worksheets.slice(0, MAX_TABLE_PREVIEW_SHEETS);
   return worksheets.map((worksheet, sheetIndex) =>
-    tablePreviewSheetFromRows(
-      worksheet.name,
-      sheetIndex,
-      worksheetPreviewRows(worksheet),
-      workbook.worksheets.length,
-    ),
+    {
+      const preview = worksheetPreviewRows(worksheet);
+      return tablePreviewSheetFromRows(
+        worksheet.name,
+        sheetIndex,
+        preview.rows,
+        preview.links,
+        workbook.worksheets.length,
+      );
+    },
   );
 }
 
@@ -16116,12 +16212,16 @@ async function buildCsvPreviewSheets(
   );
 
   return [
-    tablePreviewSheetFromRows(
-      worksheet.name,
-      0,
-      worksheetPreviewRows(worksheet),
-      1,
-    ),
+    (() => {
+      const preview = worksheetPreviewRows(worksheet);
+      return tablePreviewSheetFromRows(
+        worksheet.name,
+        0,
+        preview.rows,
+        preview.links,
+        1,
+      );
+    })(),
   ];
 }
 

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -112,6 +112,10 @@ const ADDRESS_SUGGESTIONS_POPUP_MIN_HEIGHT = 88;
 const ADDRESS_SUGGESTIONS_POPUP_MAX_HEIGHT = 320;
 const MAIN_WINDOW_CLOSED_LISTENER_BUFFER = 8;
 const MAIN_WINDOW_MIN_LISTENER_BUDGET = 32;
+const USER_BROWSER_LOCK_TIMEOUT_MS = 15_000;
+const SESSION_BROWSER_BUSY_CHECK_MS = 15_000;
+const SESSION_BROWSER_COMPLETED_GRACE_MS = 30_000;
+const SESSION_BROWSER_WARM_TTL_MS = 2 * 60 * 1000;
 const CHROME_HISTORY_IMPORT_LIMIT = 500;
 const CHROME_COOKIE_SAFE_STORAGE_SERVICE_NAMES = [
   "Chrome Safe Storage",
@@ -366,7 +370,14 @@ interface BrowserTabListPayload {
   activeTabId: string;
   tabs: BrowserStatePayload[];
   tabCounts: BrowserTabCountsPayload;
+  sessionId: string | null;
+  lifecycleState: BrowserSurfaceLifecycleState | null;
+  controlMode: BrowserSurfaceControlMode;
+  controlSessionId: string | null;
 }
+
+type BrowserSurfaceLifecycleState = "active" | "suspended";
+type BrowserSurfaceControlMode = "none" | "user_locked" | "session_owned";
 
 type OperatorSurfaceType = "browser" | "editor" | "terminal" | "app_surface";
 type OperatorSurfaceOwner = "user" | "agent";
@@ -397,9 +408,20 @@ interface BrowserTabRecord {
   popupOpenedAtMs?: number;
 }
 
+interface BrowserUserLockState {
+  sessionId: string;
+  acquiredAt: string;
+  heartbeatAt: string;
+  reason: string | null;
+}
+
 interface BrowserTabSpaceState {
   tabs: Map<string, BrowserTabRecord>;
   activeTabId: string;
+  persistedTabs: BrowserWorkspaceTabPersistencePayload[];
+  lifecycleState: BrowserSurfaceLifecycleState;
+  lastTouchedAt: string;
+  suspendTimer: ReturnType<typeof setTimeout> | null;
 }
 
 interface BrowserWorkspaceTabPersistencePayload {
@@ -420,6 +442,8 @@ interface BrowserWorkspacePersistencePayload {
   spaces?: Partial<
     Record<BrowserSpaceId, BrowserWorkspaceTabSpacePersistencePayload>
   >;
+  activeAgentSessionId?: string | null;
+  agentSessions?: Record<string, BrowserWorkspaceTabSpacePersistencePayload>;
   bookmarks: BrowserBookmarkPayload[];
   downloads: BrowserDownloadPayload[];
   history: BrowserHistoryEntryPayload[];
@@ -431,6 +455,9 @@ interface BrowserWorkspaceState {
   session: Session;
   browserIdentity: BrowserSessionIdentity;
   spaces: Record<BrowserSpaceId, BrowserTabSpaceState>;
+  userBrowserLock: BrowserUserLockState | null;
+  activeAgentSessionId: string | null;
+  agentSessionSpaces: Map<string, BrowserTabSpaceState>;
   bookmarks: BrowserBookmarkPayload[];
   downloads: BrowserDownloadPayload[];
   history: BrowserHistoryEntryPayload[];
@@ -700,6 +727,7 @@ interface WorkbenchOpenBrowserPayload {
   workspaceId?: string | null;
   url?: string | null;
   space?: BrowserSpaceId | null;
+  sessionId?: string | null;
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -723,7 +751,13 @@ let addressSuggestionsState: {
 };
 let activeBrowserWorkspaceId = "";
 let activeBrowserSpaceId: BrowserSpaceId = "user";
+let activeBrowserSessionId = "";
 const browserWorkspaces = new Map<string, BrowserWorkspaceState>();
+const sessionRuntimeStateCache = new Map<
+  string,
+  Map<string, SessionRuntimeRecordPayload>
+>();
+const userBrowserInterruptPrompts = new Set<string>();
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -4574,10 +4608,13 @@ async function copyBrowserWorkspaceProfile(
   for (const browserSpace of BROWSER_SPACE_IDS) {
     const sourceSpace = sourceWorkspace.spaces[browserSpace];
     const targetSpace = targetWorkspace.spaces[browserSpace];
+    clearBrowserTabSpaceSuspendTimer(targetSpace);
     for (const tab of targetSpace.tabs.values()) {
       closeBrowserTabRecord(tab);
     }
     targetSpace.tabs.clear();
+    targetSpace.persistedTabs = [];
+    targetSpace.lifecycleState = "active";
 
     const tabIdMap = new Map<string, string>();
     for (const sourceTab of sourceSpace.tabs.values()) {
@@ -4602,6 +4639,16 @@ async function copyBrowserWorkspaceProfile(
         ? mappedActiveTabId
         : Array.from(targetSpace.tabs.keys())[0]) || "";
   }
+  for (const tabSpace of targetWorkspace.agentSessionSpaces.values()) {
+    clearBrowserTabSpaceSuspendTimer(tabSpace);
+    for (const tab of tabSpace.tabs.values()) {
+      closeBrowserTabRecord(tab);
+    }
+    tabSpace.tabs.clear();
+  }
+  targetWorkspace.agentSessionSpaces.clear();
+  targetWorkspace.userBrowserLock = null;
+  targetWorkspace.activeAgentSessionId = null;
 
   const cookieSummary = await copyCookiesBetweenBrowserSessions(
     sourceWorkspace.session,
@@ -5564,6 +5611,23 @@ async function updateDesktopBrowserCapabilityConfig(update: {
   });
 }
 
+function currentDesktopBrowserCapabilityConfig() {
+  const enabled = Boolean(
+    desktopBrowserServiceUrl.trim() && desktopBrowserServiceAuthToken.trim(),
+  );
+  return {
+    enabled,
+    url: enabled ? desktopBrowserServiceUrl : undefined,
+    authToken: enabled ? desktopBrowserServiceAuthToken : undefined,
+  };
+}
+
+async function syncDesktopBrowserCapabilityConfig(): Promise<void> {
+  await updateDesktopBrowserCapabilityConfig(
+    currentDesktopBrowserCapabilityConfig(),
+  );
+}
+
 function desktopBrowserServiceTokenFromRequest(
   request: IncomingMessage,
 ): string {
@@ -5582,6 +5646,26 @@ function desktopBrowserWorkspaceIdFromRequest(
     return (raw[0] || "").trim();
   }
   return typeof raw === "string" ? raw.trim() : "";
+}
+
+function desktopBrowserSessionIdFromRequest(
+  request: IncomingMessage,
+): string {
+  const raw = request.headers["x-holaboss-session-id"];
+  if (Array.isArray(raw)) {
+    return (raw[0] || "").trim();
+  }
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function desktopBrowserSpaceFromRequest(
+  request: IncomingMessage,
+): BrowserSpaceId {
+  const raw = request.headers["x-holaboss-browser-space"];
+  if (Array.isArray(raw)) {
+    return browserSpaceId(raw[0] || "", "agent");
+  }
+  return browserSpaceId(typeof raw === "string" ? raw.trim() : "", "agent");
 }
 
 function writeBrowserServiceJson(
@@ -5708,15 +5792,32 @@ function browserSurfaceSummary(
   visibleInApp: boolean,
 ): string {
   const workspace = browserWorkspaceFromMap(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, space);
+  const tabSpace = browserTabSpaceState(workspace, space, null, {
+    useVisibleAgentSession: true,
+  });
   const activeTabId = tabSpace?.activeTabId ?? "";
   if (activeTabId) {
-    syncBrowserState(workspaceId, activeTabId, space);
+    syncBrowserState(
+      workspaceId,
+      activeTabId,
+      space,
+      space === "agent" ? browserVisibleAgentSessionId(workspace) : null,
+    );
   }
   const refreshedWorkspace = browserWorkspaceFromMap(workspaceId);
-  const refreshedTabSpace = browserTabSpaceState(refreshedWorkspace, space);
-  const tabCount = refreshedTabSpace?.tabs.size ?? 0;
-  const activeTab = activeTabId ? refreshedTabSpace?.tabs.get(activeTabId) ?? null : null;
+  const refreshedTabSpace = browserTabSpaceState(
+    refreshedWorkspace,
+    space,
+    null,
+    {
+      useVisibleAgentSession: true,
+    },
+  );
+  const tabCount = browserTabSpaceTabCount(refreshedTabSpace);
+  const activeTab =
+    activeTabId && refreshedTabSpace?.tabs.size
+      ? refreshedTabSpace.tabs.get(activeTabId) ?? null
+      : null;
   const spaceLabel = space === "user" ? "User browser" : "Agent browser";
   const tabSummary = `${tabCount} open ${tabCount === 1 ? "tab" : "tabs"}`;
   const summaryParts = [`${spaceLabel} surface with ${tabSummary}.`];
@@ -5729,6 +5830,21 @@ function browserSurfaceSummary(
   }
   if (visibleInApp) {
     summaryParts.push("This surface is currently visible in the app.");
+  }
+  if (space === "user") {
+    const userLock = activeUserBrowserLock(refreshedWorkspace);
+    if (userLock) {
+      summaryParts.push(
+        `Exclusive control is currently held by agent session ${userLock.sessionId}.`,
+      );
+      summaryParts.push(
+        "User interaction is intercepted first and only pauses the controlling session after explicit confirmation.",
+      );
+    } else {
+      summaryParts.push(
+        "Agent takeover is allowed through an exclusive workspace lock on this shared browser surface.",
+      );
+    }
   }
   summaryParts.push("It shares the workspace browser session and auth state with the other browser surface.");
   return summaryParts.join(" ");
@@ -5751,7 +5867,7 @@ function operatorSurfaceContextPayload(workspaceId: string): OperatorSurfaceCont
         ? activeReportedSurfaceId === `browser:${space}`
         : normalizedWorkspaceId === activeBrowserWorkspaceId &&
           activeBrowserSpaceId === space,
-    mutability: space === "agent" ? "agent_owned" : "inspect_only",
+    mutability: space === "agent" ? "agent_owned" : "takeover_allowed",
     summary: browserSurfaceSummary(
       normalizedWorkspaceId,
       space,
@@ -5825,9 +5941,15 @@ async function navigateActiveBrowserTab(
   workspaceId: string,
   targetUrl: string,
   space: BrowserSpaceId = activeBrowserSpaceId,
+  sessionId?: string | null,
 ): Promise<BrowserTabListPayload> {
-  await ensureBrowserWorkspace(workspaceId, space);
-  const activeTab = getActiveBrowserTab(workspaceId, space);
+  await ensureBrowserWorkspace(workspaceId, space, sessionId);
+  if (space === "agent" && browserSessionId(sessionId)) {
+    touchAgentSessionBrowserSpace(workspaceId, sessionId);
+  }
+  const activeTab = getActiveBrowserTab(workspaceId, space, sessionId, {
+    useVisibleAgentSession: !browserSessionId(sessionId),
+  });
   if (!activeTab) {
     throw new Error("No active browser tab is available.");
   }
@@ -5837,7 +5959,9 @@ async function navigateActiveBrowserTab(
     await activeTab.view.webContents.loadURL(targetUrl);
   } catch (error) {
     if (isAbortedBrowserLoadError(error)) {
-      return browserWorkspaceSnapshot(workspaceId, space);
+      return browserWorkspaceSnapshot(workspaceId, space, sessionId, {
+        useVisibleAgentSession: !browserSessionId(sessionId),
+      });
     }
     activeTab.state = {
       ...activeTab.state,
@@ -5848,7 +5972,9 @@ async function navigateActiveBrowserTab(
     throw error;
   }
 
-  return browserWorkspaceSnapshot(workspaceId, space);
+  return browserWorkspaceSnapshot(workspaceId, space, sessionId, {
+    useVisibleAgentSession: !browserSessionId(sessionId),
+  });
 }
 
 async function handleDesktopBrowserServiceRequest(
@@ -5859,7 +5985,9 @@ async function handleDesktopBrowserServiceRequest(
     const requestUrl = new URL(request.url || "/", "http://127.0.0.1");
     const pathname = requestUrl.pathname;
     const method = (request.method || "GET").toUpperCase();
+    const targetSpace = desktopBrowserSpaceFromRequest(request);
     const requestedWorkspaceId = desktopBrowserWorkspaceIdFromRequest(request);
+    const requestedSessionId = desktopBrowserSessionIdFromRequest(request);
     const targetWorkspaceId = requestedWorkspaceId || activeBrowserWorkspaceId;
 
     if (
@@ -5883,26 +6011,78 @@ async function handleDesktopBrowserServiceRequest(
       return;
     }
 
+    const ensuredSessionId = targetSpace === "agent" ? requestedSessionId : null;
+    const ensureTargetBrowserSpace = async (
+      reason: string,
+    ): Promise<BrowserWorkspaceState | null> => {
+      const workspace = await ensureBrowserWorkspace(
+        targetWorkspaceId,
+        targetSpace,
+        ensuredSessionId,
+      );
+      if (!workspace) {
+        return null;
+      }
+      if (targetSpace === "user") {
+        if (!requestedSessionId) {
+          writeBrowserServiceJson(response, 400, {
+            error:
+              "Header 'x-holaboss-session-id' is required when targeting the user browser.",
+          });
+          return null;
+        }
+        const lockResult = ensureUserBrowserLock(
+          targetWorkspaceId,
+          requestedSessionId,
+          reason,
+        );
+        if (!lockResult.ok) {
+          writeBrowserServiceJson(response, 409, {
+            error: "User browser is locked by another agent session.",
+            code: "user_browser_locked",
+            lock_holder_session_id: lockResult.lockHolderSessionId,
+          });
+          return null;
+        }
+      } else if (requestedSessionId) {
+        touchAgentSessionBrowserSpace(targetWorkspaceId, requestedSessionId);
+      }
+      return workspace;
+    };
+
     if (method === "GET" && pathname === "/api/v1/browser/tabs") {
-      await ensureBrowserWorkspace(targetWorkspaceId, "agent");
+      const workspace = await ensureTargetBrowserSpace("tabs");
+      if (!workspace) {
+        return;
+      }
       writeBrowserServiceJson(
         response,
         200,
-        browserWorkspaceSnapshot(targetWorkspaceId, "agent"),
+        browserWorkspaceSnapshot(targetWorkspaceId, targetSpace, ensuredSessionId, {
+          useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId,
+        }),
       );
       return;
     }
 
     if (method === "GET" && pathname === "/api/v1/browser/page") {
-      await ensureBrowserWorkspace(targetWorkspaceId, "agent");
-      const activeTab = getActiveBrowserTab(targetWorkspaceId, "agent");
+      const workspace = await ensureTargetBrowserSpace("page");
+      if (!workspace) {
+        return;
+      }
+      const activeTab = getActiveBrowserTab(
+        targetWorkspaceId,
+        targetSpace,
+        ensuredSessionId,
+        { useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId },
+      );
       if (!activeTab) {
         writeBrowserServiceJson(response, 409, {
           error: "No active browser tab is available.",
         });
         return;
       }
-      syncBrowserState(targetWorkspaceId, activeTab.state.id, "agent");
+      syncBrowserState(targetWorkspaceId, activeTab.state.id, targetSpace, ensuredSessionId);
       writeBrowserServiceJson(response, 200, browserPagePayload(activeTab));
       return;
     }
@@ -5924,17 +6104,23 @@ async function handleDesktopBrowserServiceRequest(
         });
         return;
       }
+      const workspace = await ensureTargetBrowserSpace("navigate");
+      if (!workspace) {
+        return;
+      }
       if (targetWorkspaceId && targetWorkspaceId === activeBrowserWorkspaceId) {
         emitWorkbenchOpenBrowser({
           workspaceId: targetWorkspaceId,
           url: targetUrl,
-          space: "agent",
+          space: targetSpace,
+          sessionId: requestedSessionId || null,
         });
       }
       const snapshot = await navigateActiveBrowserTab(
         targetWorkspaceId,
         targetUrl,
-        "agent",
+        targetSpace,
+        ensuredSessionId,
       );
       writeBrowserServiceJson(response, 200, snapshot);
       return;
@@ -5947,11 +6133,11 @@ async function handleDesktopBrowserServiceRequest(
           ? payload.url.trim()
           : HOME_URL;
       const background = payload.background === true;
-      const workspace = await ensureBrowserWorkspace(
-        targetWorkspaceId,
-        "agent",
-      );
-      const tabSpace = browserTabSpaceState(workspace, "agent");
+      const workspace = await ensureTargetBrowserSpace("tabs:create");
+      const tabSpace = browserTabSpaceState(workspace, targetSpace, ensuredSessionId, {
+        createIfMissing: targetSpace === "agent" && Boolean(requestedSessionId),
+        useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId,
+      });
       if (!workspace) {
         writeBrowserServiceJson(response, 409, {
           error: "No active browser workspace is available.",
@@ -5961,7 +6147,8 @@ async function handleDesktopBrowserServiceRequest(
 
       const nextTabId = createBrowserTab(targetWorkspaceId, {
         url: targetUrl,
-        browserSpace: "agent",
+        browserSpace: targetSpace,
+        sessionId: ensuredSessionId,
       });
       if (!nextTabId) {
         writeBrowserServiceJson(response, 500, {
@@ -5977,12 +6164,14 @@ async function handleDesktopBrowserServiceRequest(
         }
       }
 
-      emitBrowserState(targetWorkspaceId, "agent");
+      emitBrowserState(targetWorkspaceId, targetSpace);
       await persistBrowserWorkspace(targetWorkspaceId);
       writeBrowserServiceJson(
         response,
         200,
-        browserWorkspaceSnapshot(targetWorkspaceId, "agent"),
+        browserWorkspaceSnapshot(targetWorkspaceId, targetSpace, ensuredSessionId, {
+          useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId,
+        }),
       );
       return;
     }
@@ -5998,8 +6187,16 @@ async function handleDesktopBrowserServiceRequest(
         return;
       }
 
-      await ensureBrowserWorkspace(targetWorkspaceId, "agent");
-      const activeTab = getActiveBrowserTab(targetWorkspaceId, "agent");
+      const workspace = await ensureTargetBrowserSpace("evaluate");
+      if (!workspace) {
+        return;
+      }
+      const activeTab = getActiveBrowserTab(
+        targetWorkspaceId,
+        targetSpace,
+        ensuredSessionId,
+        { useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId },
+      );
       if (!activeTab) {
         writeBrowserServiceJson(response, 409, {
           error: "No active browser tab is available.",
@@ -6018,8 +6215,16 @@ async function handleDesktopBrowserServiceRequest(
 
     if (method === "POST" && pathname === "/api/v1/browser/screenshot") {
       const payload = await readBrowserServiceJsonBody(request);
-      await ensureBrowserWorkspace(targetWorkspaceId, "agent");
-      const activeTab = getActiveBrowserTab(targetWorkspaceId, "agent");
+      const workspace = await ensureTargetBrowserSpace("screenshot");
+      if (!workspace) {
+        return;
+      }
+      const activeTab = getActiveBrowserTab(
+        targetWorkspaceId,
+        targetSpace,
+        ensuredSessionId,
+        { useVisibleAgentSession: targetSpace === "agent" && !requestedSessionId },
+      );
       if (!activeTab) {
         writeBrowserServiceJson(response, 409, {
           error: "No active browser tab is available.",
@@ -6084,11 +6289,7 @@ async function startDesktopBrowserService(): Promise<void> {
     ...runtimeStatus,
   });
   emitRuntimeState();
-  await updateDesktopBrowserCapabilityConfig({
-    enabled: true,
-    url: desktopBrowserServiceUrl,
-    authToken,
-  });
+  await syncDesktopBrowserCapabilityConfig();
 }
 
 async function stopDesktopBrowserService(): Promise<void> {
@@ -6107,7 +6308,7 @@ async function stopDesktopBrowserService(): Promise<void> {
     ...runtimeStatus,
   });
   emitRuntimeState();
-  await updateDesktopBrowserCapabilityConfig({ enabled: false });
+  await syncDesktopBrowserCapabilityConfig();
 }
 
 function desktopBrowserStatusFields() {
@@ -6203,7 +6404,7 @@ function canUsePersistedRuntimeBindingWithoutAuth(
 }
 
 async function writeRuntimeConfigFile(update: RuntimeConfigUpdatePayload) {
-  return withRuntimeConfigMutationLock(async () => {
+  const next = await withRuntimeConfigMutationLock(async () => {
     const current = await readRuntimeConfigFile();
     const currentDocument = await readRuntimeConfigDocument();
     const runtimePayload = runtimeConfigObject(currentDocument.runtime);
@@ -6404,6 +6605,8 @@ async function writeRuntimeConfigFile(update: RuntimeConfigUpdatePayload) {
     );
     return next;
   });
+  await syncDesktopBrowserCapabilityConfig();
+  return next;
 }
 
 function runtimeConfigField(value: string | undefined): string {
@@ -7595,6 +7798,7 @@ async function setRuntimeConfigDocument(
       shouldRestartRuntime = true;
     }
   });
+  await syncDesktopBrowserCapabilityConfig();
 
   if (shouldRestartRuntime) {
     await stopEmbeddedRuntime();
@@ -11884,6 +12088,103 @@ function upsertRuntimeState(record: {
   }
 }
 
+function cloneRuntimeStateRecord(
+  record: SessionRuntimeRecordPayload,
+): SessionRuntimeRecordPayload {
+  return {
+    ...record,
+    last_error:
+      record.last_error && typeof record.last_error === "object"
+        ? { ...record.last_error }
+        : null,
+  };
+}
+
+function normalizeRuntimeStateRecord(
+  record: SessionRuntimeRecordPayload,
+): SessionRuntimeRecordPayload | null {
+  const workspaceId = record.workspace_id.trim();
+  const sessionId = browserSessionId(record.session_id);
+  if (!workspaceId || !sessionId) {
+    return null;
+  }
+  const now = utcNowIso();
+  return {
+    workspace_id: workspaceId,
+    session_id: sessionId,
+    status: record.status?.trim() || "IDLE",
+    current_input_id: record.current_input_id ?? null,
+    current_worker_id: record.current_worker_id ?? null,
+    lease_until: record.lease_until ?? null,
+    heartbeat_at: record.heartbeat_at ?? null,
+    last_error:
+      record.last_error && typeof record.last_error === "object"
+        ? { ...record.last_error }
+        : null,
+    last_turn_status: record.last_turn_status ?? null,
+    last_turn_completed_at: record.last_turn_completed_at ?? null,
+    last_turn_stop_reason: record.last_turn_stop_reason ?? null,
+    created_at: record.created_at || now,
+    updated_at: record.updated_at || now,
+  };
+}
+
+function cacheRuntimeStateRecords(
+  workspaceId: string,
+  items: SessionRuntimeRecordPayload[],
+): SessionRuntimeRecordPayload[] {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return [];
+  }
+  const workspaceRecords = new Map<string, SessionRuntimeRecordPayload>();
+  const normalizedItems: SessionRuntimeRecordPayload[] = [];
+  for (const item of items) {
+    const normalized = normalizeRuntimeStateRecord({
+      ...item,
+      workspace_id: normalizedWorkspaceId,
+    });
+    if (!normalized) {
+      continue;
+    }
+    workspaceRecords.set(normalized.session_id, normalized);
+    normalizedItems.push(cloneRuntimeStateRecord(normalized));
+  }
+  sessionRuntimeStateCache.set(normalizedWorkspaceId, workspaceRecords);
+  return normalizedItems;
+}
+
+function upsertCachedRuntimeStateRecord(
+  record: SessionRuntimeRecordPayload,
+): SessionRuntimeRecordPayload | null {
+  const normalized = normalizeRuntimeStateRecord(record);
+  if (!normalized) {
+    return null;
+  }
+  let workspaceRecords = sessionRuntimeStateCache.get(normalized.workspace_id);
+  if (!workspaceRecords) {
+    workspaceRecords = new Map<string, SessionRuntimeRecordPayload>();
+    sessionRuntimeStateCache.set(normalized.workspace_id, workspaceRecords);
+  }
+  workspaceRecords.set(normalized.session_id, normalized);
+  return cloneRuntimeStateRecord(normalized);
+}
+
+function getCachedRuntimeStateRecord(
+  workspaceId: string,
+  sessionId: string,
+): SessionRuntimeRecordPayload | null {
+  const normalizedWorkspaceId = workspaceId.trim();
+  const normalizedSessionId = browserSessionId(sessionId);
+  if (!normalizedWorkspaceId || !normalizedSessionId) {
+    return null;
+  }
+  const record = sessionRuntimeStateCache
+    .get(normalizedWorkspaceId)
+    ?.get(normalizedSessionId);
+  return record ? cloneRuntimeStateRecord(record) : null;
+}
+
 function updateQueuedInputStatus(inputId: string, status: string) {
   const database = openRuntimeDatabase();
   try {
@@ -13018,7 +13319,7 @@ async function deleteWorkspace(
 async function listRuntimeStates(
   workspaceId: string,
 ): Promise<SessionRuntimeStateListResponsePayload> {
-  return requestRuntimeJson<SessionRuntimeStateListResponsePayload>({
+  const response = await requestRuntimeJson<SessionRuntimeStateListResponsePayload>({
     method: "GET",
     path: `/api/v1/agent-sessions/by-workspace/${workspaceId}/runtime-states`,
     params: {
@@ -13026,6 +13327,12 @@ async function listRuntimeStates(
       offset: 0,
     },
   });
+  const items = cacheRuntimeStateRecords(workspaceId, response.items ?? []);
+  return {
+    ...response,
+    items,
+    count: items.length,
+  };
 }
 
 async function listAgentSessions(
@@ -13152,13 +13459,14 @@ function contextualWorkspaceCreateError(stage: string, error: unknown) {
 async function queueSessionInput(
   payload: HolabossQueueSessionInputPayload,
 ): Promise<EnqueueSessionInputResponsePayload> {
+  await syncDesktopBrowserCapabilityConfig();
   const currentConfig = await readRuntimeConfigFile();
   if (sessionQueueRequiresRuntimeBinding(currentConfig, payload.model)) {
     await ensureRuntimeBindingReadyForWorkspaceFlow("session_queue");
   }
   const idempotencyKey =
     payload.idempotency_key?.trim() || `desktop-session-input:${randomUUID()}`;
-  return requestRuntimeJson<EnqueueSessionInputResponsePayload>({
+  const response = await requestRuntimeJson<EnqueueSessionInputResponsePayload>({
     method: "POST",
     path: "/api/v1/agent-sessions/queue",
     payload: {
@@ -13174,18 +13482,50 @@ async function queueSessionInput(
     },
     retryTransientErrors: true,
   });
+  upsertCachedRuntimeStateRecord({
+    workspace_id: payload.workspace_id,
+    session_id: response.session_id,
+    status: response.status || "QUEUED",
+    current_input_id: response.input_id,
+    current_worker_id: null,
+    lease_until: null,
+    heartbeat_at: null,
+    last_error: null,
+    last_turn_status: null,
+    last_turn_completed_at: null,
+    last_turn_stop_reason: null,
+    created_at: utcNowIso(),
+    updated_at: utcNowIso(),
+  });
+  return response;
 }
 
 async function pauseSessionRun(
   payload: HolabossPauseSessionRunPayload,
 ): Promise<PauseSessionRunResponsePayload> {
-  return requestRuntimeJson<PauseSessionRunResponsePayload>({
+  const response = await requestRuntimeJson<PauseSessionRunResponsePayload>({
     method: "POST",
     path: `/api/v1/agent-sessions/${encodeURIComponent(payload.session_id)}/pause`,
     payload: {
       workspace_id: payload.workspace_id,
     },
   });
+  upsertCachedRuntimeStateRecord({
+    workspace_id: payload.workspace_id,
+    session_id: response.session_id || payload.session_id,
+    status: response.status || "PAUSED",
+    current_input_id: response.input_id || null,
+    current_worker_id: null,
+    lease_until: null,
+    heartbeat_at: null,
+    last_error: null,
+    last_turn_status: null,
+    last_turn_completed_at: null,
+    last_turn_stop_reason: null,
+    created_at: utcNowIso(),
+    updated_at: utcNowIso(),
+  });
+  return response;
 }
 
 async function* iterSseEvents(stream: NodeJS.ReadableStream) {
@@ -14370,6 +14710,13 @@ async function startEmbeddedRuntime() {
           SANDBOX_AGENT_HARNESS: harness,
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
           HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
+          HOLABOSS_DESKTOP_BROWSER_ENABLED: currentDesktopBrowserCapabilityConfig()
+            .enabled
+            ? "true"
+            : "false",
+          HOLABOSS_DESKTOP_BROWSER_URL: desktopBrowserServiceUrl,
+          HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN:
+            desktopBrowserServiceAuthToken,
           PROACTIVE_ENABLE_REMOTE_BRIDGE: "1",
           PROACTIVE_BRIDGE_BASE_URL: runtimeProactiveBridgeBaseUrl(),
           PYTHONDONTWRITEBYTECODE: "1",
@@ -14528,11 +14875,75 @@ function browserSpaceId(
   return value === "agent" ? "agent" : value === "user" ? "user" : fallback;
 }
 
+function browserSessionId(value?: string | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 function createBrowserTabSpaceState(): BrowserTabSpaceState {
+  const now = new Date().toISOString();
   return {
     tabs: new Map<string, BrowserTabRecord>(),
     activeTabId: "",
+    persistedTabs: [],
+    lifecycleState: "active",
+    lastTouchedAt: now,
+    suspendTimer: null,
   };
+}
+
+function browserTabSpaceTouch(tabSpace: BrowserTabSpaceState): void {
+  tabSpace.lastTouchedAt = new Date().toISOString();
+}
+
+function clearBrowserTabSpaceSuspendTimer(tabSpace: BrowserTabSpaceState): void {
+  if (!tabSpace.suspendTimer) {
+    return;
+  }
+  clearTimeout(tabSpace.suspendTimer);
+  tabSpace.suspendTimer = null;
+}
+
+function browserTabSpaceTabCount(tabSpace: BrowserTabSpaceState | null | undefined): number {
+  if (!tabSpace) {
+    return 0;
+  }
+  return tabSpace.tabs.size > 0 ? tabSpace.tabs.size : tabSpace.persistedTabs.length;
+}
+
+function browserTabSpacePersistencePayload(
+  tabSpace: BrowserTabSpaceState,
+): BrowserWorkspaceTabSpacePersistencePayload {
+  return {
+    activeTabId: tabSpace.activeTabId,
+    tabs:
+      tabSpace.tabs.size > 0
+        ? serializedBrowserWorkspaceTabs(tabSpace)
+        : [...tabSpace.persistedTabs],
+  };
+}
+
+function browserStateFromPersistedTab(
+  tab: BrowserWorkspaceTabPersistencePayload,
+): BrowserStatePayload {
+  return createBrowserState({
+    id: tab.id,
+    url: tab.url,
+    title: tab.title,
+    faviconUrl: tab.faviconUrl,
+    initialized: true,
+  });
+}
+
+function browserTabSpaceStates(
+  tabSpace: BrowserTabSpaceState | null | undefined,
+): BrowserStatePayload[] {
+  if (!tabSpace) {
+    return [];
+  }
+  if (tabSpace.tabs.size > 0 || tabSpace.lifecycleState === "active") {
+    return Array.from(tabSpace.tabs.values(), ({ state }) => state);
+  }
+  return tabSpace.persistedTabs.map((tab) => browserStateFromPersistedTab(tab));
 }
 
 function emptyBrowserTabCountsPayload(): BrowserTabCountsPayload {
@@ -14550,6 +14961,10 @@ function emptyBrowserTabListPayload(
     activeTabId: "",
     tabs: [],
     tabCounts: emptyBrowserTabCountsPayload(),
+    sessionId: space === "agent" ? (browserSessionId(activeBrowserSessionId) || null) : null,
+    lifecycleState: null,
+    controlMode: "none",
+    controlSessionId: null,
   };
 }
 
@@ -14561,6 +14976,8 @@ function defaultBrowserWorkspacePersistence(): BrowserWorkspacePersistencePayloa
       user: { activeTabId: "", tabs: [] },
       agent: { activeTabId: "", tabs: [] },
     },
+    activeAgentSessionId: null,
+    agentSessions: {},
     bookmarks: [],
     downloads: [],
     history: [],
@@ -14753,14 +15170,94 @@ function browserWorkspaceOrEmpty(
   return browserWorkspaceFromMap(normalizedWorkspaceId);
 }
 
-function browserTabSpaceState(
+function browserVisibleAgentSessionId(
   workspace: BrowserWorkspaceState | null | undefined,
-  space: BrowserSpaceId,
+): string {
+  if (!workspace) {
+    return "";
+  }
+  if (
+    workspace.workspaceId === activeBrowserWorkspaceId &&
+    activeBrowserSpaceId === "agent"
+  ) {
+    return (
+      browserSessionId(activeBrowserSessionId) ||
+      browserSessionId(workspace.activeAgentSessionId)
+    );
+  }
+  return browserSessionId(workspace.activeAgentSessionId);
+}
+
+function browserAgentSessionSpaceState(
+  workspace: BrowserWorkspaceState | null | undefined,
+  sessionId?: string | null,
+  options?: {
+    createIfMissing?: boolean;
+  },
 ): BrowserTabSpaceState | null {
   if (!workspace) {
     return null;
   }
-  return workspace.spaces[space] ?? null;
+  const normalizedSessionId = browserSessionId(sessionId);
+  if (!normalizedSessionId) {
+    return null;
+  }
+  let tabSpace = workspace.agentSessionSpaces.get(normalizedSessionId) ?? null;
+  if (!tabSpace && options?.createIfMissing) {
+    tabSpace = createBrowserTabSpaceState();
+    workspace.agentSessionSpaces.set(normalizedSessionId, tabSpace);
+  }
+  return tabSpace;
+}
+
+function browserFallbackAgentSessionId(
+  workspace: BrowserWorkspaceState | null | undefined,
+): string {
+  if (!workspace) {
+    return "";
+  }
+  const persistedVisibleSessionId = browserSessionId(workspace.activeAgentSessionId);
+  if (
+    persistedVisibleSessionId &&
+    browserAgentSessionSpaceState(workspace, persistedVisibleSessionId)
+  ) {
+    return persistedVisibleSessionId;
+  }
+  for (const sessionId of workspace.agentSessionSpaces.keys()) {
+    return browserSessionId(sessionId);
+  }
+  return "";
+}
+
+function browserTabSpaceState(
+  workspace: BrowserWorkspaceState | null | undefined,
+  space: BrowserSpaceId,
+  sessionId?: string | null,
+  options?: {
+    createIfMissing?: boolean;
+    useVisibleAgentSession?: boolean;
+  },
+): BrowserTabSpaceState | null {
+  if (!workspace) {
+    return null;
+  }
+  if (space === "user") {
+    return workspace.spaces.user ?? null;
+  }
+  const explicitSessionId = browserSessionId(sessionId);
+  if (explicitSessionId) {
+    return browserAgentSessionSpaceState(workspace, explicitSessionId, options);
+  }
+  if (options?.useVisibleAgentSession) {
+    const visibleSessionId = browserVisibleAgentSessionId(workspace);
+    const visibleSessionSpace = visibleSessionId
+      ? browserAgentSessionSpaceState(workspace, visibleSessionId)
+      : null;
+    if (visibleSessionSpace) {
+      return visibleSessionSpace;
+    }
+  }
+  return workspace.spaces.agent ?? null;
 }
 
 function oppositeBrowserSpaceId(space: BrowserSpaceId): BrowserSpaceId {
@@ -14773,9 +15270,12 @@ function browserWorkspaceTabCounts(
   if (!workspace) {
     return emptyBrowserTabCountsPayload();
   }
+  const visibleAgentSpace = browserTabSpaceState(workspace, "agent", null, {
+    useVisibleAgentSession: true,
+  });
   return {
-    user: workspace.spaces.user.tabs.size,
-    agent: workspace.spaces.agent.tabs.size,
+    user: browserTabSpaceTabCount(workspace.spaces.user),
+    agent: browserTabSpaceTabCount(visibleAgentSpace ?? workspace.spaces.agent),
   };
 }
 
@@ -14795,17 +15295,20 @@ function serializeBrowserWorkspace(
 ): BrowserWorkspacePersistencePayload {
   return {
     activeTabId: workspace.spaces.user.activeTabId,
-    tabs: serializedBrowserWorkspaceTabs(workspace.spaces.user),
+    tabs: browserTabSpacePersistencePayload(workspace.spaces.user).tabs,
     spaces: {
-      user: {
-        activeTabId: workspace.spaces.user.activeTabId,
-        tabs: serializedBrowserWorkspaceTabs(workspace.spaces.user),
-      },
-      agent: {
-        activeTabId: workspace.spaces.agent.activeTabId,
-        tabs: serializedBrowserWorkspaceTabs(workspace.spaces.agent),
-      },
+      user: browserTabSpacePersistencePayload(workspace.spaces.user),
+      agent: browserTabSpacePersistencePayload(workspace.spaces.agent),
     },
+    activeAgentSessionId: browserSessionId(workspace.activeAgentSessionId) || null,
+    agentSessions: Object.fromEntries(
+      Array.from(workspace.agentSessionSpaces.entries()).map(
+        ([sessionId, tabSpace]) => [
+          sessionId,
+          browserTabSpacePersistencePayload(tabSpace),
+        ],
+      ),
+    ),
     bookmarks: workspace.bookmarks,
     downloads: workspace.downloads,
     history: workspace.history,
@@ -14839,12 +15342,452 @@ function createBrowserWorkspaceState(
       user: createBrowserTabSpaceState(),
       agent: createBrowserTabSpaceState(),
     },
+    userBrowserLock: null,
+    activeAgentSessionId: null,
+    agentSessionSpaces: new Map<string, BrowserTabSpaceState>(),
     bookmarks: [],
     downloads: [],
     history: [],
     downloadTrackingRegistered: false,
     pendingDownloadOverrides: [],
   };
+}
+
+function setVisibleAgentBrowserSession(
+  workspace: BrowserWorkspaceState | null | undefined,
+  sessionId?: string | null,
+) {
+  if (!workspace) {
+    return;
+  }
+  const normalizedSessionId = browserSessionId(sessionId);
+  workspace.activeAgentSessionId = normalizedSessionId || null;
+  if (
+    workspace.workspaceId === activeBrowserWorkspaceId &&
+    activeBrowserSpaceId === "agent"
+  ) {
+    activeBrowserSessionId = normalizedSessionId;
+  }
+}
+
+function seedVisibleAgentBrowserSession(
+  workspace: BrowserWorkspaceState | null | undefined,
+  sessionId?: string | null,
+) {
+  if (!workspace) {
+    return;
+  }
+  const normalizedSessionId = browserSessionId(sessionId);
+  const currentVisibleSessionId = browserSessionId(workspace.activeAgentSessionId);
+  if (currentVisibleSessionId) {
+    return;
+  }
+  if (!normalizedSessionId) {
+    return;
+  }
+  workspace.activeAgentSessionId = normalizedSessionId;
+  if (
+    workspace.workspaceId === activeBrowserWorkspaceId &&
+    activeBrowserSpaceId === "agent" &&
+    !browserSessionId(activeBrowserSessionId)
+  ) {
+    activeBrowserSessionId = normalizedSessionId;
+  }
+}
+
+function isVisibleAgentBrowserSession(
+  workspaceId: string,
+  sessionId?: string | null,
+): boolean {
+  return (
+    activeBrowserWorkspaceId === workspaceId &&
+    activeBrowserSpaceId === "agent" &&
+    browserSessionId(activeBrowserSessionId) === browserSessionId(sessionId)
+  );
+}
+
+function activeUserBrowserLock(
+  workspace: BrowserWorkspaceState | null | undefined,
+): BrowserUserLockState | null {
+  if (!workspace?.userBrowserLock) {
+    return null;
+  }
+  const heartbeatAtMs = Date.parse(workspace.userBrowserLock.heartbeatAt);
+  if (
+    !Number.isFinite(heartbeatAtMs) ||
+    Date.now() - heartbeatAtMs > USER_BROWSER_LOCK_TIMEOUT_MS
+  ) {
+    workspace.userBrowserLock = null;
+    return null;
+  }
+  return workspace.userBrowserLock;
+}
+
+function releaseUserBrowserLock(
+  workspaceId: string,
+  sessionId?: string | null,
+): boolean {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const activeLock = activeUserBrowserLock(workspace);
+  const normalizedSessionId = browserSessionId(sessionId);
+  if (
+    !workspace ||
+    !activeLock ||
+    (normalizedSessionId && activeLock.sessionId !== normalizedSessionId)
+  ) {
+    return false;
+  }
+  workspace.userBrowserLock = null;
+  return true;
+}
+
+function ensureUserBrowserLock(
+  workspaceId: string,
+  sessionId?: string | null,
+  reason?: string | null,
+): { ok: true; lock: BrowserUserLockState } | {
+  ok: false;
+  lockHolderSessionId: string;
+} {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  if (!workspace || !normalizedSessionId) {
+    return { ok: false, lockHolderSessionId: "" };
+  }
+  const existing = activeUserBrowserLock(workspace);
+  if (existing && existing.sessionId !== normalizedSessionId) {
+    return { ok: false, lockHolderSessionId: existing.sessionId };
+  }
+  const now = new Date().toISOString();
+  workspace.userBrowserLock = existing
+    ? {
+        ...existing,
+        heartbeatAt: now,
+        reason:
+          typeof reason === "string" && reason.trim()
+            ? reason.trim()
+            : existing.reason,
+      }
+    : {
+        sessionId: normalizedSessionId,
+        acquiredAt: now,
+        heartbeatAt: now,
+        reason:
+          typeof reason === "string" && reason.trim() ? reason.trim() : null,
+      };
+  return { ok: true, lock: workspace.userBrowserLock };
+}
+
+async function pauseBrowserControlSession(
+  workspaceId: string,
+  sessionId: string,
+): Promise<void> {
+  try {
+    await pauseSessionRun({
+      workspace_id: workspaceId,
+      session_id: sessionId,
+    });
+  } finally {
+    releaseUserBrowserLock(workspaceId, sessionId);
+  }
+}
+
+function agentBrowserSessionNeedsInterrupt(
+  workspaceId: string,
+  sessionId?: string | null,
+): boolean {
+  const normalizedSessionId =
+    browserSessionId(sessionId) ||
+    browserSessionId(browserWorkspaceFromMap(workspaceId)?.activeAgentSessionId);
+  if (!workspaceId.trim() || !normalizedSessionId) {
+    return false;
+  }
+  const runtimeRecord = getCachedRuntimeStateRecord(
+    workspaceId,
+    normalizedSessionId,
+  );
+  const status = runtimeRecord?.status?.trim().toUpperCase() ?? "";
+  return status === "BUSY" || status === "QUEUED" || status === "PAUSING";
+}
+
+async function confirmBrowserInterrupt(
+  workspaceId: string,
+  sessionId: string,
+): Promise<void> {
+  if (userBrowserInterruptPrompts.has(workspaceId)) {
+    return;
+  }
+  userBrowserInterruptPrompts.add(workspaceId);
+  try {
+    const ownerWindow =
+      mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
+    const { response } = ownerWindow
+      ? await dialog.showMessageBox(ownerWindow, {
+          type: "warning",
+          buttons: ["Let agent continue", "Interrupt and take over"],
+          defaultId: 0,
+          cancelId: 0,
+          noLink: true,
+          title: "Agent Controlling Browser",
+          message: "The agent is currently controlling this browser.",
+          detail:
+            "Your input will only go through if you interrupt. Interrupting will pause the active agent session and return control to you.",
+        })
+      : await dialog.showMessageBox({
+          type: "warning",
+          buttons: ["Let agent continue", "Interrupt and take over"],
+          defaultId: 0,
+          cancelId: 0,
+          noLink: true,
+          title: "Agent Controlling Browser",
+          message: "The agent is currently controlling this browser.",
+          detail:
+            "Your input will only go through if you interrupt. Interrupting will pause the active agent session and return control to you.",
+        });
+    if (response !== 1) {
+      return;
+    }
+    await pauseBrowserControlSession(workspaceId, sessionId);
+  } catch (error) {
+    const ownerWindow =
+      mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
+    const messageBoxOptions = {
+      type: "error",
+      title: "Could Not Interrupt Agent",
+      message: "The agent session could not be paused.",
+      detail:
+        error instanceof Error
+          ? error.message
+          : "The browser remained under agent control.",
+    } as const;
+    if (ownerWindow) {
+      await dialog.showMessageBox(ownerWindow, messageBoxOptions);
+    } else {
+      await dialog.showMessageBox(messageBoxOptions);
+    }
+  } finally {
+    userBrowserInterruptPrompts.delete(workspaceId);
+  }
+}
+
+function maybePromptBrowserInterrupt(
+  workspaceId: string,
+  space: BrowserSpaceId,
+  sessionId?: string | null,
+): boolean {
+  if (space === "user") {
+    const workspace = browserWorkspaceFromMap(workspaceId);
+    const lock = activeUserBrowserLock(workspace);
+    if (!lock) {
+      return false;
+    }
+    void confirmBrowserInterrupt(workspaceId, lock.sessionId);
+    return true;
+  }
+
+  const controllingSessionId = browserSessionId(sessionId);
+  if (!agentBrowserSessionNeedsInterrupt(workspaceId, controllingSessionId)) {
+    return false;
+  }
+  void confirmBrowserInterrupt(workspaceId, controllingSessionId);
+  return true;
+}
+
+function hydrateAgentSessionBrowserSpace(
+  workspaceId: string,
+  sessionId?: string | null,
+): BrowserTabSpaceState | null {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserAgentSessionSpaceState(workspace, normalizedSessionId, {
+    createIfMissing: Boolean(normalizedSessionId),
+  });
+  if (!workspace || !tabSpace || !normalizedSessionId) {
+    return null;
+  }
+  clearBrowserTabSpaceSuspendTimer(tabSpace);
+  if (tabSpace.lifecycleState !== "suspended") {
+    browserTabSpaceTouch(tabSpace);
+    return tabSpace;
+  }
+
+  const persistedTabs = [...tabSpace.persistedTabs];
+  const persistedActiveTabId = tabSpace.activeTabId;
+  tabSpace.persistedTabs = [];
+  tabSpace.lifecycleState = "active";
+  for (const persistedTab of persistedTabs) {
+    createBrowserTab(workspaceId, {
+      browserSpace: "agent",
+      sessionId: normalizedSessionId,
+      id: typeof persistedTab.id === "string" ? persistedTab.id : undefined,
+      url:
+        typeof persistedTab.url === "string" && persistedTab.url.trim()
+          ? persistedTab.url.trim()
+          : HOME_URL,
+      title:
+        typeof persistedTab.title === "string"
+          ? persistedTab.title
+          : NEW_TAB_TITLE,
+      faviconUrl:
+        typeof persistedTab.faviconUrl === "string"
+          ? persistedTab.faviconUrl
+          : undefined,
+      skipInitialHistoryRecord: true,
+    });
+  }
+  tabSpace.activeTabId = tabSpace.tabs.has(persistedActiveTabId)
+    ? persistedActiveTabId
+    : (Array.from(tabSpace.tabs.keys())[0] ?? "");
+  if (tabSpace.tabs.size === 0) {
+    ensureBrowserTabSpaceInitialized(workspaceId, "agent", normalizedSessionId);
+  }
+  browserTabSpaceTouch(tabSpace);
+  return tabSpace;
+}
+
+function suspendAgentSessionBrowserSpace(
+  workspaceId: string,
+  sessionId?: string | null,
+): boolean {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserAgentSessionSpaceState(workspace, normalizedSessionId);
+  if (!workspace || !tabSpace || !normalizedSessionId) {
+    return false;
+  }
+  clearBrowserTabSpaceSuspendTimer(tabSpace);
+  if (isVisibleAgentBrowserSession(workspaceId, normalizedSessionId)) {
+    return false;
+  }
+  if (tabSpace.lifecycleState === "suspended") {
+    return true;
+  }
+  const persisted = browserTabSpacePersistencePayload(tabSpace);
+  for (const tab of tabSpace.tabs.values()) {
+    closeBrowserTabRecord(tab);
+  }
+  tabSpace.tabs.clear();
+  tabSpace.activeTabId = persisted.activeTabId;
+  tabSpace.persistedTabs = persisted.tabs;
+  tabSpace.lifecycleState = "suspended";
+  emitBrowserState(workspaceId, "agent");
+  void persistBrowserWorkspace(workspaceId);
+  return true;
+}
+
+function scheduleAgentSessionBrowserLifecycleCheck(
+  workspaceId: string,
+  sessionId?: string | null,
+  delayMs = SESSION_BROWSER_BUSY_CHECK_MS,
+): void {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserAgentSessionSpaceState(workspace, normalizedSessionId);
+  if (!tabSpace || !normalizedSessionId) {
+    return;
+  }
+  clearBrowserTabSpaceSuspendTimer(tabSpace);
+  tabSpace.suspendTimer = setTimeout(() => {
+    void reconcileAgentSessionBrowserSpace(workspaceId, normalizedSessionId);
+  }, Math.max(1_000, Math.round(delayMs)));
+}
+
+function touchAgentSessionBrowserSpace(
+  workspaceId: string,
+  sessionId?: string | null,
+): void {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserAgentSessionSpaceState(workspace, normalizedSessionId);
+  if (!tabSpace || !normalizedSessionId) {
+    return;
+  }
+  tabSpace.lifecycleState = "active";
+  browserTabSpaceTouch(tabSpace);
+  scheduleAgentSessionBrowserLifecycleCheck(workspaceId, normalizedSessionId);
+}
+
+async function reconcileAgentSessionBrowserSpace(
+  workspaceId: string,
+  sessionId?: string | null,
+): Promise<void> {
+  const workspace = browserWorkspaceFromMap(workspaceId);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserAgentSessionSpaceState(workspace, normalizedSessionId);
+  if (!workspace || !tabSpace || !normalizedSessionId) {
+    return;
+  }
+  clearBrowserTabSpaceSuspendTimer(tabSpace);
+  if (isVisibleAgentBrowserSession(workspaceId, normalizedSessionId)) {
+    scheduleAgentSessionBrowserLifecycleCheck(
+      workspaceId,
+      normalizedSessionId,
+      SESSION_BROWSER_BUSY_CHECK_MS,
+    );
+    return;
+  }
+
+  let runtimeRecord: SessionRuntimeRecordPayload | null = null;
+  try {
+    const runtimeStates = await listRuntimeStates(workspaceId);
+    runtimeRecord =
+      runtimeStates.items.find(
+        (item) => browserSessionId(item.session_id) === normalizedSessionId,
+      ) ?? null;
+  } catch {
+    runtimeRecord = null;
+  }
+
+  const status = runtimeRecord?.status?.trim().toUpperCase() ?? "";
+  const lastTurnStatus =
+    runtimeRecord?.last_turn_status?.trim().toLowerCase() ?? "";
+  const touchedAtMs = Date.parse(tabSpace.lastTouchedAt);
+  const ageMs = Number.isFinite(touchedAtMs)
+    ? Math.max(0, Date.now() - touchedAtMs)
+    : Number.MAX_SAFE_INTEGER;
+
+  if (status === "BUSY" || status === "QUEUED" || status === "PAUSING") {
+    scheduleAgentSessionBrowserLifecycleCheck(
+      workspaceId,
+      normalizedSessionId,
+      SESSION_BROWSER_BUSY_CHECK_MS,
+    );
+    return;
+  }
+
+  if (
+    (status === "WAITING_USER" || status === "PAUSED") &&
+    ageMs < SESSION_BROWSER_WARM_TTL_MS
+  ) {
+    scheduleAgentSessionBrowserLifecycleCheck(
+      workspaceId,
+      normalizedSessionId,
+      SESSION_BROWSER_WARM_TTL_MS - ageMs,
+    );
+    return;
+  }
+
+  if (
+    !(
+      status === "WAITING_USER" || status === "PAUSED"
+    ) &&
+    (status === "IDLE" ||
+      status === "ERROR" ||
+      !runtimeRecord ||
+      lastTurnStatus === "completed" ||
+      lastTurnStatus === "failed" ||
+      lastTurnStatus === "error") &&
+    ageMs < SESSION_BROWSER_COMPLETED_GRACE_MS
+  ) {
+    scheduleAgentSessionBrowserLifecycleCheck(
+      workspaceId,
+      normalizedSessionId,
+      SESSION_BROWSER_COMPLETED_GRACE_MS - ageMs,
+    );
+    return;
+  }
+
+  suspendAgentSessionBrowserSpace(workspaceId, normalizedSessionId);
 }
 
 const TEXT_FILE_EXTENSIONS = new Set([
@@ -16790,29 +17733,77 @@ async function recordHistoryVisit(
 function browserWorkspaceSnapshot(
   workspaceId?: string | null,
   space?: BrowserSpaceId | null,
+  sessionId?: string | null,
+  options?: {
+    useVisibleAgentSession?: boolean;
+  },
 ): BrowserTabListPayload {
   const browserSpace = browserSpaceId(space);
   const workspace = browserWorkspaceOrEmpty(workspaceId);
   if (!workspace) {
     return emptyBrowserTabListPayload(browserSpace);
   }
-  const tabSpace = browserTabSpaceState(workspace, browserSpace);
-  const tabs = Array.from(tabSpace?.tabs.values() ?? [], ({ state }) => state);
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserTabSpaceState(
+    workspace,
+    browserSpace,
+    normalizedSessionId,
+    options,
+  );
+  const tabs = browserTabSpaceStates(tabSpace);
+  const visibleSessionId =
+    browserSpace === "agent" && options?.useVisibleAgentSession
+      ? browserVisibleAgentSessionId(workspace)
+      : "";
+  const resolvedSessionId =
+    browserSpace === "agent"
+      ? normalizedSessionId ||
+        (visibleSessionId &&
+        browserAgentSessionSpaceState(workspace, visibleSessionId) === tabSpace
+          ? visibleSessionId
+          : "")
+      : "";
+  const lockSessionId =
+    browserSpace === "user" ? activeUserBrowserLock(workspace)?.sessionId ?? "" : "";
   return {
     space: browserSpace,
     activeTabId: tabSpace?.activeTabId || tabs[0]?.id || "",
     tabs,
     tabCounts: browserWorkspaceTabCounts(workspace),
+    sessionId: resolvedSessionId || null,
+    lifecycleState:
+      browserSpace === "agent" ? tabSpace?.lifecycleState ?? null : null,
+    controlMode:
+      browserSpace === "user"
+        ? lockSessionId
+          ? "user_locked"
+          : "none"
+        : resolvedSessionId
+          ? "session_owned"
+          : "none",
+    controlSessionId:
+      browserSpace === "user"
+        ? lockSessionId || null
+        : resolvedSessionId || null,
   };
 }
 
 function getActiveBrowserTab(
   workspaceId?: string | null,
   space?: BrowserSpaceId | null,
+  sessionId?: string | null,
+  options?: {
+    useVisibleAgentSession?: boolean;
+  },
 ): BrowserTabRecord | null {
   const browserSpace = browserSpaceId(space);
   const workspace = browserWorkspaceOrEmpty(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, browserSpace);
+  const tabSpace = browserTabSpaceState(
+    workspace,
+    browserSpace,
+    sessionId,
+    options,
+  );
   if (!tabSpace || !tabSpace.activeTabId) {
     return null;
   }
@@ -16842,9 +17833,12 @@ function applyBoundsToTab(
   workspaceId: string,
   tabId: string,
   space: BrowserSpaceId = activeBrowserSpaceId,
+  sessionId?: string | null,
 ) {
   const workspace = browserWorkspaceFromMap(workspaceId);
-  const tab = browserTabSpaceState(workspace, space)?.tabs.get(tabId);
+  const tab = browserTabSpaceState(workspace, space, sessionId, {
+    useVisibleAgentSession: !browserSessionId(sessionId),
+  })?.tabs.get(tabId);
   if (!tab) {
     return;
   }
@@ -16875,7 +17869,9 @@ function emitBrowserState(
   }
   mainWindow.webContents.send(
     "browser:state",
-    browserWorkspaceSnapshot(normalizedWorkspaceId, browserSpace),
+    browserWorkspaceSnapshot(normalizedWorkspaceId, browserSpace, null, {
+      useVisibleAgentSession: true,
+    }),
   );
 }
 
@@ -16944,11 +17940,22 @@ function destroyBrowserWorkspace(workspaceId: string) {
     return;
   }
   for (const browserSpace of BROWSER_SPACE_IDS) {
+    clearBrowserTabSpaceSuspendTimer(workspace.spaces[browserSpace]);
     for (const tab of workspace.spaces[browserSpace].tabs.values()) {
       closeBrowserTabRecord(tab);
     }
     workspace.spaces[browserSpace].tabs.clear();
   }
+  for (const tabSpace of workspace.agentSessionSpaces.values()) {
+    clearBrowserTabSpaceSuspendTimer(tabSpace);
+    for (const tab of tabSpace.tabs.values()) {
+      closeBrowserTabRecord(tab);
+    }
+    tabSpace.tabs.clear();
+  }
+  workspace.userBrowserLock = null;
+  workspace.agentSessionSpaces.clear();
+  sessionRuntimeStateCache.delete(workspaceId);
   browserWorkspaces.delete(workspaceId);
 }
 
@@ -16959,6 +17966,8 @@ function updateAttachedBrowserView() {
   const activeTab = getActiveBrowserTab(
     activeBrowserWorkspaceId,
     activeBrowserSpaceId,
+    null,
+    { useVisibleAgentSession: true },
   );
   if (!activeTab || !hasVisibleBrowserBounds()) {
     if (attachedBrowserTabView) {
@@ -16976,6 +17985,7 @@ function updateAttachedBrowserView() {
     activeBrowserWorkspaceId,
     activeTab.state.id,
     activeBrowserSpaceId,
+    activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
   );
 }
 
@@ -16983,11 +17993,19 @@ function syncBrowserState(
   workspaceId: string,
   tabId: string,
   space: BrowserSpaceId,
+  sessionId?: string | null,
 ) {
   const workspace = browserWorkspaceFromMap(workspaceId);
-  const tab = browserTabSpaceState(workspace, space)?.tabs.get(tabId);
+  const tabSpace = browserTabSpaceState(workspace, space, sessionId);
+  const tab = tabSpace?.tabs.get(tabId);
   if (!workspace || !tab) {
     return;
+  }
+  if (tabSpace) {
+    browserTabSpaceTouch(tabSpace);
+  }
+  if (space === "agent" && browserSessionId(sessionId)) {
+    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
   }
 
   const viewContents = tab.view.webContents;
@@ -17031,8 +18049,13 @@ function focusBrowserTabInSpace(
   tabSpace: BrowserTabSpaceState,
   tabId: string,
   space: BrowserSpaceId,
+  sessionId?: string | null,
 ) {
   tabSpace.activeTabId = tabId;
+  browserTabSpaceTouch(tabSpace);
+  if (space === "agent" && browserSessionId(sessionId)) {
+    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
+  }
   if (workspaceId === activeBrowserWorkspaceId && space === activeBrowserSpaceId) {
     updateAttachedBrowserView();
   }
@@ -17046,6 +18069,7 @@ function handleBrowserWindowOpenAsTab(
   disposition: string,
   frameName: string,
   space: BrowserSpaceId,
+  sessionId?: string | null,
 ) {
   const normalizedUrl = targetUrl.trim();
   if (!normalizedUrl) {
@@ -17063,7 +18087,9 @@ function handleBrowserWindowOpenAsTab(
   }
 
   const workspace = browserWorkspaceFromMap(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, space);
+  const tabSpace = browserTabSpaceState(workspace, space, sessionId, {
+    createIfMissing: true,
+  });
   if (!workspace || !tabSpace) {
     return;
   }
@@ -17100,7 +18126,7 @@ function handleBrowserWindowOpenAsTab(
       });
     }
     if (disposition !== "background-tab") {
-      focusBrowserTabInSpace(workspaceId, tabSpace, existingTabId, space);
+      focusBrowserTabInSpace(workspaceId, tabSpace, existingTabId, space, sessionId);
     }
     return;
   }
@@ -17108,6 +18134,7 @@ function handleBrowserWindowOpenAsTab(
   const nextTabId = createBrowserTab(workspaceId, {
     url: normalizedUrl,
     browserSpace: space,
+    sessionId,
     popupFrameName: normalizedFrameName,
     popupOpenedAtMs: now,
   });
@@ -17116,7 +18143,7 @@ function handleBrowserWindowOpenAsTab(
   }
 
   if (disposition !== "background-tab") {
-    focusBrowserTabInSpace(workspaceId, tabSpace, nextTabId, space);
+    focusBrowserTabInSpace(workspaceId, tabSpace, nextTabId, space, sessionId);
     return;
   }
 
@@ -17194,10 +18221,11 @@ function consumeBrowserDownloadOverride(
 function showBrowserViewContextMenu(params: {
   workspaceId: string;
   space: BrowserSpaceId;
+  sessionId?: string | null;
   view: BrowserView;
   context: ContextMenuParams;
 }) {
-  const { workspaceId, space, view, context } = params;
+  const { workspaceId, space, sessionId, view, context } = params;
   const template: MenuItemConstructorOptions[] = [];
   const selectionText = context.selectionText.trim();
   const linkUrl = context.linkURL.trim();
@@ -17218,6 +18246,7 @@ function showBrowserViewContextMenu(params: {
             "foreground-tab",
             "",
             space,
+            sessionId,
           ),
       },
       {
@@ -17247,6 +18276,7 @@ function showBrowserViewContextMenu(params: {
             "foreground-tab",
             "",
             space,
+            sessionId,
           ),
       },
       {
@@ -17334,6 +18364,7 @@ function createBrowserTab(
   workspaceId: string,
   options: {
     browserSpace?: BrowserSpaceId;
+    sessionId?: string | null;
     id?: string;
     url?: string;
     title?: string;
@@ -17345,10 +18376,20 @@ function createBrowserTab(
 ) {
   const workspace = browserWorkspaceFromMap(workspaceId);
   const browserSpace = browserSpaceId(options.browserSpace);
-  const tabSpace = browserTabSpaceState(workspace, browserSpace);
+  const normalizedSessionId = browserSessionId(options.sessionId);
+  const tabSpace = browserTabSpaceState(
+    workspace,
+    browserSpace,
+    normalizedSessionId,
+    {
+      createIfMissing: Boolean(normalizedSessionId),
+    },
+  );
   if (!mainWindow || !workspace || !tabSpace) {
     return null;
   }
+  tabSpace.lifecycleState = "active";
+  browserTabSpaceTouch(tabSpace);
 
   const tabId =
     options.id?.trim() ||
@@ -17433,6 +18474,7 @@ function createBrowserTab(
         disposition,
         frameName,
         browserSpace,
+        normalizedSessionId,
       );
     }
     return { action: "deny" };
@@ -17441,40 +18483,69 @@ function createBrowserTab(
   view.webContents.setZoomFactor(1);
   view.webContents.setVisualZoomLevelLimits(1, 1).catch(() => undefined);
 
-  view.webContents.on("dom-ready", () => {
-    const currentTab = browserTabSpaceState(
+  const currentTabRecord = () =>
+    browserTabSpaceState(
       browserWorkspaceFromMap(workspaceId),
       browserSpace,
+      normalizedSessionId,
     )?.tabs.get(tabId);
+
+  view.webContents.on("before-input-event", (event, input) => {
+    if (
+      (input.type === "keyDown" ||
+        input.type === "keyUp" ||
+        input.type === "char" ||
+        input.type === "rawKeyDown") &&
+      maybePromptBrowserInterrupt(
+        workspaceId,
+        browserSpace,
+        normalizedSessionId,
+      )
+    ) {
+      event.preventDefault();
+    }
+  });
+
+  view.webContents.on("before-mouse-event", (event, mouse) => {
+    if (
+      mouse.type !== "mouseMove" &&
+      mouse.type !== "mouseEnter" &&
+      mouse.type !== "mouseLeave" &&
+      maybePromptBrowserInterrupt(
+        workspaceId,
+        browserSpace,
+        normalizedSessionId,
+      )
+    ) {
+      event.preventDefault();
+    }
+  });
+
+  view.webContents.on("dom-ready", () => {
+    const currentTab = currentTabRecord();
     if (!currentTab) {
       return;
     }
     currentTab.state = { ...currentTab.state, initialized: true, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
   });
 
   view.webContents.on("did-start-loading", () => {
-    const currentTab = browserTabSpaceState(
-      browserWorkspaceFromMap(workspaceId),
-      browserSpace,
-    )?.tabs.get(tabId);
+    const currentTab = currentTabRecord();
     if (!currentTab) {
       return;
     }
     currentTab.state = { ...currentTab.state, loading: true, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
   });
 
   view.webContents.on("did-stop-loading", () => {
-    const currentTab = browserTabSpaceState(
-      browserWorkspaceFromMap(workspaceId),
-      browserSpace,
-    )?.tabs.get(tabId);
+    const currentTab = currentTabRecord();
     if (!currentTab) {
       return;
     }
     currentTab.state = { ...currentTab.state, loading: false, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
     if (suppressNextHistoryEntry) {
       suppressNextHistoryEntry = false;
       return;
@@ -17487,14 +18558,11 @@ function createBrowserTab(
   });
 
   view.webContents.on("page-title-updated", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
   });
 
   view.webContents.on("page-favicon-updated", (_event, favicons) => {
-    const currentTab = browserTabSpaceState(
-      browserWorkspaceFromMap(workspaceId),
-      browserSpace,
-    )?.tabs.get(tabId);
+    const currentTab = currentTabRecord();
     if (!currentTab) {
       return;
     }
@@ -17507,17 +18575,18 @@ function createBrowserTab(
   });
 
   view.webContents.on("did-navigate", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
   });
 
   view.webContents.on("did-navigate-in-page", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace);
+    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
   });
 
   view.webContents.on("context-menu", (_event, params) => {
     showBrowserViewContextMenu({
       workspaceId,
       space: browserSpace,
+      sessionId: normalizedSessionId,
       view,
       context: params,
     });
@@ -17532,10 +18601,7 @@ function createBrowserTab(
       ) {
         return;
       }
-      const currentTab = browserTabSpaceState(
-        browserWorkspaceFromMap(workspaceId),
-        browserSpace,
-      )?.tabs.get(tabId);
+      const currentTab = currentTabRecord();
       if (!currentTab) {
         return;
       }
@@ -17555,10 +18621,7 @@ function createBrowserTab(
       if (isAbortedBrowserLoadError(error)) {
         return;
       }
-      const currentTab = browserTabSpaceState(
-        browserWorkspaceFromMap(workspaceId),
-        browserSpace,
-      )?.tabs.get(tabId);
+      const currentTab = currentTabRecord();
       if (!currentTab) {
         return;
       }
@@ -17572,12 +18635,17 @@ function createBrowserTab(
     });
   }
 
+  if (browserSpace === "agent" && normalizedSessionId) {
+    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, normalizedSessionId);
+  }
+
   return tabId;
 }
 
 function initialBrowserTabSeed(
   workspaceId: string,
   space: BrowserSpaceId,
+  sessionId?: string | null,
 ): {
   url: string;
   title?: string;
@@ -17585,16 +18653,30 @@ function initialBrowserTabSeed(
   skipInitialHistoryRecord: boolean;
 } {
   const workspace = browserWorkspaceFromMap(workspaceId);
+  const sourceSpaceId = oppositeBrowserSpaceId(space);
+  const sourceSessionId =
+    sourceSpaceId === "agent" ? browserSessionId(sessionId) : "";
   const sourceSpace = browserTabSpaceState(
     workspace,
-    oppositeBrowserSpaceId(space),
+    sourceSpaceId,
+    sourceSessionId,
+    {
+      useVisibleAgentSession: sourceSpaceId === "agent" && !sourceSessionId,
+    },
   );
   const sourceTab =
     (sourceSpace?.activeTabId
       ? sourceSpace.tabs.get(sourceSpace.activeTabId)
       : null) ??
     (sourceSpace ? Array.from(sourceSpace.tabs.values())[0] ?? null : null);
-  if (!sourceTab) {
+  const sourceState =
+    sourceTab?.state ??
+    (sourceSpace?.activeTabId
+      ? browserTabSpaceStates(sourceSpace).find(
+          (state) => state.id === sourceSpace.activeTabId,
+        ) ?? null
+      : browserTabSpaceStates(sourceSpace)[0] ?? null);
+  if (!sourceState) {
     return {
       url: HOME_URL,
       title: NEW_TAB_TITLE,
@@ -17602,11 +18684,16 @@ function initialBrowserTabSeed(
     };
   }
 
-  const sourceContents = sourceTab.view.webContents;
   return {
-    url: sourceContents.getURL() || sourceTab.state.url || HOME_URL,
-    title: sourceContents.getTitle() || sourceTab.state.title || NEW_TAB_TITLE,
-    faviconUrl: sourceTab.state.faviconUrl,
+    url:
+      sourceTab?.view.webContents.getURL() ||
+      sourceState.url ||
+      HOME_URL,
+    title:
+      sourceTab?.view.webContents.getTitle() ||
+      sourceState.title ||
+      NEW_TAB_TITLE,
+    faviconUrl: sourceState.faviconUrl,
     // Mirrored first-tab seeding should not create duplicate history entries.
     skipInitialHistoryRecord: true,
   };
@@ -17615,19 +18702,38 @@ function initialBrowserTabSeed(
 function ensureBrowserTabSpaceInitialized(
   workspaceId: string,
   space: BrowserSpaceId,
+  sessionId?: string | null,
 ): boolean {
   const workspace = browserWorkspaceFromMap(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, space);
-  if (!workspace || !tabSpace || tabSpace.tabs.size > 0) {
+  const normalizedSessionId = browserSessionId(sessionId);
+  const tabSpace = browserTabSpaceState(
+    workspace,
+    space,
+    normalizedSessionId,
+    {
+      createIfMissing: Boolean(normalizedSessionId),
+      useVisibleAgentSession: !normalizedSessionId,
+    },
+  );
+  if (
+    !workspace ||
+    !tabSpace ||
+    tabSpace.tabs.size > 0 ||
+    tabSpace.persistedTabs.length > 0
+  ) {
     return false;
   }
 
-  const seed = initialBrowserTabSeed(workspaceId, space);
+  const seed = initialBrowserTabSeed(workspaceId, space, normalizedSessionId);
   const initialTabId = createBrowserTab(workspaceId, {
     ...seed,
     browserSpace: space,
+    sessionId: normalizedSessionId,
   });
   tabSpace.activeTabId = initialTabId ?? "";
+  if (space === "agent" && normalizedSessionId) {
+    seedVisibleAgentBrowserSession(workspace, normalizedSessionId);
+  }
   return true;
 }
 
@@ -17734,20 +18840,33 @@ function ensureBrowserWorkspaceDownloadTracking(
 async function ensureBrowserWorkspace(
   workspaceId?: string | null,
   space?: BrowserSpaceId | null,
+  sessionId?: string | null,
 ): Promise<BrowserWorkspaceState | null> {
   const normalizedWorkspaceId =
     typeof workspaceId === "string"
       ? workspaceId.trim()
       : activeBrowserWorkspaceId;
   const browserSpace = browserSpaceId(space);
+  const normalizedSessionId = browserSessionId(sessionId);
   if (!normalizedWorkspaceId) {
     return null;
   }
 
   const existing = browserWorkspaceFromMap(normalizedWorkspaceId);
   if (existing) {
-    if (ensureBrowserTabSpaceInitialized(normalizedWorkspaceId, browserSpace)) {
+    if (
+      ensureBrowserTabSpaceInitialized(
+        normalizedWorkspaceId,
+        browserSpace,
+        normalizedSessionId,
+      )
+    ) {
       void persistBrowserWorkspace(normalizedWorkspaceId);
+    }
+    if (browserSpace === "agent" && normalizedSessionId) {
+      hydrateAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
+      seedVisibleAgentBrowserSession(existing, normalizedSessionId);
+      touchAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
     }
     return existing;
   }
@@ -17767,6 +18886,8 @@ async function ensureBrowserWorkspace(
     ? persisted.downloads
     : [];
   workspace.history = Array.isArray(persisted.history) ? persisted.history : [];
+  workspace.activeAgentSessionId =
+    browserSessionId(persisted.activeAgentSessionId) || null;
 
   const persistedSpaces =
     persisted.spaces && typeof persisted.spaces === "object"
@@ -17819,8 +18940,54 @@ async function ensureBrowserWorkspace(
       : (Array.from(tabSpace.tabs.keys())[0] ?? "");
   }
 
-  if (ensureBrowserTabSpaceInitialized(normalizedWorkspaceId, browserSpace)) {
+  const persistedAgentSessions =
+    persisted.agentSessions && typeof persisted.agentSessions === "object"
+      ? persisted.agentSessions
+      : {};
+  for (const [persistedSessionId, storedTabSpace] of Object.entries(
+    persistedAgentSessions,
+  )) {
+    const normalizedPersistedSessionId = browserSessionId(persistedSessionId);
+    if (!normalizedPersistedSessionId) {
+      continue;
+    }
+    const agentTabSpace = browserAgentSessionSpaceState(
+      workspace,
+      normalizedPersistedSessionId,
+      { createIfMissing: true },
+    );
+    if (!agentTabSpace) {
+      continue;
+    }
+    const persistedTabs = Array.isArray(storedTabSpace?.tabs)
+      ? storedTabSpace.tabs.filter(
+          (persistedTab): persistedTab is BrowserWorkspaceTabPersistencePayload =>
+            Boolean(persistedTab) && typeof persistedTab === "object",
+        )
+      : [];
+    const persistedActiveTabId =
+      typeof storedTabSpace?.activeTabId === "string"
+        ? storedTabSpace.activeTabId.trim()
+        : "";
+    agentTabSpace.activeTabId = persistedActiveTabId;
+    agentTabSpace.persistedTabs = persistedTabs;
+    agentTabSpace.lifecycleState =
+      persistedTabs.length > 0 ? "suspended" : "active";
+  }
+
+  if (
+    ensureBrowserTabSpaceInitialized(
+      normalizedWorkspaceId,
+      browserSpace,
+      normalizedSessionId,
+    )
+  ) {
     void persistBrowserWorkspace(normalizedWorkspaceId);
+  }
+  if (browserSpace === "agent" && normalizedSessionId) {
+    hydrateAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
+    seedVisibleAgentBrowserSession(workspace, normalizedSessionId);
+    touchAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
   }
   return workspace;
 }
@@ -17828,13 +18995,26 @@ async function ensureBrowserWorkspace(
 async function setActiveBrowserWorkspace(
   workspaceId: string | null | undefined,
   space?: BrowserSpaceId | null,
+  sessionId?: string | null,
 ) {
+  const previousWorkspaceId = activeBrowserWorkspaceId;
+  const previousSpace = activeBrowserSpaceId;
+  const previousSessionId = activeBrowserSessionId;
   const normalizedWorkspaceId =
     typeof workspaceId === "string" ? workspaceId.trim() : "";
   const browserSpace = browserSpaceId(space);
+  const normalizedSessionId = browserSessionId(sessionId);
   activeBrowserWorkspaceId = normalizedWorkspaceId;
   activeBrowserSpaceId = browserSpace;
+  activeBrowserSessionId = browserSpace === "agent" ? normalizedSessionId : "";
   if (!normalizedWorkspaceId) {
+    if (previousSpace === "agent" && browserSessionId(previousSessionId)) {
+      scheduleAgentSessionBrowserLifecycleCheck(
+        previousWorkspaceId,
+        previousSessionId,
+        SESSION_BROWSER_BUSY_CHECK_MS,
+      );
+    }
     emitBrowserState();
     emitBookmarksState();
     emitDownloadsState();
@@ -17842,27 +19022,88 @@ async function setActiveBrowserWorkspace(
     return emptyBrowserTabListPayload(browserSpace);
   }
 
-  await ensureBrowserWorkspace(normalizedWorkspaceId, browserSpace);
+  const workspace = await ensureBrowserWorkspace(
+    normalizedWorkspaceId,
+    browserSpace,
+    normalizedSessionId,
+  );
+  if (browserSpace === "agent") {
+    if (normalizedSessionId) {
+      hydrateAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
+      setVisibleAgentBrowserSession(workspace, normalizedSessionId);
+      touchAgentSessionBrowserSpace(normalizedWorkspaceId, normalizedSessionId);
+    } else {
+      const visibleSessionId =
+        browserVisibleAgentSessionId(workspace) ||
+        browserFallbackAgentSessionId(workspace);
+      activeBrowserSessionId = browserAgentSessionSpaceState(
+        workspace,
+        visibleSessionId,
+      )
+        ? visibleSessionId
+        : "";
+      if (activeBrowserSessionId) {
+        hydrateAgentSessionBrowserSpace(normalizedWorkspaceId, activeBrowserSessionId);
+        touchAgentSessionBrowserSpace(normalizedWorkspaceId, activeBrowserSessionId);
+      }
+    }
+  }
+  if (
+    previousSpace === "agent" &&
+    browserSessionId(previousSessionId) &&
+    (previousWorkspaceId !== normalizedWorkspaceId ||
+      browserSpace !== "agent" ||
+      browserSessionId(previousSessionId) !== browserSessionId(activeBrowserSessionId))
+  ) {
+    scheduleAgentSessionBrowserLifecycleCheck(
+      previousWorkspaceId,
+      previousSessionId,
+      SESSION_BROWSER_BUSY_CHECK_MS,
+    );
+  }
   updateAttachedBrowserView();
   emitBrowserState(normalizedWorkspaceId, browserSpace);
   emitBookmarksState(normalizedWorkspaceId);
   emitDownloadsState(normalizedWorkspaceId);
   emitHistoryState(normalizedWorkspaceId);
-  return browserWorkspaceSnapshot(normalizedWorkspaceId, browserSpace);
+  return browserWorkspaceSnapshot(
+    normalizedWorkspaceId,
+    browserSpace,
+    browserSpace === "agent" ? activeBrowserSessionId : null,
+    { useVisibleAgentSession: true },
+  );
 }
 
 async function setActiveBrowserTab(
   tabId: string,
   space?: BrowserSpaceId | null,
+  sessionId?: string | null,
 ) {
   const browserSpace = browserSpaceId(space);
-  const workspace = await ensureBrowserWorkspace(undefined, browserSpace);
-  const tabSpace = browserTabSpaceState(workspace, browserSpace);
+  const normalizedSessionId =
+    browserSpace === "agent"
+      ? browserSessionId(sessionId) || browserSessionId(activeBrowserSessionId)
+      : "";
+  const workspace = await ensureBrowserWorkspace(
+    undefined,
+    browserSpace,
+    normalizedSessionId,
+  );
+  const tabSpace = browserTabSpaceState(workspace, browserSpace, normalizedSessionId, {
+    useVisibleAgentSession: !normalizedSessionId,
+  });
   if (!workspace || !tabSpace || !tabSpace.tabs.has(tabId)) {
-    return browserWorkspaceSnapshot(undefined, browserSpace);
+    return browserWorkspaceSnapshot(undefined, browserSpace, normalizedSessionId, {
+      useVisibleAgentSession: true,
+    });
   }
 
   tabSpace.activeTabId = tabId;
+  browserTabSpaceTouch(tabSpace);
+  if (browserSpace === "agent" && normalizedSessionId) {
+    setVisibleAgentBrowserSession(workspace, normalizedSessionId);
+    scheduleAgentSessionBrowserLifecycleCheck(workspace.workspaceId, normalizedSessionId);
+  }
   if (
     workspace.workspaceId === activeBrowserWorkspaceId &&
     browserSpace === activeBrowserSpaceId
@@ -17871,27 +19112,50 @@ async function setActiveBrowserTab(
   }
   emitBrowserState(workspace.workspaceId, browserSpace);
   await persistBrowserWorkspace(workspace.workspaceId);
-  return browserWorkspaceSnapshot(workspace.workspaceId, browserSpace);
+  return browserWorkspaceSnapshot(
+    workspace.workspaceId,
+    browserSpace,
+    normalizedSessionId,
+    { useVisibleAgentSession: true },
+  );
 }
 
-async function closeBrowserTab(tabId: string, space?: BrowserSpaceId | null) {
+async function closeBrowserTab(
+  tabId: string,
+  space?: BrowserSpaceId | null,
+  sessionId?: string | null,
+) {
   const browserSpace = browserSpaceId(space);
-  const workspace = await ensureBrowserWorkspace(undefined, browserSpace);
-  const tabSpace = browserTabSpaceState(workspace, browserSpace);
+  const normalizedSessionId =
+    browserSpace === "agent"
+      ? browserSessionId(sessionId) || browserSessionId(activeBrowserSessionId)
+      : "";
+  const workspace = await ensureBrowserWorkspace(
+    undefined,
+    browserSpace,
+    normalizedSessionId,
+  );
+  const tabSpace = browserTabSpaceState(workspace, browserSpace, normalizedSessionId, {
+    useVisibleAgentSession: !normalizedSessionId,
+  });
   const tab = tabSpace?.tabs.get(tabId);
   if (!workspace || !tabSpace || !tab) {
-    return browserWorkspaceSnapshot(undefined, browserSpace);
+    return browserWorkspaceSnapshot(undefined, browserSpace, normalizedSessionId, {
+      useVisibleAgentSession: true,
+    });
   }
 
   const tabIds = Array.from(tabSpace.tabs.keys());
   const closedIndex = tabIds.indexOf(tabId);
   tabSpace.tabs.delete(tabId);
   closeBrowserTabRecord(tab);
+  browserTabSpaceTouch(tabSpace);
 
   if (tabSpace.tabs.size === 0) {
     const replacementTabId = createBrowserTab(workspace.workspaceId, {
       url: HOME_URL,
       browserSpace,
+      sessionId: normalizedSessionId,
     });
     tabSpace.activeTabId = replacementTabId ?? "";
   } else if (tabSpace.activeTabId === tabId) {
@@ -17906,9 +19170,17 @@ async function closeBrowserTab(tabId: string, space?: BrowserSpaceId | null) {
   ) {
     updateAttachedBrowserView();
   }
+  if (browserSpace === "agent" && normalizedSessionId) {
+    scheduleAgentSessionBrowserLifecycleCheck(workspace.workspaceId, normalizedSessionId);
+  }
   emitBrowserState(workspace.workspaceId, browserSpace);
   await persistBrowserWorkspace(workspace.workspaceId);
-  return browserWorkspaceSnapshot(workspace.workspaceId, browserSpace);
+  return browserWorkspaceSnapshot(
+    workspace.workspaceId,
+    browserSpace,
+    normalizedSessionId,
+    { useVisibleAgentSession: true },
+  );
 }
 
 function setBrowserBounds(bounds: BrowserBoundsPayload) {
@@ -17922,6 +19194,8 @@ function setBrowserBounds(bounds: BrowserBoundsPayload) {
   const activeTab = getActiveBrowserTab(
     activeBrowserWorkspaceId,
     activeBrowserSpaceId,
+    activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    { useVisibleAgentSession: true },
   );
   if (!activeTab || !hasVisibleBrowserBounds()) {
     mainWindow?.setBrowserView(null);
@@ -19028,6 +20302,7 @@ function createMainWindow() {
   browserBounds = { x: 0, y: 0, width: 0, height: 0 };
   activeBrowserWorkspaceId = "";
   activeBrowserSpaceId = "user";
+  activeBrowserSessionId = "";
   for (const workspaceId of Array.from(browserWorkspaces.keys())) {
     destroyBrowserWorkspace(workspaceId);
   }
@@ -19117,6 +20392,7 @@ function createMainWindow() {
     }
     activeBrowserWorkspaceId = "";
     activeBrowserSpaceId = "user";
+    activeBrowserSessionId = "";
     attachedBrowserTabView = null;
     attachedAppSurfaceView = null;
     closeAllFilePreviewWatchSubscriptions();
@@ -20185,78 +21461,246 @@ app.whenReady().then(async () => {
       _event,
       workspaceId?: string | null,
       space?: BrowserSpaceId | null,
+      sessionId?: string | null,
     ) => {
-      return setActiveBrowserWorkspace(workspaceId, space);
+      return setActiveBrowserWorkspace(workspaceId, space, sessionId);
     },
   );
   ipcMain.handle("browser:getState", async () => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    return browserWorkspaceSnapshot(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
   });
   ipcMain.handle(
     "browser:setBounds",
     async (_event, bounds: BrowserBoundsPayload) => {
       setBrowserBounds(bounds);
-      return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+      return browserWorkspaceSnapshot(
+        undefined,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
     },
   );
   ipcMain.handle("browser:navigate", async (_event, targetUrl: string) => {
     if (!activeBrowserWorkspaceId) {
       return emptyBrowserTabListPayload(activeBrowserSpaceId);
     }
+    if (
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
     return navigateActiveBrowserTab(
       activeBrowserWorkspaceId,
       targetUrl,
       activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
     );
   });
   ipcMain.handle("browser:back", async () => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    const activeTab = getActiveBrowserTab(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
     if (activeTab?.view.webContents.navigationHistory.canGoBack()) {
       activeTab.view.webContents.navigationHistory.goBack();
     }
-    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+    return browserWorkspaceSnapshot(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
   });
   ipcMain.handle("browser:forward", async () => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    const activeTab = getActiveBrowserTab(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
     if (activeTab?.view.webContents.navigationHistory.canGoForward()) {
       activeTab.view.webContents.navigationHistory.goForward();
     }
-    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+    return browserWorkspaceSnapshot(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
   });
   ipcMain.handle("browser:reload", async () => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
     getActiveBrowserTab(
       undefined,
       activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
     )?.view.webContents.reload();
-    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+    return browserWorkspaceSnapshot(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
   });
   ipcMain.handle("browser:stopLoading", async () => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    const activeTab = getActiveBrowserTab(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
     if (activeTab?.view.webContents.isLoadingMainFrame()) {
       activeTab.view.webContents.stop();
     }
-    return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+    return browserWorkspaceSnapshot(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
   });
   ipcMain.handle("browser:newTab", async (_event, targetUrl?: string) => {
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
     const workspace = await ensureBrowserWorkspace(
       undefined,
       activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
     );
-    const tabSpace = browserTabSpaceState(workspace, activeBrowserSpaceId);
+    const tabSpace = browserTabSpaceState(
+      workspace,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
+    );
     if (!workspace) {
       return emptyBrowserTabListPayload(activeBrowserSpaceId);
     }
     const nextTabId = createBrowserTab(workspace.workspaceId, {
       url: targetUrl,
       browserSpace: activeBrowserSpaceId,
+      sessionId: activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
     });
     if (nextTabId && tabSpace) {
       tabSpace.activeTabId = nextTabId;
+      if (activeBrowserSpaceId === "agent" && activeBrowserSessionId) {
+        setVisibleAgentBrowserSession(workspace, activeBrowserSessionId);
+      }
       updateAttachedBrowserView();
       emitBrowserState(workspace.workspaceId, activeBrowserSpaceId);
       await persistBrowserWorkspace(workspace.workspaceId);
@@ -20264,15 +21708,63 @@ app.whenReady().then(async () => {
     return browserWorkspaceSnapshot(
       workspace.workspaceId,
       activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      { useVisibleAgentSession: true },
     );
   });
   ipcMain.handle("browser:setActiveTab", async (_event, tabId: string) => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    return setActiveBrowserTab(tabId, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    return setActiveBrowserTab(
+      tabId,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
   });
   ipcMain.handle("browser:closeTab", async (_event, tabId: string) => {
-    await ensureBrowserWorkspace(undefined, activeBrowserSpaceId);
-    return closeBrowserTab(tabId, activeBrowserSpaceId);
+    if (
+      activeBrowserWorkspaceId &&
+      maybePromptBrowserInterrupt(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+      )
+    ) {
+      return browserWorkspaceSnapshot(
+        activeBrowserWorkspaceId,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
+    }
+    await ensureBrowserWorkspace(
+      undefined,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
+    return closeBrowserTab(
+      tabId,
+      activeBrowserSpaceId,
+      activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+    );
   });
   ipcMain.handle("browser:getBookmarks", async () => {
     const workspace = await ensureBrowserWorkspace();
@@ -20287,7 +21779,12 @@ app.whenReady().then(async () => {
         return workspace?.bookmarks ?? [];
       }
 
-      const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+      const activeTab = getActiveBrowserTab(
+        undefined,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
       const faviconUrl =
         activeTab?.state.url === url ? activeTab.state.faviconUrl : undefined;
 
@@ -20455,13 +21952,39 @@ app.whenReady().then(async () => {
   ipcMain.handle(
     "browser:openHistoryUrl",
     async (_event, targetUrl: string) => {
+      if (
+        activeBrowserWorkspaceId &&
+        maybePromptBrowserInterrupt(
+          activeBrowserWorkspaceId,
+          activeBrowserSpaceId,
+          activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        )
+      ) {
+        return browserWorkspaceSnapshot(
+          activeBrowserWorkspaceId,
+          activeBrowserSpaceId,
+          activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+          { useVisibleAgentSession: true },
+        );
+      }
       const workspace = await ensureBrowserWorkspace(
         undefined,
         activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
       );
-      const activeTab = getActiveBrowserTab(undefined, activeBrowserSpaceId);
+      const activeTab = getActiveBrowserTab(
+        undefined,
+        activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
+      );
       if (!workspace || !activeTab) {
-        return browserWorkspaceSnapshot(undefined, activeBrowserSpaceId);
+        return browserWorkspaceSnapshot(
+          undefined,
+          activeBrowserSpaceId,
+          activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+          { useVisibleAgentSession: true },
+        );
       }
 
       try {
@@ -20470,7 +21993,12 @@ app.whenReady().then(async () => {
         await activeTab.view.webContents.loadURL(targetUrl);
       } catch (error) {
         if (isAbortedBrowserLoadError(error)) {
-          return browserWorkspaceSnapshot(workspace.workspaceId, activeBrowserSpaceId);
+          return browserWorkspaceSnapshot(
+            workspace.workspaceId,
+            activeBrowserSpaceId,
+            activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+            { useVisibleAgentSession: true },
+          );
         }
         activeTab.state = {
           ...activeTab.state,
@@ -20483,6 +22011,8 @@ app.whenReady().then(async () => {
       return browserWorkspaceSnapshot(
         workspace.workspaceId,
         activeBrowserSpaceId,
+        activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
+        { useVisibleAgentSession: true },
       );
     },
   );

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -140,6 +140,10 @@ interface BrowserTabListPayload {
   activeTabId: string;
   tabs: BrowserStatePayload[];
   tabCounts: BrowserTabCountsPayload;
+  sessionId: string | null;
+  lifecycleState: "active" | "suspended" | null;
+  controlMode: "none" | "user_locked" | "session_owned";
+  controlSessionId: string | null;
 }
 
 interface BrowserBookmarkPayload {
@@ -265,6 +269,7 @@ interface WorkbenchOpenBrowserPayload {
   workspaceId?: string | null;
   url?: string | null;
   space?: BrowserSpaceId | null;
+  sessionId?: string | null;
 }
 
 interface TemplateAgentInfoPayload {
@@ -1385,8 +1390,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
     }
   },
   browser: {
-    setActiveWorkspace: (workspaceId?: string | null, space?: BrowserSpaceId | null) =>
-      ipcRenderer.invoke("browser:setActiveWorkspace", workspaceId, space) as Promise<BrowserTabListPayload>,
+    setActiveWorkspace: (
+      workspaceId?: string | null,
+      space?: BrowserSpaceId | null,
+      sessionId?: string | null,
+    ) =>
+      ipcRenderer.invoke("browser:setActiveWorkspace", workspaceId, space, sessionId) as Promise<BrowserTabListPayload>,
     getState: () => ipcRenderer.invoke("browser:getState") as Promise<BrowserTabListPayload>,
     setBounds: (bounds: BrowserBoundsPayload) => ipcRenderer.invoke("browser:setBounds", bounds) as Promise<BrowserTabListPayload>,
     navigate: (targetUrl: string) => ipcRenderer.invoke("browser:navigate", targetUrl) as Promise<BrowserTabListPayload>,

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -21,6 +21,7 @@ interface FilePreviewTableSheetPayload {
   index: number;
   columns: string[];
   rows: string[][];
+  links?: (string | null)[][];
   totalRows: number;
   totalColumns: number;
   truncated: boolean;

--- a/desktop/electron/runtime-config-write-lock.test.mjs
+++ b/desktop/electron/runtime-config-write-lock.test.mjs
@@ -24,7 +24,7 @@ test("desktop runtime config mutations are serialized and written atomically", a
   );
   assert.match(
     source,
-    /async function writeRuntimeConfigTextAtomically\(nextText: string\): Promise<void> \{/,
+    /async function writeRuntimeConfigTextAtomically\(\s*nextText: string,\s*\): Promise<void> \{/,
   );
   assert.match(
     source,
@@ -57,11 +57,15 @@ test("desktop runtime config writers use the shared mutation lock", async () => 
 
   assert.match(
     writeRuntimeConfigSection,
-    /return withRuntimeConfigMutationLock\(async \(\) => \{/,
+    /const next = await withRuntimeConfigMutationLock\(async \(\) => \{/,
   );
   assert.match(
     writeRuntimeConfigSection,
     /await writeRuntimeConfigTextAtomically\(/,
+  );
+  assert.match(
+    writeRuntimeConfigSection,
+    /await syncDesktopBrowserCapabilityConfig\(\);\s*return next;/,
   );
   assert.match(
     browserCapabilitySection,
@@ -78,5 +82,38 @@ test("desktop runtime config writers use the shared mutation lock", async () => 
   assert.match(
     setRuntimeConfigDocumentSection,
     /await writeRuntimeConfigTextAtomically\(nextText\);/,
+  );
+  assert.match(
+    setRuntimeConfigDocumentSection,
+    /await syncDesktopBrowserCapabilityConfig\(\);/,
+  );
+});
+
+test("desktop runtime propagates the live browser capability into queued runs and embedded runtime env", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+  const queueSessionInputSection =
+    source.match(
+      /async function queueSessionInput\([\s\S]*?\n}\n\nasync function pauseSessionRun/,
+    )?.[0] ?? "";
+  const startEmbeddedRuntimeSection =
+    source.match(
+      /async function startEmbeddedRuntime\(\) \{[\s\S]*?\n}\n\nfunction persistFileBookmarks/,
+    )?.[0] ?? "";
+
+  assert.match(
+    queueSessionInputSection,
+    /await syncDesktopBrowserCapabilityConfig\(\);\s*const currentConfig = await readRuntimeConfigFile\(\);/,
+  );
+  assert.match(
+    startEmbeddedRuntimeSection,
+    /HOLABOSS_DESKTOP_BROWSER_ENABLED: currentDesktopBrowserCapabilityConfig\(\)\s*[\s\S]*?\.enabled\s*[\s\S]*?\?\s*"true"\s*:\s*"false"/,
+  );
+  assert.match(
+    startEmbeddedRuntimeSection,
+    /HOLABOSS_DESKTOP_BROWSER_URL: desktopBrowserServiceUrl,/,
+  );
+  assert.match(
+    startEmbeddedRuntimeSection,
+    /HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN:\s*desktopBrowserServiceAuthToken,/,
   );
 });

--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -108,6 +108,10 @@ test("app shell opens the centered add apps dialog from the applications explore
   );
   assert.doesNotMatch(
     source,
+    /const shouldSuspendBrowserNativeView =\s*isUtilityPaneResizing \|\|/,
+  );
+  assert.doesNotMatch(
+    source,
     /const handleAddApp = \(\) => \{\s*handleOpenMarketplace\("apps"\);\s*\};/,
   );
 });
@@ -347,9 +351,21 @@ test("app shell no longer reserves a separate safe pane region for update toasts
   assert.doesNotMatch(source, /anchoredToastStackStyle/);
   assert.match(
     source,
-    /const shouldSuspendBrowserNativeView =\s*isUtilityPaneResizing \|\|[\s\S]*workspaceSwitcherOpen \|\|[\s\S]*settingsDialogOpen \|\|[\s\S]*createWorkspacePanelOpen \|\|[\s\S]*publishOpen;/,
+    /const shouldSuspendBrowserNativeView =\s*workspaceSwitcherOpen \|\|[\s\S]*settingsDialogOpen \|\|[\s\S]*createWorkspacePanelOpen \|\|[\s\S]*publishOpen;/,
+  );
+  assert.doesNotMatch(
+    source,
+    /const shouldSuspendBrowserNativeView =\s*isUtilityPaneResizing \|\|/,
   );
   assert.match(source, /<SpaceBrowserDisplayPane[\s\S]*suspendNativeView=\{shouldSuspendBrowserNativeView\}/);
+  assert.doesNotMatch(
+    source,
+    /const startSpaceDisplayResize = useCallback\([\s\S]*?window\.electronAPI\.browser\.setBounds\(/,
+  );
+  assert.doesNotMatch(
+    source,
+    /const startUtilityPaneResize = useCallback\([\s\S]*?window\.electronAPI\.browser\.setBounds\(/,
+  );
 });
 
 test("app shell keeps a fixed explorer width and resizes the display against chat in space mode", async () => {
@@ -464,6 +480,50 @@ test("app shell raises a local toast when fresh task proposals arrive and opens 
   assert.match(source, /openTaskProposalInbox\(notification\.workspace_id\);/);
 });
 
+test("app shell does not replay agent browser navigations through the user-facing browser IPC", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(source, /window\.electronAPI\.workbench\.onOpenBrowser\(/);
+  assert.match(source, /const requestedUrl =\s*typeof payload\.url === "string" \? payload\.url\.trim\(\) : "";/);
+  assert.match(
+    source,
+    /if \(requestedUrl\) \{\s*openBrowserPane\(\);\s*void window\.electronAPI\.browser\s*\.setActiveWorkspace\(\s*payload\.workspaceId \?\? selectedWorkspaceId \?\? null,\s*targetBrowserSpace,\s*payload\.sessionId \?\? null,\s*\)\s*\.catch\(\(\) => undefined\);\s*return;\s*\}/,
+  );
+  assert.doesNotMatch(
+    source,
+    /if \(requestedUrl\) \{[\s\S]*browser\.navigate\(requestedUrl\)/,
+  );
+});
+
+test("app shell keeps agent browser open requests session-scoped until the user explicitly jumps to that browser", async () => {
+  const source = await readFile(APP_SHELL_PATH, "utf8");
+
+  assert.match(
+    source,
+    /const \[chatBrowserJumpRequestKeysBySessionId,\s*setChatBrowserJumpRequestKeysBySessionId\] =\s*useState<Record<string, number>>\(\{\}\);/,
+  );
+  assert.match(
+    source,
+    /const consumeChatBrowserJumpRequest = useCallback\([\s\S]*delete next\[normalizedSessionId\];[\s\S]*\);/,
+  );
+  assert.match(
+    source,
+    /const handleJumpToSessionBrowser = useCallback\([\s\S]*revealBrowserPane\("agent"\);[\s\S]*window\.electronAPI\.browser\s*\.setActiveWorkspace\(selectedWorkspaceId, "agent", normalizedSessionId\)/,
+  );
+  assert.match(
+    source,
+    /const activeChatBrowserJumpRequest = useMemo\(\(\) => \{[\s\S]*chatBrowserJumpRequestKeysBySessionId\[normalizedSessionId\] \?\? 0;/,
+  );
+  assert.match(
+    source,
+    /if \(targetBrowserSpace === "agent" && normalizedSessionId\) \{\s*setChatBrowserJumpRequestKeysBySessionId\(\(current\) => \(\{\s*\.\.\.current,\s*\[normalizedSessionId\]: Date\.now\(\),\s*\}\)\);\s*return;\s*\}/,
+  );
+  assert.match(
+    source,
+    /<ChatPane[\s\S]*browserJumpRequest=\{activeChatBrowserJumpRequest\}[\s\S]*onBrowserJumpRequestConsumed=\{consumeChatBrowserJumpRequest\}[\s\S]*onJumpToSessionBrowser=\{handleJumpToSessionBrowser\}/,
+  );
+});
+
 test("app shell tracks unread task proposals and badges the inbox control", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
@@ -532,7 +592,7 @@ test("app shell routes agent-originated browser opens into the agent browser spa
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /const targetBrowserSpace =\s*payload\.space === "agent" \? "agent" : "user";/);
-  assert.match(source, /\.setActiveWorkspace\(\s*payload\.workspaceId \?\? selectedWorkspaceId \?\? null,\s*targetBrowserSpace,\s*\)/);
+  assert.match(source, /\.setActiveWorkspace\(\s*payload\.workspaceId \?\? selectedWorkspaceId \?\? null,\s*targetBrowserSpace,\s*payload\.sessionId \?\? null,\s*\)/);
   assert.match(source, /\.setActiveWorkspace\(targetWorkspaceId, "user"\)/);
   assert.match(source, /const handleOpenLinkInNewAppBrowserTab = useCallback\(/);
   assert.match(source, /\.then\(\(\) => window\.electronAPI\.browser\.newTab\(normalizedUrl\)\)/);

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1066,6 +1066,8 @@ function AppShellContent() {
   } | null>(null);
   const [chatSessionOpenRequest, setChatSessionOpenRequest] =
     useState<ChatSessionOpenRequest | null>(null);
+  const [chatBrowserJumpRequestKeysBySessionId, setChatBrowserJumpRequestKeysBySessionId] =
+    useState<Record<string, number>>({});
   const [chatComposerPrefillRequest, setChatComposerPrefillRequest] =
     useState<ChatComposerPrefillRequest | null>(null);
   const [chatExplorerAttachmentRequest, setChatExplorerAttachmentRequest] =
@@ -1682,6 +1684,8 @@ function AppShellContent() {
         }
 
         const targetBrowserSpace = payload.space === "agent" ? "agent" : "user";
+        const normalizedSessionId =
+          typeof payload.sessionId === "string" ? payload.sessionId.trim() : "";
         const openBrowserPane = () => {
           setActiveShellView("space");
           setSpaceExplorerMode("browser");
@@ -1696,14 +1700,21 @@ function AppShellContent() {
 
         const requestedUrl =
           typeof payload.url === "string" ? payload.url.trim() : "";
+        if (targetBrowserSpace === "agent" && normalizedSessionId) {
+          setChatBrowserJumpRequestKeysBySessionId((current) => ({
+            ...current,
+            [normalizedSessionId]: Date.now(),
+          }));
+          return;
+        }
         if (requestedUrl) {
           openBrowserPane();
           void window.electronAPI.browser
             .setActiveWorkspace(
               payload.workspaceId ?? selectedWorkspaceId ?? null,
               targetBrowserSpace,
+              payload.sessionId ?? null,
             )
-            .then(() => window.electronAPI.browser.navigate(requestedUrl))
             .catch(() => undefined);
           return;
         }
@@ -1712,6 +1723,7 @@ function AppShellContent() {
           .setActiveWorkspace(
             payload.workspaceId ?? selectedWorkspaceId ?? null,
             targetBrowserSpace,
+            payload.sessionId ?? null,
           )
           .catch(() => undefined);
       },
@@ -1990,6 +2002,55 @@ function AppShellContent() {
     }));
   }, []);
 
+  const consumeChatBrowserJumpRequest = useCallback(
+    (sessionId: string, requestKey: number) => {
+      const normalizedSessionId = sessionId.trim();
+      if (!normalizedSessionId || requestKey <= 0) {
+        return;
+      }
+      setChatBrowserJumpRequestKeysBySessionId((current) => {
+        if ((current[normalizedSessionId] ?? 0) !== requestKey) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[normalizedSessionId];
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleJumpToSessionBrowser = useCallback(
+    (sessionId: string, requestKey: number) => {
+      const normalizedSessionId = sessionId.trim();
+      if (!selectedWorkspaceId || !normalizedSessionId) {
+        return;
+      }
+      revealBrowserPane("agent");
+      void window.electronAPI.browser
+        .setActiveWorkspace(selectedWorkspaceId, "agent", normalizedSessionId)
+        .catch(() => undefined);
+      consumeChatBrowserJumpRequest(normalizedSessionId, requestKey);
+    },
+    [consumeChatBrowserJumpRequest, revealBrowserPane, selectedWorkspaceId],
+  );
+
+  const activeChatBrowserJumpRequest = useMemo(() => {
+    const normalizedSessionId = (activeChatSessionId || "").trim();
+    if (!normalizedSessionId) {
+      return null;
+    }
+    const requestKey =
+      chatBrowserJumpRequestKeysBySessionId[normalizedSessionId] ?? 0;
+    if (requestKey <= 0) {
+      return null;
+    }
+    return {
+      sessionId: normalizedSessionId,
+      requestKey,
+    };
+  }, [activeChatSessionId, chatBrowserJumpRequestKeysBySessionId]);
+
   const handleOpenLinkInAppBrowser = useCallback(
     (url: string, workspaceIdOverride?: string | null) => {
       const normalizedUrl = url.trim();
@@ -2115,6 +2176,7 @@ function AppShellContent() {
 
   useEffect(() => {
     setChatSessionOpenRequest(null);
+    setChatBrowserJumpRequestKeysBySessionId({});
     setActiveChatSessionId(null);
   }, [selectedWorkspaceId]);
 
@@ -3147,7 +3209,6 @@ function AppShellContent() {
     effectiveAppUpdateStatus && effectiveAppUpdateStatus.downloaded,
   );
   const shouldSuspendBrowserNativeView =
-    isUtilityPaneResizing ||
     workspaceSwitcherOpen ||
     settingsDialogOpen ||
     workspaceAppsDialogOpen ||
@@ -3282,6 +3343,9 @@ function AppShellContent() {
             handleChatExplorerAttachmentRequestConsumed
           }
           onActiveSessionIdChange={setActiveChatSessionId}
+          browserJumpRequest={activeChatBrowserJumpRequest}
+          onBrowserJumpRequestConsumed={consumeChatBrowserJumpRequest}
+          onJumpToSessionBrowser={handleJumpToSessionBrowser}
           onOpenInbox={handleOpenInboxPane}
           inboxUnreadCount={unreadTaskProposalCount}
           onRequestCreateSession={(request) => void handleCreateSession(request)}
@@ -3318,10 +3382,13 @@ function AppShellContent() {
     activeAppId,
     agentView,
     chatFocusRequestKey,
+    activeChatBrowserJumpRequest,
     chatSessionJumpRequest,
     chatSessionOpenRequest,
     chatComposerPrefillRequest,
+    consumeChatBrowserJumpRequest,
     handleChatComposerPrefillConsumed,
+    handleJumpToSessionBrowser,
     handleOpenInboxPane,
     handleReturnToChatPane,
     handleCreateSession,
@@ -3542,12 +3609,6 @@ function AppShellContent() {
       } catch {
         // BrowserView resizing falls back to the window listeners below.
       }
-      void window.electronAPI.browser.setBounds({
-        x: 0,
-        y: 0,
-        width: 0,
-        height: 0,
-      });
       setIsUtilityPaneResizing(true);
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
@@ -3630,14 +3691,6 @@ function AppShellContent() {
         event.currentTarget.setPointerCapture(event.pointerId);
       } catch {
         // BrowserView resizing falls back to the window listeners below.
-      }
-      if (spaceVisibility.browser) {
-        void window.electronAPI.browser.setBounds({
-          x: 0,
-          y: 0,
-          width: 0,
-          height: 0,
-        });
       }
       setIsUtilityPaneResizing(true);
       document.body.style.cursor = "col-resize";

--- a/desktop/src/components/panes/BrowserPane.test.mjs
+++ b/desktop/src/components/panes/BrowserPane.test.mjs
@@ -43,9 +43,11 @@ test("browser pane keeps control treatment without a session selector in the chr
   );
   assert.doesNotMatch(source, /Shared agent browser/);
   assert.doesNotMatch(source, /<span className="truncate">\{sessionBrowserStatus\.detail\}<\/span>/);
-  assert.match(source, /border-primary\/70/);
-  assert.match(source, /boxShadow:\s*"0 0 40px color-mix\(in oklch, var\(--primary\) 34%, transparent\)"/);
-  assert.match(source, /rounded-\[inherit\] border-2 border-primary\/60/);
+  assert.match(source, /browser-active-glow border-transparent/);
+  assert.match(source, /browser-active-glow-frame pointer-events-none absolute inset-0 rounded-\[inherit\]/);
+  assert.doesNotMatch(source, /border-primary\/70/);
+  assert.doesNotMatch(source, /browserBoundsRef/);
+  assert.match(source, /const rect = viewport\.getBoundingClientRect\(\);/);
   assert.doesNotMatch(source, /absolute left-3 top-3 inline-flex items-center gap-1\.5 rounded-full/);
 });
 

--- a/desktop/src/components/panes/BrowserPane.test.mjs
+++ b/desktop/src/components/panes/BrowserPane.test.mjs
@@ -30,6 +30,25 @@ test("browser pane exposes a single inline browser-space switcher", async () => 
   assert.doesNotMatch(source, /aria-label="Downloads"/);
 });
 
+test("browser pane keeps control treatment without a session selector in the chrome", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(source, /Choose session browser/);
+  assert.doesNotMatch(source, /No session browsers/);
+  assert.doesNotMatch(source, /onSelectAgentSessionBrowser/);
+  assert.match(source, /const glowPreviewEnabled = useBrowserGlowPreview\(\);/);
+  assert.match(
+    source,
+    /const showAgentActivityHighlight =\s*sessionBrowserStatus\?\.tone === "active" \|\| glowPreviewEnabled;/,
+  );
+  assert.doesNotMatch(source, /Shared agent browser/);
+  assert.doesNotMatch(source, /<span className="truncate">\{sessionBrowserStatus\.detail\}<\/span>/);
+  assert.match(source, /border-primary\/70/);
+  assert.match(source, /boxShadow:\s*"0 0 40px color-mix\(in oklch, var\(--primary\) 34%, transparent\)"/);
+  assert.match(source, /rounded-\[inherit\] border-2 border-primary\/60/);
+  assert.doesNotMatch(source, /absolute left-3 top-3 inline-flex items-center gap-1\.5 rounded-full/);
+});
+
 test("browser pane preserves explicit URL schemes and supports localhost-style input", async () => {
   const source = await readFile(sourcePath, "utf8");
 
@@ -88,4 +107,12 @@ test("browser pane keeps loading state in the address bar and turns refresh into
   );
   assert.doesNotMatch(source, /tab\.loading \? \(\s*<Loader2 size=\{11\} className="shrink-0 animate-spin" \/>\s*\) : null/);
   assert.doesNotMatch(source, /activeTab\.initialized && activeTab\.loading/);
+});
+
+test("browser pane only clears native browser bounds on suspend or unmount, not every layout sync", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /if \(suspendNativeView\) \{\s*void window\.electronAPI\.browser\.setBounds\(\{\s*x: 0,\s*y: 0,\s*width: 0,\s*height: 0,\s*\}\);\s*return;\s*\}/s);
+  assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*window\.setTimeout\(queueSync, 400\);[\s\S]*return \(\) => \{\s*observer\.disconnect\(\);[\s\S]*window\.cancelAnimationFrame\(rafId\);\s*\};\s*\}, \[layoutSyncKey, suspendNativeView\]\);/s);
+  assert.match(source, /useEffect\(\(\) => \{\s*return \(\) => \{\s*void window\.electronAPI\.browser\.setBounds\(\{\s*x: 0,\s*y: 0,\s*width: 0,\s*height: 0,\s*\}\);\s*\};\s*\}, \[\]\);/s);
 });

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -22,6 +22,10 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PaneCard } from "@/components/ui/PaneCard";
+import {
+  browserSurfaceStatusSummary,
+} from "@/components/panes/browserSessionUi";
+import { useBrowserGlowPreview } from "@/components/panes/useBrowserGlowPreview";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
 const HOME_URL = "https://www.google.com";
@@ -30,6 +34,7 @@ const EXPLICIT_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 const LOCALHOST_PATTERN = /^localhost(?::\d+)?(?:[/?#]|$)/i;
 const IPV4_HOST_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?:[/?#]|$)/;
 const IPV6_HOST_PATTERN = /^\[[0-9a-fA-F:]+\](?::\d+)?(?:[/?#]|$)/;
+const BROWSER_SESSION_POLL_INTERVAL_MS = 2000;
 
 const EMPTY_BROWSER_STATE: BrowserStatePayload = {
   id: "",
@@ -50,7 +55,21 @@ const INITIAL_STATE: BrowserTabListPayload = {
     user: 0,
     agent: 0,
   },
+  sessionId: null,
+  lifecycleState: null,
+  controlMode: "none",
+  controlSessionId: null,
 };
+
+function runtimeStateIndex(
+  items: SessionRuntimeRecordPayload[],
+): Record<string, SessionRuntimeRecordPayload> {
+  return Object.fromEntries(
+    items
+      .filter((item) => Boolean(item.session_id.trim()))
+      .map((item) => [item.session_id, item]),
+  );
+}
 
 function normalizeUrl(rawInput: string) {
   const trimmed = rawInput.trim();
@@ -98,6 +117,9 @@ export function BrowserPane({
   const [historyEntries, setHistoryEntries] = useState<
     BrowserHistoryEntryPayload[]
   >([]);
+  const [runtimeStatesBySessionId, setRuntimeStatesBySessionId] = useState<
+    Record<string, SessionRuntimeRecordPayload>
+  >({});
   const [addressFocused, setAddressFocused] = useState(false);
   const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] =
     useState(-1);
@@ -174,6 +196,46 @@ export function BrowserPane({
       unsubscribe();
     };
   }, [selectedWorkspaceId, visibleBrowserSpace]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) {
+      setRuntimeStatesBySessionId({});
+      return;
+    }
+
+    let cancelled = false;
+    let requestInFlight = false;
+
+    const loadSessionState = async () => {
+      if (requestInFlight) {
+        return;
+      }
+      requestInFlight = true;
+      try {
+        const runtimeStatesResponse =
+          await window.electronAPI.workspace.listRuntimeStates(
+            selectedWorkspaceId,
+          );
+        if (cancelled) {
+          return;
+        }
+        setRuntimeStatesBySessionId(runtimeStateIndex(runtimeStatesResponse.items));
+      } finally {
+        requestInFlight = false;
+      }
+    };
+
+    void loadSessionState();
+    const intervalId = window.setInterval(
+      () => void loadSessionState(),
+      BROWSER_SESSION_POLL_INTERVAL_MS,
+    );
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [selectedWorkspaceId]);
 
   useEffect(() => {
     let mounted = true;
@@ -300,6 +362,11 @@ export function BrowserPane({
       observer.disconnect();
       window.removeEventListener("resize", queueSync);
       window.cancelAnimationFrame(rafId);
+    };
+  }, [layoutSyncKey, suspendNativeView]);
+
+  useEffect(() => {
+    return () => {
       void window.electronAPI.browser.setBounds({
         x: 0,
         y: 0,
@@ -307,7 +374,7 @@ export function BrowserPane({
         height: 0,
       });
     };
-  }, [layoutSyncKey, suspendNativeView]);
+  }, []);
 
   const navigateTo = (rawInput: string) => {
     const nextUrl = normalizeUrl(rawInput);
@@ -357,6 +424,33 @@ export function BrowserPane({
       downloads.filter((download) => download.status === "progressing").length,
     [downloads],
   );
+  const currentSessionId = useMemo(
+    () => browserState.controlSessionId || browserState.sessionId || null,
+    [browserState.controlSessionId, browserState.sessionId],
+  );
+  const currentRuntimeState = useMemo(
+    () =>
+      currentSessionId ? runtimeStatesBySessionId[currentSessionId] ?? null : null,
+    [currentSessionId, runtimeStatesBySessionId],
+  );
+  const sessionBrowserStatus = useMemo(
+    () =>
+      browserSurfaceStatusSummary({
+        browserSpace: visibleBrowserSpace,
+        controlMode: browserState.controlMode,
+        lifecycleState: browserState.lifecycleState,
+        runtimeState: currentRuntimeState,
+      }),
+    [
+      browserState.controlMode,
+      browserState.lifecycleState,
+      currentRuntimeState,
+      visibleBrowserSpace,
+    ],
+  );
+  const glowPreviewEnabled = useBrowserGlowPreview();
+  const showAgentActivityHighlight =
+    sessionBrowserStatus?.tone === "active" || glowPreviewEnabled;
   const historySuggestions = useMemo(() => {
     if (!addressFocused) {
       return [];
@@ -747,7 +841,6 @@ export function BrowserPane({
               </div>
             </form>
           </div>
-
           {showBookmarkStrip ? (
             <div className="flex min-h-6 items-center gap-0.5 overflow-x-auto px-1.5 py-0.5">
               {bookmarks.slice(0, 12).map((bookmark) => (
@@ -783,8 +876,27 @@ export function BrowserPane({
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-px pb-px">
           <div
             ref={viewportRef}
-            className="relative min-h-0 flex-1 overflow-hidden rounded-b-xl bg-card"
+            className={`relative min-h-0 flex-1 overflow-hidden rounded-b-xl border bg-card transition-all ${
+              showAgentActivityHighlight
+                ? "border-primary/70"
+                : "border-transparent"
+            }`}
+            style={
+              showAgentActivityHighlight
+                ? {
+                    boxShadow:
+                      "0 0 40px color-mix(in oklch, var(--primary) 34%, transparent)",
+                  }
+                : undefined
+            }
           >
+            {showAgentActivityHighlight ? (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 rounded-[inherit] border-2 border-primary/60 shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--primary)_30%,transparent)]"
+              />
+            ) : null}
+
             {!activeTab.initialized ? (
               <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
                 <div className="pointer-events-none w-full max-w-[320px] rounded-[24px] border border-border/55 bg-card px-5 py-5 shadow-xl backdrop-blur">

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -878,22 +878,14 @@ export function BrowserPane({
             ref={viewportRef}
             className={`relative min-h-0 flex-1 overflow-hidden rounded-b-xl border bg-card transition-all ${
               showAgentActivityHighlight
-                ? "border-primary/70"
+                ? "browser-active-glow border-transparent"
                 : "border-transparent"
             }`}
-            style={
-              showAgentActivityHighlight
-                ? {
-                    boxShadow:
-                      "0 0 40px color-mix(in oklch, var(--primary) 34%, transparent)",
-                  }
-                : undefined
-            }
           >
             {showAgentActivityHighlight ? (
               <div
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-0 rounded-[inherit] border-2 border-primary/60 shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--primary)_30%,transparent)]"
+                className="browser-active-glow-frame pointer-events-none absolute inset-0 rounded-[inherit]"
               />
             ) : null}
 

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -217,6 +217,60 @@ test("chat trace summary keeps a live run in progress when no active step label 
   );
 });
 
+test("chat pane persists terminal run failures in-thread when no assistant text was emitted", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /type ChatAssistantSegment =/);
+  assert.match(source, /tone\?: "default" \| "error";/);
+  assert.match(
+    source,
+    /const liveAssistantSegmentsRef = useRef<ChatAssistantSegment\[]>\(\[]\);/,
+  );
+  assert.match(
+    source,
+    /function commitLiveAssistantMessage\(options\?: \{\s*fallbackText\?: string;\s*tone\?: ChatMessage\["tone"\];\s*\}\)/,
+  );
+  assert.match(
+    source,
+    /if \(options\?\.fallbackText && !hasOutputSegment\) \{\s*nextSegments = appendAssistantOutputSegment\(\s*nextSegments,\s*options\.fallbackText,\s*options\.tone \?\? "default",\s*\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /const shouldPersistFailureText =\s*!liveAssistantTextRef\.current &&\s*!assistantSegmentsIncludeOutput\(liveAssistantSegmentsRef\.current\);\s*const committedFailureMessage = commitLiveAssistantMessage\(\{\s*fallbackText: shouldPersistFailureText \? detail : undefined,\s*tone: shouldPersistFailureText \? "error" : "default",\s*\}\);/,
+  );
+  assert.match(
+    source,
+    /segment\.tone === "error" \?\s*\(\s*<div[\s\S]*theme-chat-system-bubble mt-2 rounded-\[14px\] border px-3 py-2\.5 text-\[12px\] text-foreground/,
+  );
+});
+
+test("chat history reconstructs failed turns even when no assistant history message exists", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /function inputIdFromHistoryMessage\(message: SessionHistoryMessagePayload\)/);
+  assert.match(source, /function turnInputIdsFromHistoryMessages\(/);
+  assert.match(
+    source,
+    /const assistantInputIds = turnInputIdsFromHistoryMessages\(\s*historyMessages,\s*\);/,
+  );
+  assert.match(
+    source,
+    /const assistantHistoryInputIds = new Set\(/,
+  );
+  assert.match(
+    source,
+    /if \(restoredAssistantState\.segments\) \{\s*nextMessage\.segments = restoredAssistantState\.segments;\s*nextMessage\.text = "";\s*nextMessage\.executionItems = undefined;\s*\} else if \(restoredAssistantState\.executionItems\) \{\s*nextMessage\.executionItems = restoredAssistantState\.executionItems;\s*\}/,
+  );
+  assert.match(
+    source,
+    /nextMessage\.role === "user" &&[\s\S]*!assistantHistoryInputIds\.has\(userInputId\)/,
+  );
+  assert.match(
+    source,
+    /const syntheticAssistantMessage: ChatMessage = \{\s*id: `assistant-\$\{userInputId\}`,[\s\S]*segments: restoredAssistantState\.segments,[\s\S]*executionItems:\s*restoredAssistantState\.segments\s*\?\s*undefined\s*:\s*restoredAssistantState\.executionItems,/,
+  );
+});
+
 test("chat trace collapsed summary surfaces the current active step", async () => {
   const source = await readFile(sourcePath, "utf8");
 
@@ -282,29 +336,35 @@ test("chat pane keeps a persistent working line visible once the live run has st
 
   assert.match(
     source,
-    /const showWorkingStatusLine =\s*live &&\s*\(executionItems\.length > 0 \|\| Boolean\(text\)\);/,
+    /const showWorkingStatusLine =\s*live &&\s*renderedSegments\.length > 0;/,
   );
   assert.match(
     source,
-    /showStatusPlaceholder =[\s\S]*live &&[\s\S]*Boolean\(normalizedStatus\) &&[\s\S]*!text &&[\s\S]*executionItems\.length === 0;/,
+    /showStatusPlaceholder =[\s\S]*live &&[\s\S]*Boolean\(normalizedStatus\) &&[\s\S]*renderedSegments\.length === 0;/,
   );
   assert.match(
     source,
-    /{showWorkingStatusLine \? \(\s*<LiveStatusLine[\s\S]*label="Working"[\s\S]*className=\{executionItems\.length > 0 \? "mt-1" : ""\}/,
+    /{showWorkingStatusLine \? \(\s*<LiveStatusLine[\s\S]*label="Working"[\s\S]*renderedSegments\.some\(\(segment\) => segment\.kind === "execution"\)/,
   );
 });
 
 test("chat pane renders an execution timeline that interleaves thinking segments with trace entries", async () => {
   const source = await readFile(sourcePath, "utf8");
 
+  assert.match(source, /type ChatAssistantSegment =/);
   assert.match(source, /executionItems\?: ChatExecutionTimelineItem\[];/);
+  assert.match(source, /segments\?: ChatAssistantSegment\[];/);
+  assert.match(source, /function appendAssistantOutputSegment\(/);
+  assert.match(source, /function appendAssistantExecutionSegment\(/);
+  assert.match(source, /function liveAssistantSegmentsForRender\(/);
   assert.match(source, /function appendExecutionTimelineThinkingDelta\(/);
   assert.match(source, /function upsertExecutionTimelineTraceItem\(/);
   assert.match(source, /function traceStepsFromExecutionItems\(items: ChatExecutionTimelineItem\[]\)/);
-  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*executionItems = appendExecutionTimelineThinkingDelta\(/);
-  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*executionItems = upsertExecutionTimelineTraceItem\(/);
-  assert.match(source, /appendLiveThinkingDelta\(delta: string, order: number\)/);
-  assert.match(source, /appendExecutionTimelineThinkingDelta\(prev, delta, order\)/);
+  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*flushOutputSegment\(\);[\s\S]*executionItems = appendExecutionTimelineThinkingDelta\(/);
+  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*flushOutputSegment\(\);[\s\S]*executionItems = upsertExecutionTimelineTraceItem\(/);
+  assert.match(source, /assistantHistoryStateFromOutputEvents[\s\S]*if \(event\.event_type === "output_delta"\) \{\s*flushExecutionSegment\(\);/);
+  assert.match(source, /appendLiveThinkingDelta\(delta: string, order: number\) \{\s*flushLiveAssistantOutputSegment\(\);/);
+  assert.match(source, /appendLiveAssistantDelta\(delta: string\) \{\s*flushLiveExecutionSegment\(\);/);
   assert.match(
     source,
     /function ExecutionTimelineThinkingEntry[\s\S]*className="py-1"[\s\S]*className="-ml-2\.5 w-\[calc\(100%\+0\.625rem\)\] rounded-\[16px\] border border-border\/25 bg-muted\/30 px-3\.5 py-3"/,
@@ -313,9 +373,10 @@ test("chat pane renders an execution timeline that interleaves thinking segments
     source,
     /function ExecutionTimelineThinkingEntry[\s\S]*className="chat-markdown chat-thinking-markdown max-w-full text-foreground\/82"/,
   );
-  assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{message\.executionItems \?\? \[\]\}/);
-  assert.match(source, /<AssistantTurn[\s\S]*executionItems=\{liveExecutionItems\}/);
-  assert.match(source, /<TraceStepGroup[\s\S]*items=\{executionItems\}/);
+  assert.match(source, /<AssistantTurn[\s\S]*segments=\{message\.segments \?\? \[\]\}/);
+  assert.match(source, /<AssistantTurn[\s\S]*segments=\{renderedLiveAssistantSegments\}/);
+  assert.match(source, /\{renderedSegments\.map\(\(segment, index\) =>/);
+  assert.match(source, /segment\.kind === "execution" \?\s*\(\s*<TraceStepGroup/);
   assert.match(source, /<ExecutionTimelineThinkingEntry/);
   assert.match(source, /<TraceTimelineStepEntry/);
   assert.doesNotMatch(source, /<ThinkingPanel/);
@@ -827,8 +888,29 @@ test("live trace auto-expands during the run and collapses when output starts", 
   );
   assert.match(
     source,
-    /<TraceStepGroup[\s\S]*items=\{executionItems\}[\s\S]*live=\{live\}[\s\S]*liveOutputStarted=\{live && Boolean\(text\)\}/,
+    /<TraceStepGroup[\s\S]*items=\{segment\.items\}[\s\S]*live=\{live\}[\s\S]*liveOutputStarted=\{[\s\S]*renderedSegments[\s\S]*slice\(index \+ 1\)[\s\S]*some\(\(nextSegment\) => nextSegment\.kind === "output"\)/,
   );
+});
+
+test("chat pane preserves interleaved assistant output and execution segments from ordered events", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /let segments: ChatAssistantSegment\[] = \[];/);
+  assert.match(source, /const flushExecutionSegment = \(\) => \{/);
+  assert.match(source, /const flushOutputSegment = \(\) => \{/);
+  assert.match(
+    source,
+    /if \(event\.event_type === "thinking_delta"\) \{\s*flushOutputSegment\(\);/,
+  );
+  assert.match(
+    source,
+    /if \(event\.event_type === "output_delta"\) \{\s*flushExecutionSegment\(\);/,
+  );
+  assert.match(
+    source,
+    /flushOutputSegment\(\);\s*flushExecutionSegment\(\);\s*return \{\s*segments: segments\.length > 0 \? segments : undefined,/,
+  );
+  assert.match(source, /const renderedLiveAssistantSegments = liveAssistantSegmentsForRender\(/);
 });
 
 test("chat pane can jump to a requested sub-session run", async () => {
@@ -1010,5 +1092,57 @@ test("chat pane custom scrollbar thumb can be dragged", async () => {
   assert.match(
     source,
     /onLostPointerCapture=\{\(\) => \{\s*clearChatScrollbarDragState\(\);\s*\}\}/,
+  );
+});
+
+test("chat pane offers an explicit jump-to-browser CTA instead of auto-switching the visible agent browser session", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /interface ChatPaneBrowserJumpRequest \{/);
+  assert.match(source, /browserJumpRequest\?: ChatPaneBrowserJumpRequest \| null;/);
+  assert.match(
+    source,
+    /onBrowserJumpRequestConsumed\?:\s*\(\s*sessionId: string,\s*requestKey: number,\s*\) => void;/,
+  );
+  assert.match(source, /onJumpToSessionBrowser\?: \(sessionId: string, requestKey: number\) => void;/);
+  assert.match(
+    source,
+    /const \[visibleBrowserState,\s*setVisibleBrowserState\] =\s*useState<\s*BrowserTabListPayload\s*>\(\(\) => initialBrowserState\("user"\)\);/,
+  );
+  assert.match(source, /const applyVisibleBrowserState = \(state: BrowserTabListPayload\) => \{/);
+  assert.match(source, /window\.electronAPI\.browser\.getState\(\)\.then\(applyVisibleBrowserState\);/);
+  assert.match(source, /window\.electronAPI\.browser\.onStateChange\(applyVisibleBrowserState\);/);
+  assert.match(
+    source,
+    /const visibleAgentBrowserSessionId =\s*visibleBrowserState\.space === "agent"\s*\?\s*visibleBrowserState\.controlSessionId \|\| visibleBrowserState\.sessionId \|\| ""\s*:\s*"";/,
+  );
+  assert.match(
+    source,
+    /const showSessionBrowserJumpCta = Boolean\(\s*browserJumpRequest &&\s*activeSessionId &&\s*browserJumpRequest\.sessionId === activeSessionId &&\s*\(visibleBrowserState\.space !== "agent" \|\|\s*visibleAgentBrowserSessionId !== activeSessionId\),\s*\);/,
+  );
+  assert.match(
+    source,
+    /onBrowserJumpRequestConsumed\?\.\(\s*activeSessionId,\s*browserJumpRequest\.requestKey,\s*\);/,
+  );
+  assert.match(
+    source,
+    /onJumpToSessionBrowser\?\.\(\s*browserJumpRequest\.sessionId,\s*browserJumpRequest\.requestKey,\s*\);/,
+  );
+  assert.match(source, /statusAccessory = null,/);
+  assert.match(source, /statusAccessory\?: ReactNode;/);
+  assert.match(
+    source,
+    /const renderStatusLine = \(nextLabel: string, className = ""\) => \{/,
+  );
+  assert.match(
+    source,
+    /if \(!statusAccessory\) \{\s*return <LiveStatusLine label=\{nextLabel\} className=\{className\} \/>\s*;\s*\}/,
+  );
+  assert.doesNotMatch(source, /showLiveAssistantTurn \|\|\s*showSessionBrowserJumpCta/);
+  assert.doesNotMatch(source, /This session started using its browser\./);
+  assert.match(source, /Jump to browser/);
+  assert.match(
+    source,
+    /<AssistantTurn[\s\S]*statusAccessory=\{\s*showSessionBrowserJumpCta\s*\?\s*\(/,
   );
 });

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -623,10 +623,8 @@ test("chat pane syncs the shared file display from live file-oriented tool calls
     source,
     /syncableWorkspacePathFromRecord\(payload\.result,\s*\[\s*"file_path",\s*"path",\s*\]\)/,
   );
-  assert.match(
-    source,
-    /toolName === "read" \|\| toolName === "edit"/,
-  );
+  assert.doesNotMatch(source, /toolName === "read" \|\| toolName === "edit"/);
+  assert.match(source, /if \(toolName === "edit"\) \{/);
   assert.match(
     source,
     /if \(eventType === "tool_call"\) \{\s*const fileDisplayTarget =\s*fileDisplaySyncTargetFromToolPayload\(eventPayload\);[\s\S]*onSyncFileDisplayFromAgentOperation\?\.\(fileDisplayTarget\);/,

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -1785,7 +1785,7 @@ function fileDisplaySyncTargetFromToolPayload(
     ]);
   }
 
-  if (toolName === "read" || toolName === "edit") {
+  if (toolName === "edit") {
     if (phase !== "started" && phase !== "completed") {
       return null;
     }

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -5,6 +5,7 @@ import {
   FormEvent,
   KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
   type RefObject,
   useEffect,
   useLayoutEffect,
@@ -65,12 +66,25 @@ import * as modelCatalog from "../../../shared/model-catalog.js";
 type ChatAttachment = SessionInputAttachmentPayload;
 type ChatPaneVariant = "default" | "onboarding";
 
+type ChatAssistantSegment =
+  | {
+      kind: "execution";
+      items: ChatExecutionTimelineItem[];
+    }
+  | {
+      kind: "output";
+      text: string;
+      tone?: "default" | "error";
+    };
+
 interface ChatMessage {
   id: string;
   role: "user" | "assistant";
   text: string;
+  tone?: "default" | "error";
   createdAt?: string;
   attachments?: ChatAttachment[];
+  segments?: ChatAssistantSegment[];
   executionItems?: ChatExecutionTimelineItem[];
   outputs?: WorkspaceOutputRecordPayload[];
   memoryProposals?: MemoryUpdateProposalRecordPayload[];
@@ -79,6 +93,22 @@ interface ChatMessage {
 interface ChatSerializedQuotedSkillBlock {
   skillIds: string[];
   body: string;
+}
+
+function initialBrowserState(space: BrowserSpaceId): BrowserTabListPayload {
+  return {
+    space,
+    activeTabId: "",
+    tabs: [],
+    tabCounts: {
+      user: 0,
+      agent: 0,
+    },
+    sessionId: null,
+    lifecycleState: null,
+    controlMode: "none",
+    controlSessionId: null,
+  };
 }
 
 type ChatTraceStepStatus = "running" | "completed" | "error" | "waiting";
@@ -745,9 +775,80 @@ function hasRenderableMessageContent(
 function hasRenderableAssistantTurn(message: ChatMessage) {
   return (
     hasRenderableMessageContent(message.text, message.attachments ?? []) ||
+    (message.segments?.some((segment) =>
+      segment.kind === "output"
+        ? Boolean(segment.text.trim())
+        : segment.items.length > 0,
+    ) ??
+      false) ||
     (message.executionItems?.length ?? 0) > 0 ||
     (message.outputs?.length ?? 0) > 0 ||
     (message.memoryProposals?.length ?? 0) > 0
+  );
+}
+
+function appendAssistantOutputSegment(
+  segments: ChatAssistantSegment[],
+  text: string,
+  tone: ChatMessage["tone"] = "default",
+): ChatAssistantSegment[] {
+  if (!text) {
+    return segments;
+  }
+  const next = [...segments];
+  const previous = next[next.length - 1];
+  if (
+    previous?.kind === "output" &&
+    (previous.tone ?? "default") === tone
+  ) {
+    next[next.length - 1] = {
+      ...previous,
+      text: `${previous.text}${text}`,
+    };
+    return next;
+  }
+  next.push({
+    kind: "output",
+    text,
+    tone,
+  });
+  return next;
+}
+
+function appendAssistantExecutionSegment(
+  segments: ChatAssistantSegment[],
+  items: ChatExecutionTimelineItem[],
+): ChatAssistantSegment[] {
+  if (items.length === 0) {
+    return segments;
+  }
+  return [
+    ...segments,
+    {
+      kind: "execution",
+      items,
+    },
+  ];
+}
+
+function liveAssistantSegmentsForRender(
+  segments: ChatAssistantSegment[],
+  executionItems: ChatExecutionTimelineItem[],
+  text: string,
+) {
+  let next = segments;
+  if (executionItems.length > 0) {
+    next = appendAssistantExecutionSegment(next, executionItems);
+  }
+  if (text) {
+    next = appendAssistantOutputSegment(next, text, "default");
+  }
+  return next;
+}
+
+function assistantSegmentsIncludeOutput(segments: ChatAssistantSegment[]) {
+  return segments.some(
+    (segment) => segment.kind === "output" && Boolean(segment.text.trim()),
   );
 }
 
@@ -1513,6 +1614,13 @@ function inputIdFromMessageId(messageId: string, role: "user" | "assistant") {
   return messageId.startsWith(prefix) ? messageId.slice(prefix.length) : "";
 }
 
+function inputIdFromHistoryMessage(message: SessionHistoryMessagePayload) {
+  if (message.role === "user" || message.role === "assistant") {
+    return inputIdFromMessageId(message.id, message.role);
+  }
+  return "";
+}
+
 function historyMessagesInDisplayOrder(
   messages: SessionHistoryMessagePayload[],
   order: "asc" | "desc",
@@ -1520,16 +1628,13 @@ function historyMessagesInDisplayOrder(
   return order === "desc" ? [...messages].reverse() : messages;
 }
 
-function assistantInputIdsFromHistoryMessages(
+function turnInputIdsFromHistoryMessages(
   messages: SessionHistoryMessagePayload[],
 ) {
   const seen = new Set<string>();
   const inputIds: string[] = [];
   for (const message of messages) {
-    if (message.role !== "assistant") {
-      continue;
-    }
-    const inputId = inputIdFromMessageId(message.id, "assistant");
+    const inputId = inputIdFromHistoryMessage(message);
     if (!inputId || seen.has(inputId)) {
       continue;
     }
@@ -2226,8 +2331,36 @@ function assistantHistoryStateFromOutputEvents(
   const orderedEvents = [...outputEvents].sort(
     (left, right) => left.sequence - right.sequence || left.id - right.id,
   );
+  let segments: ChatAssistantSegment[] = [];
   let executionItems: ChatExecutionTimelineItem[] = [];
+  let outputText = "";
+  let outputTone: ChatMessage["tone"] = "default";
   let encounteredTerminalEvent = false;
+  let failureText = "";
+  let terminalCreatedAt = "";
+
+  const flushExecutionSegment = () => {
+    if (executionItems.length === 0) {
+      return;
+    }
+    segments = appendAssistantExecutionSegment(segments, executionItems);
+    executionItems = [];
+  };
+
+  const flushOutputSegment = () => {
+    if (!outputText) {
+      return;
+    }
+    segments = appendAssistantOutputSegment(segments, outputText, outputTone);
+    outputText = "";
+    outputTone = "default";
+  };
+
+  const hasAssistantOutput =
+    outputText.trim().length > 0 ||
+    segments.some(
+      (segment) => segment.kind === "output" && segment.text.trim().length > 0,
+    );
 
   for (const event of orderedEvents) {
     if (encounteredTerminalEvent) {
@@ -2236,6 +2369,7 @@ function assistantHistoryStateFromOutputEvents(
     const eventPayload = isRecord(event.payload) ? event.payload : {};
 
     if (event.event_type === "thinking_delta") {
+      flushOutputSegment();
       const delta =
         typeof eventPayload.delta === "string" ? eventPayload.delta : "";
       executionItems = appendExecutionTimelineThinkingDelta(
@@ -2251,6 +2385,7 @@ function assistantHistoryStateFromOutputEvents(
       event.sequence,
     );
     if (phaseStep) {
+      flushOutputSegment();
       executionItems = upsertExecutionTimelineTraceItem(
         executionItems,
         phaseStep,
@@ -2263,10 +2398,18 @@ function assistantHistoryStateFromOutputEvents(
       event.sequence,
     );
     if (toolStep) {
+      flushOutputSegment();
       executionItems = upsertExecutionTimelineTraceItem(
         executionItems,
         toolStep,
       );
+    }
+
+    if (event.event_type === "output_delta") {
+      flushExecutionSegment();
+      const delta =
+        typeof eventPayload.delta === "string" ? eventPayload.delta : "";
+      outputText = `${outputText}${delta}`;
     }
 
     if (event.event_type === "run_completed") {
@@ -2285,6 +2428,13 @@ function assistantHistoryStateFromOutputEvents(
         executionItems,
         "error",
       );
+      failureText = runFailedDetail(eventPayload);
+      terminalCreatedAt = event.created_at;
+      if (!hasAssistantOutput) {
+        flushExecutionSegment();
+        outputText = failureText;
+        outputTone = "error";
+      }
     }
 
     if (isTerminalSessionOutputEventType(event.event_type)) {
@@ -2292,8 +2442,14 @@ function assistantHistoryStateFromOutputEvents(
     }
   }
 
+  flushOutputSegment();
+  flushExecutionSegment();
+
   return {
+    segments: segments.length > 0 ? segments : undefined,
     executionItems: executionItems.length > 0 ? executionItems : undefined,
+    failureText: failureText || undefined,
+    terminalCreatedAt: terminalCreatedAt || undefined,
   };
 }
 
@@ -2383,6 +2539,11 @@ interface ChatPaneExplorerAttachmentRequest {
   requestKey: number;
 }
 
+interface ChatPaneBrowserJumpRequest {
+  sessionId: string;
+  requestKey: number;
+}
+
 interface ChatPaneProps {
   onOpenOutput?: (output: WorkspaceOutputRecordPayload) => void;
   onSyncFileDisplayFromAgentOperation?: (path: string) => void;
@@ -2398,6 +2559,12 @@ interface ChatPaneProps {
   explorerAttachmentRequest?: ChatPaneExplorerAttachmentRequest | null;
   onExplorerAttachmentRequestConsumed?: (requestKey: number) => void;
   onActiveSessionIdChange?: (sessionId: string | null) => void;
+  browserJumpRequest?: ChatPaneBrowserJumpRequest | null;
+  onBrowserJumpRequestConsumed?: (
+    sessionId: string,
+    requestKey: number,
+  ) => void;
+  onJumpToSessionBrowser?: (sessionId: string, requestKey: number) => void;
   onOpenInbox?: () => void;
   inboxUnreadCount?: number;
   onRequestCreateSession?: (request: ChatPaneSessionOpenRequest) => void;
@@ -2418,6 +2585,9 @@ export function ChatPane({
   explorerAttachmentRequest = null,
   onExplorerAttachmentRequestConsumed,
   onActiveSessionIdChange,
+  browserJumpRequest = null,
+  onBrowserJumpRequestConsumed,
+  onJumpToSessionBrowser,
   onOpenInbox,
   inboxUnreadCount = 0,
   onRequestCreateSession,
@@ -2443,6 +2613,9 @@ export function ChatPane({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sessionOutputs, setSessionOutputs] = useState<
     WorkspaceOutputRecordPayload[]
+  >([]);
+  const [liveAssistantSegments, setLiveAssistantSegments] = useState<
+    ChatAssistantSegment[]
   >([]);
   const [liveAssistantText, setLiveAssistantText] = useState("");
   const [liveAgentStatus, setLiveAgentStatus] = useState("");
@@ -2515,6 +2688,8 @@ export function ChatPane({
   const [availableSessionsError, setAvailableSessionsError] = useState("");
   const [localSessionOpenRequest, setLocalSessionOpenRequest] =
     useState<ChatPaneSessionOpenRequest | null>(null);
+  const [visibleBrowserState, setVisibleBrowserState] =
+    useState<BrowserTabListPayload>(() => initialBrowserState("user"));
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesContentRef = useRef<HTMLDivElement>(null);
   const chatScrollbarThumbRef = useRef<HTMLDivElement>(null);
@@ -2554,6 +2729,7 @@ export function ChatPane({
   const localSessionOpenRequestRef =
     useRef<ChatPaneSessionOpenRequest | null>(null);
   const draftParentSessionIdRef = useRef<string | null>(null);
+  const liveAssistantSegmentsRef = useRef<ChatAssistantSegment[]>([]);
   const liveAssistantTextRef = useRef("");
   const liveExecutionItemsRef = useRef<ChatExecutionTimelineItem[]>([]);
   const historyViewportGenerationRef = useRef(0);
@@ -2712,10 +2888,12 @@ export function ChatPane({
   }
 
   function resetLiveTurn() {
+    liveAssistantSegmentsRef.current = [];
     liveAssistantTextRef.current = "";
     liveExecutionItemsRef.current = [];
     activeAssistantMessageIdRef.current = null;
     lastSyncedAgentOperationFileKeyRef.current = "";
+    setLiveAssistantSegments([]);
     setLiveAssistantText("");
     setLiveAgentStatus("");
     setLiveExecutionItems([]);
@@ -2826,8 +3004,15 @@ export function ChatPane({
       }
     }
 
+    const assistantHistoryInputIds = new Set(
+      historyMessages
+        .filter((message) => message.role === "assistant")
+        .map((message) => inputIdFromMessageId(message.id, "assistant"))
+        .filter(Boolean),
+    );
+
     return historyMessages
-      .map((message) => {
+      .flatMap((message) => {
         const attachments = attachmentsFromMetadata(message.metadata);
         const nextMessage: ChatMessage = {
           id:
@@ -2838,6 +3023,7 @@ export function ChatPane({
           createdAt: message.created_at || undefined,
           attachments,
         };
+        const renderedMessages: ChatMessage[] = [nextMessage];
 
         if (nextMessage.role === "assistant") {
           const inputId = inputIdFromMessageId(nextMessage.id, "assistant");
@@ -2852,8 +3038,20 @@ export function ChatPane({
             const turnMemoryProposals = sortMemoryUpdateProposals(
               memoryProposalsByInputId.get(inputId) ?? [],
             );
-            if (restoredAssistantState.executionItems) {
+            if (restoredAssistantState.segments) {
+              nextMessage.segments = restoredAssistantState.segments;
+              nextMessage.text = "";
+              nextMessage.executionItems = undefined;
+            } else if (restoredAssistantState.executionItems) {
               nextMessage.executionItems = restoredAssistantState.executionItems;
+            }
+            if (
+              !nextMessage.text &&
+              !nextMessage.segments &&
+              restoredAssistantState.failureText
+            ) {
+              nextMessage.text = restoredAssistantState.failureText;
+              nextMessage.tone = "error";
             }
             if (turnMemoryProposals.length > 0) {
               nextMessage.memoryProposals = turnMemoryProposals;
@@ -2864,7 +3062,50 @@ export function ChatPane({
           }
         }
 
-        return nextMessage;
+        const userInputId =
+          nextMessage.role === "user"
+            ? inputIdFromMessageId(nextMessage.id, "user")
+            : "";
+        if (
+          nextMessage.role === "user" &&
+          userInputId &&
+          !assistantHistoryInputIds.has(userInputId)
+        ) {
+          const restoredAssistantState = assistantHistoryStateFromOutputEvents(
+            outputEventsByInputId.get(userInputId) ?? [],
+          );
+          const turnOutputs = sortOutputs(outputsByInputId.get(userInputId) ?? []);
+          const turnMemoryProposals = sortMemoryUpdateProposals(
+            memoryProposalsByInputId.get(userInputId) ?? [],
+          );
+          const syntheticAssistantMessage: ChatMessage = {
+            id: `assistant-${userInputId}`,
+            role: "assistant",
+            text:
+              restoredAssistantState.segments || !restoredAssistantState.failureText
+                ? ""
+                : restoredAssistantState.failureText,
+            tone:
+              restoredAssistantState.segments || !restoredAssistantState.failureText
+                ? "default"
+                : "error",
+            createdAt:
+              restoredAssistantState.terminalCreatedAt || nextMessage.createdAt,
+            segments: restoredAssistantState.segments,
+            executionItems:
+              restoredAssistantState.segments
+                ? undefined
+                : restoredAssistantState.executionItems,
+            outputs: turnOutputs.length > 0 ? turnOutputs : undefined,
+            memoryProposals:
+              turnMemoryProposals.length > 0 ? turnMemoryProposals : undefined,
+          };
+          if (hasRenderableAssistantTurn(syntheticAssistantMessage)) {
+            renderedMessages.push(syntheticAssistantMessage);
+          }
+        }
+
+        return renderedMessages;
       })
       .filter(
         (message) =>
@@ -2906,7 +3147,7 @@ export function ChatPane({
       history.messages,
       params.order,
     );
-    const assistantInputIds = assistantInputIdsFromHistoryMessages(
+    const assistantInputIds = turnInputIdsFromHistoryMessages(
       historyMessages,
     );
     if (assistantInputIds.length === 0) {
@@ -3218,7 +3459,48 @@ export function ChatPane({
     }
   }
 
+  function setLiveAssistantSegmentsState(nextSegments: ChatAssistantSegment[]) {
+    liveAssistantSegmentsRef.current = nextSegments;
+    setLiveAssistantSegments(nextSegments);
+  }
+
+  function flushLiveAssistantOutputSegment(
+    tone: ChatMessage["tone"] = "default",
+  ) {
+    if (!liveAssistantTextRef.current) {
+      return;
+    }
+    flushSync(() => {
+      setLiveAssistantSegmentsState(
+        appendAssistantOutputSegment(
+          liveAssistantSegmentsRef.current,
+          liveAssistantTextRef.current,
+          tone,
+        ),
+      );
+      liveAssistantTextRef.current = "";
+      setLiveAssistantText("");
+    });
+  }
+
+  function flushLiveExecutionSegment() {
+    if (liveExecutionItemsRef.current.length === 0) {
+      return;
+    }
+    flushSync(() => {
+      setLiveAssistantSegmentsState(
+        appendAssistantExecutionSegment(
+          liveAssistantSegmentsRef.current,
+          liveExecutionItemsRef.current,
+        ),
+      );
+      liveExecutionItemsRef.current = [];
+      setLiveExecutionItems([]);
+    });
+  }
+
   function appendLiveAssistantDelta(delta: string) {
+    flushLiveExecutionSegment();
     flushSync(() => {
       setLiveAssistantText((prev) => {
         const next = `${prev}${delta}`;
@@ -3229,6 +3511,7 @@ export function ChatPane({
   }
 
   function appendLiveThinkingDelta(delta: string, order: number) {
+    flushLiveAssistantOutputSegment();
     flushSync(() => {
       setLiveExecutionItems((prev) => {
         const next = appendExecutionTimelineThinkingDelta(prev, delta, order);
@@ -3238,14 +3521,44 @@ export function ChatPane({
     });
   }
 
-  function commitLiveAssistantMessage() {
+  function commitLiveAssistantMessage(options?: {
+    fallbackText?: string;
+    tone?: ChatMessage["tone"];
+  }) {
     const messageId =
       activeAssistantMessageIdRef.current ?? `assistant-${Date.now()}`;
-    const assistantText = liveAssistantTextRef.current;
-    const executionItems = liveExecutionItemsRef.current;
-    if (!assistantText && executionItems.length === 0) {
+    let nextSegments = liveAssistantSegmentsRef.current;
+
+    if (liveExecutionItemsRef.current.length > 0) {
+      nextSegments = appendAssistantExecutionSegment(
+        nextSegments,
+        liveExecutionItemsRef.current,
+      );
+    }
+
+    if (liveAssistantTextRef.current) {
+      nextSegments = appendAssistantOutputSegment(
+        nextSegments,
+        liveAssistantTextRef.current,
+        "default",
+      );
+    }
+
+    const hasOutputSegment = nextSegments.some(
+      (segment) =>
+        segment.kind === "output" && Boolean(segment.text.trim()),
+    );
+    if (options?.fallbackText && !hasOutputSegment) {
+      nextSegments = appendAssistantOutputSegment(
+        nextSegments,
+        options.fallbackText,
+        options.tone ?? "default",
+      );
+    }
+
+    if (nextSegments.length === 0) {
       resetLiveTurn();
-      return;
+      return false;
     }
 
     setMessages((prev) => [
@@ -3253,11 +3566,13 @@ export function ChatPane({
       {
         id: messageId,
         role: "assistant",
-        text: assistantText,
-        executionItems: executionItems.length > 0 ? executionItems : undefined,
+        text: "",
+        tone: "default",
+        segments: nextSegments,
       },
     ]);
     resetLiveTurn();
+    return true;
   }
 
   function scheduleConversationRefresh(
@@ -3520,6 +3835,7 @@ export function ChatPane({
   }
 
   function upsertLiveTraceStep(step: ChatTraceStep) {
+    flushLiveAssistantOutputSegment();
     const next = upsertExecutionTimelineTraceItem(
       liveExecutionItemsRef.current,
       step,
@@ -3554,6 +3870,7 @@ export function ChatPane({
   }, [
     isHistoryViewportPending,
     isResponding,
+    liveAssistantSegments,
     liveAssistantText,
     liveExecutionItems,
     messages,
@@ -4553,14 +4870,17 @@ export function ChatPane({
             return;
           }
           const detail = runFailedDetail(eventPayload);
-          setChatErrorMessage(detail);
           finalizeLiveTraceSteps("error");
-          if (
-            liveAssistantTextRef.current ||
-            liveExecutionItemsRef.current.length > 0
-          ) {
-            commitLiveAssistantMessage();
-          }
+          const shouldPersistFailureText =
+            !liveAssistantTextRef.current &&
+            !assistantSegmentsIncludeOutput(liveAssistantSegmentsRef.current);
+          const committedFailureMessage = commitLiveAssistantMessage({
+            fallbackText: shouldPersistFailureText ? detail : undefined,
+            tone: shouldPersistFailureText ? "error" : "default",
+          });
+          setChatErrorMessage(
+            committedFailureMessage && shouldPersistFailureText ? "" : detail,
+          );
           setIsResponding(false);
           activeStreamIdRef.current = null;
           pendingInputIdRef.current = null;
@@ -4679,11 +4999,22 @@ export function ChatPane({
           activeStreamIdRef.current = null;
         }
         setIsResponding(false);
-        resetLiveTurn();
 
         if (status === "ERROR") {
           const detail = runtimeStateErrorDetail(currentState.last_error);
-          setChatErrorMessage(detail);
+          finalizeLiveTraceSteps("error");
+          const shouldPersistFailureText =
+            !liveAssistantTextRef.current &&
+            !assistantSegmentsIncludeOutput(liveAssistantSegmentsRef.current);
+          const committedFailureMessage = commitLiveAssistantMessage({
+            fallbackText: shouldPersistFailureText ? detail : undefined,
+            tone: shouldPersistFailureText ? "error" : "default",
+          });
+          setChatErrorMessage(
+            committedFailureMessage && shouldPersistFailureText ? "" : detail,
+          );
+        } else {
+          resetLiveTurn();
         }
         pendingInputIdRef.current = null;
       } catch {
@@ -5124,6 +5455,25 @@ export function ChatPane({
     onExplorerAttachmentRequestConsumed,
   ]);
 
+  useEffect(() => {
+    let mounted = true;
+
+    const applyVisibleBrowserState = (state: BrowserTabListPayload) => {
+      if (mounted) {
+        setVisibleBrowserState(state);
+      }
+    };
+
+    void window.electronAPI.browser.getState().then(applyVisibleBrowserState);
+    const unsubscribe =
+      window.electronAPI.browser.onStateChange(applyVisibleBrowserState);
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
   function onAttachmentInputChange(event: ChangeEvent<HTMLInputElement>) {
     const files = Array.from(event.target.files ?? []);
     appendPendingLocalFiles(files);
@@ -5151,6 +5501,16 @@ export function ChatPane({
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     void sendMessage(input);
+  };
+
+  const jumpToSessionBrowser = () => {
+    if (!browserJumpRequest || browserJumpRequest.sessionId !== activeSessionId) {
+      return;
+    }
+    onJumpToSessionBrowser?.(
+      browserJumpRequest.sessionId,
+      browserJumpRequest.requestKey,
+    );
   };
 
   const onComposerKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -5191,8 +5551,25 @@ export function ChatPane({
         selectedWorkspace?.harness,
         runtimeConfig?.defaultModel,
       );
+  const visibleAgentBrowserSessionId =
+    visibleBrowserState.space === "agent"
+      ? visibleBrowserState.controlSessionId || visibleBrowserState.sessionId || ""
+      : "";
+  const showSessionBrowserJumpCta = Boolean(
+    browserJumpRequest &&
+      activeSessionId &&
+      browserJumpRequest.sessionId === activeSessionId &&
+      (visibleBrowserState.space !== "agent" ||
+        visibleAgentBrowserSessionId !== activeSessionId),
+  );
+  const renderedLiveAssistantSegments = liveAssistantSegmentsForRender(
+    liveAssistantSegments,
+    liveExecutionItems,
+    liveAssistantText,
+  );
   const showLiveAssistantTurn =
     isResponding ||
+    liveAssistantSegments.length > 0 ||
     Boolean(liveAssistantText) ||
     liveExecutionItems.length > 0;
   const hasMessages = messages.length > 0 || showLiveAssistantTurn;
@@ -5221,6 +5598,31 @@ export function ChatPane({
       })),
     [pendingAttachments],
   );
+
+  useEffect(() => {
+    if (
+      !browserJumpRequest ||
+      !activeSessionId ||
+      browserJumpRequest.sessionId !== activeSessionId
+    ) {
+      return;
+    }
+    if (
+      visibleBrowserState.space === "agent" &&
+      visibleAgentBrowserSessionId === activeSessionId
+    ) {
+      onBrowserJumpRequestConsumed?.(
+        activeSessionId,
+        browserJumpRequest.requestKey,
+      );
+    }
+  }, [
+    activeSessionId,
+    browserJumpRequest,
+    onBrowserJumpRequestConsumed,
+    visibleAgentBrowserSessionId,
+    visibleBrowserState.space,
+  ]);
   const availableWorkspaceSkillMap = useMemo(
     () =>
       new Map(
@@ -5880,6 +6282,8 @@ export function ChatPane({
                         label={assistantLabel}
                         mode={assistantMode}
                         text={message.text}
+                        tone={message.tone ?? "default"}
+                        segments={message.segments ?? []}
                         executionItems={message.executionItems ?? []}
                         memoryProposals={message.memoryProposals ?? []}
                         outputs={message.outputs ?? []}
@@ -5926,6 +6330,8 @@ export function ChatPane({
                       label={assistantLabel}
                       mode={assistantMode}
                       text={liveAssistantText}
+                      tone="default"
+                      segments={renderedLiveAssistantSegments}
                       executionItems={liveExecutionItems}
                       memoryProposals={[]}
                       outputs={[]}
@@ -5946,6 +6352,20 @@ export function ChatPane({
                       onToggleTraceStep={toggleTraceStep}
                       onLinkClick={onOpenLinkInBrowser}
                       live
+                      statusAccessory={
+                        showSessionBrowserJumpCta ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={jumpToSessionBrowser}
+                            className="rounded-full"
+                          >
+                            <span>Jump to browser</span>
+                            <ArrowRight size={13} />
+                          </Button>
+                        ) : null
+                      }
                       status={
                         liveAgentStatus || (isResponding ? "Working" : "")
                       }
@@ -6545,6 +6965,8 @@ function AssistantTurn({
   label,
   mode,
   text,
+  tone = "default",
+  segments,
   executionItems,
   memoryProposals,
   outputs,
@@ -6563,10 +6985,13 @@ function AssistantTurn({
   onLinkClick,
   status = "",
   live = false,
+  statusAccessory = null,
 }: {
   label: string;
   mode: string;
   text: string;
+  tone?: ChatMessage["tone"];
+  segments: ChatAssistantSegment[];
   executionItems: ChatExecutionTimelineItem[];
   memoryProposals: MemoryUpdateProposalRecordPayload[];
   outputs: WorkspaceOutputRecordPayload[];
@@ -6590,49 +7015,111 @@ function AssistantTurn({
   onLinkClick?: (url: string) => void;
   status?: string;
   live?: boolean;
+  statusAccessory?: ReactNode;
 }) {
   const normalizedStatus = status.replace(/\.+$/, "").trim();
+  const renderedSegments =
+    segments.length > 0
+      ? segments
+      : executionItems.length > 0 || Boolean(text)
+        ? [
+            ...(executionItems.length > 0
+              ? ([
+                  {
+                    kind: "execution",
+                    items: executionItems,
+                  },
+                ] as ChatAssistantSegment[])
+              : []),
+            ...(text
+              ? ([
+                  {
+                    kind: "output",
+                    text,
+                    tone,
+                  },
+                ] as ChatAssistantSegment[])
+              : []),
+          ]
+        : [];
   const showStatusPlaceholder =
     live &&
     Boolean(normalizedStatus) &&
-    !text &&
-    executionItems.length === 0;
+    renderedSegments.length === 0;
   const showWorkingStatusLine =
     live &&
-    (executionItems.length > 0 || Boolean(text));
+    renderedSegments.length > 0;
+  const renderStatusLine = (nextLabel: string, className = "") => {
+    if (!statusAccessory) {
+      return <LiveStatusLine label={nextLabel} className={className} />;
+    }
+    return (
+      <div
+        className={`flex min-w-0 items-center justify-between gap-3 ${className}`.trim()}
+      >
+        <LiveStatusLine label={nextLabel} className="min-w-0" />
+        <div className="shrink-0">{statusAccessory}</div>
+      </div>
+    );
+  };
 
   return (
     <div className="flex min-w-0 justify-start">
       <article className="min-w-0 flex-1">
-        {showStatusPlaceholder ? (
-          <LiveStatusLine label={normalizedStatus} />
-        ) : null}
+        {showStatusPlaceholder ? renderStatusLine(normalizedStatus) : null}
 
-        {executionItems.length > 0 ? (
-          <TraceStepGroup
-            items={executionItems}
-            collapsedByStepId={collapsedTraceByStepId}
-            onToggleStep={onToggleTraceStep}
-            live={live}
-            liveOutputStarted={live && Boolean(text)}
-            onLinkClick={onLinkClick}
-          />
-        ) : null}
+        {renderedSegments.map((segment, index) =>
+          segment.kind === "execution" ? (
+            <TraceStepGroup
+              key={`execution-${index}`}
+              items={segment.items}
+              collapsedByStepId={collapsedTraceByStepId}
+              onToggleStep={onToggleTraceStep}
+              live={live}
+              liveOutputStarted={
+                live &&
+                renderedSegments
+                  .slice(index + 1)
+                  .some((nextSegment) => nextSegment.kind === "output")
+              }
+              onLinkClick={onLinkClick}
+            />
+          ) : segment.tone === "error" ? (
+            <div
+              key={`output-${index}`}
+              className="theme-chat-system-bubble mt-2 rounded-[14px] border px-3 py-2.5 text-[12px] text-foreground"
+            >
+              <div className="flex items-start gap-2">
+                <AlertTriangle
+                  size={14}
+                  className="mt-0.5 shrink-0 text-destructive"
+                />
+                <SimpleMarkdown
+                  className="chat-markdown max-w-full text-foreground"
+                  onLinkClick={onLinkClick}
+                >
+                  {segment.text}
+                </SimpleMarkdown>
+              </div>
+            </div>
+          ) : (
+            <SimpleMarkdown
+              key={`output-${index}`}
+              className="chat-markdown chat-assistant-markdown mt-2 max-w-full text-foreground"
+              onLinkClick={onLinkClick}
+            >
+              {segment.text}
+            </SimpleMarkdown>
+          ),
+        )}
 
         {showWorkingStatusLine ? (
-          <LiveStatusLine
-            label="Working"
-            className={executionItems.length > 0 ? "mt-1" : ""}
-          />
-        ) : null}
-
-        {text ? (
-          <SimpleMarkdown
-            className="chat-markdown chat-assistant-markdown mt-2 max-w-full text-foreground"
-            onLinkClick={onLinkClick}
-          >
-            {text}
-          </SimpleMarkdown>
+          renderStatusLine(
+            "Working",
+            renderedSegments.some((segment) => segment.kind === "execution")
+              ? "mt-1"
+              : "",
+          )
         ) : null}
 
         {memoryProposals.length > 0 ? (

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -328,7 +328,7 @@ test("file explorer renders editable spreadsheet previews", async () => {
   assert.match(source, /window\.electronAPI\.fs\.writeTableFile\(\s*preview\.absolutePath,\s*tablePreviewDraft,\s*selectedWorkspaceId \?\? null,\s*\)/);
   assert.match(
     source,
-    /<SpreadsheetEditor[\s\S]*sheets=\{previewTableSheets\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}/,
+    /<SpreadsheetEditor[\s\S]*sheets=\{previewTableSheets\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}[\s\S]*onOpenLinkInBrowser=\{openPreviewLink\}/,
   );
 });
 

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -2900,6 +2900,7 @@ export function FileExplorerPane({
                   : null
             }
             onChange={setTablePreviewDraft}
+            onOpenLinkInBrowser={openPreviewLink}
           />
         ) : (
           <div className="flex h-full flex-col items-center justify-center rounded-lg border border-border bg-muted px-5 text-center">

--- a/desktop/src/components/panes/InternalSurfacePane.test.mjs
+++ b/desktop/src/components/panes/InternalSurfacePane.test.mjs
@@ -83,7 +83,7 @@ test("internal surface enables editing and saving for file displays", async () =
   );
   assert.match(
     source,
-    /<SpreadsheetEditor[\s\S]*sheets=\{tablePreviewDraft\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}/,
+    /<SpreadsheetEditor[\s\S]*sheets=\{tablePreviewDraft\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}[\s\S]*onOpenLinkInBrowser=\{openPreviewLink\}/,
   );
 });
 
@@ -103,7 +103,7 @@ test("internal surface renders editable spreadsheet previews", async () => {
   assert.match(source, /window\.electronAPI\.fs\.writeTableFile\(\s*preview\.absolutePath,\s*tablePreviewDraft,\s*selectedWorkspaceId \?\? null,\s*\)/);
   assert.match(
     source,
-    /<SpreadsheetEditor[\s\S]*sheets=\{tablePreviewDraft\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}/,
+    /<SpreadsheetEditor[\s\S]*sheets=\{tablePreviewDraft\}[\s\S]*editable=\{preview\.isEditable\}[\s\S]*onChange=\{setTablePreviewDraft\}[\s\S]*onOpenLinkInBrowser=\{openPreviewLink\}/,
   );
 });
 

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -613,6 +613,7 @@ export function InternalSurfacePane({
                   : null
             }
             onChange={setTablePreviewDraft}
+            onOpenLinkInBrowser={openPreviewLink}
           />
         );
       }

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const sourcePath = path.join(__dirname, "SpaceBrowserDisplayPane.tsx");
 const glowPreviewHookPath = path.join(__dirname, "useBrowserGlowPreview.ts");
+const stylesPath = path.join(__dirname, "..", "..", "index.css");
 
 test("space browser display selects the full address when the navigation field is clicked", async () => {
   const source = await readFile(sourcePath, "utf8");
@@ -95,10 +96,25 @@ test("space browser display keeps takeover status without chrome session control
     /const showAgentActivityHighlight =\s*sessionBrowserStatus\?\.tone === "active" \|\| glowPreviewEnabled;/,
   );
   assert.doesNotMatch(source, /<span className="truncate">\{sessionBrowserStatus\.detail\}<\/span>/);
-  assert.match(source, /border-primary\/70/);
-  assert.match(source, /boxShadow:\s*"0 0 40px color-mix\(in oklch, var\(--primary\) 34%, transparent\)"/);
-  assert.match(source, /rounded-\[inherit\] border-2 border-primary\/60/);
+  assert.match(source, /browser-active-glow border-border\/45/);
+  assert.match(source, /browser-active-glow-frame pointer-events-none absolute inset-0 rounded-\[inherit\]/);
+  assert.doesNotMatch(source, /border-primary\/70/);
+  assert.doesNotMatch(source, /browserBoundsRef/);
+  assert.match(source, /const rect = viewport\.getBoundingClientRect\(\);/);
   assert.doesNotMatch(source, /absolute left-3 top-3 inline-flex items-center gap-1\.5 rounded-full/);
+});
+
+test("browser glow styles animate the active browser border", async () => {
+  const source = await readFile(stylesPath, "utf8");
+
+  assert.match(source, /@keyframes holaboss-browser-active-glow/);
+  assert.match(source, /@keyframes holaboss-browser-active-frame/);
+  assert.match(source, /0 0 44px color-mix\(in oklch, var\(--primary\) 56%, transparent\)/);
+  assert.match(source, /inset 0 0 72px color-mix\(in oklch, var\(--primary\) 24%, transparent\)/);
+  assert.match(source, /inset 0 0 38px color-mix\(in oklch, var\(--primary\) 30%, transparent\)/);
+  assert.match(source, /\.browser-active-glow \{[\s\S]*animation: holaboss-browser-active-glow 2\.8s ease-in-out infinite;/);
+  assert.match(source, /\.browser-active-glow-frame \{[\s\S]*animation: holaboss-browser-active-frame 2\.8s ease-in-out infinite;/);
+  assert.match(source, /@media \(prefers-reduced-motion: reduce\)/);
 });
 
 test("browser glow preview hook exposes a console toggle", async () => {

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const sourcePath = path.join(__dirname, "SpaceBrowserDisplayPane.tsx");
+const glowPreviewHookPath = path.join(__dirname, "useBrowserGlowPreview.ts");
 
 test("space browser display selects the full address when the navigation field is clicked", async () => {
   const source = await readFile(sourcePath, "utf8");
@@ -56,7 +57,7 @@ test("space browser display uses stored history entries for address suggestions"
 
   assert.match(
     source,
-    /useWorkspaceBrowser\(browserSpace, \{ includeHistory: true \}\)/,
+    /useWorkspaceBrowser\(browserSpace, \{\s*includeHistory: true,\s*includeSessions: true,\s*\}\)/,
   );
   assert.match(source, /const \[addressFocused, setAddressFocused\] = useState\(false\);/);
   assert.match(
@@ -79,4 +80,43 @@ test("space browser display uses stored history entries for address suggestions"
     source,
     /onBlur=\{\(\) =>\s*window\.setTimeout\(\(\) => setAddressFocused\(false\), 120\)\s*\}/,
   );
+});
+
+test("space browser display keeps takeover status without chrome session controls", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(source, /Choose agent session browser/);
+  assert.doesNotMatch(source, /No session browsers/);
+  assert.doesNotMatch(source, /selectAgentSessionBrowser/);
+  assert.doesNotMatch(source, /Shared agent browser/);
+  assert.match(source, /const glowPreviewEnabled = useBrowserGlowPreview\(\);/);
+  assert.match(
+    source,
+    /const showAgentActivityHighlight =\s*sessionBrowserStatus\?\.tone === "active" \|\| glowPreviewEnabled;/,
+  );
+  assert.doesNotMatch(source, /<span className="truncate">\{sessionBrowserStatus\.detail\}<\/span>/);
+  assert.match(source, /border-primary\/70/);
+  assert.match(source, /boxShadow:\s*"0 0 40px color-mix\(in oklch, var\(--primary\) 34%, transparent\)"/);
+  assert.match(source, /rounded-\[inherit\] border-2 border-primary\/60/);
+  assert.doesNotMatch(source, /absolute left-3 top-3 inline-flex items-center gap-1\.5 rounded-full/);
+});
+
+test("browser glow preview hook exposes a console toggle", async () => {
+  const source = await readFile(glowPreviewHookPath, "utf8");
+
+  assert.match(source, /const BROWSER_GLOW_PREVIEW_EVENT = "holaboss:browser-glow-preview-change";/);
+  assert.match(source, /__holabossDevBrowserGlowPreview\?: \{/);
+  assert.match(source, /window\.__holabossDevBrowserGlowPreview = \{/);
+  assert.match(source, /on: \(\) => setBrowserGlowPreviewEnabled\(true\)/);
+  assert.match(source, /off: \(\) => setBrowserGlowPreviewEnabled\(false\)/);
+  assert.match(source, /toggle: \(\) =>\s*setBrowserGlowPreviewEnabled\(/);
+  assert.match(source, /window\.dispatchEvent\(\s*new CustomEvent\(BROWSER_GLOW_PREVIEW_EVENT/);
+});
+
+test("space browser display only clears native browser bounds on suspend or unmount, not every layout sync", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /if \(suspendNativeView\) \{\s*void window\.electronAPI\.browser\.setBounds\(\{\s*x: 0,\s*y: 0,\s*width: 0,\s*height: 0,\s*\}\);\s*return;\s*\}/s);
+  assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*window\.setTimeout\(queueSync, 400\);[\s\S]*return \(\) => \{\s*observer\.disconnect\(\);[\s\S]*window\.cancelAnimationFrame\(rafId\);\s*\};\s*\}, \[layoutSyncKey, suspendNativeView\]\);/s);
+  assert.match(source, /useEffect\(\(\) => \{\s*return \(\) => \{\s*void window\.electronAPI\.browser\.setBounds\(\{\s*x: 0,\s*y: 0,\s*width: 0,\s*height: 0,\s*\}\);\s*\};\s*\}, \[\]\);/s);
 });

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -17,6 +17,10 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  browserSurfaceStatusSummary,
+} from "@/components/panes/browserSessionUi";
+import { useBrowserGlowPreview } from "@/components/panes/useBrowserGlowPreview";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
 const HOME_URL = "https://www.google.com";
@@ -70,9 +74,38 @@ export function SpaceBrowserDisplayPane({
   const addressInputRef = useRef<HTMLInputElement | null>(null);
   const addressFieldRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const { activeTab, activeBookmark, historyEntries, isBookmarked } =
-    useWorkspaceBrowser(browserSpace, { includeHistory: true });
+  const {
+    activeTab,
+    activeBookmark,
+    historyEntries,
+    isBookmarked,
+    browserState,
+    currentRuntimeState,
+  } = useWorkspaceBrowser(browserSpace, {
+    includeHistory: true,
+    includeSessions: true,
+  });
   const isActiveTabBusy = activeTab.loading || !activeTab.initialized;
+
+  const sessionBrowserStatus = useMemo(
+    () =>
+      browserSurfaceStatusSummary({
+        browserSpace,
+        controlMode: browserState.controlMode,
+        lifecycleState: browserState.lifecycleState,
+        runtimeState: currentRuntimeState,
+      }),
+    [
+      browserSpace,
+      browserState.controlMode,
+      browserState.lifecycleState,
+      currentRuntimeState,
+    ],
+  );
+  const glowPreviewEnabled = useBrowserGlowPreview();
+
+  const showAgentActivityHighlight =
+    sessionBrowserStatus?.tone === "active" || glowPreviewEnabled;
 
   useEffect(() => {
     setInputValue(activeTab.url || "");
@@ -122,6 +155,11 @@ export function SpaceBrowserDisplayPane({
       observer.disconnect();
       window.removeEventListener("resize", queueSync);
       window.cancelAnimationFrame(rafId);
+    };
+  }, [layoutSyncKey, suspendNativeView]);
+
+  useEffect(() => {
+    return () => {
       void window.electronAPI.browser.setBounds({
         x: 0,
         y: 0,
@@ -129,7 +167,7 @@ export function SpaceBrowserDisplayPane({
         height: 0,
       });
     };
-  }, [layoutSyncKey, suspendNativeView]);
+  }, []);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -305,7 +343,7 @@ export function SpaceBrowserDisplayPane({
       }`}
     >
       <div className="shrink-0 border-b border-border/45 px-4 py-2">
-        <div className="flex items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
           <Button
             variant="ghost"
             size="icon-sm"
@@ -391,14 +429,34 @@ export function SpaceBrowserDisplayPane({
           >
             <Star size={13} fill={isBookmarked ? "currentColor" : "none"} />
           </Button>
+
         </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden p-3">
         <div
           ref={viewportRef}
-          className="relative h-full min-h-0 overflow-hidden rounded-xl border border-border bg-card"
+          className={`relative h-full min-h-0 overflow-hidden rounded-xl border bg-card transition-all ${
+            showAgentActivityHighlight
+              ? "border-primary/70"
+              : "border-border"
+          }`}
+          style={
+            showAgentActivityHighlight
+              ? {
+                  boxShadow:
+                    "0 0 40px color-mix(in oklch, var(--primary) 34%, transparent)",
+                }
+              : undefined
+          }
         >
+          {showAgentActivityHighlight ? (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 rounded-[inherit] border-2 border-primary/60 shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--primary)_30%,transparent)]"
+            />
+          ) : null}
+
           {!activeTab.initialized ? (
             <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
               <div className="pointer-events-none w-full max-w-[360px] rounded-[24px] border border-border bg-card/92 px-6 py-6 shadow-lg backdrop-blur-sm">

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -438,22 +438,14 @@ export function SpaceBrowserDisplayPane({
           ref={viewportRef}
           className={`relative h-full min-h-0 overflow-hidden rounded-xl border bg-card transition-all ${
             showAgentActivityHighlight
-              ? "border-primary/70"
+              ? "browser-active-glow border-border/45"
               : "border-border"
           }`}
-          style={
-            showAgentActivityHighlight
-              ? {
-                  boxShadow:
-                    "0 0 40px color-mix(in oklch, var(--primary) 34%, transparent)",
-                }
-              : undefined
-          }
         >
           {showAgentActivityHighlight ? (
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 rounded-[inherit] border-2 border-primary/60 shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--primary)_30%,transparent)]"
+              className="browser-active-glow-frame pointer-events-none absolute inset-0 rounded-[inherit]"
             />
           ) : null}
 

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.test.mjs
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.test.mjs
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "SpaceBrowserExplorerPane.tsx");
+const browserSessionUiPath = path.join(__dirname, "browserSessionUi.ts");
+
+test("space browser explorer styles the agent session selector like the app's standard dropdowns", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(source, /Agent Session Browser/);
+  assert.match(
+    source,
+    /<div className="mt-2\.5 flex items-center gap-1\.5">/,
+  );
+  assert.match(
+    source,
+    /<SelectTrigger className="h-9 min-w-0 flex-1 basis-0 rounded-\[11px\] border-border\/45 bg-card px-3 text-left text-xs font-medium shadow-none">/,
+  );
+  assert.match(
+    source,
+    /<SelectContent align="start" className="p-1">/,
+  );
+  assert.match(
+    source,
+    /className="rounded-\[11px\] px-3 py-2 text-xs"/,
+  );
+  assert.match(
+    source,
+    /className="grid w-full min-w-0 grid-cols-\[minmax\(0,1fr\)_auto\] items-center gap-3"/,
+  );
+  assert.match(
+    source,
+    /className="min-w-0 truncate font-medium text-foreground"/,
+  );
+  assert.match(
+    source,
+    /const isSelectedSession =\s*\(browserState\.sessionId \?\? ""\) === session\.session_id;/,
+  );
+  assert.match(
+    source,
+    /!isSelectedSession \?\s*\(\s*<span className="shrink-0 text-\[10px\] font-semibold uppercase tracking-\[0\.12em\] text-muted-foreground\/85">/,
+  );
+  assert.match(
+    source,
+    /className=\{`shrink-0 gap-1 rounded-full px-1\.5 py-0\.5 text-\[10px\]/,
+  );
+});
+
+test("browser session status badges use short single-word labels", async () => {
+  const source = await readFile(browserSessionUiPath, "utf8");
+
+  assert.match(source, /label: "Active"/);
+  assert.match(source, /label: "Waiting"/);
+  assert.match(source, /label: "Paused"/);
+  assert.match(source, /label: "Error"/);
+  assert.match(source, /label: "Sleeping"/);
+  assert.match(source, /label: "Locked"/);
+  assert.match(source, /label: "Ready"/);
+  assert.doesNotMatch(source, /label: "Agent paused"/);
+  assert.doesNotMatch(source, /label: "Agent operating"/);
+});
+
+test("space browser explorer uses readable light-theme colors for session status badges", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /text-emerald-700 dark:border-emerald-400\/40 dark:bg-emerald-500\/10 dark:text-emerald-200/,
+  );
+  assert.match(
+    source,
+    /text-amber-700 dark:border-amber-400\/30 dark:bg-amber-500\/10 dark:text-amber-100/,
+  );
+  assert.match(
+    source,
+    /text-sky-700 dark:border-sky-400\/30 dark:bg-sky-500\/10 dark:text-sky-100/,
+  );
+  assert.match(
+    source,
+    /text-rose-700 dark:border-rose-400\/35 dark:bg-rose-500\/10 dark:text-rose-100/,
+  );
+});
+
+test("space browser explorer does not render a per-tab agent status dot", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.doesNotMatch(
+    source,
+    /tab\.id === activeTab\.id[\s\S]*sessionBrowserStatus[\s\S]*inline-block size-2 shrink-0 rounded-full/,
+  );
+});

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -1,7 +1,21 @@
-import { Bot, Globe, Plus, Star, User, X } from "lucide-react";
+import { useMemo } from "react";
+import { Bot, Globe, Pause, Plus, Star, User, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  browserSessionStatusLabel,
+  browserSessionTitle,
+  browserSurfaceStatusSummary,
+  compareBrowserSessionOptions,
+} from "@/components/panes/browserSessionUi";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 
 interface SpaceBrowserExplorerPaneProps {
@@ -15,8 +29,46 @@ export function SpaceBrowserExplorerPane({
   onBrowserSpaceChange,
   onActivateDisplay,
 }: SpaceBrowserExplorerPaneProps) {
-  const { selectedWorkspaceId, browserState, activeTab, bookmarks } =
-    useWorkspaceBrowser(browserSpace);
+  const {
+    selectedWorkspaceId,
+    browserState,
+    activeTab,
+    bookmarks,
+    agentSessions,
+    runtimeStatesBySessionId,
+    currentSession,
+    currentRuntimeState,
+  } = useWorkspaceBrowser(browserSpace, { includeSessions: true });
+
+  const sortedAgentSessions = useMemo(
+    () =>
+      [...agentSessions].sort((left, right) =>
+        compareBrowserSessionOptions(left, right, runtimeStatesBySessionId),
+      ),
+    [agentSessions, runtimeStatesBySessionId],
+  );
+  const hasAgentSessionBrowsers = sortedAgentSessions.length > 0;
+
+  const sessionBrowserStatus = useMemo(
+    () =>
+      browserSurfaceStatusSummary({
+        browserSpace,
+        controlMode: browserState.controlMode,
+        lifecycleState: browserState.lifecycleState,
+        runtimeState: currentRuntimeState,
+      }),
+    [
+      browserSpace,
+      browserState.controlMode,
+      browserState.lifecycleState,
+      currentRuntimeState,
+    ],
+  );
+
+  const currentSessionLabel = browserSessionTitle(
+    currentSession,
+    browserState.controlSessionId || browserState.sessionId,
+  );
 
   const openBrowserSpace = (space: BrowserSpaceId) => {
     if (!selectedWorkspaceId || space === browserSpace) {
@@ -34,6 +86,18 @@ export function SpaceBrowserExplorerPane({
   const openNewTab = () => {
     onActivateDisplay();
     void window.electronAPI.browser.newTab();
+  };
+
+  const selectAgentSessionBrowser = (value: string | null) => {
+    if (!selectedWorkspaceId || !value) {
+      return;
+    }
+    onActivateDisplay();
+    void window.electronAPI.browser.setActiveWorkspace(
+      selectedWorkspaceId,
+      "agent",
+      value,
+    );
   };
 
   return (
@@ -66,6 +130,88 @@ export function SpaceBrowserExplorerPane({
             </TabsTrigger>
           </TabsList>
         </Tabs>
+
+        {browserSpace === "agent" ? (
+          <div className="mt-2.5 flex items-center gap-1.5">
+            <Select
+              value={browserState.sessionId ?? undefined}
+              onValueChange={selectAgentSessionBrowser}
+              disabled={!hasAgentSessionBrowsers}
+            >
+              <SelectTrigger className="h-9 min-w-0 flex-1 basis-0 rounded-[11px] border-border/45 bg-card px-3 text-left text-xs font-medium shadow-none">
+                <SelectValue
+                  placeholder={
+                    hasAgentSessionBrowsers
+                      ? "Choose session browser"
+                      : "No session browsers"
+                  }
+                >
+                  {browserState.sessionId
+                    ? currentSessionLabel
+                    : hasAgentSessionBrowsers
+                      ? "Choose session browser"
+                      : "No session browsers"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start" className="p-1">
+                {sortedAgentSessions.map((session) => {
+                  const runtimeState =
+                    runtimeStatesBySessionId[session.session_id] ?? null;
+                  const isSelectedSession =
+                    (browserState.sessionId ?? "") === session.session_id;
+                  return (
+                    <SelectItem
+                      key={session.session_id}
+                      value={session.session_id}
+                      className="rounded-[11px] px-3 py-2 text-xs"
+                    >
+                      <span className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                        <span className="min-w-0 truncate font-medium text-foreground">
+                          {browserSessionTitle(session, session.session_id)}
+                        </span>
+                        {!isSelectedSession ? (
+                          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/85">
+                            {browserSessionStatusLabel(runtimeState)}
+                          </span>
+                        ) : null}
+                      </span>
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+
+            {sessionBrowserStatus ? (
+              <Badge
+                variant="secondary"
+                className={`shrink-0 gap-1 rounded-full px-1.5 py-0.5 text-[10px] ${
+                  sessionBrowserStatus.tone === "active"
+                    ? "border border-emerald-300/60 bg-emerald-500/12 text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200"
+                    : sessionBrowserStatus.tone === "waiting"
+                      ? "border border-amber-300/60 bg-amber-500/12 text-amber-700 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-100"
+                      : sessionBrowserStatus.tone === "paused"
+                        ? "border border-sky-300/60 bg-sky-500/12 text-sky-700 dark:border-sky-400/30 dark:bg-sky-500/10 dark:text-sky-100"
+                        : sessionBrowserStatus.tone === "error"
+                          ? "border border-rose-300/60 bg-rose-500/12 text-rose-700 dark:border-rose-400/35 dark:bg-rose-500/10 dark:text-rose-100"
+                          : ""
+                }`}
+              >
+                {sessionBrowserStatus.tone === "paused" ? (
+                  <Pause size={10} />
+                ) : (
+                  <span
+                    className={`inline-block size-2 rounded-full ${
+                      sessionBrowserStatus.flashing
+                        ? "animate-pulse bg-emerald-300"
+                        : "bg-current/80"
+                    }`}
+                  />
+                )}
+                {sessionBrowserStatus.label}
+              </Badge>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">

--- a/desktop/src/components/panes/SpreadsheetEditor.test.mjs
+++ b/desktop/src/components/panes/SpreadsheetEditor.test.mjs
@@ -10,14 +10,21 @@ const sourcePath = path.join(__dirname, "SpreadsheetEditor.tsx");
 test("spreadsheet editor preserves link metadata and opens sheet links through the browser callback", async () => {
   const source = await readFile(sourcePath, "utf8");
 
+  assert.match(source, /import type \{ MouseEvent \} from "react";/);
+  assert.match(source, /import \{ ArrowUpRight, Plus \} from "lucide-react";/);
   assert.match(source, /onOpenLinkInBrowser\?: \(url: string\) => void;/);
   assert.match(source, /function normalizeSpreadsheetCellLinkTarget\(/);
   assert.match(source, /function cloneTablePreviewSheetLinks\(/);
   assert.match(source, /links: cloneTablePreviewSheetLinks\(sheet\.links, sheet\.rows, sheet\.columns\),/);
   assert.match(source, /if \(onOpenLinkInBrowser\) \{\s*onOpenLinkInBrowser\(url\);\s*return;\s*\}/);
   assert.match(source, /window\.electronAPI\.ui\.openExternalUrl\(url\)/);
+  assert.match(source, /const maybeOpenEditableSpreadsheetCellLink = \(\s*event: MouseEvent<HTMLInputElement>,\s*url: string \| null,\s*\) => \{/);
+  assert.match(source, /if \(!url \|\| \(!event\.metaKey && !event\.ctrlKey\)\) \{\s*return;\s*\}/);
+  assert.match(source, /onClick=\{\(event\) =>\s*maybeOpenEditableSpreadsheetCellLink\(\s*event,\s*cellLink,\s*\)\s*\}/);
   assert.match(source, /nextLinks\[rowIndex\]\[columnIndex\] =\s*normalizeSpreadsheetCellLinkTarget\(value\);/);
   assert.match(source, /activeSheet\.links\?\.\[rowIndex\]\?\.\[columnIndex\] \?\?\s*normalizeSpreadsheetCellLinkTarget\(value\)/);
+  assert.match(source, /aria-label=\{`Open link from row \$\{rowIndex \+ 1\}, column \$\{columnIndex \+ 1\}`\}/);
+  assert.match(source, /<ArrowUpRight size=\{12\} \/>/);
   assert.match(source, /onClick=\{\(\) => openSpreadsheetCellLink\(cellLink\)\}/);
   assert.match(source, /text-primary underline underline-offset-2/);
 });

--- a/desktop/src/components/panes/SpreadsheetEditor.test.mjs
+++ b/desktop/src/components/panes/SpreadsheetEditor.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "SpreadsheetEditor.tsx");
+
+test("spreadsheet editor preserves link metadata and opens sheet links through the browser callback", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /onOpenLinkInBrowser\?: \(url: string\) => void;/);
+  assert.match(source, /function normalizeSpreadsheetCellLinkTarget\(/);
+  assert.match(source, /function cloneTablePreviewSheetLinks\(/);
+  assert.match(source, /links: cloneTablePreviewSheetLinks\(sheet\.links, sheet\.rows, sheet\.columns\),/);
+  assert.match(source, /if \(onOpenLinkInBrowser\) \{\s*onOpenLinkInBrowser\(url\);\s*return;\s*\}/);
+  assert.match(source, /window\.electronAPI\.ui\.openExternalUrl\(url\)/);
+  assert.match(source, /nextLinks\[rowIndex\]\[columnIndex\] =\s*normalizeSpreadsheetCellLinkTarget\(value\);/);
+  assert.match(source, /activeSheet\.links\?\.\[rowIndex\]\?\.\[columnIndex\] \?\?\s*normalizeSpreadsheetCellLinkTarget\(value\)/);
+  assert.match(source, /onClick=\{\(\) => openSpreadsheetCellLink\(cellLink\)\}/);
+  assert.match(source, /text-primary underline underline-offset-2/);
+});

--- a/desktop/src/components/panes/SpreadsheetEditor.tsx
+++ b/desktop/src/components/panes/SpreadsheetEditor.tsx
@@ -1,4 +1,5 @@
-import { Plus } from "lucide-react";
+import type { MouseEvent } from "react";
+import { ArrowUpRight, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface SpreadsheetEditorProps {
@@ -160,6 +161,17 @@ export function SpreadsheetEditor({
       return;
     }
     void window.electronAPI.ui.openExternalUrl(url);
+  };
+
+  const maybeOpenEditableSpreadsheetCellLink = (
+    event: MouseEvent<HTMLInputElement>,
+    url: string | null,
+  ) => {
+    if (!url || (!event.metaKey && !event.ctrlKey)) {
+      return;
+    }
+    event.preventDefault();
+    openSpreadsheetCellLink(url);
   };
 
   const updateHeaderValue = (columnIndex: number, value: string) => {
@@ -403,18 +415,41 @@ export function SpreadsheetEditor({
                         className="min-w-[164px] border-b border-r border-border px-0 py-0 align-top"
                       >
                         {editable ? (
-                          <input
-                            value={value}
-                            onChange={(event) =>
-                              updateCellValue(
-                                rowIndex,
-                                columnIndex,
-                                event.target.value,
-                              )
-                            }
-                            aria-label={`Row ${rowIndex + 1}, Column ${columnIndex + 1}`}
-                            className="embedded-input h-9 w-full border-0 bg-transparent px-3 text-xs text-foreground outline-none"
-                          />
+                          <div className="flex h-9 items-center gap-1 px-2">
+                            <input
+                              value={value}
+                              onChange={(event) =>
+                                updateCellValue(
+                                  rowIndex,
+                                  columnIndex,
+                                  event.target.value,
+                                )
+                              }
+                              onClick={(event) =>
+                                maybeOpenEditableSpreadsheetCellLink(
+                                  event,
+                                  cellLink,
+                                )
+                              }
+                              aria-label={`Row ${rowIndex + 1}, Column ${columnIndex + 1}`}
+                              className={`embedded-input h-full min-w-0 flex-1 border-0 bg-transparent px-1 text-xs outline-none ${
+                                cellLink
+                                  ? "text-primary underline underline-offset-2"
+                                  : "text-foreground"
+                              }`}
+                            />
+                            {cellLink ? (
+                              <button
+                                type="button"
+                                onClick={() => openSpreadsheetCellLink(cellLink)}
+                                aria-label={`Open link from row ${rowIndex + 1}, column ${columnIndex + 1}`}
+                                title={cellLink}
+                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-primary transition-colors hover:bg-primary/10 hover:text-primary/85"
+                              >
+                                <ArrowUpRight size={12} />
+                              </button>
+                            ) : null}
+                          </div>
                         ) : cellLink ? (
                           <button
                             type="button"

--- a/desktop/src/components/panes/SpreadsheetEditor.tsx
+++ b/desktop/src/components/panes/SpreadsheetEditor.tsx
@@ -8,6 +8,52 @@ interface SpreadsheetEditorProps {
   editable?: boolean;
   readOnlyReason?: string | null;
   onChange?: (sheets: FilePreviewTableSheetPayload[]) => void;
+  onOpenLinkInBrowser?: (url: string) => void;
+}
+
+function normalizeSpreadsheetCellLinkTarget(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("#")) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^localhost(?::\d+)?(?:[/?#]|$)/i.test(trimmed)) {
+    return `http://${trimmed}`;
+  }
+
+  if (
+    /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?:[/?#]|$)/.test(trimmed) ||
+    /^(?:www\.)?(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d+)?(?:[/?#]|$)/.test(
+      trimmed,
+    )
+  ) {
+    return /^www\./i.test(trimmed) ? `https://${trimmed}` : `https://${trimmed}`;
+  }
+
+  return null;
+}
+
+function cloneTablePreviewSheetLinks(
+  links: (string | null)[][] | null | undefined,
+  rows: string[][],
+  columns: string[],
+): (string | null)[][] {
+  return rows.map((row, rowIndex) =>
+    Array.from(
+      { length: Math.max(columns.length, row.length, 1) },
+      (_unused, columnIndex) =>
+        normalizeSpreadsheetCellLinkTarget(links?.[rowIndex]?.[columnIndex]) ??
+        null,
+    ),
+  );
 }
 
 export function cloneTablePreviewSheets(
@@ -18,6 +64,7 @@ export function cloneTablePreviewSheets(
         ...sheet,
         columns: [...sheet.columns],
         rows: sheet.rows.map((row) => [...row]),
+        links: cloneTablePreviewSheetLinks(sheet.links, sheet.rows, sheet.columns),
       }))
     : [];
 }
@@ -52,6 +99,24 @@ export function areTablePreviewSheetsEqual(
 
     return (
       sheet.columns.every((column, columnIndex) => column === candidate.columns[columnIndex]) &&
+      cloneTablePreviewSheetLinks(sheet.links, sheet.rows, sheet.columns).every(
+        (row, rowIndex) =>
+          row.length ===
+            cloneTablePreviewSheetLinks(
+              candidate.links,
+              candidate.rows,
+              candidate.columns,
+            )[rowIndex]?.length &&
+          row.every(
+            (value, columnIndex) =>
+              value ===
+              cloneTablePreviewSheetLinks(
+                candidate.links,
+                candidate.rows,
+                candidate.columns,
+              )[rowIndex]?.[columnIndex],
+          ),
+      ) &&
       sheet.rows.every(
         (row, rowIndex) =>
           row.length === candidate.rows[rowIndex]?.length &&
@@ -84,9 +149,18 @@ export function SpreadsheetEditor({
   editable = false,
   readOnlyReason = null,
   onChange,
+  onOpenLinkInBrowser,
 }: SpreadsheetEditorProps) {
   const activeSheet =
     sheets[Math.min(activeSheetIndex, Math.max(sheets.length - 1, 0))] ?? null;
+
+  const openSpreadsheetCellLink = (url: string) => {
+    if (onOpenLinkInBrowser) {
+      onOpenLinkInBrowser(url);
+      return;
+    }
+    void window.electronAPI.ui.openExternalUrl(url);
+  };
 
   const updateHeaderValue = (columnIndex: number, value: string) => {
     if (!editable || !onChange || !activeSheet) {
@@ -127,9 +201,20 @@ export function SpreadsheetEditor({
             nextRow.push("");
           }
           nextRows[rowIndex] = nextRow;
+          const nextLinks = cloneTablePreviewSheetLinks(
+            sheet.links,
+            nextRows,
+            sheet.columns,
+          );
+          nextLinks[rowIndex] = [
+            ...(nextLinks[rowIndex] ?? Array.from({ length: sheet.columns.length }, () => null)),
+          ];
+          nextLinks[rowIndex][columnIndex] =
+            normalizeSpreadsheetCellLinkTarget(value);
           return {
             ...sheet,
             rows: nextRows,
+            links: nextLinks,
           };
         },
         activeSheetIndex,
@@ -149,6 +234,10 @@ export function SpreadsheetEditor({
           rows: [
             ...sheet.rows,
             Array.from({ length: Math.max(sheet.columns.length, 1) }, () => ""),
+          ],
+          links: [
+            ...cloneTablePreviewSheetLinks(sheet.links, sheet.rows, sheet.columns),
+            Array.from({ length: Math.max(sheet.columns.length, 1) }, () => null),
           ],
           totalRows: Math.max(sheet.totalRows + 1, sheet.rows.length + 1),
         }),
@@ -170,10 +259,16 @@ export function SpreadsheetEditor({
             nextSpreadsheetColumnName(sheet.columns.length),
           ];
           const nextRows = sheet.rows.map((row) => [...row, ""]);
+          const nextLinks = cloneTablePreviewSheetLinks(
+            sheet.links,
+            nextRows,
+            nextColumns,
+          );
           return {
             ...sheet,
             columns: nextColumns,
             rows: nextRows,
+            links: nextLinks,
             totalColumns: Math.max(
               sheet.totalColumns + 1,
               sheet.columns.length + 1,
@@ -299,6 +394,9 @@ export function SpreadsheetEditor({
                   </td>
                   {activeSheet.columns.map((_column, columnIndex) => {
                     const value = row[columnIndex] ?? "";
+                    const cellLink =
+                      activeSheet.links?.[rowIndex]?.[columnIndex] ??
+                      normalizeSpreadsheetCellLinkTarget(value);
                     return (
                       <td
                         key={`cell-${rowIndex}-${columnIndex}`}
@@ -317,6 +415,15 @@ export function SpreadsheetEditor({
                             aria-label={`Row ${rowIndex + 1}, Column ${columnIndex + 1}`}
                             className="embedded-input h-9 w-full border-0 bg-transparent px-3 text-xs text-foreground outline-none"
                           />
+                        ) : cellLink ? (
+                          <button
+                            type="button"
+                            onClick={() => openSpreadsheetCellLink(cellLink)}
+                            title={cellLink}
+                            className="block h-full w-full cursor-pointer bg-transparent px-3 py-2 text-left text-xs break-words whitespace-pre-wrap text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
+                          >
+                            {value || cellLink}
+                          </button>
                         ) : (
                           <div className="px-3 py-2 break-words whitespace-pre-wrap">
                             {value || "\u00a0"}

--- a/desktop/src/components/panes/browserSessionUi.ts
+++ b/desktop/src/components/panes/browserSessionUi.ts
@@ -1,0 +1,185 @@
+const ACTIVE_BROWSER_SESSION_STATUSES = new Set(["BUSY", "QUEUED", "PAUSING"]);
+
+function normalizedRuntimeStatus(
+  runtimeState: SessionRuntimeRecordPayload | null | undefined,
+): string {
+  return runtimeState?.status?.trim().toUpperCase() ?? "";
+}
+
+export function browserSessionTitle(
+  session: AgentSessionRecordPayload | null | undefined,
+  sessionId?: string | null,
+): string {
+  const explicitTitle = session?.title?.trim();
+  if (explicitTitle) {
+    return explicitTitle;
+  }
+  const kind = session?.kind?.trim();
+  const suffix = typeof sessionId === "string" && sessionId.trim()
+    ? sessionId.trim().slice(0, 8)
+    : "browser";
+  if (kind === "sub_session") {
+    return `Sub-session ${suffix}`;
+  }
+  if (kind === "cronjob") {
+    return `Cronjob ${suffix}`;
+  }
+  return `Session ${suffix}`;
+}
+
+export function browserSessionStatusLabel(
+  runtimeState: SessionRuntimeRecordPayload | null | undefined,
+): string {
+  const status = normalizedRuntimeStatus(runtimeState);
+  if (ACTIVE_BROWSER_SESSION_STATUSES.has(status)) {
+    return "Operating";
+  }
+  if (status === "WAITING_USER") {
+    return "Waiting";
+  }
+  if (status === "PAUSED") {
+    return "Paused";
+  }
+  if (status === "ERROR") {
+    return "Error";
+  }
+  return "Idle";
+}
+
+export function compareBrowserSessionOptions(
+  left: AgentSessionRecordPayload,
+  right: AgentSessionRecordPayload,
+  runtimeStatesBySessionId: Record<string, SessionRuntimeRecordPayload>,
+): number {
+  const leftPriority = browserSessionPriority(
+    runtimeStatesBySessionId[left.session_id] ?? null,
+  );
+  const rightPriority = browserSessionPriority(
+    runtimeStatesBySessionId[right.session_id] ?? null,
+  );
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+  return (
+    new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime()
+  );
+}
+
+function browserSessionPriority(
+  runtimeState: SessionRuntimeRecordPayload | null | undefined,
+): number {
+  const status = normalizedRuntimeStatus(runtimeState);
+  if (ACTIVE_BROWSER_SESSION_STATUSES.has(status)) {
+    return 0;
+  }
+  if (status === "WAITING_USER") {
+    return 1;
+  }
+  if (status === "PAUSED") {
+    return 2;
+  }
+  return 3;
+}
+
+export function browserSurfaceStatusSummary(params: {
+  browserSpace: BrowserSpaceId;
+  controlMode: BrowserTabListPayload["controlMode"];
+  lifecycleState: BrowserTabListPayload["lifecycleState"];
+  runtimeState: SessionRuntimeRecordPayload | null;
+}): {
+  label: string;
+  detail: string;
+  tone: "idle" | "active" | "waiting" | "paused" | "error";
+  flashing: boolean;
+} | null {
+  const runtimeStatus = normalizedRuntimeStatus(params.runtimeState);
+  const waiting =
+    runtimeStatus === "WAITING_USER" ||
+    params.runtimeState?.last_turn_status?.trim().toLowerCase() === "waiting_user";
+  const paused =
+    runtimeStatus === "PAUSED" ||
+    params.runtimeState?.last_turn_status?.trim().toLowerCase() === "paused";
+  const errored =
+    runtimeStatus === "ERROR" ||
+    params.runtimeState?.last_turn_status?.trim().toLowerCase() === "error" ||
+    params.runtimeState?.last_turn_status?.trim().toLowerCase() === "failed";
+  const active = ACTIVE_BROWSER_SESSION_STATUSES.has(runtimeStatus);
+
+  if (active) {
+    return {
+      label: "Active",
+      detail:
+        params.browserSpace === "user"
+          ? "Your input will ask for confirmation before interrupting this session."
+          : "This session currently controls its own browser surface.",
+      tone: "active",
+      flashing: true,
+    };
+  }
+
+  if (waiting) {
+    return {
+      label: "Waiting",
+      detail:
+        params.browserSpace === "user"
+          ? "The shared user browser is still owned by this session until it is interrupted or the lock expires."
+          : "The session browser is warm and ready to continue.",
+      tone: "waiting",
+      flashing: false,
+    };
+  }
+
+  if (paused) {
+    return {
+      label: "Paused",
+      detail:
+        params.browserSpace === "user"
+          ? "The session was paused and user takeover is available."
+          : "This session browser can be resumed later.",
+      tone: "paused",
+      flashing: false,
+    };
+  }
+
+  if (errored) {
+    return {
+      label: "Error",
+      detail:
+        params.browserSpace === "user"
+          ? "The session encountered an error while controlling the shared browser."
+          : "The session browser remains available for inspection.",
+      tone: "error",
+      flashing: false,
+    };
+  }
+
+  if (params.lifecycleState === "suspended") {
+    return {
+      label: "Sleeping",
+      detail: "Tabs were serialized and will be rehydrated when this session is reopened.",
+      tone: "idle",
+      flashing: false,
+    };
+  }
+
+  if (params.controlMode === "user_locked") {
+    return {
+      label: "Locked",
+      detail:
+        "The shared user browser is reserved for one session. Interaction will ask before interrupting it.",
+      tone: "waiting",
+      flashing: false,
+    };
+  }
+
+  if (params.controlMode === "session_owned") {
+    return {
+      label: "Ready",
+      detail: "Choose a different agent session to inspect another browser surface.",
+      tone: "idle",
+      flashing: false,
+    };
+  }
+
+  return null;
+}

--- a/desktop/src/components/panes/useBrowserGlowPreview.ts
+++ b/desktop/src/components/panes/useBrowserGlowPreview.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+const BROWSER_GLOW_PREVIEW_EVENT = "holaboss:browser-glow-preview-change";
+
+declare global {
+  interface Window {
+    __holabossBrowserGlowPreviewEnabled?: boolean;
+    __holabossDevBrowserGlowPreview?: {
+      on: () => void;
+      off: () => void;
+      toggle: () => void;
+      set: (next: boolean) => void;
+      get: () => boolean;
+    };
+  }
+}
+
+function setBrowserGlowPreviewEnabled(next: boolean) {
+  window.__holabossBrowserGlowPreviewEnabled = next;
+  window.dispatchEvent(
+    new CustomEvent(BROWSER_GLOW_PREVIEW_EVENT, {
+      detail: next,
+    }),
+  );
+}
+
+export function useBrowserGlowPreview() {
+  const [enabled, setEnabled] = useState(
+    () => window.__holabossBrowserGlowPreviewEnabled === true,
+  );
+
+  useEffect(() => {
+    const applyCurrentState = () => {
+      setEnabled(window.__holabossBrowserGlowPreviewEnabled === true);
+    };
+
+    const handlePreviewChange = () => {
+      applyCurrentState();
+    };
+
+    applyCurrentState();
+    window.addEventListener(
+      BROWSER_GLOW_PREVIEW_EVENT,
+      handlePreviewChange as EventListener,
+    );
+    window.__holabossDevBrowserGlowPreview = {
+      on: () => setBrowserGlowPreviewEnabled(true),
+      off: () => setBrowserGlowPreviewEnabled(false),
+      toggle: () =>
+        setBrowserGlowPreviewEnabled(
+          window.__holabossBrowserGlowPreviewEnabled !== true,
+        ),
+      set: (next: boolean) => setBrowserGlowPreviewEnabled(next),
+      get: () => window.__holabossBrowserGlowPreviewEnabled === true,
+    };
+
+    return () => {
+      window.removeEventListener(
+        BROWSER_GLOW_PREVIEW_EVENT,
+        handlePreviewChange as EventListener,
+      );
+    };
+  }, []);
+
+  return enabled;
+}

--- a/desktop/src/components/panes/useWorkspaceBrowser.ts
+++ b/desktop/src/components/panes/useWorkspaceBrowser.ts
@@ -21,12 +21,29 @@ function initialBrowserState(space: BrowserSpaceId): BrowserTabListPayload {
       user: 0,
       agent: 0,
     },
+    sessionId: null,
+    lifecycleState: null,
+    controlMode: "none",
+    controlSessionId: null,
   };
 }
 
 interface UseWorkspaceBrowserOptions {
   includeDownloads?: boolean;
   includeHistory?: boolean;
+  includeSessions?: boolean;
+}
+
+const BROWSER_SESSION_POLL_INTERVAL_MS = 2000;
+
+function runtimeStateIndex(
+  items: SessionRuntimeRecordPayload[],
+): Record<string, SessionRuntimeRecordPayload> {
+  return Object.fromEntries(
+    items
+      .filter((item) => Boolean(item.session_id.trim()))
+      .map((item) => [item.session_id, item]),
+  );
 }
 
 export function useWorkspaceBrowser(
@@ -42,6 +59,12 @@ export function useWorkspaceBrowser(
   const [historyEntries, setHistoryEntries] = useState<
     BrowserHistoryEntryPayload[]
   >([]);
+  const [agentSessions, setAgentSessions] = useState<AgentSessionRecordPayload[]>(
+    [],
+  );
+  const [runtimeStatesBySessionId, setRuntimeStatesBySessionId] = useState<
+    Record<string, SessionRuntimeRecordPayload>
+  >({});
 
   useEffect(() => {
     let mounted = true;
@@ -133,6 +156,53 @@ export function useWorkspaceBrowser(
     };
   }, [options?.includeDownloads, options?.includeHistory, selectedWorkspaceId]);
 
+  useEffect(() => {
+    if (!options?.includeSessions) {
+      setAgentSessions([]);
+      setRuntimeStatesBySessionId({});
+      return;
+    }
+    if (!selectedWorkspaceId) {
+      setAgentSessions([]);
+      setRuntimeStatesBySessionId({});
+      return;
+    }
+
+    let cancelled = false;
+    let requestInFlight = false;
+
+    const loadSessionState = async () => {
+      if (requestInFlight) {
+        return;
+      }
+      requestInFlight = true;
+      try {
+        const [sessionsResponse, runtimeStatesResponse] = await Promise.all([
+          window.electronAPI.workspace.listAgentSessions(selectedWorkspaceId),
+          window.electronAPI.workspace.listRuntimeStates(selectedWorkspaceId),
+        ]);
+        if (cancelled) {
+          return;
+        }
+        setAgentSessions(sessionsResponse.items);
+        setRuntimeStatesBySessionId(runtimeStateIndex(runtimeStatesResponse.items));
+      } finally {
+        requestInFlight = false;
+      }
+    };
+
+    void loadSessionState();
+    const intervalId = window.setInterval(
+      () => void loadSessionState(),
+      BROWSER_SESSION_POLL_INTERVAL_MS,
+    );
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [options?.includeSessions, selectedWorkspaceId]);
+
   const activeTab = useMemo(
     () =>
       browserState.tabs.find((tab) => tab.id === browserState.activeTabId) ??
@@ -146,6 +216,26 @@ export function useWorkspaceBrowser(
     [activeTab.url, bookmarks],
   );
 
+  const currentSessionId = useMemo(
+    () => browserState.controlSessionId || browserState.sessionId || null,
+    [browserState.controlSessionId, browserState.sessionId],
+  );
+
+  const currentSession = useMemo(
+    () =>
+      currentSessionId
+        ? agentSessions.find((session) => session.session_id === currentSessionId) ??
+          null
+        : null,
+    [agentSessions, currentSessionId],
+  );
+
+  const currentRuntimeState = useMemo(
+    () =>
+      currentSessionId ? runtimeStatesBySessionId[currentSessionId] ?? null : null,
+    [currentSessionId, runtimeStatesBySessionId],
+  );
+
   return {
     selectedWorkspaceId,
     browserState,
@@ -155,5 +245,10 @@ export function useWorkspaceBrowser(
     historyEntries,
     activeBookmark,
     isBookmarked: Boolean(activeBookmark),
+    agentSessions,
+    runtimeStatesBySessionId,
+    currentSessionId,
+    currentSession,
+    currentRuntimeState,
   };
 }

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -218,6 +218,51 @@ body {
   box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.1);
 }
 
+@keyframes holaboss-browser-active-glow {
+  0%,
+  100% {
+    box-shadow:
+      0 0 24px color-mix(in oklch, var(--primary) 28%, transparent),
+      inset 0 0 32px color-mix(in oklch, var(--primary) 12%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 44px color-mix(in oklch, var(--primary) 56%, transparent),
+      inset 0 0 72px color-mix(in oklch, var(--primary) 24%, transparent);
+  }
+}
+
+@keyframes holaboss-browser-active-frame {
+  0%,
+  100% {
+    opacity: 0.62;
+    box-shadow:
+      inset 0 0 18px color-mix(in oklch, var(--primary) 14%, transparent);
+  }
+  50% {
+    opacity: 0.96;
+    box-shadow:
+      inset 0 0 38px color-mix(in oklch, var(--primary) 30%, transparent);
+  }
+}
+
+.browser-active-glow {
+  will-change: box-shadow;
+  animation: holaboss-browser-active-glow 2.8s ease-in-out infinite;
+}
+
+.browser-active-glow-frame {
+  will-change: opacity, box-shadow;
+  animation: holaboss-browser-active-frame 2.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .browser-active-glow,
+  .browser-active-glow-frame {
+    animation: none;
+  }
+}
+
 /* ---- Focus ---- */
 
 :where(

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -145,6 +145,10 @@ declare global {
     activeTabId: string;
     tabs: BrowserStatePayload[];
     tabCounts: BrowserTabCountsPayload;
+    sessionId: string | null;
+    lifecycleState: "active" | "suspended" | null;
+    controlMode: "none" | "user_locked" | "session_owned";
+    controlSessionId: string | null;
   }
 
   interface BrowserBookmarkPayload {
@@ -293,6 +297,7 @@ declare global {
     workspaceId?: string | null;
     url?: string | null;
     space?: BrowserSpaceId | null;
+    sessionId?: string | null;
   }
 
   interface TemplateAgentInfoPayload {
@@ -1494,7 +1499,11 @@ declare global {
       onError: (callback: (context: AuthErrorPayload) => unknown) => () => void;
     };
     browser: {
-      setActiveWorkspace: (workspaceId?: string | null, space?: BrowserSpaceId | null) => Promise<BrowserTabListPayload>;
+      setActiveWorkspace: (
+        workspaceId?: string | null,
+        space?: BrowserSpaceId | null,
+        sessionId?: string | null,
+      ) => Promise<BrowserTabListPayload>;
       getState: () => Promise<BrowserTabListPayload>;
       setBounds: (bounds: BrowserBoundsPayload) => Promise<BrowserTabListPayload>;
       navigate: (targetUrl: string) => Promise<BrowserTabListPayload>;

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -22,6 +22,7 @@ declare global {
     index: number;
     columns: string[];
     rows: string[][];
+    links?: (string | null)[][];
     totalRows: number;
     totalColumns: number;
     truncated: boolean;

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -238,17 +238,23 @@ test("browser capability routes proxy to the browser tool service", async () => 
     workspaceRoot: path.join(root, "workspace")
   });
   const browserToolService = {
-    async getStatus(context?: { workspaceId?: string | null }) {
+    async getStatus(context?: { workspaceId?: string | null; sessionId?: string | null }) {
       return {
         available: true,
         workspace_id: context?.workspaceId ?? null,
+        session_id: context?.sessionId ?? null,
         tools: [{ id: "browser_get_state" }]
       };
     },
-    async execute(toolId: string, args: Record<string, unknown>, context?: { workspaceId?: string | null }) {
+    async execute(
+      toolId: string,
+      args: Record<string, unknown>,
+      context?: { workspaceId?: string | null; sessionId?: string | null }
+    ) {
       return {
         tool_id: toolId,
         workspace_id: context?.workspaceId ?? null,
+        session_id: context?.sessionId ?? null,
         args
       };
     }
@@ -259,13 +265,15 @@ test("browser capability routes proxy to the browser tool service", async () => 
     method: "GET",
     url: "/api/v1/capabilities/browser",
     headers: {
-      "x-holaboss-workspace-id": "workspace-1"
+      "x-holaboss-workspace-id": "workspace-1",
+      "x-holaboss-session-id": "session-1"
     }
   });
   assert.equal(statusResponse.statusCode, 200);
   assert.deepEqual(statusResponse.json(), {
     available: true,
     workspace_id: "workspace-1",
+    session_id: "session-1",
     tools: [{ id: "browser_get_state" }]
   });
 
@@ -273,7 +281,8 @@ test("browser capability routes proxy to the browser tool service", async () => 
     method: "POST",
     url: "/api/v1/capabilities/browser/tools/browser_click",
     headers: {
-      "x-holaboss-workspace-id": "workspace-1"
+      "x-holaboss-workspace-id": "workspace-1",
+      "x-holaboss-session-id": "session-1"
     },
     payload: {
       index: 3
@@ -283,6 +292,7 @@ test("browser capability routes proxy to the browser tool service", async () => 
   assert.deepEqual(executeResponse.json(), {
     tool_id: "browser_click",
     workspace_id: "workspace-1",
+    session_id: "session-1",
     args: {
       index: 3
     }

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -2705,8 +2705,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
   app.get("/api/v1/capabilities/browser", async (request, reply) => {
     const workspaceId = headerString(request.headers as Record<string, unknown>, "x-holaboss-workspace-id");
+    const sessionId = capabilitySessionId({
+      headers: request.headers as Record<string, unknown>,
+      query: isRecord(request.query) ? request.query : null,
+    });
     try {
-      return await browserToolService.getStatus({ workspaceId });
+      return await browserToolService.getStatus({ workspaceId, sessionId });
     } catch (error) {
       if (error instanceof DesktopBrowserToolServiceError) {
         return sendError(reply, error.statusCode, error.message);
@@ -2721,8 +2725,16 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { toolId: string };
     const workspaceId = headerString(request.headers as Record<string, unknown>, "x-holaboss-workspace-id");
+    const sessionId = capabilitySessionId({
+      headers: request.headers as Record<string, unknown>,
+      body: request.body,
+    });
     try {
-      return await browserToolService.execute(requiredString(params.toolId, "toolId"), request.body, { workspaceId });
+      return await browserToolService.execute(
+        requiredString(params.toolId, "toolId"),
+        request.body,
+        { workspaceId, sessionId },
+      );
     } catch (error) {
       if (error instanceof DesktopBrowserToolServiceError) {
         return sendError(reply, error.statusCode, error.message);

--- a/runtime/api-server/src/desktop-browser-tools.test.ts
+++ b/runtime/api-server/src/desktop-browser-tools.test.ts
@@ -55,8 +55,8 @@ test("desktop browser tool service reports unavailable when runtime lacks browse
   assert.equal(Array.isArray(status.tools), true);
 });
 
-test("desktop browser tool service executes browser_get_state against the desktop browser service", async () => {
-  const requests: Array<{ path: string; token: string; workspaceId: string; body: string }> = [];
+test("desktop browser tool service forwards workspace and session context to the desktop browser service", async () => {
+  const requests: Array<{ path: string; token: string; workspaceId: string; sessionId: string; body: string }> = [];
   const browserServer = await startBrowserServer(async (request, response) => {
     const chunks: Buffer[] = [];
     for await (const chunk of request) {
@@ -67,6 +67,7 @@ test("desktop browser tool service executes browser_get_state against the deskto
       path: request.url ?? "",
       token: String(request.headers["x-holaboss-desktop-token"] ?? ""),
       workspaceId: String(request.headers["x-holaboss-workspace-id"] ?? ""),
+      sessionId: String(request.headers["x-holaboss-session-id"] ?? ""),
       body
     });
     response.setHeader("content-type", "application/json; charset=utf-8");
@@ -129,7 +130,11 @@ test("desktop browser tool service executes browser_get_state against the deskto
       })
     });
 
-    const result = await service.execute("browser_get_state", { include_screenshot: true }, { workspaceId: "workspace-1" });
+    const result = await service.execute(
+      "browser_get_state",
+      { include_screenshot: true },
+      { workspaceId: "workspace-1", sessionId: "session-1" }
+    );
     assert.deepEqual(result, {
       ok: true,
       page: { tabId: "tab-1", url: "https://example.com", title: "Example" },
@@ -150,11 +155,11 @@ test("desktop browser tool service executes browser_get_state against the deskto
       }
     });
     assert.deepEqual(
-      requests.map((entry) => [entry.path, entry.token, entry.workspaceId]),
+      requests.map((entry) => [entry.path, entry.token, entry.workspaceId, entry.sessionId]),
       [
-        ["/api/v1/browser/page", "browser-token", "workspace-1"],
-        ["/api/v1/browser/evaluate", "browser-token", "workspace-1"],
-        ["/api/v1/browser/screenshot", "browser-token", "workspace-1"]
+        ["/api/v1/browser/page", "browser-token", "workspace-1", "session-1"],
+        ["/api/v1/browser/evaluate", "browser-token", "workspace-1", "session-1"],
+        ["/api/v1/browser/screenshot", "browser-token", "workspace-1", "session-1"]
       ]
     );
   } finally {
@@ -163,7 +168,7 @@ test("desktop browser tool service executes browser_get_state against the deskto
 });
 
 test("desktop browser tool service executes browser_open_tab against the desktop browser service", async () => {
-  const requests: Array<{ path: string; token: string; workspaceId: string; body: string }> = [];
+  const requests: Array<{ path: string; token: string; workspaceId: string; sessionId: string; body: string }> = [];
   const browserServer = await startBrowserServer(async (request, response) => {
     const chunks: Buffer[] = [];
     for await (const chunk of request) {
@@ -174,6 +179,7 @@ test("desktop browser tool service executes browser_open_tab against the desktop
       path: request.url ?? "",
       token: String(request.headers["x-holaboss-desktop-token"] ?? ""),
       workspaceId: String(request.headers["x-holaboss-workspace-id"] ?? ""),
+      sessionId: String(request.headers["x-holaboss-session-id"] ?? ""),
       body
     });
     response.setHeader("content-type", "application/json; charset=utf-8");
@@ -232,6 +238,7 @@ test("desktop browser tool service executes browser_open_tab against the desktop
         path: "/api/v1/browser/tabs",
         token: "browser-token",
         workspaceId: "workspace-1",
+        sessionId: "",
         body: JSON.stringify({ url: "https://example.org", background: true })
       }
     ]);

--- a/runtime/api-server/src/desktop-browser-tools.ts
+++ b/runtime/api-server/src/desktop-browser-tools.ts
@@ -15,6 +15,8 @@ export {
 
 export interface DesktopBrowserToolExecutionContext {
   workspaceId?: string | null;
+  sessionId?: string | null;
+  space?: "agent" | "user" | null;
 }
 
 export interface DesktopBrowserToolServiceLike {
@@ -36,6 +38,8 @@ type BrowserFetchOptions = {
   path: string;
   body?: Record<string, unknown>;
   workspaceId?: string | null;
+  sessionId?: string | null;
+  space?: "agent" | "user" | null;
 };
 
 const INTERACTIVE_ELEMENTS_SELECTOR = [
@@ -111,6 +115,15 @@ function browserToolHeaders(
   const workspaceId = typeof context.workspaceId === "string" ? context.workspaceId.trim() : "";
   if (workspaceId) {
     headers["x-holaboss-workspace-id"] = workspaceId;
+  }
+  const sessionId = typeof context.sessionId === "string" ? context.sessionId.trim() : "";
+  if (sessionId) {
+    headers["x-holaboss-session-id"] = sessionId;
+  }
+  const browserSpace =
+    context.space === "user" || context.space === "agent" ? context.space : "";
+  if (browserSpace) {
+    headers["x-holaboss-browser-space"] = browserSpace;
   }
   return headers;
 }
@@ -333,7 +346,13 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
     let reachable = false;
     if (configured) {
       try {
-        await this.#browserFetch(config, { method: "GET", path: "/health", workspaceId: context.workspaceId });
+        await this.#browserFetch(config, {
+          method: "GET",
+          path: "/health",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         reachable = true;
       } catch {
         reachable = false;
@@ -368,7 +387,9 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
           method: "POST",
           path: "/navigate",
           body: { url },
-          workspaceId: context.workspaceId
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
         });
         return { ok: true, navigation: result };
       }
@@ -381,12 +402,20 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
             url,
             background: optionalBoolean(args.background, false)
           },
-          workspaceId: context.workspaceId
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
         });
         return { ok: true, tabs: result };
       }
       case "browser_get_state": {
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         const state = await this.#evaluate(config, interactiveElementsExpression(), context);
         const payload: Record<string, unknown> = {
           ok: true,
@@ -398,7 +427,9 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
             method: "POST",
             path: "/screenshot",
             body: { format: "png" },
-            workspaceId: context.workspaceId
+            workspaceId: context.workspaceId,
+            sessionId: context.sessionId,
+            space: context.space,
           });
         }
         return payload;
@@ -406,7 +437,13 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
       case "browser_click": {
         const index = requiredPositiveInteger(args.index, "index");
         const result = await this.#evaluate(config, clickExpression(index), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_type": {
@@ -422,13 +459,25 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
           }),
           context
         );
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_press": {
         const key = requiredString(args.key, "key");
         const result = await this.#evaluate(config, pressExpression(key), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_scroll": {
@@ -437,22 +486,45 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
         const direction = args.direction === "up" ? "up" : "down";
         const deltaY = explicitDelta ?? (direction === "up" ? -Math.abs(amount) : Math.abs(amount));
         const result = await this.#evaluate(config, scrollExpression(deltaY), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_back": {
         const result = await this.#evaluate(config, historyExpression("back"), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_forward": {
         const result = await this.#evaluate(config, historyExpression("forward"), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+          space: context.space,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_reload": {
         const result = await this.#evaluate(config, reloadExpression(), context);
-        const page = await this.#browserFetch(config, { method: "GET", path: "/page", workspaceId: context.workspaceId });
+        const page = await this.#browserFetch(config, {
+          method: "GET",
+          path: "/page",
+          workspaceId: context.workspaceId,
+          sessionId: context.sessionId,
+        });
         return { ok: true, action: result, page };
       }
       case "browser_screenshot": {
@@ -467,14 +539,22 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
               format,
               ...(quality !== null ? { quality } : {})
             },
-            workspaceId: context.workspaceId
+            workspaceId: context.workspaceId,
+            sessionId: context.sessionId,
+            space: context.space,
           })
         };
       }
       case "browser_list_tabs": {
         return {
           ok: true,
-          tabs: await this.#browserFetch(config, { method: "GET", path: "/tabs", workspaceId: context.workspaceId })
+          tabs: await this.#browserFetch(config, {
+            method: "GET",
+            path: "/tabs",
+            workspaceId: context.workspaceId,
+            sessionId: context.sessionId,
+            space: context.space,
+          })
         };
       }
     }
@@ -489,7 +569,9 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
       method: "POST",
       path: "/evaluate",
       body: evaluateExpressionPayload(expression),
-      workspaceId: context.workspaceId
+      workspaceId: context.workspaceId,
+      sessionId: context.sessionId,
+      space: context.space,
     });
     const payload = asRecord(response);
     return asRecord(payload?.result) ?? {};
@@ -499,7 +581,10 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
     const requestUrl = `${browserBaseUrl(config)}${options.path}`;
     const response = await this.#fetch(requestUrl, {
       method: options.method,
-      headers: browserToolHeaders(config, { workspaceId: options.workspaceId }),
+      headers: browserToolHeaders(config, {
+        workspaceId: options.workspaceId,
+        sessionId: options.sessionId,
+      }),
       body: options.body ? JSON.stringify(options.body) : undefined
     });
     let payload: unknown = null;

--- a/runtime/api-server/src/runtime-config.test.ts
+++ b/runtime/api-server/src/runtime-config.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, test } from "node:test";
 
-import { FileRuntimeConfigService, runtimeConfigHeaders } from "./runtime-config.js";
+import {
+  FileRuntimeConfigService,
+  resolveProductRuntimeConfig,
+  runtimeConfigHeaders,
+} from "./runtime-config.js";
 
 const tempDirs: string[] = [];
 const envNames = [
@@ -14,6 +18,9 @@ const envNames = [
   "HOLABOSS_USER_ID",
   "HOLABOSS_MODEL_PROXY_BASE_URL",
   "HOLABOSS_DEFAULT_MODEL",
+  "HOLABOSS_DESKTOP_BROWSER_ENABLED",
+  "HOLABOSS_DESKTOP_BROWSER_URL",
+  "HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN",
   "SANDBOX_AGENT_HARNESS"
 ] as const;
 
@@ -206,6 +213,38 @@ test("file runtime config service treats pi harness as ready without extra harne
     browser_state: "unavailable",
     browser_url: null
   });
+});
+
+test("runtime config prefers live embedded desktop browser capability env over stale file state", () => {
+  const root = makeTempDir("hb-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = path.join(root, "state", "runtime-config.json");
+  process.env.HOLABOSS_DESKTOP_BROWSER_ENABLED = "true";
+  process.env.HOLABOSS_DESKTOP_BROWSER_URL = "http://127.0.0.1:8787/api/v1/browser";
+  process.env.HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN = "browser-token";
+
+  fs.mkdirSync(path.join(root, "state"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "state", "runtime-config.json"),
+    `${JSON.stringify({
+      capabilities: {
+        desktop_browser: {
+          enabled: false
+        }
+      }
+    }, null, 2)}\n`,
+    "utf8"
+  );
+
+  const config = resolveProductRuntimeConfig({
+    requireAuth: false,
+    requireUser: false,
+    requireBaseUrl: false
+  });
+
+  assert.equal(config.desktopBrowserEnabled, true);
+  assert.equal(config.desktopBrowserUrl, "http://127.0.0.1:8787/api/v1/browser");
+  assert.equal(config.desktopBrowserAuthToken, "browser-token");
 });
 
 test("runtime config headers reuse the shared runtime config parser", () => {

--- a/runtime/api-server/src/runtime-config.ts
+++ b/runtime/api-server/src/runtime-config.ts
@@ -11,6 +11,9 @@ const HOLABOSS_SANDBOX_AUTH_TOKEN_ENV = "HOLABOSS_SANDBOX_AUTH_TOKEN";
 const HOLABOSS_USER_ID_ENV = "HOLABOSS_USER_ID";
 const HOLABOSS_DEFAULT_MODEL_ENV = "HOLABOSS_DEFAULT_MODEL";
 const HOLABOSS_RUNTIME_CONFIG_PATH_ENV = "HOLABOSS_RUNTIME_CONFIG_PATH";
+const HOLABOSS_DESKTOP_BROWSER_ENABLED_ENV = "HOLABOSS_DESKTOP_BROWSER_ENABLED";
+const HOLABOSS_DESKTOP_BROWSER_URL_ENV = "HOLABOSS_DESKTOP_BROWSER_URL";
+const HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN_ENV = "HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN";
 const HB_SANDBOX_ROOT_ENV = "HB_SANDBOX_ROOT";
 const SANDBOX_AGENT_HARNESS_ENV = "SANDBOX_AGENT_HARNESS";
 
@@ -173,11 +176,22 @@ function loadRuntimeConfigPayload(): {
   const holabossEnabled =
     explicitHolabossEnabled ??
     Boolean(authToken || userId || modelProxyBaseUrl || defaultProvider === HOLABOSS_PROXY_PROVIDER);
+  const envDesktopBrowserEnabled = normalizeBool(
+    firstEnvValue(HOLABOSS_DESKTOP_BROWSER_ENABLED_ENV)
+  );
+  const envDesktopBrowserUrl = firstEnvValue(HOLABOSS_DESKTOP_BROWSER_URL_ENV);
+  const envDesktopBrowserAuthToken = firstEnvValue(HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN_ENV);
   const explicitDesktopBrowserEnabled = normalizeBool(desktopBrowserCapability.enabled);
-  const desktopBrowserEnabled = explicitDesktopBrowserEnabled ?? false;
+  const desktopBrowserEnabled =
+    envDesktopBrowserEnabled ??
+    explicitDesktopBrowserEnabled ??
+    Boolean(envDesktopBrowserUrl && envDesktopBrowserAuthToken);
   const desktopBrowserUrl =
-    normalizeString(desktopBrowserCapability.url) || normalizeString(desktopBrowserCapability.mcp_url);
-  const desktopBrowserAuthToken = normalizeString(desktopBrowserCapability.auth_token);
+    envDesktopBrowserUrl ||
+    normalizeString(desktopBrowserCapability.url) ||
+    normalizeString(desktopBrowserCapability.mcp_url);
+  const desktopBrowserAuthToken =
+    envDesktopBrowserAuthToken || normalizeString(desktopBrowserCapability.auth_token);
   const runtimeMode =
     normalizeString(runtimePayload.mode) || (holabossEnabled ? "product" : DEFAULT_RUNTIME_MODE);
 

--- a/runtime/harness-host/src/pi-browser-tools.test.ts
+++ b/runtime/harness-host/src/pi-browser-tools.test.ts
@@ -28,7 +28,7 @@ test("resolvePiDesktopBrowserToolDefinitions returns an empty tool list when bro
 });
 
 test("Pi desktop browser tools execute through the runtime capability API", async () => {
-  const requests: Array<{ method: string; url: string; workspaceId: string; body: string }> = [];
+  const requests: Array<{ method: string; url: string; workspaceId: string; sessionId: string; body: string }> = [];
   const fetchImpl: typeof fetch = async (input, init) => {
     const url = String(input);
     if (url.endsWith("/api/v1/capabilities/browser")) {
@@ -43,6 +43,7 @@ test("Pi desktop browser tools execute through the runtime capability API", asyn
       method: String(init?.method ?? "GET"),
       url,
       workspaceId: String((init?.headers as Record<string, string> | undefined)?.["x-holaboss-workspace-id"] ?? ""),
+      sessionId: String((init?.headers as Record<string, string> | undefined)?.["x-holaboss-session-id"] ?? ""),
       body,
     });
     if (url.endsWith("/api/v1/capabilities/browser/tools/browser_get_state")) {
@@ -57,6 +58,7 @@ test("Pi desktop browser tools execute through the runtime capability API", asyn
   const tools = await resolvePiDesktopBrowserToolDefinitions({
     runtimeApiBaseUrl: "http://127.0.0.1:5060",
     workspaceId: "workspace-1",
+    sessionId: "session-1",
     fetchImpl,
   });
 
@@ -80,6 +82,7 @@ test("Pi desktop browser tools execute through the runtime capability API", asyn
         method: "POST",
         url: "http://127.0.0.1:5060/api/v1/capabilities/browser/tools/browser_get_state",
         workspaceId: "workspace-1",
+        sessionId: "session-1",
         body: JSON.stringify({ include_screenshot: true }),
       },
     ]);
@@ -89,7 +92,7 @@ test("Pi desktop browser tools execute through the runtime capability API", asyn
 });
 
 test("Pi desktop browser tools fall back to node http when no fetch implementation is provided", async () => {
-  const requests: Array<{ method: string; url: string; workspaceId: string; body: string }> = [];
+  const requests: Array<{ method: string; url: string; workspaceId: string; sessionId: string; body: string }> = [];
   const server = http.createServer((request, response) => {
     const url = request.url ?? "";
     if (request.method === "GET" && url === "/api/v1/capabilities/browser") {
@@ -109,6 +112,7 @@ test("Pi desktop browser tools fall back to node http when no fetch implementati
           method: request.method ?? "GET",
           url,
           workspaceId: String(request.headers["x-holaboss-workspace-id"] ?? ""),
+          sessionId: String(request.headers["x-holaboss-session-id"] ?? ""),
           body,
         });
         response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
@@ -131,6 +135,7 @@ test("Pi desktop browser tools fall back to node http when no fetch implementati
     const tools = await resolvePiDesktopBrowserToolDefinitions({
       runtimeApiBaseUrl,
       workspaceId: "workspace-1",
+      sessionId: "session-1",
     });
 
     const getStateTool = tools.find((tool) => tool.name === "browser_get_state");
@@ -143,6 +148,7 @@ test("Pi desktop browser tools fall back to node http when no fetch implementati
         method: "POST",
         url: "/api/v1/capabilities/browser/tools/browser_get_state",
         workspaceId: "workspace-1",
+        sessionId: "session-1",
         body: JSON.stringify({ include_screenshot: false }),
       },
     ]);

--- a/runtime/harness-host/src/pi-browser-tools.ts
+++ b/runtime/harness-host/src/pi-browser-tools.ts
@@ -17,6 +17,8 @@ const DEFAULT_BROWSER_TOOL_TIMEOUT_MS = 30000;
 export interface PiDesktopBrowserToolOptions {
   runtimeApiBaseUrl: string;
   workspaceId?: string | null;
+  sessionId?: string | null;
+  space?: "agent" | "user" | null;
   fetchImpl?: typeof fetch;
 }
 
@@ -36,11 +38,22 @@ function browserCapabilityToolUrl(runtimeApiBaseUrl: string, toolId: DesktopBrow
   return `${runtimeApiBaseUrl}${BROWSER_CAPABILITY_TOOL_PATH}/${toolId}`;
 }
 
-function browserCapabilityHeaders(workspaceId?: string | null): Record<string, string> {
+function browserCapabilityHeaders(
+  workspaceId?: string | null,
+  sessionId?: string | null,
+  space?: "agent" | "user" | null,
+): Record<string, string> {
   const headers: Record<string, string> = {};
   const normalizedWorkspaceId = typeof workspaceId === "string" ? workspaceId.trim() : "";
   if (normalizedWorkspaceId) {
     headers["x-holaboss-workspace-id"] = normalizedWorkspaceId;
+  }
+  const normalizedSessionId = typeof sessionId === "string" ? sessionId.trim() : "";
+  if (normalizedSessionId) {
+    headers["x-holaboss-session-id"] = normalizedSessionId;
+  }
+  if (space === "agent" || space === "user") {
+    headers["x-holaboss-browser-space"] = space;
   }
   return headers;
 }
@@ -226,6 +239,8 @@ async function executeBrowserTool(params: {
   toolParams: unknown;
   runtimeApiBaseUrl: string;
   workspaceId?: string | null;
+  sessionId?: string | null;
+  space?: "agent" | "user" | null;
   fetchImpl?: typeof fetch;
   signal: AbortSignal | undefined;
 }) {
@@ -238,7 +253,11 @@ async function executeBrowserTool(params: {
           method: "POST",
           headers: {
             "content-type": "application/json; charset=utf-8",
-            ...browserCapabilityHeaders(params.workspaceId),
+            ...browserCapabilityHeaders(
+              params.workspaceId,
+              params.sessionId,
+              params.space,
+            ),
           },
           body,
           signal,
@@ -254,7 +273,11 @@ async function executeBrowserTool(params: {
         method: "POST",
         headers: {
           "content-type": "application/json; charset=utf-8",
-          ...browserCapabilityHeaders(params.workspaceId),
+          ...browserCapabilityHeaders(
+            params.workspaceId,
+            params.sessionId,
+            params.space,
+          ),
         },
         body,
         signal,
@@ -291,6 +314,8 @@ export function createPiDesktopBrowserToolDefinition(
         toolParams,
         runtimeApiBaseUrl: options.runtimeApiBaseUrl,
         workspaceId: options.workspaceId,
+        sessionId: options.sessionId,
+        space: options.space,
         fetchImpl,
         signal,
       }),
@@ -309,6 +334,8 @@ export async function resolvePiDesktopBrowserToolDefinitions(
   options: {
     runtimeApiBaseUrl?: string | null;
     workspaceId?: string | null;
+    sessionId?: string | null;
+    space?: "agent" | "user" | null;
     fetchImpl?: typeof fetch;
   } = {}
 ): Promise<ToolDefinition[]> {
@@ -323,7 +350,11 @@ export async function resolvePiDesktopBrowserToolDefinitions(
       ? await (async () => {
           const raw = await fetchImpl(browserCapabilityStatusUrl(runtimeApiBaseUrl), {
             method: "GET",
-            headers: browserCapabilityHeaders(options.workspaceId),
+            headers: browserCapabilityHeaders(
+              options.workspaceId,
+              options.sessionId,
+              options.space,
+            ),
             signal: AbortSignal.timeout(2000),
           });
           return {
@@ -335,7 +366,11 @@ export async function resolvePiDesktopBrowserToolDefinitions(
       : await nodeRequestJson({
           url: browserCapabilityStatusUrl(runtimeApiBaseUrl),
           method: "GET",
-          headers: browserCapabilityHeaders(options.workspaceId),
+          headers: browserCapabilityHeaders(
+            options.workspaceId,
+            options.sessionId,
+            options.space,
+          ),
           signal: AbortSignal.timeout(2000),
         });
     if (!response.ok || !isRecord(response.payload) || response.payload.available !== true) {
@@ -348,6 +383,8 @@ export async function resolvePiDesktopBrowserToolDefinitions(
   return createPiDesktopBrowserToolDefinitions({
     runtimeApiBaseUrl,
     workspaceId: options.workspaceId,
+    sessionId: options.sessionId,
+    space: options.space,
     fetchImpl,
   });
 }

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3656,6 +3656,7 @@ async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSe
     ? await resolvePiDesktopBrowserToolDefinitions({
         runtimeApiBaseUrl: request.runtime_api_base_url,
         workspaceId: request.workspace_id,
+        sessionId: request.session_id,
       })
     : [];
   const resourceLoader = new DefaultResourceLoader({


### PR DESCRIPTION
## Context
- closes #157
- addresses the agent browser UX and ownership work discussed in #157
- follows up with spreadsheet/file preview interaction fixes found during local QA

## What Changed
- make agent browser activity session-aware without letting background sessions steal the visible browser surface
- refine browser control UX with clearer active-state glow treatment, selector cleanup, and explicit jump-to-browser behavior
- preserve spreadsheet hyperlink targets in preview payloads and route sheet links into the in-app browser
- stop passive file reads from forcing files into the shared display while keeping explicit file-producing operations synced

## UI Notes
- the agent browser now keeps the visible surface pinned until the user explicitly switches sessions
- browser activity uses a softer animated glow instead of a hard edge treatment
- spreadsheet URL cells are now interactive in both read-only and editable previews

## Validation
- `node --test desktop/electron/file-explorer-spreadsheet-preview.test.mjs desktop/src/components/panes/SpreadsheetEditor.test.mjs desktop/src/components/panes/FileExplorerPane.test.mjs desktop/src/components/panes/InternalSurfacePane.test.mjs`
- `node --test --test-name-pattern "chat pane syncs the shared file display from live file-oriented tool calls|spreadsheet editor preserves link metadata and opens sheet links through the browser callback" desktop/src/components/panes/ChatPane.test.mjs desktop/src/components/panes/SpreadsheetEditor.test.mjs`
- `npm run typecheck` in `desktop`

## Notes
- no Supabase or migration changes
- no environment changes required
