### PR TITLE
feat: add queued session input flow and editing

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -2709,6 +2709,14 @@ interface PauseSessionRunResponsePayload {
   status: string;
 }
 
+interface UpdateQueuedSessionInputResponsePayload {
+  input_id: string;
+  session_id: string;
+  status: string;
+  text: string;
+  updated_at: string;
+}
+
 interface HolabossClientConfigPayload {
   projectsUrl: string;
   marketplaceUrl: string;
@@ -2896,6 +2904,13 @@ interface HolabossQueueSessionInputPayload {
 interface HolabossPauseSessionRunPayload {
   workspace_id: string;
   session_id: string;
+}
+
+interface HolabossUpdateQueuedSessionInputPayload {
+  workspace_id: string;
+  session_id: string;
+  input_id: string;
+  text: string;
 }
 
 interface HolabossStreamSessionOutputsPayload {
@@ -13606,6 +13621,19 @@ async function pauseSessionRun(
   return response;
 }
 
+async function updateQueuedSessionInput(
+  payload: HolabossUpdateQueuedSessionInputPayload,
+): Promise<UpdateQueuedSessionInputResponsePayload> {
+  return requestRuntimeJson<UpdateQueuedSessionInputResponsePayload>({
+    method: "PATCH",
+    path: `/api/v1/agent-sessions/${encodeURIComponent(payload.session_id)}/inputs/${encodeURIComponent(payload.input_id)}`,
+    payload: {
+      workspace_id: payload.workspace_id,
+      text: payload.text,
+    },
+  });
+}
+
 async function* iterSseEvents(stream: NodeJS.ReadableStream) {
   const decoder = new TextDecoder();
   let buffer = "";
@@ -21419,6 +21447,12 @@ app.whenReady().then(async () => {
     ["main"],
     async (_event, payload: HolabossPauseSessionRunPayload) =>
       pauseSessionRun(payload),
+  );
+  handleTrustedIpc(
+    "workspace:updateQueuedSessionInput",
+    ["main"],
+    async (_event, payload: HolabossUpdateQueuedSessionInputPayload) =>
+      updateQueuedSessionInput(payload),
   );
   handleTrustedIpc(
     "workspace:openSessionOutputStream",

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -2585,6 +2585,9 @@ interface SessionRuntimeRecordPayload {
   workspace_id: string;
   session_id: string;
   status: string;
+  effective_state?: string | null;
+  runtime_status?: string | null;
+  has_queued_inputs?: boolean;
   current_input_id: string | null;
   current_worker_id: string | null;
   lease_until: string | null;
@@ -2694,6 +2697,10 @@ interface EnqueueSessionInputResponsePayload {
   input_id: string;
   session_id: string;
   status: string;
+  effective_state?: string | null;
+  runtime_status?: string | null;
+  current_input_id?: string | null;
+  has_queued_inputs?: boolean;
 }
 
 interface PauseSessionRunResponsePayload {
@@ -12164,6 +12171,9 @@ function normalizeRuntimeStateRecord(
     workspace_id: workspaceId,
     session_id: sessionId,
     status: record.status?.trim() || "IDLE",
+    effective_state: record.effective_state?.trim() || null,
+    runtime_status: record.runtime_status?.trim() || null,
+    has_queued_inputs: record.has_queued_inputs === true,
     current_input_id: record.current_input_id ?? null,
     current_worker_id: record.current_worker_id ?? null,
     lease_until: record.lease_until ?? null,
@@ -12234,6 +12244,14 @@ function getCachedRuntimeStateRecord(
     .get(normalizedWorkspaceId)
     ?.get(normalizedSessionId);
   return record ? cloneRuntimeStateRecord(record) : null;
+}
+
+function runtimeRecordEffectiveStatus(
+  record: SessionRuntimeRecordPayload | null | undefined,
+): string {
+  return record?.effective_state?.trim().toUpperCase()
+    || record?.status?.trim().toUpperCase()
+    || "";
 }
 
 function updateQueuedInputStatus(inputId: string, status: string) {
@@ -13533,11 +13551,17 @@ async function queueSessionInput(
     },
     retryTransientErrors: true,
   });
+  const runtimeStatus = response.runtime_status?.trim() || response.status || "QUEUED";
+  const effectiveState =
+    response.effective_state?.trim() || runtimeStatus || "QUEUED";
   upsertCachedRuntimeStateRecord({
     workspace_id: payload.workspace_id,
     session_id: response.session_id,
-    status: response.status || "QUEUED",
-    current_input_id: response.input_id,
+    status: runtimeStatus,
+    effective_state: effectiveState,
+    runtime_status: runtimeStatus,
+    has_queued_inputs: response.has_queued_inputs === true,
+    current_input_id: response.current_input_id ?? response.input_id,
     current_worker_id: null,
     lease_until: null,
     heartbeat_at: null,
@@ -13565,6 +13589,9 @@ async function pauseSessionRun(
     workspace_id: payload.workspace_id,
     session_id: response.session_id || payload.session_id,
     status: response.status || "PAUSED",
+    effective_state: response.status || "PAUSED",
+    runtime_status: response.status || "PAUSED",
+    has_queued_inputs: false,
     current_input_id: response.input_id || null,
     current_worker_id: null,
     lease_until: null,
@@ -15557,7 +15584,7 @@ function agentBrowserSessionNeedsInterrupt(
     workspaceId,
     normalizedSessionId,
   );
-  const status = runtimeRecord?.status?.trim().toUpperCase() ?? "";
+  const status = runtimeRecordEffectiveStatus(runtimeRecord);
   return status === "BUSY" || status === "QUEUED" || status === "PAUSING";
 }
 
@@ -15789,7 +15816,7 @@ async function reconcileAgentSessionBrowserSpace(
     runtimeRecord = null;
   }
 
-  const status = runtimeRecord?.status?.trim().toUpperCase() ?? "";
+  const status = runtimeRecordEffectiveStatus(runtimeRecord);
   const lastTurnStatus =
     runtimeRecord?.last_turn_status?.trim().toLowerCase() ?? "";
   const touchedAtMs = Date.parse(tabSpace.lastTouchedAt);

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -638,6 +638,9 @@ interface SessionRuntimeRecordPayload {
   workspace_id: string;
   session_id: string;
   status: string;
+  effective_state?: string | null;
+  runtime_status?: string | null;
+  has_queued_inputs?: boolean;
   current_input_id: string | null;
   current_worker_id: string | null;
   lease_until: string | null;
@@ -711,6 +714,10 @@ interface EnqueueSessionInputResponsePayload {
   input_id: string;
   session_id: string;
   status: string;
+  effective_state?: string | null;
+  runtime_status?: string | null;
+  current_input_id?: string | null;
+  has_queued_inputs?: boolean;
 }
 
 interface PauseSessionRunResponsePayload {

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -726,6 +726,14 @@ interface PauseSessionRunResponsePayload {
   status: string;
 }
 
+interface UpdateQueuedSessionInputResponsePayload {
+  input_id: string;
+  session_id: string;
+  status: string;
+  text: string;
+  updated_at: string;
+}
+
 interface HolabossClientConfigPayload {
   projectsUrl: string;
   marketplaceUrl: string;
@@ -808,6 +816,13 @@ interface HolabossQueueSessionInputPayload {
 interface HolabossPauseSessionRunPayload {
   workspace_id: string;
   session_id: string;
+}
+
+interface HolabossUpdateQueuedSessionInputPayload {
+  workspace_id: string;
+  session_id: string;
+  input_id: string;
+  text: string;
 }
 
 interface HolabossStreamSessionOutputsPayload {
@@ -1305,6 +1320,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:queueSessionInput", payload) as Promise<EnqueueSessionInputResponsePayload>,
     pauseSessionRun: (payload: HolabossPauseSessionRunPayload) =>
       ipcRenderer.invoke("workspace:pauseSessionRun", payload) as Promise<PauseSessionRunResponsePayload>,
+    updateQueuedSessionInput: (payload: HolabossUpdateQueuedSessionInputPayload) =>
+      ipcRenderer.invoke("workspace:updateQueuedSessionInput", payload) as Promise<UpdateQueuedSessionInputResponsePayload>,
     openSessionOutputStream: (payload: HolabossStreamSessionOutputsPayload) =>
       ipcRenderer.invoke("workspace:openSessionOutputStream", payload) as Promise<HolabossSessionStreamHandlePayload>,
     closeSessionOutputStream: (streamId: string, reason?: string) =>

--- a/desktop/src/components/layout/OperationsDrawer.tsx
+++ b/desktop/src/components/layout/OperationsDrawer.tsx
@@ -435,23 +435,32 @@ function normalizeTurnResultStatus(status: string | null | undefined): string {
   return typeof status === "string" ? status.trim().toLowerCase() : "";
 }
 
+function runningSessionRuntimeStatus(entry: {
+  status: string;
+  effective_state?: string | null;
+}): string {
+  return (entry.effective_state || entry.status || "").trim().toUpperCase();
+}
+
 function runningSessionState(entry: {
   status: string;
+  effective_state?: string | null;
   last_turn_status: string | null;
 }): string {
-  if (entry.status === "BUSY") {
+  const runtimeStatus = runningSessionRuntimeStatus(entry);
+  if (runtimeStatus === "BUSY") {
     return "RUNNING";
   }
-  if (entry.status === "QUEUED") {
+  if (runtimeStatus === "QUEUED") {
     return "QUEUED";
   }
-  if (entry.status === "WAITING_USER") {
+  if (runtimeStatus === "WAITING_USER") {
     return "WAITING";
   }
-  if (entry.status === "PAUSED") {
+  if (runtimeStatus === "PAUSED") {
     return "PAUSED";
   }
-  if (entry.status === "ERROR") {
+  if (runtimeStatus === "ERROR") {
     return "ERROR";
   }
 
@@ -473,15 +482,17 @@ function runningSessionState(entry: {
 
 function runningSessionStateTimestamp(entry: {
   status: string;
+  effective_state?: string | null;
   updated_at: string;
   last_turn_completed_at: string | null;
 }): string {
+  const runtimeStatus = runningSessionRuntimeStatus(entry);
   if (
-    entry.status === "BUSY" ||
-    entry.status === "QUEUED" ||
-    entry.status === "WAITING_USER" ||
-    entry.status === "PAUSED" ||
-    entry.status === "ERROR"
+    runtimeStatus === "BUSY" ||
+    runtimeStatus === "QUEUED" ||
+    runtimeStatus === "WAITING_USER" ||
+    runtimeStatus === "PAUSED" ||
+    runtimeStatus === "ERROR"
   ) {
     return entry.updated_at;
   }

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -1015,16 +1015,125 @@ test("chat composer exposes a pause action for in-flight runs and calls the runt
   );
   assert.match(
     source,
-    /<Composer[\s\S]*pausePending=\{isPausePending\}[\s\S]*pauseDisabled=\{\s*pendingInputIdRef\.current === STREAM_ATTACH_PENDING\s*\}[\s\S]*onPause=\{pauseCurrentRun\}/,
+    /<Composer[\s\S]*pausePending=\{isPausePending\}[\s\S]*pauseDisabled=\{\s*pendingInputIdRef\.current === STREAM_ATTACH_PENDING \|\|\s*isSubmittingMessage\s*\}[\s\S]*onPause=\{pauseCurrentRun\}/,
   );
   assert.match(
     source,
-    /isResponding \? \(\s*<Button[\s\S]*onClick=\{onPause\}[\s\S]*>\s*\{pausePending \? \(\s*<Loader2[\s\S]*\) : \(\s*<Square[\s\S]*\)\}\s*Pause\s*<\/Button>\s*\) : \(\s*<Button[\s\S]*<ArrowUp/,
+    /\{isResponding \? \(\s*<Button[\s\S]*onClick=\{onPause\}[\s\S]*>\s*\{pausePending \? \(\s*<Loader2[\s\S]*\) : \(\s*<Square[\s\S]*\)\}\s*Pause\s*<\/Button>\s*\) : null\}[\s\S]*<Button[\s\S]*aria-label=\{isResponding \? "Queue message" : "Send message"\}[\s\S]*<ArrowUp/,
   );
-  assert.match(source, /disabled=\{pausePending \|\| pauseDisabled\}/);
+  assert.match(source, /disabled=\{pausePending \|\| pauseDisabled \|\| disabled\}/);
 });
 
-test("chat pane renders a collapsed current todo panel above the composer", async () => {
+test("chat pane keeps the current stream attached while queueing a follow-up input", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const \[isSubmittingMessage, setIsSubmittingMessage\] = useState\(false\);/);
+  assert.match(
+    source,
+    /const \[queuedSessionInputs, setQueuedSessionInputs\] = useState<\s*QueuedSessionInput\[\]\s*>\(\[]\);/,
+  );
+  assert.match(
+    source,
+    /quotedSkillIds\.length === 0\) \|\|\s*isSubmittingMessage/,
+  );
+  assert.match(
+    source,
+    /const queueOntoActiveRun =\s*isResponding[\s\S]*targetSessionId === activeSessionIdRef\.current;/,
+  );
+  assert.match(
+    source,
+    /if \(!queueOntoActiveRun\) \{\s*setMessages\(\(prev\) => \[\.\.\.prev, userMessage\]\);\s*\}/,
+  );
+  assert.match(
+    source,
+    /if \(!queueOntoActiveRun\) \{[\s\S]*openSessionOutputStream\(\{[\s\S]*eventType: "stream_open_prequeue"/,
+  );
+  assert.match(
+    source,
+    /setQueuedSessionInputs\(\(current\) => \[[\s\S]*inputId: queued\.input_id,[\s\S]*status: "queued",[\s\S]*\}\s*,\s*\]\);/,
+  );
+  assert.match(source, /eventType: "stream_open_queued_handoff"/);
+  assert.match(source, /function queuedSessionInputPreviewText\(item: QueuedSessionInput\)/);
+  assert.match(source, /function QueuedSessionInputRail\(/);
+  assert.match(
+    source,
+    /<QueuedSessionInputRail items=\{displayedQueuedSessionInputs\}>[\s\S]*<Composer/,
+  );
+  assert.match(source, /children: ReactNode;/);
+  assert.match(source, /const panelInsetPx = \d+;/);
+  assert.match(source, /const panelHeightPx = \d+;/);
+  assert.match(source, /const queueViewportHeightPx = \d+;/);
+  assert.match(source, /className="pointer-events-none absolute inset-x-0 top-0"/);
+  assert.match(source, /className="pointer-events-auto absolute inset-x-0 overflow-hidden rounded-\[28px\]/);
+  assert.match(source, /className="overflow-y-auto pr-1\.5"/);
+  assert.match(source, /\{items\.map\(\(item\) => \{/);
+  assert.match(source, /<CornerDownLeft[\s\S]*size=\{15\}/);
+  assert.match(source, /className="relative z-10 rounded-\[24px\] bg-background"/);
+  assert.match(source, /style=\{\{\s*marginTop: `\$\{-overlapPx\}px`\s*\}\}/);
+  assert.doesNotMatch(source, /Queued messages/);
+  assert.doesNotMatch(source, /Up next/);
+  assert.doesNotMatch(source, /Sending next/);
+  assert.match(source, /const inputDisabled = disabled;/);
+  assert.match(source, /if \(!dataTransfer \|\| disabled\) \{/);
+});
+
+test("chat pane exposes a queued message preview hook for dev console inspection", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const QUEUED_MESSAGES_PREVIEW_EVENT =\s*"holaboss:queued-messages-preview-change";/,
+  );
+  assert.match(source, /__holabossQueuedMessagesPreviewState\?: QueuedSessionInputPreviewDescriptor\[\];/);
+  assert.match(source, /__holabossDevQueuedMessagesPreview\?: \{/);
+  assert.match(source, /window\.dispatchEvent\(new CustomEvent\(QUEUED_MESSAGES_PREVIEW_EVENT\)\);/);
+  assert.match(source, /function useQueuedSessionInputPreview\(params:/);
+  assert.match(source, /window\.__holabossDevQueuedMessagesPreview = \{/);
+  assert.match(
+    source,
+    /single:\s*\([\s\S]*Draft a concise follow-up after the current run finishes\.[\s\S]*=>/,
+  );
+  assert.match(source, /multiple: \(\) =>/);
+  assert.match(source, /clear: \(\) => setQueuedSessionInputPreviewState\(\[]\)/);
+  assert.match(source, /set: \(entries\) => setQueuedSessionInputPreviewState\(entries\)/);
+  assert.match(source, /const queuedSessionInputPreview = useQueuedSessionInputPreview\(/);
+  assert.match(
+    source,
+    /const displayedQueuedSessionInputs =\s*queuedSessionInputPreview\.length > 0[\s\S]*\?\s*queuedSessionInputPreview[\s\S]*:\s*activeQueuedSessionInputs;/,
+  );
+});
+
+test("chat pane exposes a todo preview hook for combined todo and queue design inspection", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /const TODO_PREVIEW_EVENT = "holaboss:todo-preview-change";/);
+  assert.match(source, /__holabossTodoPreviewState\?: TodoPlanPreviewState \| null;/);
+  assert.match(source, /__holabossDevTodoPreview\?: \{/);
+  assert.match(source, /function defaultTodoPlanPreview\(\): ChatTodoPlan/);
+  assert.match(source, /window\.__holabossDevTodoPreview = \{/);
+  assert.match(source, /sample: \(\) =>/);
+  assert.match(source, /expanded: \(\) =>/);
+  assert.match(source, /collapsed: \(\) =>/);
+  assert.match(source, /clear: \(\) => setTodoPlanPreviewState\(null\)/);
+  assert.match(source, /set: \(plan, options\) =>/);
+  assert.match(source, /const todoPlanPreview = useTodoPlanPreview\(\);/);
+  assert.match(
+    source,
+    /const displayedTodoPlan = todoPlanPreview\?\.plan \?\? currentTodoPlan;/,
+  );
+  assert.match(
+    source,
+    /const displayedTodoPanelExpanded =\s*todoPlanPreview\?\.expanded \?\? todoPanelExpanded;/,
+  );
+  assert.match(source, /const toggleTodoPanel = \(\) => \{/);
+  assert.match(source, /if \(todoPlanPreview\) \{/);
+  assert.match(source, /setTodoPlanPreviewState\(\{\s*\.\.\.todoPlanPreview,/);
+  assert.match(source, /todoPlan=\{displayedTodoPlan\}/);
+  assert.match(source, /expanded=\{displayedTodoPanelExpanded\}/);
+  assert.match(source, /onToggle=\{toggleTodoPanel\}/);
+});
+
+test("chat pane renders a collapsed current todo panel near the top of the pane", async () => {
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(source, /function CurrentTodoPanel\(/);
@@ -1053,9 +1162,10 @@ test("chat pane renders a collapsed current todo panel above the composer", asyn
   assert.match(source, /\{visiblePhases\.map\(\(phase\) => \{/);
   assert.match(
     source,
-    /<div className="space-y-3">[\s\S]*\{currentTodoPlan \? \(\s*<CurrentTodoPanel[\s\S]*todoPlan=\{currentTodoPlan\}[\s\S]*expanded=\{todoPanelExpanded\}[\s\S]*onToggle=\{\(\) =>[\s\S]*setTodoPanelExpanded\(\(value\) => !value\)[\s\S]*\}\s*\/>\s*\) : null\}[\s\S]*<Composer/,
+    /const todoPanelSlotHeightPx = 58;[\s\S]*\{displayedTodoPlan \? \(\s*<div[\s\S]*className="relative z-20 shrink-0 px-6 pt-3"[\s\S]*style=\{\{\s*height: `\$\{todoPanelSlotHeightPx\}px`\s*\}\}[\s\S]*<div className="absolute inset-x-6 top-3">[\s\S]*<CurrentTodoPanel[\s\S]*todoPlan=\{displayedTodoPlan\}[\s\S]*expanded=\{displayedTodoPanelExpanded\}[\s\S]*onToggle=\{toggleTodoPanel\}[\s\S]*<\/div>[\s\S]*<\/div>\s*\) : null\}[\s\S]*<div className="relative flex min-h-0 flex-1 flex-col">/,
   );
   assert.match(source, /aria-expanded=\{expanded\}/);
+  assert.match(source, /className="max-h-\[320px\] overflow-y-auto border-t border-border\/20 px-3 py-3"/);
   assert.match(
     source,
     /className=\{`shrink-0 text-muted-foreground transition \$\{expanded \? "rotate-0" : "-rotate-90"\}`\}/,

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -1054,10 +1054,15 @@ test("chat pane keeps the current stream attached while queueing a follow-up inp
   );
   assert.match(source, /eventType: "stream_open_queued_handoff"/);
   assert.match(source, /function queuedSessionInputPreviewText\(item: QueuedSessionInput\)/);
+  assert.match(source, /async function updateQueuedSessionInputText\(/);
+  assert.match(
+    source,
+    /window\.electronAPI\.workspace\.updateQueuedSessionInput\(\{\s*workspace_id: item\.workspaceId,\s*session_id: item\.sessionId,\s*input_id: item\.inputId,\s*text: serializedText,\s*\}\)/,
+  );
   assert.match(source, /function QueuedSessionInputRail\(/);
   assert.match(
     source,
-    /<QueuedSessionInputRail items=\{displayedQueuedSessionInputs\}>[\s\S]*<Composer/,
+    /<QueuedSessionInputRail[\s\S]*items=\{displayedQueuedSessionInputs\}[\s\S]*onEditItem=\{updateQueuedSessionInputText\}[\s\S]*<Composer/,
   );
   assert.match(source, /children: ReactNode;/);
   assert.match(source, /const panelInsetPx = \d+;/);
@@ -1068,6 +1073,9 @@ test("chat pane keeps the current stream attached while queueing a follow-up inp
   assert.match(source, /className="overflow-y-auto pr-1\.5"/);
   assert.match(source, /\{items\.map\(\(item\) => \{/);
   assert.match(source, /<CornerDownLeft[\s\S]*size=\{15\}/);
+  assert.match(source, /aria-label="Edit queued message"/);
+  assert.match(source, /aria-label="Save queued message edit"/);
+  assert.match(source, /aria-label="Cancel queued message edit"/);
   assert.match(source, /className="relative z-10 rounded-\[24px\] bg-background"/);
   assert.match(source, /style=\{\{\s*marginTop: `\$\{-overlapPx\}px`\s*\}\}/);
   assert.doesNotMatch(source, /Queued messages/);

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -23,6 +23,7 @@ import {
   Check,
   ChevronDown,
   Clock3,
+  CornerDownLeft,
   Copy,
   FileText,
   Folder,
@@ -90,6 +91,56 @@ interface ChatMessage {
   executionItems?: ChatExecutionTimelineItem[];
   outputs?: WorkspaceOutputRecordPayload[];
   memoryProposals?: MemoryUpdateProposalRecordPayload[];
+}
+
+type QueuedSessionInputStatus = "queued" | "sending";
+
+interface QueuedSessionInput {
+  inputId: string;
+  sessionId: string;
+  workspaceId: string;
+  text: string;
+  createdAt: string;
+  attachments: ChatAttachment[];
+  status: QueuedSessionInputStatus;
+}
+
+interface QueuedSessionInputPreviewDescriptor {
+  text: string;
+  createdAt?: string;
+  attachments?: ChatAttachment[];
+  status: QueuedSessionInputStatus;
+}
+
+interface TodoPlanPreviewState {
+  plan: ChatTodoPlan;
+  expanded: boolean;
+}
+
+declare global {
+  interface Window {
+    __holabossQueuedMessagesPreviewState?: QueuedSessionInputPreviewDescriptor[];
+    __holabossDevQueuedMessagesPreview?: {
+      single: (text?: string) => void;
+      multiple: () => void;
+      clear: () => void;
+      set: (
+        entries:
+          | string
+          | Array<string | Partial<QueuedSessionInputPreviewDescriptor>>,
+      ) => void;
+      get: () => QueuedSessionInputPreviewDescriptor[];
+    };
+    __holabossTodoPreviewState?: TodoPlanPreviewState | null;
+    __holabossDevTodoPreview?: {
+      sample: () => void;
+      expanded: () => void;
+      collapsed: () => void;
+      clear: () => void;
+      set: (plan: ChatTodoPlan, options?: { expanded?: boolean }) => void;
+      get: () => TodoPlanPreviewState | null;
+    };
+  }
 }
 
 interface ChatSerializedQuotedSkillBlock {
@@ -305,6 +356,9 @@ const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
 const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
 const CHAT_SERIALIZED_SKILL_COMMAND_PATTERN = /^\/([A-Za-z0-9_-]+)$/;
+const QUEUED_MESSAGES_PREVIEW_EVENT =
+  "holaboss:queued-messages-preview-change";
+const TODO_PREVIEW_EVENT = "holaboss:todo-preview-change";
 const LEGACY_UNAVAILABLE_CHAT_MODELS = new Set(["openai/gpt-5.2-mini"]);
 const DEPRECATED_CHAT_MODELS = new Set([
   "openai/gpt-5.1",
@@ -1088,6 +1142,17 @@ function runtimeStateStatus(value: string | null | undefined): string {
   return (value || "").trim().toUpperCase();
 }
 
+function runtimeStateEffectiveStatus(
+  runtimeState:
+    | Pick<SessionRuntimeRecordPayload, "status" | "effective_state">
+    | null
+    | undefined,
+): string {
+  return runtimeStateStatus(
+    runtimeState?.effective_state ?? runtimeState?.status,
+  );
+}
+
 function normalizeSessionTurnStatus(value: string | null | undefined): string {
   return (value || "").trim().toLowerCase();
 }
@@ -1108,11 +1173,14 @@ function defaultWorkspaceSessionTitle(
 
 function chatSessionStatusLabel(
   runtimeState:
-    | Pick<SessionRuntimeRecordPayload, "status" | "last_turn_status">
+    | Pick<
+        SessionRuntimeRecordPayload,
+        "status" | "effective_state" | "last_turn_status"
+      >
     | null
     | undefined,
 ): string {
-  const status = runtimeStateStatus(runtimeState?.status);
+  const status = runtimeStateEffectiveStatus(runtimeState);
   if (status === "BUSY") {
     return "Running";
   }
@@ -1700,6 +1768,316 @@ function turnInputIdsFromHistoryMessages(
     inputIds.push(inputId);
   }
   return inputIds;
+}
+
+function reconcileQueuedSessionInputs(
+  queuedInputs: QueuedSessionInput[],
+  params: {
+    workspaceId: string;
+    sessionId: string;
+    persistedInputIds: Set<string>;
+    activeInputId?: string | null;
+    activeStatus?: string | null;
+  },
+): QueuedSessionInput[] {
+  const activeInputId = (params.activeInputId || "").trim();
+  const activeStatus = runtimeStateStatus(params.activeStatus);
+  return queuedInputs
+    .filter((item) => {
+      if (
+        item.workspaceId !== params.workspaceId ||
+        item.sessionId !== params.sessionId
+      ) {
+        return true;
+      }
+      return !params.persistedInputIds.has(item.inputId);
+    })
+    .map((item) => {
+      if (
+        item.workspaceId !== params.workspaceId ||
+        item.sessionId !== params.sessionId
+      ) {
+        return item;
+      }
+      if (!activeInputId || item.inputId !== activeInputId) {
+        return item;
+      }
+      const status: QueuedSessionInputStatus =
+        activeStatus === "BUSY" ? "sending" : "queued";
+      return {
+        ...item,
+        status,
+      };
+    });
+}
+
+function defaultQueuedSessionInputPreviewEntries(
+  mode: "single" | "multiple",
+): QueuedSessionInputPreviewDescriptor[] {
+  const now = Date.now();
+  if (mode === "single") {
+    return [
+      {
+        text: "Draft a concise follow-up after the current run finishes.",
+        createdAt: new Date(now).toISOString(),
+        status: "queued",
+        attachments: [],
+      },
+    ];
+  }
+  return [
+    {
+      text: serializeQuotedSkillPrompt(
+        "Pull the latest renewal risk notes before replying.",
+        ["customer_lookup"],
+      ),
+      createdAt: new Date(now - 2 * 60_000).toISOString(),
+      status: "sending",
+      attachments: [],
+    },
+    {
+      text: "Draft a tighter follow-up once the risk notes land.",
+      createdAt: new Date(now - 60_000).toISOString(),
+      status: "queued",
+      attachments: [],
+    },
+    {
+      text: "Prepare a brief handoff summary for the account manager.",
+      createdAt: new Date(now).toISOString(),
+      status: "queued",
+      attachments: [],
+    },
+  ];
+}
+
+function normalizeQueuedSessionInputPreviewEntries(
+  entries: unknown,
+): QueuedSessionInputPreviewDescriptor[] {
+  const rawEntries =
+    typeof entries === "string" ? [entries] : Array.isArray(entries) ? entries : [];
+  const normalized: QueuedSessionInputPreviewDescriptor[] = [];
+  rawEntries.forEach((entry, index) => {
+    if (typeof entry === "string") {
+      const text = entry.trim();
+      if (!text) {
+        return;
+      }
+      normalized.push({
+        text,
+        createdAt: new Date(Date.now() - index * 60_000).toISOString(),
+        status: "queued",
+        attachments: [],
+      });
+      return;
+    }
+    if (!entry || typeof entry !== "object") {
+      return;
+    }
+    const payload = entry as Partial<QueuedSessionInputPreviewDescriptor>;
+    const text = typeof payload.text === "string" ? payload.text.trim() : "";
+    if (!text) {
+      return;
+    }
+    const attachments = Array.isArray(payload.attachments)
+      ? payload.attachments
+          .map((attachment) => normalizeChatAttachment(attachment))
+          .filter(
+            (attachment): attachment is ChatAttachment => Boolean(attachment),
+          )
+      : [];
+    normalized.push({
+      text,
+      createdAt:
+        typeof payload.createdAt === "string" && payload.createdAt.trim()
+          ? payload.createdAt
+          : new Date(Date.now() - index * 60_000).toISOString(),
+      status: payload.status === "sending" ? "sending" : "queued",
+      attachments,
+    });
+  });
+  return normalized;
+}
+
+function setQueuedSessionInputPreviewState(entries: unknown) {
+  window.__holabossQueuedMessagesPreviewState =
+    normalizeQueuedSessionInputPreviewEntries(entries);
+  window.dispatchEvent(new CustomEvent(QUEUED_MESSAGES_PREVIEW_EVENT));
+}
+
+function defaultTodoPlanPreview(): ChatTodoPlan {
+  return {
+    sessionId: "preview-session",
+    updatedAt: new Date().toISOString(),
+    phases: [
+      {
+        id: "phase-research",
+        name: "Research",
+        tasks: [
+          {
+            id: "task-research-1",
+            content: "Review the previous response for open threads",
+            status: "completed",
+          },
+          {
+            id: "task-research-2",
+            content: "Pull the latest account context before replying",
+            status: "in_progress",
+            details: "Waiting on the current run to finish before the follow-up can start.",
+          },
+        ],
+      },
+      {
+        id: "phase-reply",
+        name: "Reply",
+        tasks: [
+          {
+            id: "task-reply-1",
+            content: "Draft the queued follow-up",
+            status: "pending",
+          },
+          {
+            id: "task-reply-2",
+            content: "Tighten the closing CTA",
+            status: "pending",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function setTodoPlanPreviewState(next: TodoPlanPreviewState | null) {
+  window.__holabossTodoPreviewState = next;
+  window.dispatchEvent(new CustomEvent(TODO_PREVIEW_EVENT));
+}
+
+function useQueuedSessionInputPreview(params: {
+  workspaceId?: string | null;
+  sessionId?: string | null;
+}) {
+  const workspaceId = (params.workspaceId || "").trim();
+  const sessionId = (params.sessionId || "").trim();
+  const [previewItems, setPreviewItems] = useState<QueuedSessionInput[]>([]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
+    const applyCurrentState = () => {
+      const items = window.__holabossQueuedMessagesPreviewState ?? [];
+      setPreviewItems(
+        items.map((item, index) => ({
+          inputId: `preview-queued-${index + 1}`,
+          sessionId,
+          workspaceId,
+          text: item.text,
+          createdAt: item.createdAt || new Date().toISOString(),
+          attachments: item.attachments ?? [],
+          status: item.status,
+        })),
+      );
+    };
+
+    const handlePreviewChange = () => {
+      applyCurrentState();
+    };
+
+    applyCurrentState();
+    window.addEventListener(
+      QUEUED_MESSAGES_PREVIEW_EVENT,
+      handlePreviewChange as EventListener,
+    );
+    window.__holabossDevQueuedMessagesPreview = {
+      single: (
+        text = "Draft a concise follow-up after the current run finishes.",
+      ) =>
+        setQueuedSessionInputPreviewState([
+          {
+            text,
+            status: "queued",
+            attachments: [],
+          },
+        ]),
+      multiple: () =>
+        setQueuedSessionInputPreviewState(
+          defaultQueuedSessionInputPreviewEntries("multiple"),
+        ),
+      clear: () => setQueuedSessionInputPreviewState([]),
+      set: (entries) => setQueuedSessionInputPreviewState(entries),
+      get: () => window.__holabossQueuedMessagesPreviewState ?? [],
+    };
+
+    return () => {
+      window.removeEventListener(
+        QUEUED_MESSAGES_PREVIEW_EVENT,
+        handlePreviewChange as EventListener,
+      );
+      delete window.__holabossDevQueuedMessagesPreview;
+    };
+  }, [sessionId, workspaceId]);
+
+  return previewItems;
+}
+
+function useTodoPlanPreview() {
+  const [preview, setPreview] = useState<TodoPlanPreviewState | null>(
+    () => window.__holabossTodoPreviewState ?? null,
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
+    const applyCurrentState = () => {
+      setPreview(window.__holabossTodoPreviewState ?? null);
+    };
+
+    const handlePreviewChange = () => {
+      applyCurrentState();
+    };
+
+    applyCurrentState();
+    window.addEventListener(
+      TODO_PREVIEW_EVENT,
+      handlePreviewChange as EventListener,
+    );
+    window.__holabossDevTodoPreview = {
+      sample: () =>
+        setTodoPlanPreviewState({
+          plan: defaultTodoPlanPreview(),
+          expanded: false,
+        }),
+      expanded: () =>
+        setTodoPlanPreviewState({
+          plan: defaultTodoPlanPreview(),
+          expanded: true,
+        }),
+      collapsed: () =>
+        setTodoPlanPreviewState({
+          plan: defaultTodoPlanPreview(),
+          expanded: false,
+        }),
+      clear: () => setTodoPlanPreviewState(null),
+      set: (plan, options) =>
+        setTodoPlanPreviewState({
+          plan,
+          expanded: options?.expanded === true,
+        }),
+      get: () => window.__holabossTodoPreviewState ?? null,
+    };
+
+    return () => {
+      window.removeEventListener(
+        TODO_PREVIEW_EVENT,
+        handlePreviewChange as EventListener,
+      );
+      delete window.__holabossDevTodoPreview;
+    };
+  }, []);
+
+  return preview;
 }
 
 function mergeUniqueByKey<T>(
@@ -2696,6 +3074,7 @@ export function ChatPane({
   const [loadedHistoryMessageCount, setLoadedHistoryMessageCount] = useState(0);
   const [totalHistoryMessageCount, setTotalHistoryMessageCount] = useState(0);
   const [isResponding, setIsResponding] = useState(false);
+  const [isSubmittingMessage, setIsSubmittingMessage] = useState(false);
   const [isPausePending, setIsPausePending] = useState(false);
   const [chatErrorMessage, setChatErrorMessage] = useState("");
   const [attachmentGateMessage, setAttachmentGateMessage] = useState("");
@@ -2728,6 +3107,9 @@ export function ChatPane({
     proposalId: string;
     action: "accept" | "dismiss";
   } | null>(null);
+  const [queuedSessionInputs, setQueuedSessionInputs] = useState<
+    QueuedSessionInput[]
+  >([]);
   const [currentTodoPlan, setCurrentTodoPlan] = useState<ChatTodoPlan | null>(
     null,
   );
@@ -3369,12 +3751,23 @@ export function ChatPane({
     const currentRuntimeState = runtimeStates.find(
       (item) => item.session_id === nextSessionId,
     );
-    const currentRuntimeStatus = runtimeStateStatus(
-      currentRuntimeState?.status,
-    );
+    const currentRuntimeStatus =
+      runtimeStateEffectiveStatus(currentRuntimeState);
     const currentRuntimeInputId = (
       currentRuntimeState?.current_input_id || ""
     ).trim();
+    const persistedInputIds = new Set(
+      turnInputIdsFromHistoryMessages(page.history.messages),
+    );
+    setQueuedSessionInputs((current) =>
+      reconcileQueuedSessionInputs(current, {
+        workspaceId,
+        sessionId: nextSessionId,
+        persistedInputIds,
+        activeInputId: currentRuntimeInputId,
+        activeStatus: currentRuntimeStatus,
+      }),
+    );
     const hasAssistantMessage = page.renderedMessages.some(
       (message) => message.role === "assistant",
     );
@@ -4577,6 +4970,10 @@ export function ChatPane({
   }, [selectedWorkspaceId]);
 
   useEffect(() => {
+    setQueuedSessionInputs([]);
+  }, [selectedWorkspaceId]);
+
+  useEffect(() => {
     const unsubscribe = window.electronAPI.workspace.onSessionStreamEvent(
       (payload) => {
         const currentStreamId = activeStreamIdRef.current;
@@ -4790,6 +5187,25 @@ export function ChatPane({
             action: "adopt_stream_for_event",
             detail: `pending_input=${pendingInputId}`,
           });
+        }
+
+        if (
+          eventSessionId &&
+          eventInputId &&
+          (eventType === "run_claimed" || eventType === "run_started")
+        ) {
+          setQueuedSessionInputs((current) =>
+            current.map((item) =>
+              item.workspaceId === (selectedWorkspaceId || "").trim() &&
+              item.sessionId === eventSessionId &&
+              item.inputId === eventInputId
+                ? {
+                    ...item,
+                    status: "sending",
+                  }
+                : item,
+            ),
+          );
         }
 
         if (
@@ -5043,7 +5459,7 @@ export function ChatPane({
         if (!currentState) {
           return;
         }
-        const status = runtimeStateStatus(currentState.status);
+        const status = runtimeStateEffectiveStatus(currentState);
         if (status === "BUSY" || status === "QUEUED") {
           return;
         }
@@ -5108,7 +5524,7 @@ export function ChatPane({
       (!trimmed &&
         pendingAttachments.length === 0 &&
         quotedSkillIds.length === 0) ||
-      isResponding
+      isSubmittingMessage
     ) {
       return;
     }
@@ -5171,6 +5587,12 @@ export function ChatPane({
       setChatErrorMessage("No active session found for this workspace.");
       return;
     }
+    const queueOntoActiveRun =
+      isResponding &&
+      !pendingSessionTarget &&
+      targetSessionId === activeSessionIdRef.current;
+
+    setIsSubmittingMessage(true);
 
     appendStreamTelemetry({
       streamId: activeStreamIdRef.current || "-",
@@ -5182,24 +5604,6 @@ export function ChatPane({
       action: "queue_begin",
       detail: `workspace=${selectedWorkspace.id}`,
     });
-    const currentStreamId = activeStreamIdRef.current;
-    if (currentStreamId) {
-      await closeStreamWithReason(
-        currentStreamId,
-        "send_new_message_close_previous_stream",
-      );
-      activeStreamIdRef.current = null;
-      appendStreamTelemetry({
-        streamId: currentStreamId,
-        transportType: "client",
-        eventName: "sendMessage",
-        eventType: "close_prev_stream",
-        inputId: "",
-        sessionId: targetSessionId || "",
-        action: "closed_previous_stream",
-        detail: "before new send",
-      });
-    }
 
     try {
       const missingQuotedSkillIds = quotedSkillIds.filter(
@@ -5272,44 +5676,68 @@ export function ChatPane({
         trimmed,
         quotedSkillIds,
       );
+      const queuedMessageCreatedAt = new Date().toISOString();
       const userMessage: ChatMessage = {
         id: `user-${Date.now()}`,
         role: "user",
         text: serializedPrompt,
-        createdAt: new Date().toISOString(),
+        createdAt: queuedMessageCreatedAt,
         attachments: stagedAttachments,
       };
 
       shouldAutoScrollRef.current = true;
-      setMessages((prev) => [...prev, userMessage]);
-      resetLiveTurn();
+      if (!queueOntoActiveRun) {
+        setMessages((prev) => [...prev, userMessage]);
+      }
       setInput("");
       setQuotedSkillIds([]);
       setPendingAttachments([]);
-      setIsResponding(true);
-      setLiveAgentStatus("Thinking");
       setChatErrorMessage("");
-      activeAssistantMessageIdRef.current = null;
-      pendingInputIdRef.current = STREAM_ATTACH_PENDING;
+      if (!queueOntoActiveRun) {
+        const currentStreamId = activeStreamIdRef.current;
+        if (currentStreamId) {
+          await closeStreamWithReason(
+            currentStreamId,
+            "send_new_message_close_previous_stream",
+          );
+          activeStreamIdRef.current = null;
+          appendStreamTelemetry({
+            streamId: currentStreamId,
+            transportType: "client",
+            eventName: "sendMessage",
+            eventType: "close_prev_stream",
+            inputId: "",
+            sessionId: targetSessionId || "",
+            action: "closed_previous_stream",
+            detail: "before new send",
+          });
+        }
 
-      const preOpenedStream =
-        await window.electronAPI.workspace.openSessionOutputStream({
+        resetLiveTurn();
+        setIsResponding(true);
+        setLiveAgentStatus("Thinking");
+        activeAssistantMessageIdRef.current = null;
+        pendingInputIdRef.current = STREAM_ATTACH_PENDING;
+
+        const preOpenedStream =
+          await window.electronAPI.workspace.openSessionOutputStream({
+            sessionId: targetSessionId,
+            workspaceId: selectedWorkspace.id,
+            includeHistory: false,
+            stopOnTerminal: true,
+          });
+        activeStreamIdRef.current = preOpenedStream.streamId;
+        appendStreamTelemetry({
+          streamId: preOpenedStream.streamId,
+          transportType: "client",
+          eventName: "openSessionOutputStream",
+          eventType: "stream_open_prequeue",
+          inputId: "",
           sessionId: targetSessionId,
-          workspaceId: selectedWorkspace.id,
-          includeHistory: false,
-          stopOnTerminal: true,
+          action: "stream_requested_prequeue",
+          detail: "session tail stream opened before queue",
         });
-      activeStreamIdRef.current = preOpenedStream.streamId;
-      appendStreamTelemetry({
-        streamId: preOpenedStream.streamId,
-        transportType: "client",
-        eventName: "openSessionOutputStream",
-        eventType: "stream_open_prequeue",
-        inputId: "",
-        sessionId: targetSessionId,
-        action: "stream_requested_prequeue",
-        detail: "session tail stream opened before queue",
-      });
+      }
 
       const queued = await window.electronAPI.workspace.queueSessionInput({
         text: serializedPrompt,
@@ -5322,7 +5750,6 @@ export function ChatPane({
         thinking_value: effectiveThinkingValue,
       });
       setActiveSession(queued.session_id);
-      pendingInputIdRef.current = queued.input_id;
       appendStreamTelemetry({
         streamId: "-",
         transportType: "client",
@@ -5331,9 +5758,72 @@ export function ChatPane({
         inputId: queued.input_id,
         sessionId: queued.session_id,
         action: "queued_input",
-        detail: "queue response received",
+        detail: queueOntoActiveRun
+          ? "queue response received while current run remained attached"
+          : "queue response received",
       });
-      if (queued.session_id !== targetSessionId) {
+      if (!queueOntoActiveRun) {
+        pendingInputIdRef.current = queued.input_id;
+      } else {
+        setQueuedSessionInputs((current) => [
+          ...current,
+          {
+            inputId: queued.input_id,
+            sessionId: queued.session_id,
+            workspaceId: selectedWorkspace.id,
+            text: serializedPrompt,
+            createdAt: queuedMessageCreatedAt,
+            attachments: stagedAttachments,
+            status: "queued",
+          },
+        ]);
+        const shouldAttachQueuedRun =
+          activeSessionIdRef.current === queued.session_id &&
+          !activeStreamIdRef.current &&
+          !pendingInputIdRef.current;
+        if (shouldAttachQueuedRun) {
+          pendingInputIdRef.current = queued.input_id;
+          setIsResponding(true);
+          setLiveAgentStatus("Queued");
+          const resumed = await window.electronAPI.workspace
+            .openSessionOutputStream({
+              sessionId: queued.session_id,
+              workspaceId: selectedWorkspace.id,
+              inputId: queued.input_id,
+              includeHistory: true,
+              stopOnTerminal: true,
+            })
+            .catch((error) => {
+              pendingInputIdRef.current = null;
+              setIsResponding(false);
+              throw error;
+            });
+          activeStreamIdRef.current = resumed.streamId;
+          setQueuedSessionInputs((current) =>
+            current.map((item) =>
+              item.inputId === queued.input_id &&
+              item.sessionId === queued.session_id &&
+              item.workspaceId === selectedWorkspace.id
+                ? {
+                    ...item,
+                    status: "sending",
+                  }
+                : item,
+            ),
+          );
+          appendStreamTelemetry({
+            streamId: resumed.streamId,
+            transportType: "client",
+            eventName: "openSessionOutputStream",
+            eventType: "stream_open_queued_handoff",
+            inputId: queued.input_id,
+            sessionId: queued.session_id,
+            action: "stream_requested_queued_handoff",
+            detail: "current run finished before queue response arrived",
+          });
+        }
+      }
+      if (!queueOntoActiveRun && queued.session_id !== targetSessionId) {
         const staleStreamId = activeStreamIdRef.current;
         if (staleStreamId) {
           await closeStreamWithReason(staleStreamId, "queue_session_retarget");
@@ -5369,17 +5859,21 @@ export function ChatPane({
         });
       }
     } catch (error) {
-      const activeStreamId = activeStreamIdRef.current;
-      if (activeStreamId) {
-        await closeStreamWithReason(activeStreamId, "send_message_error").catch(
-          () => undefined,
-        );
+      if (!queueOntoActiveRun) {
+        const activeStreamId = activeStreamIdRef.current;
+        if (activeStreamId) {
+          await closeStreamWithReason(activeStreamId, "send_message_error").catch(
+            () => undefined,
+          );
+        }
       }
       setChatErrorMessage(normalizeErrorMessage(error));
-      setIsResponding(false);
-      activeAssistantMessageIdRef.current = null;
-      activeStreamIdRef.current = null;
-      pendingInputIdRef.current = null;
+      if (!queueOntoActiveRun) {
+        setIsResponding(false);
+        activeAssistantMessageIdRef.current = null;
+        activeStreamIdRef.current = null;
+        pendingInputIdRef.current = null;
+      }
       appendStreamTelemetry({
         streamId: "-",
         transportType: "client",
@@ -5390,6 +5884,8 @@ export function ChatPane({
         action: "send_failed",
         detail: normalizeErrorMessage(error),
       });
+    } finally {
+      setIsSubmittingMessage(false);
     }
   }
 
@@ -5631,6 +6127,28 @@ export function ChatPane({
     liveAssistantSegments.length > 0 ||
     Boolean(liveAssistantText) ||
     liveExecutionItems.length > 0;
+  const queuedSessionInputPreview = useQueuedSessionInputPreview({
+    workspaceId: selectedWorkspaceId,
+    sessionId: activeSessionId,
+  });
+  const todoPlanPreview = useTodoPlanPreview();
+  const activeQueuedSessionInputs = useMemo(
+    () =>
+      queuedSessionInputs.filter(
+        (item) =>
+          item.workspaceId === (selectedWorkspaceId || "").trim() &&
+          item.sessionId === (activeSessionId || "").trim(),
+      ),
+    [activeSessionId, queuedSessionInputs, selectedWorkspaceId],
+  );
+  const displayedQueuedSessionInputs =
+    queuedSessionInputPreview.length > 0
+      ? queuedSessionInputPreview
+      : activeQueuedSessionInputs;
+  const displayedTodoPlan = todoPlanPreview?.plan ?? currentTodoPlan;
+  const displayedTodoPanelExpanded =
+    todoPlanPreview?.expanded ?? todoPanelExpanded;
+  const todoPanelSlotHeightPx = 58;
   const hasMessages = messages.length > 0 || showLiveAssistantTurn;
   const streamTelemetryTail = useMemo(
     () => streamTelemetry.slice(-80).reverse(),
@@ -5955,7 +6473,7 @@ export function ChatPane({
       : "");
   const composerDisabledReason =
     composerBaseDisabledReason ||
-    (isResponding ? "Current run is still in progress." : "");
+    (isSubmittingMessage ? "Submitting message..." : "");
   const composerDisabled = Boolean(composerDisabledReason);
   const pendingImageInputUnsupportedMessage =
     pendingAttachments.some((attachment) => pendingAttachmentIsImage(attachment)) &&
@@ -6128,6 +6646,17 @@ export function ChatPane({
     onRequestCreateSession?.(draftRequest);
   };
 
+  const toggleTodoPanel = () => {
+    if (todoPlanPreview) {
+      setTodoPlanPreviewState({
+        ...todoPlanPreview,
+        expanded: !todoPlanPreview.expanded,
+      });
+      return;
+    }
+    setTodoPanelExpanded((value) => !value);
+  };
+
   return (
     <PaneCard
       className={
@@ -6281,6 +6810,21 @@ export function ChatPane({
                 </div>
               </div>
             ) : null}
+          </div>
+        ) : null}
+
+        {displayedTodoPlan ? (
+          <div
+            className="relative z-20 shrink-0 px-6 pt-3"
+            style={{ height: `${todoPanelSlotHeightPx}px` }}
+          >
+            <div className="absolute inset-x-6 top-3">
+              <CurrentTodoPanel
+                todoPlan={displayedTodoPlan}
+                expanded={displayedTodoPanelExpanded}
+                onToggle={toggleTodoPanel}
+              />
+            </div>
           </div>
         ) : null}
 
@@ -6456,75 +7000,69 @@ export function ChatPane({
                   </div>
                   <form onSubmit={onSubmit} className="w-full">
                     <div className="space-y-3">
-                      {currentTodoPlan ? (
-                        <CurrentTodoPanel
-                          todoPlan={currentTodoPlan}
-                          expanded={todoPanelExpanded}
-                          onToggle={() =>
-                            setTodoPanelExpanded((value) => !value)
+                      <QueuedSessionInputRail items={displayedQueuedSessionInputs}>
+                        <Composer
+                          input={input}
+                          quotedSkills={quotedSkills}
+                          slashCommands={slashCommandOptions}
+                          attachments={pendingAttachmentItems}
+                          isResponding={isResponding}
+                          pausePending={isPausePending}
+                          pauseDisabled={
+                            pendingInputIdRef.current === STREAM_ATTACH_PENDING ||
+                            isSubmittingMessage
                           }
+                          disabled={composerDisabled}
+                          disabledReason={composerDisabledReason}
+                          selectedModel={effectiveChatModelPreference}
+                          resolvedModelLabel={
+                            resolvedChatModel || modelSelectionUnavailableReason
+                          }
+                          runtimeDefaultModelLabel={runtimeDefaultModel}
+                          modelOptions={availableChatModelOptions}
+                          modelOptionGroups={availableChatModelOptionGroups}
+                          runtimeDefaultModelAvailable={
+                            runtimeDefaultModelAvailable
+                          }
+                          selectedThinkingValue={effectiveThinkingValue}
+                          thinkingValues={selectedThinkingValues}
+                          showThinkingValueSelector={showThinkingValueSelector}
+                          modelSelectionUnavailableReason={
+                            modelSelectionUnavailableReason
+                          }
+                          submitDisabled={Boolean(
+                            pendingImageInputUnsupportedMessage,
+                          )}
+                          placeholder={textareaPlaceholder}
+                          showModelSelector={!isOnboardingVariant}
+                          onModelChange={setChatModelPreference}
+                          onThinkingValueChange={setSelectedThinkingValue}
+                          onOpenModelProviders={() =>
+                            void window.electronAPI.ui.openSettingsPane(
+                              "providers",
+                            )
+                          }
+                          textareaRef={textareaRef}
+                          fileInputRef={fileInputRef}
+                          onChange={setInput}
+                          onKeyDown={onComposerKeyDown}
+                          onCompositionStart={onComposerCompositionStart}
+                          onCompositionEnd={onComposerCompositionEnd}
+                          onAttachmentInputChange={onAttachmentInputChange}
+                          onPause={pauseCurrentRun}
+                          onAddDroppedFiles={appendPendingLocalFiles}
+                          onAddExplorerAttachments={
+                            appendPendingExplorerAttachments
+                          }
+                          onSelectSlashCommand={(command) => {
+                            if (command.kind === "skill") {
+                              addQuotedSkill(command.skillId);
+                            }
+                          }}
+                          onRemoveQuotedSkill={removeQuotedSkill}
+                          onRemoveAttachment={removePendingAttachment}
                         />
-                      ) : null}
-                      <Composer
-                        input={input}
-                        quotedSkills={quotedSkills}
-                        slashCommands={slashCommandOptions}
-                        attachments={pendingAttachmentItems}
-                        isResponding={isResponding}
-                        pausePending={isPausePending}
-                        pauseDisabled={
-                          pendingInputIdRef.current === STREAM_ATTACH_PENDING
-                        }
-                        disabled={composerDisabled}
-                        disabledReason={composerDisabledReason}
-                        selectedModel={effectiveChatModelPreference}
-                        resolvedModelLabel={
-                          resolvedChatModel || modelSelectionUnavailableReason
-                        }
-                        runtimeDefaultModelLabel={runtimeDefaultModel}
-                        modelOptions={availableChatModelOptions}
-                        modelOptionGroups={availableChatModelOptionGroups}
-                        runtimeDefaultModelAvailable={
-                          runtimeDefaultModelAvailable
-                        }
-                        selectedThinkingValue={effectiveThinkingValue}
-                        thinkingValues={selectedThinkingValues}
-                        showThinkingValueSelector={showThinkingValueSelector}
-                        modelSelectionUnavailableReason={
-                          modelSelectionUnavailableReason
-                        }
-                        submitDisabled={Boolean(
-                          pendingImageInputUnsupportedMessage,
-                        )}
-                        placeholder={textareaPlaceholder}
-                        showModelSelector={!isOnboardingVariant}
-                        onModelChange={setChatModelPreference}
-                        onThinkingValueChange={setSelectedThinkingValue}
-                        onOpenModelProviders={() =>
-                          void window.electronAPI.ui.openSettingsPane(
-                            "providers",
-                          )
-                        }
-                        textareaRef={textareaRef}
-                        fileInputRef={fileInputRef}
-                        onChange={setInput}
-                        onKeyDown={onComposerKeyDown}
-                        onCompositionStart={onComposerCompositionStart}
-                        onCompositionEnd={onComposerCompositionEnd}
-                        onAttachmentInputChange={onAttachmentInputChange}
-                        onPause={pauseCurrentRun}
-                        onAddDroppedFiles={appendPendingLocalFiles}
-                        onAddExplorerAttachments={
-                          appendPendingExplorerAttachments
-                        }
-                        onSelectSlashCommand={(command) => {
-                          if (command.kind === "skill") {
-                            addQuotedSkill(command.skillId);
-                          }
-                        }}
-                        onRemoveQuotedSkill={removeQuotedSkill}
-                        onRemoveAttachment={removePendingAttachment}
-                      />
+                      </QueuedSessionInputRail>
                     </div>
                   </form>
                 </div>
@@ -6582,70 +7120,66 @@ export function ChatPane({
               className={`shrink-0 px-6 pb-5 pt-3 ${
                 showHistoryRestoreScreen ? "invisible" : ""
               }`}
-            >
-              <form onSubmit={onSubmit} className="w-full">
-                <div className="space-y-3">
-                  {currentTodoPlan ? (
-                    <CurrentTodoPanel
-                      todoPlan={currentTodoPlan}
-                      expanded={todoPanelExpanded}
-                      onToggle={() => setTodoPanelExpanded((value) => !value)}
-                    />
-                  ) : null}
-                  <Composer
-                    input={input}
-                    quotedSkills={quotedSkills}
-                    slashCommands={slashCommandOptions}
-                    attachments={pendingAttachmentItems}
-                    isResponding={isResponding}
-                    pausePending={isPausePending}
-                    pauseDisabled={
-                      pendingInputIdRef.current === STREAM_ATTACH_PENDING
-                    }
-                    disabled={composerDisabled}
-                    disabledReason={composerDisabledReason}
-                    selectedModel={effectiveChatModelPreference}
-                    resolvedModelLabel={
-                      resolvedChatModel || modelSelectionUnavailableReason
-                    }
-                    runtimeDefaultModelLabel={runtimeDefaultModel}
-                    modelOptions={availableChatModelOptions}
-                    modelOptionGroups={availableChatModelOptionGroups}
-                    runtimeDefaultModelAvailable={runtimeDefaultModelAvailable}
-                    selectedThinkingValue={effectiveThinkingValue}
-                    thinkingValues={selectedThinkingValues}
-                    showThinkingValueSelector={showThinkingValueSelector}
-                    modelSelectionUnavailableReason={
-                      modelSelectionUnavailableReason
-                    }
-                    submitDisabled={Boolean(
-                      pendingImageInputUnsupportedMessage,
-                    )}
-                    placeholder={textareaPlaceholder}
-                    showModelSelector={!isOnboardingVariant}
-                    onModelChange={setChatModelPreference}
-                    onThinkingValueChange={setSelectedThinkingValue}
-                    onOpenModelProviders={() =>
-                      void window.electronAPI.ui.openSettingsPane("providers")
-                    }
-                    textareaRef={textareaRef}
-                    fileInputRef={fileInputRef}
-                    onChange={setInput}
-                    onKeyDown={onComposerKeyDown}
-                    onCompositionStart={onComposerCompositionStart}
-                    onCompositionEnd={onComposerCompositionEnd}
-                    onAttachmentInputChange={onAttachmentInputChange}
-                    onPause={pauseCurrentRun}
-                    onAddDroppedFiles={appendPendingLocalFiles}
-                    onAddExplorerAttachments={appendPendingExplorerAttachments}
-                    onSelectSlashCommand={(command) => {
-                      if (command.kind === "skill") {
-                        addQuotedSkill(command.skillId);
+          >
+            <form onSubmit={onSubmit} className="w-full">
+              <div className="space-y-3">
+                  <QueuedSessionInputRail items={displayedQueuedSessionInputs}>
+                    <Composer
+                      input={input}
+                      quotedSkills={quotedSkills}
+                      slashCommands={slashCommandOptions}
+                      attachments={pendingAttachmentItems}
+                      isResponding={isResponding}
+                      pausePending={isPausePending}
+                      pauseDisabled={
+                        pendingInputIdRef.current === STREAM_ATTACH_PENDING ||
+                        isSubmittingMessage
                       }
-                    }}
-                    onRemoveQuotedSkill={removeQuotedSkill}
-                    onRemoveAttachment={removePendingAttachment}
-                  />
+                      disabled={composerDisabled}
+                      disabledReason={composerDisabledReason}
+                      selectedModel={effectiveChatModelPreference}
+                      resolvedModelLabel={
+                        resolvedChatModel || modelSelectionUnavailableReason
+                      }
+                      runtimeDefaultModelLabel={runtimeDefaultModel}
+                      modelOptions={availableChatModelOptions}
+                      modelOptionGroups={availableChatModelOptionGroups}
+                      runtimeDefaultModelAvailable={runtimeDefaultModelAvailable}
+                      selectedThinkingValue={effectiveThinkingValue}
+                      thinkingValues={selectedThinkingValues}
+                      showThinkingValueSelector={showThinkingValueSelector}
+                      modelSelectionUnavailableReason={
+                        modelSelectionUnavailableReason
+                      }
+                      submitDisabled={Boolean(
+                        pendingImageInputUnsupportedMessage,
+                      )}
+                      placeholder={textareaPlaceholder}
+                      showModelSelector={!isOnboardingVariant}
+                      onModelChange={setChatModelPreference}
+                      onThinkingValueChange={setSelectedThinkingValue}
+                      onOpenModelProviders={() =>
+                        void window.electronAPI.ui.openSettingsPane("providers")
+                      }
+                      textareaRef={textareaRef}
+                      fileInputRef={fileInputRef}
+                      onChange={setInput}
+                      onKeyDown={onComposerKeyDown}
+                      onCompositionStart={onComposerCompositionStart}
+                      onCompositionEnd={onComposerCompositionEnd}
+                      onAttachmentInputChange={onAttachmentInputChange}
+                      onPause={pauseCurrentRun}
+                      onAddDroppedFiles={appendPendingLocalFiles}
+                      onAddExplorerAttachments={appendPendingExplorerAttachments}
+                      onSelectSlashCommand={(command) => {
+                        if (command.kind === "skill") {
+                          addQuotedSkill(command.skillId);
+                        }
+                      }}
+                      onRemoveQuotedSkill={removeQuotedSkill}
+                      onRemoveAttachment={removePendingAttachment}
+                    />
+                  </QueuedSessionInputRail>
                 </div>
               </form>
             </div>
@@ -7020,6 +7554,79 @@ function UserTurn({
   );
 }
 
+function queuedSessionInputPreviewText(item: QueuedSessionInput) {
+  const parsedQuotedSkills = parseSerializedQuotedSkillPrompt(item.text);
+  const previewText =
+    parsedQuotedSkills.body ||
+    parsedQuotedSkills.skillIds.map((skillId) => `/${skillId}`).join(" ");
+  return previewText.replace(/\s+/g, " ").trim();
+}
+
+function QueuedSessionInputRail({
+  items,
+  children,
+}: {
+  items: QueuedSessionInput[];
+  children: ReactNode;
+}) {
+  if (items.length === 0) {
+    return <>{children}</>;
+  }
+  const panelInsetPx = 18;
+  const panelHeightPx = 112;
+  const overlapPx = 28;
+  const queueViewportHeightPx = 50;
+  const reservedTopPx = 94;
+
+  return (
+    <div className="relative" style={{ paddingTop: `${reservedTopPx}px` }}>
+      <div className="pointer-events-none absolute inset-x-0 top-0">
+        <div
+          className="pointer-events-auto absolute inset-x-0 overflow-hidden rounded-[28px] border border-border/32 bg-background shadow-[0_16px_34px_rgba(15,23,42,0.06)]"
+          style={{
+            left: `${panelInsetPx}px`,
+            right: `${panelInsetPx}px`,
+            height: `${panelHeightPx}px`,
+          }}
+        >
+          <div className="px-5 pt-4">
+            <div
+              className="overflow-y-auto pr-1.5"
+              style={{ maxHeight: `${queueViewportHeightPx}px` }}
+            >
+              <div className="space-y-1.5">
+                {items.map((item) => {
+                  const previewText = queuedSessionInputPreviewText(item);
+                  return (
+                    <div
+                      key={item.inputId}
+                      className="flex items-center gap-3 rounded-[14px] px-1 text-[14px] leading-7 text-foreground/84"
+                    >
+                      <CornerDownLeft
+                        size={15}
+                        className="shrink-0 text-muted-foreground/62"
+                      />
+                      <div className="min-w-0 truncate">
+                        {previewText || "Queued message"}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="relative z-10 rounded-[24px] bg-background"
+        style={{ marginTop: `${-overlapPx}px` }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function AssistantTurn({
   label,
   mode,
@@ -7340,12 +7947,12 @@ function CurrentTodoPanel({
     totalTaskCount > 0 ? `${currentTaskPosition}/${totalTaskCount}` : "0/0";
 
   return (
-    <div className="overflow-hidden rounded-[18px] border border-border/35 bg-muted/50">
+    <div className="overflow-hidden rounded-[18px] border border-border/45 bg-background shadow-[0_16px_34px_rgba(15,23,42,0.08)]">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition hover:bg-background/30"
+        className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition hover:bg-muted/55"
       >
         <div
           className={`inline-flex size-5 shrink-0 items-center justify-center rounded-full ${
@@ -7373,7 +7980,7 @@ function CurrentTodoPanel({
       </button>
 
       {expanded ? (
-        <div className="border-t border-border/20 px-3 py-3">
+        <div className="max-h-[320px] overflow-y-auto border-t border-border/20 px-3 py-3">
           <div className="space-y-3">
             {visiblePhases.map((phase) => {
               const phaseCompletedCount = phase.tasks.filter(
@@ -7383,7 +7990,7 @@ function CurrentTodoPanel({
               return (
                 <div
                   key={phase.id}
-                  className="rounded-[16px] border border-border/25 bg-muted/50 px-3 py-3"
+                  className="rounded-[16px] border border-border/30 bg-muted/75 px-3 py-3"
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div className="text-[12px] font-medium text-foreground">
@@ -8419,7 +9026,7 @@ function Composer({
     !runtimeDefaultModelAvailable &&
     modelOptions.length === 0 &&
     modelOptionGroups.length === 0;
-  const inputDisabled = disabled || isResponding;
+  const inputDisabled = disabled;
   const activeSlashRange = useMemo(
     () => findActiveSlashCommandRange(input, caretIndex),
     [caretIndex, input],
@@ -8745,7 +9352,7 @@ function Composer({
   };
 
   const allowAttachmentDrop = (dataTransfer: DataTransfer | null) => {
-    if (!dataTransfer || disabled || isResponding) {
+    if (!dataTransfer || disabled) {
       return false;
     }
 
@@ -8989,7 +9596,7 @@ function Composer({
                   runtimeDefaultModelAvailable={runtimeDefaultModelAvailable}
                   modelOptions={modelOptions}
                   modelOptionGroups={modelOptionGroups}
-                  disabled={isResponding}
+                  disabled={disabled}
                   compact={compactComposerControls}
                   onModelChange={onModelChange}
                 />
@@ -9017,7 +9624,7 @@ function Composer({
               <ThinkingValueSelect
                 selectedThinkingValue={selectedThinkingValue}
                 thinkingValues={thinkingValues}
-                disabled={isResponding}
+                disabled={disabled}
                 compact={compactComposerControls}
                 compactWidth={
                   compactComposerControls ? compactThinkingControlWidth : undefined
@@ -9176,7 +9783,7 @@ function Composer({
                 type="button"
                 variant="outline"
                 size="sm"
-                disabled={pausePending || pauseDisabled}
+                disabled={pausePending || pauseDisabled || disabled}
                 onClick={onPause}
                 className="rounded-full px-3"
               >
@@ -9187,22 +9794,22 @@ function Composer({
                 )}
                 Pause
               </Button>
-            ) : (
-              <Button
-                size="icon"
-                disabled={
-                  (!input.trim() &&
-                    attachments.length === 0 &&
-                    quotedSkills.length === 0) ||
-                  disabled ||
-                  submitDisabled
-                }
-                render={<button type="submit" />}
-                className="rounded-full"
-              >
-                <ArrowUp size={16} />
-              </Button>
-            )}
+            ) : null}
+            <Button
+              size="icon"
+              aria-label={isResponding ? "Queue message" : "Send message"}
+              disabled={
+                (!input.trim() &&
+                  attachments.length === 0 &&
+                  quotedSkills.length === 0) ||
+                disabled ||
+                submitDisabled
+              }
+              render={<button type="submit" />}
+              className="rounded-full"
+            >
+              <ArrowUp size={16} />
+            </Button>
           </div>
         </div>
       </div>

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -5912,6 +5912,78 @@ export function ChatPane({
     }
   }
 
+  async function updateQueuedSessionInputText(
+    item: QueuedSessionInput,
+    nextText: string,
+  ) {
+    const parsedQuotedSkills = parseSerializedQuotedSkillPrompt(item.text);
+    const skillOnlyPreviewText = parsedQuotedSkills.skillIds.join(" ");
+    const normalizedNextText = nextText.trim();
+    const serializedText =
+      !parsedQuotedSkills.body &&
+      parsedQuotedSkills.skillIds.length > 0 &&
+      normalizedNextText === skillOnlyPreviewText
+        ? item.text.trim()
+        : serializeQuotedSkillPrompt(nextText, parsedQuotedSkills.skillIds);
+    if (!serializedText.trim() && item.attachments.length === 0) {
+      throw new Error("Queued message can't be empty.");
+    }
+
+    if (queuedSessionInputPreview.length > 0) {
+      const previewIndex =
+        Number.parseInt(
+          item.inputId.replace("preview-queued-", "").trim(),
+          10,
+        ) - 1;
+      const currentEntries = window.__holabossQueuedMessagesPreviewState ?? [];
+      if (previewIndex < 0 || previewIndex >= currentEntries.length) {
+        throw new Error("Queued preview item not found.");
+      }
+      const updatedEntries = currentEntries.map((entry, index) => {
+        if (index !== previewIndex) {
+          return entry;
+        }
+        if (typeof entry === "string") {
+          return {
+            text: serializedText,
+            status: item.status,
+            attachments: item.attachments,
+          };
+        }
+        return {
+          ...entry,
+          text: serializedText,
+        };
+      });
+      setQueuedSessionInputPreviewState(updatedEntries);
+      return;
+    }
+
+    if (item.status !== "queued") {
+      throw new Error("Only queued messages can be edited.");
+    }
+
+    const updated = await window.electronAPI.workspace.updateQueuedSessionInput({
+      workspace_id: item.workspaceId,
+      session_id: item.sessionId,
+      input_id: item.inputId,
+      text: serializedText,
+    });
+
+    setQueuedSessionInputs((current) =>
+      current.map((currentItem) =>
+        currentItem.inputId === item.inputId &&
+        currentItem.sessionId === item.sessionId &&
+        currentItem.workspaceId === item.workspaceId
+          ? {
+              ...currentItem,
+              text: updated.text,
+            }
+          : currentItem,
+      ),
+    );
+  }
+
   function appendPendingLocalFiles(files: File[]) {
     if (files.length === 0) {
       return;
@@ -7000,7 +7072,10 @@ export function ChatPane({
                   </div>
                   <form onSubmit={onSubmit} className="w-full">
                     <div className="space-y-3">
-                      <QueuedSessionInputRail items={displayedQueuedSessionInputs}>
+                      <QueuedSessionInputRail
+                        items={displayedQueuedSessionInputs}
+                        onEditItem={updateQueuedSessionInputText}
+                      >
                         <Composer
                           input={input}
                           quotedSkills={quotedSkills}
@@ -7123,7 +7198,10 @@ export function ChatPane({
           >
             <form onSubmit={onSubmit} className="w-full">
               <div className="space-y-3">
-                  <QueuedSessionInputRail items={displayedQueuedSessionInputs}>
+                  <QueuedSessionInputRail
+                    items={displayedQueuedSessionInputs}
+                    onEditItem={updateQueuedSessionInputText}
+                  >
                     <Composer
                       input={input}
                       quotedSkills={quotedSkills}
@@ -7564,19 +7642,62 @@ function queuedSessionInputPreviewText(item: QueuedSessionInput) {
 
 function QueuedSessionInputRail({
   items,
+  onEditItem,
   children,
 }: {
   items: QueuedSessionInput[];
+  onEditItem?: (item: QueuedSessionInput, nextText: string) => Promise<void>;
   children: ReactNode;
 }) {
-  if (items.length === 0) {
-    return <>{children}</>;
-  }
+  const [editingInputId, setEditingInputId] = useState("");
+  const [editingDraft, setEditingDraft] = useState("");
+  const [editingError, setEditingError] = useState("");
+  const [savingInputId, setSavingInputId] = useState("");
   const panelInsetPx = 18;
   const panelHeightPx = 112;
   const overlapPx = 28;
   const queueViewportHeightPx = 50;
   const reservedTopPx = 94;
+
+  useEffect(() => {
+    if (!editingInputId) {
+      return;
+    }
+    const activeItem = items.find((item) => item.inputId === editingInputId);
+    if (!activeItem || activeItem.status !== "queued") {
+      setEditingInputId("");
+      setEditingDraft("");
+      setEditingError("");
+      setSavingInputId("");
+    }
+  }, [editingInputId, items]);
+
+  const cancelEditing = () => {
+    setEditingInputId("");
+    setEditingDraft("");
+    setEditingError("");
+    setSavingInputId("");
+  };
+
+  const saveEditingItem = async (item: QueuedSessionInput) => {
+    if (!onEditItem || savingInputId || item.status !== "queued") {
+      return;
+    }
+    setEditingError("");
+    setSavingInputId(item.inputId);
+    try {
+      await onEditItem(item, editingDraft);
+      cancelEditing();
+    } catch (error) {
+      setEditingError(normalizeErrorMessage(error));
+    } finally {
+      setSavingInputId("");
+    }
+  };
+
+  if (items.length === 0) {
+    return <>{children}</>;
+  }
 
   return (
     <div className="relative" style={{ paddingTop: `${reservedTopPx}px` }}>
@@ -7597,18 +7718,100 @@ function QueuedSessionInputRail({
               <div className="space-y-1.5">
                 {items.map((item) => {
                   const previewText = queuedSessionInputPreviewText(item);
+                  const isEditing = editingInputId === item.inputId;
+                  const isSaving = savingInputId === item.inputId;
                   return (
                     <div
                       key={item.inputId}
-                      className="flex items-center gap-3 rounded-[14px] px-1 text-[14px] leading-7 text-foreground/84"
+                      className="rounded-[14px] px-1 text-[14px] leading-7 text-foreground/84"
                     >
-                      <CornerDownLeft
-                        size={15}
-                        className="shrink-0 text-muted-foreground/62"
-                      />
-                      <div className="min-w-0 truncate">
-                        {previewText || "Queued message"}
-                      </div>
+                      {isEditing ? (
+                        <div className="space-y-1.5">
+                          <div className="flex items-center gap-2">
+                            <CornerDownLeft
+                              size={15}
+                              className="shrink-0 text-muted-foreground/62"
+                            />
+                            <Input
+                              value={editingDraft}
+                              onChange={(event) =>
+                                setEditingDraft(event.target.value)
+                              }
+                              onKeyDown={(event) => {
+                                if (event.key === "Enter") {
+                                  event.preventDefault();
+                                  void saveEditingItem(item);
+                                } else if (event.key === "Escape") {
+                                  event.preventDefault();
+                                  cancelEditing();
+                                }
+                              }}
+                              disabled={isSaving}
+                              autoFocus
+                              className="h-8 min-w-0 flex-1 rounded-[10px] border-border/40 bg-background px-2.5 text-[13px]"
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              disabled={isSaving}
+                              onClick={() => {
+                                void saveEditingItem(item);
+                              }}
+                              className="size-7 rounded-full text-muted-foreground hover:bg-foreground/6 hover:text-foreground"
+                              aria-label="Save queued message edit"
+                            >
+                              {isSaving ? (
+                                <Loader2 size={13} className="animate-spin" />
+                              ) : (
+                                <Check size={13} />
+                              )}
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              disabled={isSaving}
+                              onClick={cancelEditing}
+                              className="size-7 rounded-full text-muted-foreground hover:bg-foreground/6 hover:text-foreground"
+                              aria-label="Cancel queued message edit"
+                            >
+                              <X size={13} />
+                            </Button>
+                          </div>
+                          {editingError ? (
+                            <div className="pl-6 text-[11px] leading-5 text-destructive">
+                              {editingError}
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-3">
+                          <CornerDownLeft
+                            size={15}
+                            className="shrink-0 text-muted-foreground/62"
+                          />
+                          <div className="min-w-0 flex-1 truncate">
+                            {previewText || "Queued message"}
+                          </div>
+                          {onEditItem && item.status === "queued" ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              onClick={() => {
+                                setEditingInputId(item.inputId);
+                                setEditingDraft(previewText);
+                                setEditingError("");
+                              }}
+                              className="size-7 rounded-full text-muted-foreground hover:bg-foreground/6 hover:text-foreground"
+                              aria-label="Edit queued message"
+                            >
+                              <PencilLine size={13} />
+                            </Button>
+                          ) : null}
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/desktop/src/components/panes/browserSessionUi.ts
+++ b/desktop/src/components/panes/browserSessionUi.ts
@@ -3,7 +3,11 @@ const ACTIVE_BROWSER_SESSION_STATUSES = new Set(["BUSY", "QUEUED", "PAUSING"]);
 function normalizedRuntimeStatus(
   runtimeState: SessionRuntimeRecordPayload | null | undefined,
 ): string {
-  return runtimeState?.status?.trim().toUpperCase() ?? "";
+  return (
+    runtimeState?.effective_state?.trim().toUpperCase() ||
+    runtimeState?.status?.trim().toUpperCase() ||
+    ""
+  );
 }
 
 export function browserSessionTitle(

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -705,6 +705,9 @@ declare global {
     workspace_id: string;
     session_id: string;
     status: string;
+    effective_state?: string | null;
+    runtime_status?: string | null;
+    has_queued_inputs?: boolean;
     current_input_id: string | null;
     current_worker_id: string | null;
     lease_until: string | null;
@@ -814,6 +817,10 @@ declare global {
     input_id: string;
     session_id: string;
     status: string;
+    effective_state?: string | null;
+    runtime_status?: string | null;
+    current_input_id?: string | null;
+    has_queued_inputs?: boolean;
   }
 
   interface PauseSessionRunResponsePayload {

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -829,6 +829,14 @@ declare global {
     status: string;
   }
 
+  interface UpdateQueuedSessionInputResponsePayload {
+    input_id: string;
+    session_id: string;
+    status: string;
+    text: string;
+    updated_at: string;
+  }
+
   interface HolabossClientConfigPayload {
     projectsUrl: string;
     marketplaceUrl: string;
@@ -1085,6 +1093,13 @@ declare global {
   interface HolabossPauseSessionRunPayload {
     workspace_id: string;
     session_id: string;
+  }
+
+  interface HolabossUpdateQueuedSessionInputPayload {
+    workspace_id: string;
+    session_id: string;
+    input_id: string;
+    text: string;
   }
 
   interface HolabossSessionStreamHandlePayload {
@@ -1457,6 +1472,9 @@ declare global {
       ) => Promise<StageSessionAttachmentsResponsePayload>;
       queueSessionInput: (payload: HolabossQueueSessionInputPayload) => Promise<EnqueueSessionInputResponsePayload>;
       pauseSessionRun: (payload: HolabossPauseSessionRunPayload) => Promise<PauseSessionRunResponsePayload>;
+      updateQueuedSessionInput: (
+        payload: HolabossUpdateQueuedSessionInputPayload
+      ) => Promise<UpdateQueuedSessionInputResponsePayload>;
       openSessionOutputStream: (payload: HolabossStreamSessionOutputsPayload) => Promise<HolabossSessionStreamHandlePayload>;
       closeSessionOutputStream: (streamId: string, reason?: string) => Promise<void>;
       getSessionStreamDebug: () => Promise<HolabossSessionStreamDebugEntry[]>;

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -4632,6 +4632,112 @@ test("queue route preserves an existing explicit session title", async () => {
   store.close();
 });
 
+test("queued input edit route updates queued input text without writing session history", async () => {
+  const root = makeTempDir("hb-runtime-api-edit-queued-input-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const app = buildTestRuntimeApiServer({ store });
+
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: {
+      text: "draft this first",
+      attachments: [],
+      image_urls: [],
+      model: null,
+      thinking_value: null,
+      context: {},
+    },
+  });
+
+  const response = await app.inject({
+    method: "PATCH",
+    url: `/api/v1/agent-sessions/session-main/inputs/${queued.inputId}`,
+    payload: {
+      workspace_id: workspace.id,
+      text: "draft this second",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().input_id, queued.inputId);
+  assert.equal(response.json().session_id, "session-main");
+  assert.equal(response.json().status, "QUEUED");
+  assert.equal(response.json().text, "draft this second");
+
+  const updated = store.getInput(queued.inputId);
+  assert.ok(updated);
+  assert.equal(updated?.payload.text, "draft this second");
+  const history = store.listSessionMessages({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+  });
+  assert.equal(history.length, 0);
+
+  await app.close();
+  store.close();
+});
+
+test("queued input edit route rejects edits after the input is claimed", async () => {
+  const root = makeTempDir("hb-runtime-api-edit-claimed-input-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const app = buildTestRuntimeApiServer({ store });
+
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: {
+      text: "draft this first",
+      attachments: [],
+      image_urls: [],
+      model: null,
+      thinking_value: null,
+      context: {},
+    },
+  });
+  store.updateInput(queued.inputId, {
+    status: "CLAIMED",
+    claimedBy: "worker-1",
+    claimedUntil: "2026-04-17T12:00:00.000Z",
+  });
+
+  const response = await app.inject({
+    method: "PATCH",
+    url: `/api/v1/agent-sessions/session-main/inputs/${queued.inputId}`,
+    payload: {
+      workspace_id: workspace.id,
+      text: "edited too late",
+    },
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(
+    response.json().detail,
+    "queued input can no longer be edited",
+  );
+
+  await app.close();
+  store.close();
+});
+
 test("pause route delegates to the configured queue worker", async () => {
   const root = makeTempDir("hb-runtime-api-pause-route-");
   const store = new RuntimeStateStore({

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -2162,6 +2162,8 @@ test("runtime states and history endpoints read TS state store", async () => {
   assert.equal(states.json().count, 1);
   assert.equal(states.json().items[0].session_id, "session-main");
   assert.equal(states.json().items[0].status, "IDLE");
+  assert.equal(states.json().items[0].effective_state, "IDLE");
+  assert.equal(states.json().items[0].has_queued_inputs, false);
   assert.equal(states.json().items[0].last_turn_status, "completed");
   assert.equal(states.json().items[0].last_turn_completed_at, "2026-01-01T00:00:05.000Z");
   assert.equal(states.json().items[0].last_turn_stop_reason, "ok");
@@ -4439,7 +4441,7 @@ test("app list and build-status infer pending when installed app has setup but n
   store.close();
 });
 
-test("queue route persists input, user message, and runtime state", async () => {
+test("queue route persists input and runtime state without writing session history until claim", async () => {
   const root = makeTempDir("hb-runtime-api-");
   const store = new RuntimeStateStore({
     dbPath: path.join(root, "runtime.db"),
@@ -4465,6 +4467,9 @@ test("queue route persists input, user message, and runtime state", async () => 
 
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().status, "QUEUED");
+  assert.equal(response.json().effective_state, "QUEUED");
+  assert.equal(response.json().runtime_status, "QUEUED");
+  assert.equal(response.json().has_queued_inputs, true);
   const sessionId = response.json().session_id;
   assert.ok(typeof sessionId === "string" && sessionId.trim().length > 0);
 
@@ -4489,9 +4494,99 @@ test("queue route persists input, user message, and runtime state", async () => 
   assert.equal(binding.harnessSessionId, sessionId);
 
   const history = store.listSessionMessages({ workspaceId: workspace.id, sessionId });
-  assert.equal(history.length, 1);
-  assert.equal(history[0].role, "user");
-  assert.equal(history[0].text, "hello world");
+  assert.equal(history.length, 0);
+
+  await app.close();
+  store.close();
+});
+
+test("queue route preserves the active claimed input while adding later queued work", async () => {
+  const root = makeTempDir("hb-runtime-api-queue-preserve-active-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+  const app = buildTestRuntimeApiServer({ store });
+
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  store.ensureSession({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    kind: "workspace_session",
+  });
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: "session-main",
+  });
+  const active = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "currently running" },
+  });
+  store.updateInput(active.inputId, {
+    status: "CLAIMED",
+    claimedBy: "worker-1",
+    claimedUntil: "2026-04-17T12:00:00.000Z",
+  });
+  store.updateRuntimeState({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    status: "BUSY",
+    currentInputId: active.inputId,
+    currentWorkerId: "worker-1",
+    leaseUntil: "2026-04-17T12:00:00.000Z",
+    heartbeatAt: "2026-04-17T11:55:00.000Z",
+    lastError: null,
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/v1/agent-sessions/queue",
+    payload: {
+      workspace_id: workspace.id,
+      session_id: "session-main",
+      text: "queue this next",
+    }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().status, "QUEUED");
+  assert.equal(response.json().effective_state, "BUSY");
+  assert.equal(response.json().runtime_status, "BUSY");
+  assert.equal(response.json().current_input_id, active.inputId);
+  assert.equal(response.json().has_queued_inputs, true);
+
+  const runtimeState = store.getRuntimeState({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+  });
+  assert.equal(runtimeState?.status, "BUSY");
+  assert.equal(runtimeState?.currentInputId, active.inputId);
+  assert.equal(runtimeState?.currentWorkerId, "worker-1");
+  const history = store.listSessionMessages({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+  });
+  assert.equal(history.length, 0);
+
+  const states = await app.inject({
+    method: "GET",
+    url: `/api/v1/agent-sessions/by-workspace/${workspace.id}/runtime-states`
+  });
+
+  assert.equal(states.statusCode, 200);
+  assert.equal(states.json().items[0].status, "BUSY");
+  assert.equal(states.json().items[0].effective_state, "BUSY");
+  assert.equal(states.json().items[0].runtime_status, "BUSY");
+  assert.equal(states.json().items[0].has_queued_inputs, true);
+  assert.equal(states.json().items[0].current_input_id, active.inputId);
 
   await app.close();
   store.close();
@@ -4784,9 +4879,7 @@ test("accept task proposal creates a child session with queued work", async () =
     workspaceId: workspace.id,
     sessionId: body.session.session_id
   });
-  assert.equal(childHistory.length, 1);
-  assert.equal(childHistory[0].role, "user");
-  assert.equal(childHistory[0].text, "Write the follow-up and send a reminder");
+  assert.equal(childHistory.length, 0);
 
   const secondAccept = await app.inject({
     method: "POST",

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -5210,7 +5210,7 @@ test("queue route rejects inputs while workspace apps are still building", async
   store.close();
 });
 
-test("queue route accepts staged file and folder attachments and history hydrates attachment metadata", async () => {
+test("queue route accepts staged file and folder attachments and history hydrates attachment metadata after claim", async () => {
   const root = makeTempDir("hb-runtime-api-queue-attachments-");
   const store = new RuntimeStateStore({
     dbPath: path.join(root, "runtime.db"),
@@ -5294,12 +5294,29 @@ test("queue route accepts staged file and folder attachments and history hydrate
   });
 
   assert.equal(historyResponse.statusCode, 200);
-  assert.deepEqual(historyResponse.json().messages, [
+  assert.deepEqual(historyResponse.json().messages, []);
+
+  store.insertSessionMessage({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    role: "user",
+    text: "",
+    messageId: `user-${response.json().input_id}`,
+    createdAt: "2026-01-01T00:00:00.000Z"
+  });
+
+  const claimedHistoryResponse = await app.inject({
+    method: "GET",
+    url: `/api/v1/agent-sessions/session-main/history?workspace_id=${workspace.id}`
+  });
+
+  assert.equal(claimedHistoryResponse.statusCode, 200);
+  assert.deepEqual(claimedHistoryResponse.json().messages, [
     {
       id: `user-${response.json().input_id}`,
       role: "user",
       text: "",
-      created_at: historyResponse.json().messages[0]?.created_at,
+      created_at: "2026-01-01T00:00:00.000Z",
       metadata: {
         attachments: [
           {

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -636,9 +636,13 @@ function runtimeStatePayload(record: SessionRuntimeStateRecord): Record<string, 
 function runtimeStateListItemPayload(params: {
   record: SessionRuntimeStateRecord;
   lastTurnResult?: TurnResultRecord | null;
+  hasQueuedInputs?: boolean;
 }): Record<string, unknown> {
+  const hasQueuedInputs = params.hasQueuedInputs ?? false;
   return {
     ...runtimeStatePayload(params.record),
+    ...effectiveSessionState(params.record, hasQueuedInputs),
+    has_queued_inputs: hasQueuedInputs,
     last_turn_status: params.lastTurnResult?.status ?? null,
     last_turn_completed_at: params.lastTurnResult?.completedAt ?? null,
     last_turn_stop_reason: params.lastTurnResult?.stopReason ?? null,
@@ -1133,6 +1137,17 @@ function effectiveSessionState(
     heartbeat_at: runtimeState?.heartbeatAt ?? null,
     lease_until: runtimeState?.leaseUntil ?? null
   };
+}
+
+function runtimeStateHasClaimedActiveInput(
+  store: RuntimeStateStore,
+  runtimeState: SessionRuntimeStateRecord | null,
+): boolean {
+  const currentInputId = runtimeState?.currentInputId?.trim() ?? "";
+  if (!currentInputId) {
+    return false;
+  }
+  return store.getInput(currentInputId)?.status === "CLAIMED";
 }
 
 function runnerOutputEventPayload(record: OutputEventRecord): Record<string, unknown> {
@@ -5319,11 +5334,16 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         harnessSessionId: resolvedSessionId
       });
     }
-    store.ensureRuntimeState({
-      workspaceId,
-      sessionId: resolvedSessionId,
-      status: "QUEUED"
-    });
+    const runtimeStateBeforeQueue =
+      store.getRuntimeState({
+        workspaceId,
+        sessionId: resolvedSessionId,
+      }) ??
+      store.ensureRuntimeState({
+        workspaceId,
+        sessionId: resolvedSessionId,
+        status: "IDLE"
+      });
     const record = store.enqueueInput({
       workspaceId,
       sessionId: resolvedSessionId,
@@ -5338,13 +5358,6 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         context: {}
       }
     });
-    store.insertSessionMessage({
-      workspaceId,
-      sessionId: resolvedSessionId,
-      role: "user",
-      text: trimmedText,
-      messageId: `user-${record.inputId}`
-    });
     createInputMemoryUpdateProposals({
       store,
       workspaceId,
@@ -5353,21 +5366,43 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       sourceMessageId: `user-${record.inputId}`,
       text: trimmedText,
     });
-    store.updateRuntimeState({
+    if (runtimeStateHasClaimedActiveInput(store, runtimeStateBeforeQueue)) {
+      store.updateRuntimeState({
+        workspaceId,
+        sessionId: resolvedSessionId,
+        status: runtimeStateBeforeQueue?.status ?? "BUSY",
+        currentInputId: runtimeStateBeforeQueue?.currentInputId ?? null,
+        currentWorkerId: runtimeStateBeforeQueue?.currentWorkerId ?? null,
+        leaseUntil: runtimeStateBeforeQueue?.leaseUntil ?? null,
+        heartbeatAt: runtimeStateBeforeQueue?.heartbeatAt ?? null,
+        lastError: runtimeStateBeforeQueue?.lastError ?? null
+      });
+    } else {
+      store.updateRuntimeState({
+        workspaceId,
+        sessionId: resolvedSessionId,
+        status: "QUEUED",
+        currentInputId: record.inputId,
+        currentWorkerId: null,
+        leaseUntil: null,
+        heartbeatAt: null,
+        lastError: null
+      });
+    }
+    const runtimeStateAfterQueue = store.getRuntimeState({
       workspaceId,
       sessionId: resolvedSessionId,
-      status: "QUEUED",
-      currentInputId: record.inputId,
-      currentWorkerId: null,
-      leaseUntil: null,
-      heartbeatAt: null,
-      lastError: null
     });
+    const queueAwareState = effectiveSessionState(runtimeStateAfterQueue, true);
     queueWorker?.wake();
     return {
       input_id: record.inputId,
       session_id: record.sessionId,
-      status: record.status
+      status: record.status,
+      effective_state: queueAwareState.effective_state,
+      runtime_status: queueAwareState.runtime_status,
+      current_input_id: queueAwareState.current_input_id,
+      has_queued_inputs: true,
     };
   });
 
@@ -5450,8 +5485,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const params = request.params as { workspaceId: string };
     const items = store
       .listRuntimeStates(params.workspaceId)
-      .map((item: SessionRuntimeStateRecord) =>
-        runtimeStateListItemPayload({
+      .map((item: SessionRuntimeStateRecord) => {
+        const hasQueuedInputs = store.hasAvailableInputsForSession({
+          workspaceId: params.workspaceId,
+          sessionId: item.sessionId,
+        });
+        return runtimeStateListItemPayload({
           record: item,
           lastTurnResult:
             store.listTurnResults({
@@ -5460,8 +5499,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
               limit: 1,
               offset: 0,
             })[0] ?? null,
-        }),
-      );
+          hasQueuedInputs,
+        });
+      });
     return { items, count: items.length };
   });
 
@@ -5800,10 +5840,15 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
           limit: 1,
           offset: 0,
         })[0] ?? null;
+      const hasQueuedInputs = store.hasAvailableInputsForSession({
+        workspaceId: params.workspaceId,
+        sessionId: row.sessionId,
+      });
       return {
         ...runtimeStateListItemPayload({
           record: row,
           lastTurnResult,
+          hasQueuedInputs,
         }),
         artifacts: artifactsBySession.get(row.sessionId) ?? [],
       };
@@ -6345,13 +6390,6 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
             : null,
         }
       }
-    });
-    store.insertSessionMessage({
-      workspaceId: proposal.workspaceId,
-      sessionId,
-      role: "user",
-      text: taskPrompt,
-      messageId: `user-${record.inputId}`
     });
     store.updateRuntimeState({
       workspaceId: proposal.workspaceId,

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -5438,6 +5438,60 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     };
   });
 
+  app.patch("/api/v1/agent-sessions/:sessionId/inputs/:inputId", async (request, reply) => {
+    if (!isRecord(request.body)) {
+      return sendError(reply, 400, "request body must be an object");
+    }
+    const params = request.params as { sessionId: string; inputId: string };
+    const workspaceId = optionalString(request.body.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
+    const workspace = store.getWorkspace(workspaceId);
+    if (!workspace) {
+      return sendError(reply, 404, "workspace not found");
+    }
+
+    const input = store.getInput(params.inputId);
+    if (
+      !input ||
+      input.workspaceId !== workspaceId ||
+      input.sessionId !== params.sessionId
+    ) {
+      return sendError(reply, 404, "queued input not found");
+    }
+    if (input.status !== "QUEUED") {
+      return sendError(reply, 409, "queued input can no longer be edited");
+    }
+
+    const existingPayload = isRecord(input.payload) ? input.payload : {};
+    const trimmedText = (optionalString(request.body.text) ?? "").trim();
+    const existingAttachments = Array.isArray(existingPayload.attachments)
+      ? existingPayload.attachments
+      : [];
+    if (!trimmedText && existingAttachments.length === 0) {
+      return sendError(reply, 422, "text or attachments are required");
+    }
+
+    const updated = store.updateInput(params.inputId, {
+      payload: {
+        ...existingPayload,
+        text: trimmedText,
+      },
+    });
+    if (!updated) {
+      return sendError(reply, 500, "failed to update queued input");
+    }
+
+    return {
+      input_id: updated.inputId,
+      session_id: updated.sessionId,
+      status: updated.status,
+      text: optionalString(updated.payload.text) ?? "",
+      updated_at: updated.updatedAt,
+    };
+  });
+
   app.get("/api/v1/agent-sessions", async (request, reply) => {
     const query = isRecord(request.query) ? request.query : {};
     const workspaceId = optionalString(query.workspace_id);

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -241,9 +241,12 @@ test("claimed input persists runner events, assistant text, and idle state on su
     "output_delta",
     "run_completed",
   ]);
-  assert.equal(messages.length, 1);
-  assert.equal(messages[0].role, "assistant");
-  assert.equal(messages[0].text, "Hello from TS");
+  assert.equal(messages.length, 2);
+  assert.equal(messages[0].id, `user-${queued.inputId}`);
+  assert.equal(messages[0].role, "user");
+  assert.equal(messages[0].text, "hello");
+  assert.equal(messages[1].role, "assistant");
+  assert.equal(messages[1].text, "Hello from TS");
   assert.ok(turnResult);
   assert.equal(turnResult.status, "completed");
   assert.equal(turnResult.stopReason, "ok");
@@ -650,10 +653,13 @@ test("claimed input captures file outputs and persists an assistant turn for out
   assert.equal(outputs[0].metadata.origin_type, "file");
   assert.equal(outputs[0].metadata.change_type, "created");
   assert.equal(outputs[0].metadata.category, "document");
-  assert.equal(messages.length, 1);
-  assert.equal(messages[0].id, `assistant-${queued.inputId}`);
-  assert.equal(messages[0].role, "assistant");
-  assert.equal(messages[0].text, "");
+  assert.equal(messages.length, 2);
+  assert.equal(messages[0].id, `user-${queued.inputId}`);
+  assert.equal(messages[0].role, "user");
+  assert.equal(messages[0].text, "create a report file");
+  assert.equal(messages[1].id, `assistant-${queued.inputId}`);
+  assert.equal(messages[1].role, "assistant");
+  assert.equal(messages[1].text, "");
 
   store.close();
 });
@@ -863,8 +869,11 @@ test("claimed input honors a persisted failure terminal after claim recovery abo
     events.map((event) => event.eventType),
     ["run_started", "output_delta", "run_failed"]
   );
-  assert.equal(messages.length, 1);
-  assert.equal(messages[0]?.text, "Partial answer");
+  assert.equal(messages.length, 2);
+  assert.equal(messages[0]?.id, `user-${queued.inputId}`);
+  assert.equal(messages[0]?.text, "hello");
+  assert.equal(messages[1]?.id, `assistant-${queued.inputId}`);
+  assert.equal(messages[1]?.text, "Partial answer");
   assert.ok(turnResult);
   assert.equal(turnResult.status, "failed");
   assert.equal(turnResult.stopReason, "RuntimeError");

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -259,6 +259,24 @@ function eventTimestampOrNow(event: RunnerEvent): string {
   return createdAtForEvent(event) ?? new Date().toISOString();
 }
 
+function orderedAssistantMessageTimestamp(
+  turnStartedAt: string,
+  completedAt: string | null,
+): string {
+  const startedAtMs = Date.parse(turnStartedAt);
+  const completedAtMs = Date.parse(completedAt ?? "");
+  if (Number.isFinite(startedAtMs) && Number.isFinite(completedAtMs)) {
+    return new Date(Math.max(startedAtMs + 1, completedAtMs)).toISOString();
+  }
+  if (Number.isFinite(startedAtMs)) {
+    return new Date(startedAtMs + 1).toISOString();
+  }
+  if (Number.isFinite(completedAtMs)) {
+    return new Date(completedAtMs).toISOString();
+  }
+  return new Date().toISOString();
+}
+
 function tokenUsageFromPayload(payload: Record<string, unknown>): Record<string, unknown> | null {
   const direct = jsonRecord(payload.token_usage);
   if (direct) {
@@ -796,6 +814,14 @@ export async function processClaimedInput(params: {
     attachments,
     workspace
   });
+  store.insertSessionMessage({
+    workspaceId: record.workspaceId,
+    sessionId: record.sessionId,
+    role: "user",
+    text: String(record.payload.text ?? ""),
+    messageId: `user-${record.inputId}`,
+    createdAt: turnStartedAt,
+  });
 
   store.updateRuntimeState({
     workspaceId: record.workspaceId,
@@ -1287,7 +1313,11 @@ export async function processClaimedInput(params: {
         sessionId: record.sessionId,
         role: "assistant",
         text: assistantText,
-        messageId: `assistant-${record.inputId}`
+        messageId: `assistant-${record.inputId}`,
+        createdAt: orderedAssistantMessageTimestamp(
+          turnStartedAt,
+          completedAt,
+        ),
       });
     }
     const turnResult = persistTurnResult({

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -996,6 +996,43 @@ test("session messages preserve ascending order and include metadata placeholder
   store.close();
 });
 
+test("session messages preserve sub-second ordering within the same second", () => {
+  const root = makeTempDir("hb-state-store-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  store.insertSessionMessage({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    role: "user",
+    text: "first",
+    messageId: "m-user",
+    createdAt: "2026-01-01T00:00:00.100Z"
+  });
+  store.insertSessionMessage({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    role: "assistant",
+    text: "second",
+    messageId: "m-assistant",
+    createdAt: "2026-01-01T00:00:00.200Z"
+  });
+
+  assert.deepEqual(
+    store
+      .listSessionMessages({
+        workspaceId: "workspace-1",
+        sessionId: "session-main",
+      })
+      .map((message) => message.id),
+    ["m-user", "m-assistant"],
+  );
+
+  store.close();
+});
+
 test("output events support latest id, incremental listing, and tail mode", () => {
   const root = makeTempDir("hb-state-store-");
   const store = new RuntimeStateStore({

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -2067,7 +2067,7 @@ export class RuntimeStateStore {
       values.push(params.role);
     }
     const direction = params.order === "desc" ? "DESC" : "ASC";
-    query += ` ORDER BY datetime(created_at) ${direction}, id ${direction}`;
+    query += ` ORDER BY julianday(created_at) ${direction}, id ${direction}`;
     if (params.limit !== undefined || params.offset !== undefined) {
       query += " LIMIT ? OFFSET ?";
       values.push(params.limit ?? -1, params.offset ?? 0);


### PR DESCRIPTION
## Context

This branch adds queued input support for agent sessions and refines the desktop queue/todo UX so follow-up prompts stay visible, editable, and separate from committed chat history.

## What changed

- add runtime support for queued session inputs without writing queued prompts into `session_messages` before claim
- expose queue-aware runtime state so the desktop app can keep the current stream attached while follow-up inputs wait
- update the desktop composer/queue UI to show queued prompts separately from normal chat messages
- move the todo panel to the top of the pane and keep expansion from reflowing the whole chat area
- add inline editing for queued messages with runtime persistence through the Electron bridge
- add dev preview hooks for queued messages and todos to inspect the combined design states

## Validation

- `cd runtime/api-server && node --import tsx --test --test-name-pattern 'queue route persists input and runtime state without writing session history until claim|queue route preserves the active claimed input while adding later queued work|queued input edit route updates queued input text without writing session history|queued input edit route rejects edits after the input is claimed' src/app.test.ts`
- `cd runtime/api-server && npm run typecheck`
- `cd desktop && node --test --test-name-pattern 'chat pane renders a collapsed current todo panel near the top of the pane|chat pane keeps the current stream attached while queueing a follow-up input|chat pane exposes a queued message preview hook for dev console inspection|chat pane exposes a todo preview hook for combined todo and queue design inspection|chat composer exposes a pause action for in-flight runs and calls the runtime pause API' src/components/panes/ChatPane.test.mjs`
- `cd desktop && npm run typecheck`
