### PR TITLE
feat: add separate OpenAI Codex OAuth provider path

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -167,6 +167,25 @@ const RUNTIME_HOLABOSS_PROVIDER_ALIASES = [
   "holaboss",
   RUNTIME_HOLABOSS_PROVIDER_ID,
 ] as const;
+const OPENAI_CODEX_PROVIDER_ID = "openai_codex";
+const OPENAI_CODEX_PROVIDER_LABEL = "OpenAI Codex";
+const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const OPENAI_CODEX_DEFAULT_MODELS = ["gpt-5.4", "gpt-5.3-codex"] as const;
+const OPENAI_CODEX_OAUTH_ISSUER = "https://auth.openai.com";
+const OPENAI_CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENAI_CODEX_OAUTH_DEVICE_CODE_URL =
+  `${OPENAI_CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/usercode`;
+const OPENAI_CODEX_OAUTH_DEVICE_TOKEN_URL =
+  `${OPENAI_CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/token`;
+const OPENAI_CODEX_OAUTH_TOKEN_URL =
+  `${OPENAI_CODEX_OAUTH_ISSUER}/oauth/token`;
+const OPENAI_CODEX_OAUTH_DEVICE_PAGE_URL =
+  `${OPENAI_CODEX_OAUTH_ISSUER}/codex/device`;
+const OPENAI_CODEX_OAUTH_REDIRECT_URI =
+  `${OPENAI_CODEX_OAUTH_ISSUER}/deviceauth/callback`;
+const OPENAI_CODEX_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const OPENAI_CODEX_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const OPENAI_CODEX_DEVICE_TIMEOUT_MS = 15 * 60 * 1000;
 const RUNTIME_DEPRECATED_MODEL_IDS = new Set([
   "gpt-5.1",
   "gpt-5.1-codex",
@@ -807,6 +826,8 @@ let appUpdateCheckTimer: NodeJS.Timeout | null = null;
 let appUpdateCheckPromise: Promise<AppUpdateStatusPayload> | null = null;
 let appUpdateEventsConfigured = false;
 let appUpdatePreferences: AppUpdatePreferencesPayload = {};
+let codexOauthRefreshTimer: NodeJS.Timeout | null = null;
+let codexOauthRefreshPromise: Promise<boolean> | null = null;
 let runtimeModelCatalogState: RuntimeModelCatalogPayload = {
   catalogVersion: null,
   defaultBackgroundModel: null,
@@ -5592,6 +5613,192 @@ async function writeRuntimeConfigTextAtomically(
   }
 }
 
+function openAiCodexAccessTokenExpiresAt(expiresIn: unknown): string {
+  const rawSeconds =
+    typeof expiresIn === "number"
+      ? expiresIn
+      : typeof expiresIn === "string"
+        ? Number.parseInt(expiresIn, 10)
+        : NaN;
+  const seconds =
+    Number.isFinite(rawSeconds) && rawSeconds > 0 ? rawSeconds : 3600;
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+function openAiCodexExpiryTimestampMs(value: unknown): number {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) {
+    return 0;
+  }
+  const timestamp = Date.parse(normalized);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function openAiCodexNeedsRefresh(
+  expiresAt: unknown,
+  skewMs = OPENAI_CODEX_REFRESH_SKEW_MS,
+): boolean {
+  const expiryTimestampMs = openAiCodexExpiryTimestampMs(expiresAt);
+  if (!expiryTimestampMs) {
+    return true;
+  }
+  return expiryTimestampMs - Date.now() <= skewMs;
+}
+
+function openAiCodexProviderStateFromDocument(document: Record<string, unknown>) {
+  const providersPayload = runtimeConfigObject(document.providers);
+  const providerPayload = runtimeConfigObject(
+    providersPayload[OPENAI_CODEX_PROVIDER_ID],
+  );
+  const optionsPayload = runtimeConfigObject(providerPayload.options);
+  return {
+    providersPayload,
+    providerPayload,
+    optionsPayload,
+    authMode: runtimeFirstNonEmptyString(
+      providerPayload.auth_mode as string | undefined,
+      optionsPayload.auth_mode as string | undefined,
+    ),
+    baseUrl: runtimeFirstNonEmptyString(
+      providerPayload.base_url as string | undefined,
+      providerPayload.baseURL as string | undefined,
+      optionsPayload.base_url as string | undefined,
+      optionsPayload.baseURL as string | undefined,
+      OPENAI_CODEX_BASE_URL,
+    ),
+    accessToken: runtimeFirstNonEmptyString(
+      providerPayload.api_key as string | undefined,
+      providerPayload.auth_token as string | undefined,
+    ),
+    refreshToken: runtimeFirstNonEmptyString(
+      optionsPayload.refresh_token as string | undefined,
+      optionsPayload.refreshToken as string | undefined,
+    ),
+    accessTokenExpiresAt: runtimeFirstNonEmptyString(
+      optionsPayload.access_token_expires_at as string | undefined,
+      optionsPayload.accessTokenExpiresAt as string | undefined,
+    ),
+  };
+}
+
+function runtimeDocumentHasProviderModels(
+  document: Record<string, unknown>,
+  providerId: string,
+): boolean {
+  const modelsPayload = runtimeConfigObject(document.models);
+  for (const [token, rawModel] of Object.entries(modelsPayload)) {
+    const modelPayload = runtimeConfigObject(rawModel);
+    const configuredProviderId = runtimeFirstNonEmptyString(
+      modelPayload.provider as string | undefined,
+      modelPayload.provider_id as string | undefined,
+      token.includes("/") ? token.split("/")[0]?.trim() : "",
+    );
+    if (configuredProviderId === providerId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function withOpenAiCodexProviderState(
+  document: Record<string, unknown>,
+  update: {
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresAt: string;
+    lastRefreshAt?: string;
+  },
+): Record<string, unknown> {
+  const providersPayload = runtimeConfigObject(document.providers);
+  const existingProviderPayload = runtimeConfigObject(
+    providersPayload[OPENAI_CODEX_PROVIDER_ID],
+  );
+  const existingOptionsPayload = runtimeConfigObject(existingProviderPayload.options);
+  const nextProviderPayload: Record<string, unknown> = {
+    ...existingProviderPayload,
+    kind: RUNTIME_PROVIDER_KIND_OPENAI_COMPATIBLE,
+    base_url: OPENAI_CODEX_BASE_URL,
+    api_key: update.accessToken.trim(),
+    options: {
+      ...existingOptionsPayload,
+      auth_mode: "codex_oauth",
+      refresh_token: update.refreshToken.trim(),
+      access_token_expires_at: update.accessTokenExpiresAt.trim(),
+      last_refresh_at:
+        update.lastRefreshAt?.trim() || existingOptionsPayload.last_refresh_at || utcNowIso(),
+    },
+  };
+  const nextProviders = {
+    ...providersPayload,
+    [OPENAI_CODEX_PROVIDER_ID]: nextProviderPayload,
+  };
+  const currentModels = runtimeConfigObject(document.models);
+  const nextModels: Record<string, unknown> = { ...currentModels };
+  if (!runtimeDocumentHasProviderModels(document, OPENAI_CODEX_PROVIDER_ID)) {
+    for (const modelId of OPENAI_CODEX_DEFAULT_MODELS) {
+      nextModels[`${OPENAI_CODEX_PROVIDER_ID}/${modelId}`] = {
+        provider: OPENAI_CODEX_PROVIDER_ID,
+        model: modelId,
+      };
+    }
+  }
+  return {
+    ...document,
+    providers: nextProviders,
+    models: nextModels,
+  };
+}
+
+async function updateRuntimeConfigDocumentWithoutRestart(
+  mutate: (currentDocument: Record<string, unknown>) => Record<string, unknown>,
+): Promise<RuntimeConfigPayload> {
+  let didWrite = false;
+  await withRuntimeConfigMutationLock(async () => {
+    const currentDocument = await readRuntimeConfigDocument();
+    const nextDocument = mutate(currentDocument);
+    const currentText =
+      Object.keys(currentDocument).length > 0
+        ? `${JSON.stringify(currentDocument, null, 2)}\n`
+        : "";
+    const nextText = `${JSON.stringify(nextDocument, null, 2)}\n`;
+    if (currentText === nextText) {
+      return;
+    }
+    await writeRuntimeConfigTextAtomically(nextText);
+    didWrite = true;
+  });
+
+  const config = await getRuntimeConfigWithoutCatalogRefresh();
+  if (didWrite) {
+    await emitRuntimeConfig(config);
+  }
+  return config;
+}
+
+async function openAiCodexTokenResponseJson(
+  response: Response,
+  fallbackMessage: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const payload = (await response.json()) as unknown;
+    return runtimeConfigObject(payload);
+  } catch {
+    throw new Error(fallbackMessage);
+  }
+}
+
+function openAiCodexErrorMessage(
+  payload: Record<string, unknown>,
+  fallbackMessage: string,
+): string {
+  return runtimeFirstNonEmptyString(
+    payload.error_description as string | undefined,
+    payload.message as string | undefined,
+    payload.error as string | undefined,
+    fallbackMessage,
+  );
+}
+
 async function updateDesktopBrowserCapabilityConfig(update: {
   enabled: boolean;
   url?: string;
@@ -6743,6 +6950,9 @@ function normalizeRuntimeProviderModelToken(
 
 function runtimeProviderLabel(providerId: string): string {
   const normalized = providerId.trim().toLowerCase();
+  if (normalized === OPENAI_CODEX_PROVIDER_ID) {
+    return OPENAI_CODEX_PROVIDER_LABEL;
+  }
   if (normalized === "openai" || normalized.includes("openai")) {
     return "OpenAI";
   }
@@ -7832,6 +8042,294 @@ async function setRuntimeConfigDocument(
   const config = await getRuntimeConfig();
   await emitRuntimeConfig(config);
   return config;
+}
+
+async function requestOpenAiCodexDeviceCode(): Promise<{
+  userCode: string;
+  deviceAuthId: string;
+  intervalSeconds: number;
+}> {
+  const response = await fetch(OPENAI_CODEX_OAUTH_DEVICE_CODE_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: OPENAI_CODEX_OAUTH_CLIENT_ID,
+    }),
+  });
+  const payload = await openAiCodexTokenResponseJson(
+    response,
+    "OpenAI Codex device-code login returned an invalid response.",
+  );
+  if (!response.ok) {
+    throw new Error(
+      openAiCodexErrorMessage(
+        payload,
+        `OpenAI Codex device-code login failed with status ${response.status}.`,
+      ),
+    );
+  }
+  const userCode = runtimeFirstNonEmptyString(
+    payload.user_code as string | undefined,
+  );
+  const deviceAuthId = runtimeFirstNonEmptyString(
+    payload.device_auth_id as string | undefined,
+  );
+  const rawInterval =
+    typeof payload.interval === "number"
+      ? payload.interval
+      : Number.parseInt(String(payload.interval ?? ""), 10);
+  const intervalSeconds =
+    Number.isFinite(rawInterval) && rawInterval > 0 ? rawInterval : 5;
+  if (!userCode || !deviceAuthId) {
+    throw new Error(
+      "OpenAI Codex device-code login response was missing required fields.",
+    );
+  }
+  return {
+    userCode,
+    deviceAuthId,
+    intervalSeconds: Math.max(3, intervalSeconds),
+  };
+}
+
+async function waitForOpenAiCodexAuthorizationCode(params: {
+  deviceAuthId: string;
+  userCode: string;
+  intervalSeconds: number;
+}): Promise<{
+  authorizationCode: string;
+  codeVerifier: string;
+}> {
+  const deadline = Date.now() + OPENAI_CODEX_DEVICE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, params.intervalSeconds * 1000),
+    );
+    const response = await fetch(OPENAI_CODEX_OAUTH_DEVICE_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        device_auth_id: params.deviceAuthId,
+        user_code: params.userCode,
+      }),
+    });
+    if (response.status === 403 || response.status === 404) {
+      continue;
+    }
+    const payload = await openAiCodexTokenResponseJson(
+      response,
+      "OpenAI Codex device authorization returned an invalid response.",
+    );
+    if (!response.ok) {
+      throw new Error(
+        openAiCodexErrorMessage(
+          payload,
+          `OpenAI Codex device authorization failed with status ${response.status}.`,
+        ),
+      );
+    }
+    const authorizationCode = runtimeFirstNonEmptyString(
+      payload.authorization_code as string | undefined,
+    );
+    const codeVerifier = runtimeFirstNonEmptyString(
+      payload.code_verifier as string | undefined,
+    );
+    if (!authorizationCode || !codeVerifier) {
+      throw new Error(
+        "OpenAI Codex device authorization response was missing required fields.",
+      );
+    }
+    return {
+      authorizationCode,
+      codeVerifier,
+    };
+  }
+  throw new Error("OpenAI Codex sign-in timed out after 15 minutes.");
+}
+
+async function exchangeOpenAiCodexAuthorizationCode(params: {
+  authorizationCode: string;
+  codeVerifier: string;
+}): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: string;
+}> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: params.authorizationCode,
+    redirect_uri: OPENAI_CODEX_OAUTH_REDIRECT_URI,
+    client_id: OPENAI_CODEX_OAUTH_CLIENT_ID,
+    code_verifier: params.codeVerifier,
+  });
+  const response = await fetch(OPENAI_CODEX_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  const payload = await openAiCodexTokenResponseJson(
+    response,
+    "OpenAI Codex token exchange returned an invalid response.",
+  );
+  if (!response.ok) {
+    throw new Error(
+      openAiCodexErrorMessage(
+        payload,
+        `OpenAI Codex token exchange failed with status ${response.status}.`,
+      ),
+    );
+  }
+  const accessToken = runtimeFirstNonEmptyString(
+    payload.access_token as string | undefined,
+  );
+  const refreshToken = runtimeFirstNonEmptyString(
+    payload.refresh_token as string | undefined,
+  );
+  if (!accessToken || !refreshToken) {
+    throw new Error(
+      "OpenAI Codex token exchange did not return both access and refresh tokens.",
+    );
+  }
+  return {
+    accessToken,
+    refreshToken,
+    accessTokenExpiresAt: openAiCodexAccessTokenExpiresAt(payload.expires_in),
+  };
+}
+
+async function refreshOpenAiCodexAccessToken(refreshToken: string): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: string;
+}> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: OPENAI_CODEX_OAUTH_CLIENT_ID,
+  });
+  const response = await fetch(OPENAI_CODEX_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  const payload = await openAiCodexTokenResponseJson(
+    response,
+    "OpenAI Codex token refresh returned an invalid response.",
+  );
+  if (!response.ok) {
+    throw new Error(
+      openAiCodexErrorMessage(
+        payload,
+        `OpenAI Codex token refresh failed with status ${response.status}.`,
+      ),
+    );
+  }
+  const accessToken = runtimeFirstNonEmptyString(
+    payload.access_token as string | undefined,
+  );
+  const nextRefreshToken = runtimeFirstNonEmptyString(
+    payload.refresh_token as string | undefined,
+    refreshToken,
+  );
+  if (!accessToken || !nextRefreshToken) {
+    throw new Error(
+      "OpenAI Codex token refresh did not return valid credentials.",
+    );
+  }
+  return {
+    accessToken,
+    refreshToken: nextRefreshToken,
+    accessTokenExpiresAt: openAiCodexAccessTokenExpiresAt(payload.expires_in),
+  };
+}
+
+async function connectOpenAiCodexProvider(): Promise<RuntimeConfigPayload> {
+  const challenge = await requestOpenAiCodexDeviceCode();
+  clipboard.writeText(challenge.userCode);
+  const dialogOptions = {
+    type: "info",
+    buttons: ["Continue"],
+    defaultId: 0,
+    title: OPENAI_CODEX_PROVIDER_LABEL,
+    message: "Complete OpenAI Codex sign-in in your browser.",
+    detail:
+      "The device code was copied to your clipboard.\n\n" +
+      `If paste does not work, enter this code manually:\n${challenge.userCode}`,
+    noLink: true,
+  } satisfies Electron.MessageBoxOptions;
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    await dialog.showMessageBox(mainWindow, dialogOptions);
+  } else {
+    await dialog.showMessageBox(dialogOptions);
+  }
+  await shell.openExternal(OPENAI_CODEX_OAUTH_DEVICE_PAGE_URL);
+  const authorization = await waitForOpenAiCodexAuthorizationCode(challenge);
+  const exchanged = await exchangeOpenAiCodexAuthorizationCode(authorization);
+  const config = await updateRuntimeConfigDocumentWithoutRestart(
+    (currentDocument) =>
+      withOpenAiCodexProviderState(currentDocument, {
+        ...exchanged,
+        lastRefreshAt: utcNowIso(),
+      }),
+  );
+  ensureOpenAiCodexRefreshLoop();
+  return config;
+}
+
+async function refreshOpenAiCodexProviderCredentials(options?: {
+  force?: boolean;
+}): Promise<boolean> {
+  if (codexOauthRefreshPromise) {
+    return codexOauthRefreshPromise;
+  }
+  const refreshWork = (async () => {
+    const currentDocument = await readRuntimeConfigDocument();
+    const state = openAiCodexProviderStateFromDocument(currentDocument);
+    if (state.authMode !== "codex_oauth") {
+      return false;
+    }
+    if (!state.refreshToken.trim()) {
+      return false;
+    }
+    if (
+      !options?.force &&
+      !openAiCodexNeedsRefresh(state.accessTokenExpiresAt)
+    ) {
+      return false;
+    }
+    const refreshed = await refreshOpenAiCodexAccessToken(state.refreshToken);
+    await updateRuntimeConfigDocumentWithoutRestart((document) =>
+      withOpenAiCodexProviderState(document, {
+        ...refreshed,
+        lastRefreshAt: utcNowIso(),
+      }),
+    );
+    return true;
+  })();
+  codexOauthRefreshPromise = refreshWork.finally(() => {
+    codexOauthRefreshPromise = null;
+  });
+  return codexOauthRefreshPromise;
+}
+
+function ensureOpenAiCodexRefreshLoop(): void {
+  if (codexOauthRefreshTimer) {
+    return;
+  }
+  codexOauthRefreshTimer = setInterval(() => {
+    void refreshOpenAiCodexProviderCredentials().catch((error) => {
+      console.warn("OpenAI Codex token refresh failed:", error);
+    });
+  }, OPENAI_CODEX_REFRESH_INTERVAL_MS);
+  codexOauthRefreshTimer.unref();
 }
 
 function runtimeUserProfileNameSourceFromApi(
@@ -20719,6 +21217,8 @@ app.whenReady().then(async () => {
 
   await loadBrowserPersistence();
   await bootstrapRuntimeDatabase();
+  ensureOpenAiCodexRefreshLoop();
+  void refreshOpenAiCodexProviderCredentials().catch(() => undefined);
 
   handleTrustedIpc(
     "fs:listDirectory",
@@ -20989,6 +21489,11 @@ app.whenReady().then(async () => {
     ["main", "auth-popup"],
     async (_event, rawDocument: string) =>
       setRuntimeConfigDocument(rawDocument),
+  );
+  handleTrustedIpc(
+    "runtime:connectCodexOAuth",
+    ["main", "auth-popup"],
+    async () => connectOpenAiCodexProvider(),
   );
   handleTrustedIpc(
     "ui:getTheme",

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1124,6 +1124,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("runtime:setConfigDocument", rawDocument) as Promise<RuntimeConfigPayload>,
     exchangeBinding: (sandboxId: string) =>
       ipcRenderer.invoke("runtime:exchangeBinding", sandboxId) as Promise<RuntimeConfigPayload>,
+    connectCodexOAuth: () =>
+      ipcRenderer.invoke("runtime:connectCodexOAuth") as Promise<RuntimeConfigPayload>,
     onConfigChange: (listener: (config: RuntimeConfigPayload) => void) => {
       const wrapped = (_event: Electron.IpcRendererEvent, config: RuntimeConfigPayload) => listener(config);
       ipcRenderer.on("runtime:config", wrapped);

--- a/desktop/shared/model-catalog.ts
+++ b/desktop/shared/model-catalog.ts
@@ -98,6 +98,27 @@ export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = {
       },
     ],
   },
+  openai_codex: {
+    source: "local",
+    models: [
+      {
+        model_id: "gpt-5.4",
+        label: "GPT-5.4",
+        reasoning: true,
+        thinking_values: [...OPENAI_GPT54_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+      {
+        model_id: "gpt-5.3-codex",
+        label: "GPT-5.3 Codex",
+        reasoning: true,
+        thinking_values: [...OPENAI_GPT53_CODEX_THINKING_VALUES],
+        default_thinking_value: "medium",
+        input_modalities: ["text", "image"],
+      },
+    ],
+  },
   anthropic_direct: {
     source: "local",
     models: [

--- a/desktop/src/components/auth/AuthPanel.test.mjs
+++ b/desktop/src/components/auth/AuthPanel.test.mjs
@@ -319,6 +319,8 @@ test("direct Anthropic, OpenRouter, and Gemini defaults advertise current provid
     source.match(/const KNOWN_PROVIDER_TEMPLATES:[\s\S]*?function isKnownProviderId/)?.[0] ?? "";
   const openaiTemplate =
     providerTemplatesBlock.match(/openai_direct:\s*\{[\s\S]*?apiKeyPlaceholder: "sk-your-openai-key"[\s\S]*?\n\s*}/)?.[0] ?? "";
+  const codexTemplate =
+    providerTemplatesBlock.match(/openai_codex:\s*\{[\s\S]*?apiKeyPlaceholder: ""[\s\S]*?\n\s*}/)?.[0] ?? "";
   const anthropicTemplate =
     providerTemplatesBlock.match(/anthropic_direct:\s*\{[\s\S]*?apiKeyPlaceholder: "sk-ant-your-anthropic-key"[\s\S]*?\n\s*}/)?.[0] ?? "";
   const openrouterTemplate =
@@ -334,6 +336,16 @@ test("direct Anthropic, OpenRouter, and Gemini defaults advertise current provid
   assert.match(openaiTemplate, /defaultImageModel: "gpt-image-1\.5"/);
   assert.match(openaiTemplate, /imageModelSuggestions: \["gpt-image-1\.5", "gpt-image-1", "gpt-image-1-mini", "chatgpt-image-latest"\]/);
   assert.doesNotMatch(openaiTemplate, /gpt-5\.4-mini/);
+
+  assert.match(codexTemplate, /label: "OpenAI Codex"/);
+  assert.match(codexTemplate, /defaultBaseUrl: "https:\/\/chatgpt\.com\/backend-api\/codex"/);
+  assert.match(codexTemplate, /defaultModels: \["gpt-5\.4", "gpt-5\.3-codex"\]/);
+  assert.match(codexTemplate, /defaultBackgroundModel: "gpt-5\.4"/);
+  assert.match(codexTemplate, /defaultImageModel: null/);
+  assert.match(source, /handleConnectCodexProvider\(providerId: KnownProviderId\)/);
+  assert.match(source, /window\.electronAPI\.runtime\.connectCodexOAuth\(\)/);
+  assert.match(source, /apiKey: providerId === "openai_codex" \? "" : apiKey/);
+  assert.match(source, /providerId === "openai_codex"/);
 
   assert.match(
     anthropicTemplate,

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -43,7 +43,7 @@ interface AuthPanelProps {
 const AUTH_BROWSER_SIGN_IN_MESSAGE =
   "Sign-in opened in the browser. Complete the flow on the Holaboss sign-in page.";
 
-const KNOWN_PROVIDER_ORDER = ["holaboss", "openai_direct", "anthropic_direct", "openrouter_direct", "gemini_direct", "ollama_direct", "minimax_direct"] as const;
+const KNOWN_PROVIDER_ORDER = ["holaboss", "openai_direct", "openai_codex", "anthropic_direct", "openrouter_direct", "gemini_direct", "ollama_direct", "minimax_direct"] as const;
 type KnownProviderId = (typeof KNOWN_PROVIDER_ORDER)[number];
 const AUTH_PANEL_SELECT_TRIGGER_CLASS_NAME =
   "auth-settings-control theme-control-surface relative isolate h-9 w-full overflow-hidden rounded-[10px] border border-border/45 bg-muted px-2.5 text-sm text-foreground shadow-none transition-colors hover:border-border/65 focus-visible:border-border/65 focus-visible:ring-0 focus-visible:ring-transparent aria-invalid:border-border/45 aria-invalid:ring-0";
@@ -176,6 +176,18 @@ const KNOWN_PROVIDER_TEMPLATES: Record<KnownProviderId, KnownProviderTemplate> =
     imageModelSuggestions: ["gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini", "chatgpt-image-latest"],
     apiKeyPlaceholder: "sk-your-openai-key"
   },
+  openai_codex: {
+    id: "openai_codex",
+    label: "OpenAI Codex",
+    description: "ChatGPT/Codex OAuth for GPT-5 models without a separate API key.",
+    kind: "openai_compatible",
+    defaultBaseUrl: "https://chatgpt.com/backend-api/codex",
+    defaultModels: ["gpt-5.4", "gpt-5.3-codex"],
+    defaultBackgroundModel: "gpt-5.4",
+    defaultImageModel: null,
+    imageModelSuggestions: [],
+    apiKeyPlaceholder: ""
+  },
   anthropic_direct: {
     id: "anthropic_direct",
     label: "Anthropic",
@@ -273,6 +285,12 @@ function createDefaultProviderDrafts(): ProviderDraftMap {
       baseUrl: KNOWN_PROVIDER_TEMPLATES.openai_direct.defaultBaseUrl,
       apiKey: "",
       modelsText: KNOWN_PROVIDER_TEMPLATES.openai_direct.defaultModels.join(", "),
+    },
+    openai_codex: {
+      enabled: false,
+      baseUrl: KNOWN_PROVIDER_TEMPLATES.openai_codex.defaultBaseUrl,
+      apiKey: "",
+      modelsText: KNOWN_PROVIDER_TEMPLATES.openai_codex.defaultModels.join(", "),
     },
     anthropic_direct: {
       enabled: false,
@@ -475,11 +493,11 @@ function enabledProviderIdsForDrafts(providerDrafts: ProviderDraftMap, isSignedI
 }
 
 function directProviderRequiresManualFields(providerId: KnownProviderId): boolean {
-  return providerId !== "holaboss";
+  return providerId !== "holaboss" && providerId !== "openai_codex";
 }
 
 function providerBrandIconMarkup(providerId: KnownProviderId): string | null {
-  if (providerId === "openai_direct") {
+  if (providerId === "openai_direct" || providerId === "openai_codex") {
     return openaiLogoMarkup;
   }
   if (providerId === "anthropic_direct") {
@@ -1052,7 +1070,7 @@ function deriveProviderDraftsFromDocument(
         Object.keys(providerPayload).length > 0 ||
         (providerId === "holaboss" && Boolean((runtimeConfig?.modelProxyBaseUrl || "").trim())),
       baseUrl,
-      apiKey,
+      apiKey: providerId === "openai_codex" ? "" : apiKey,
       modelsText: (normalizedModelIds.length > 0 ? normalizedModelIds : template.defaultModels).join(", "),
     };
   }
@@ -1169,6 +1187,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   const [isStartingSignIn, setIsStartingSignIn] = useState(false);
   const [isSavingRuntimeConfigDocument, setIsSavingRuntimeConfigDocument] = useState(false);
   const [isExchangingRuntimeBinding, setIsExchangingRuntimeBinding] = useState(false);
+  const [connectingProviderId, setConnectingProviderId] = useState<KnownProviderId | null>(null);
   const [disconnectingProviderId, setDisconnectingProviderId] = useState<KnownProviderId | null>(null);
   const [isProviderDraftDirty, setIsProviderDraftDirty] = useState(false);
   const [providerSaveStatus, setProviderSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -1704,19 +1723,19 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   }
 
   function providerDraftValidationError(providerId: KnownProviderId): string {
+    const draft = providerDrafts[providerId];
+    const label = KNOWN_PROVIDER_TEMPLATES[providerId].label;
+    if (providerId !== "holaboss" && parseModelsText(draft.modelsText).length === 0) {
+      return `${label} requires at least one model before it can be connected.`;
+    }
     if (!directProviderRequiresManualFields(providerId)) {
       return "";
     }
-    const draft = providerDrafts[providerId];
-    const label = KNOWN_PROVIDER_TEMPLATES[providerId].label;
     if (!draft.baseUrl.trim()) {
       return `${label} requires a base URL before it can be connected.`;
     }
     if (!draft.apiKey.trim()) {
       return `${label} requires an API key before it can be connected.`;
-    }
-    if (parseModelsText(draft.modelsText).length === 0) {
-      return `${label} requires at least one model before it can be connected.`;
     }
     return "";
   }
@@ -2130,6 +2149,47 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     );
   }
 
+  async function handleConnectCodexProvider(providerId: KnownProviderId) {
+    if (!window.electronAPI || providerId !== "openai_codex") {
+      return;
+    }
+    if (isProviderDraftDirty) {
+      setAuthError("Save or discard your other runtime provider edits before connecting OpenAI Codex.");
+      setAuthMessage("");
+      return;
+    }
+
+    setConnectingProviderId(providerId);
+    setProviderSaveStatus("saving");
+    setAuthError("");
+    setAuthMessage("OpenAI Codex sign-in is starting in your browser. The device code will be copied to your clipboard.");
+    try {
+      const nextConfig = await window.electronAPI.runtime.connectCodexOAuth();
+      const nextDocumentText = await window.electronAPI.runtime.getConfigDocument();
+      const persisted = persistedProviderSettingsSnapshot(
+        nextDocumentText,
+        nextConfig,
+      );
+      setRuntimeConfig(nextConfig);
+      setRuntimeConfigDocument(nextDocumentText);
+      setSandboxId(nextConfig.sandboxId ?? sandboxId);
+      setProviderDrafts(persisted.drafts);
+      setBackgroundTasksDraft(persisted.backgroundTasks);
+      setRecallEmbeddingsDraft(persisted.recallEmbeddings);
+      setImageGenerationDraft(persisted.imageGeneration);
+      setExpandedProviderId(providerId);
+      setIsProviderDraftDirty(false);
+      setProviderSaveStatus("saved");
+      setAuthMessage("OpenAI Codex connected. Future access token refreshes are managed locally on this desktop.");
+    } catch (error) {
+      setAuthError(error instanceof Error ? error.message : "Failed to connect OpenAI Codex.");
+      setAuthMessage("");
+      setProviderSaveStatus("error");
+    } finally {
+      setConnectingProviderId(null);
+    }
+  }
+
   async function handleExchangeRuntimeBinding() {
     if (!window.electronAPI) {
       return;
@@ -2156,6 +2216,111 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
     } finally {
       setIsExchangingRuntimeBinding(false);
     }
+  }
+
+  function renderProviderModelSelection(
+    providerId: KnownProviderId,
+    draft: ProviderDraft,
+  ): ReactNode {
+    const selectedModelIds = parseModelsText(draft.modelsText);
+    const catalogModelOptions = providerCatalogChatModelOptions(providerId);
+    const unknownSelectedModelIds = selectedModelIds.filter(
+      (modelId) =>
+        !catalogModelOptions.some((option) => option.modelId === modelId),
+    );
+
+    return (
+      <label className="grid gap-1">
+        <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Models</span>
+        <div className="grid gap-2">
+          {catalogModelOptions.length > 0 ? (
+            <div className="grid gap-2">
+              <div className="grid gap-1.5">
+                {catalogModelOptions.map((option) => {
+                  const selected = selectedModelIds.includes(option.modelId);
+                  return (
+                    <div
+                      key={option.modelId}
+                      className={`rounded-[10px] border px-2.5 py-1.5 text-left transition ${
+                        selected
+                          ? "border-primary/25 bg-primary/[0.06] text-foreground"
+                          : "border-border/35 bg-card/70 text-muted-foreground"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[13px] font-medium leading-4">
+                            {option.label}
+                          </div>
+                          {option.label !== option.modelId ? (
+                            <div className="truncate pt-0.5 text-[10px] leading-4 text-muted-foreground">
+                              {option.modelId}
+                            </div>
+                          ) : null}
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1.5 pl-1">
+                          <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/80">
+                            {selected ? "On" : "Off"}
+                          </span>
+                          <Switch
+                            checked={selected}
+                            aria-label={`Toggle ${option.label}`}
+                            onCheckedChange={() =>
+                              toggleProviderDraftModel(providerId, option.modelId)
+                            }
+                            className="mt-0.5"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              Add models in <code>desktop/shared/model-catalog.ts</code> to configure this provider.
+            </div>
+          )}
+
+          {selectedModelIds.length === 0 ? (
+            <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              Select at least one configured model before saving.
+            </div>
+          ) : null}
+
+          {unknownSelectedModelIds.length > 0 ? (
+            <div className="grid gap-2">
+              <div className="text-xs leading-5 text-muted-foreground">
+                Some saved models are not in the local catalog. Add them in{" "}
+                <code>desktop/shared/model-catalog.ts</code> to make them selectable again.
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {unknownSelectedModelIds.map((modelId) => (
+                  <Badge
+                    key={modelId}
+                    variant="outline"
+                    className="flex items-center gap-1 border-border/45 bg-muted/35 pr-1 text-foreground"
+                  >
+                    <span className="max-w-[220px] truncate">
+                      {providerModelDisplayLabel(providerId, modelId)}
+                    </span>
+                    <button
+                      type="button"
+                      className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
+                      onClick={() => removeProviderDraftModel(providerId, modelId)}
+                      aria-label={`Remove ${modelId}`}
+                    >
+                      <X size={12} />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </label>
+    );
   }
 
   function renderProviderDrawerContent(providerId: KnownProviderId): ReactNode {
@@ -2207,6 +2372,40 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
         </div>
       );
     }
+    if (providerId === "openai_codex") {
+      return (
+        <div className="grid gap-2">
+          <div className="rounded-[12px] border border-border/35 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            Sign in with your ChatGPT account in the browser. holaOS keeps the active Codex access token refreshed locally for this desktop.
+          </div>
+          <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2">
+            <div className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Base URL</div>
+            <div className="pt-1 font-mono text-[13px] text-foreground">
+              {template.defaultBaseUrl}
+            </div>
+          </div>
+          {renderProviderModelSelection(providerId, draft)}
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleSaveRuntimeSettings(providerId)}
+              disabled={isSavingRuntimeConfigDocument}
+            >
+              {isSavingRuntimeConfigDocument ? "Saving..." : "Save"}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleCancelProviderEditing(providerId)}
+              disabled={isSavingRuntimeConfigDocument}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="grid gap-2">
         <label className="grid gap-1">
@@ -2228,107 +2427,7 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
             spellCheck={false}
           />
         </label>
-        <label className="grid gap-1">
-          <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Models</span>
-          {(() => {
-            const selectedModelIds = parseModelsText(draft.modelsText);
-            const catalogModelOptions = providerCatalogChatModelOptions(providerId);
-            const unknownSelectedModelIds = selectedModelIds.filter(
-              (modelId) =>
-                !catalogModelOptions.some((option) => option.modelId === modelId),
-            );
-
-            return (
-              <div className="grid gap-2">
-                {catalogModelOptions.length > 0 ? (
-                  <div className="grid gap-2">
-                    <div className="grid gap-1.5">
-                      {catalogModelOptions.map((option) => {
-                        const selected = selectedModelIds.includes(option.modelId);
-                        return (
-                          <div
-                            key={option.modelId}
-                            className={`rounded-[10px] border px-2.5 py-1.5 text-left transition ${
-                              selected
-                                ? "border-primary/25 bg-primary/[0.06] text-foreground"
-                                : "border-border/35 bg-card/70 text-muted-foreground"
-                            }`}
-                          >
-                            <div className="flex items-center justify-between gap-2">
-                              <div className="min-w-0 flex-1">
-                                <div className="truncate text-[13px] font-medium leading-4">
-                                  {option.label}
-                                </div>
-                                {option.label !== option.modelId ? (
-                                  <div className="truncate pt-0.5 text-[10px] leading-4 text-muted-foreground">
-                                    {option.modelId}
-                                  </div>
-                                ) : null}
-                              </div>
-                              <div className="flex shrink-0 items-center gap-1.5 pl-1">
-                                <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/80">
-                                  {selected ? "On" : "Off"}
-                                </span>
-                                <Switch
-                                  checked={selected}
-                                  aria-label={`Toggle ${option.label}`}
-                                  onCheckedChange={() =>
-                                    toggleProviderDraftModel(providerId, option.modelId)
-                                  }
-                                  className="mt-0.5"
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                    Add models in <code>desktop/shared/model-catalog.ts</code> to configure this provider.
-                  </div>
-                )}
-
-                {selectedModelIds.length === 0 ? (
-                  <div className="rounded-[12px] border border-border/35 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                    Select at least one configured model before saving.
-                  </div>
-                ) : null}
-
-                {unknownSelectedModelIds.length > 0 ? (
-                  <div className="grid gap-2">
-                    <div className="text-xs leading-5 text-muted-foreground">
-                      Some saved models are not in the local catalog. Add them in{" "}
-                      <code>desktop/shared/model-catalog.ts</code> to make them selectable again.
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      {unknownSelectedModelIds.map((modelId) => (
-                        <Badge
-                          key={modelId}
-                          variant="outline"
-                          className="flex items-center gap-1 border-border/45 bg-muted/35 pr-1 text-foreground"
-                        >
-                          <span className="max-w-[220px] truncate">
-                            {providerModelDisplayLabel(providerId, modelId)}
-                          </span>
-                          <button
-                            type="button"
-                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
-                            onClick={() => removeProviderDraftModel(providerId, modelId)}
-                            aria-label={`Remove ${modelId}`}
-                          >
-                            <X size={12} />
-                          </button>
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            );
-          })()}
-        </label>
+        {renderProviderModelSelection(providerId, draft)}
         <div className="flex flex-wrap gap-2 pt-1">
           <Button
             variant="outline"
@@ -2354,11 +2453,15 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
   function renderProviderRow(providerId: KnownProviderId, isLast: boolean) {
     const template = KNOWN_PROVIDER_TEMPLATES[providerId];
     const isHolabossProvider = providerId === "holaboss";
+    const isCodexProvider = providerId === "openai_codex";
     const isConnected = providerConnected(providerId);
     const draftEnabled = providerDraftEnabled(providerId);
+    const isConnecting = connectingProviderId === providerId;
     const isDisconnecting = disconnectingProviderId === providerId;
     const hasPendingConnection = !isConnected && draftEnabled;
-    const isExpandable = isHolabossProvider ? isConnected : draftEnabled || isConnected;
+    const isExpandable = isHolabossProvider || isCodexProvider
+      ? isConnected
+      : draftEnabled || isConnected;
     const isExpanded = isExpandable && expandedProviderId === providerId;
 
     return (
@@ -2403,6 +2506,39 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                   disabled={isStartingSignIn}
                 >
                   {isStartingSignIn ? "Opening..." : "Sign in"}
+                </Button>
+              )
+            ) : isCodexProvider ? (
+              isConnected ? (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
+                    onClick={() => setExpandedProviderId((current) => (current === providerId ? null : providerId))}
+                    disabled={isSavingRuntimeConfigDocument}
+                  >
+                    {isExpanded ? "Hide" : "Edit"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
+                    onClick={() => void handleDisconnectRuntimeProvider(providerId)}
+                    disabled={isSavingRuntimeConfigDocument || isConnecting}
+                  >
+                    {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={PROVIDER_ROW_ACTION_ITEM_CLASS_NAME}
+                  onClick={() => void handleConnectCodexProvider(providerId)}
+                  disabled={isSavingRuntimeConfigDocument || isConnecting}
+                >
+                  {isConnecting ? "Connecting..." : "Connect"}
                 </Button>
               )
             ) : isConnected ? (

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -1357,6 +1357,7 @@ declare global {
       setProfile: (payload: RuntimeUserProfileUpdatePayload) => Promise<RuntimeUserProfilePayload>;
       setConfigDocument: (rawDocument: string) => Promise<RuntimeConfigPayload>;
       exchangeBinding: (sandboxId: string) => Promise<RuntimeConfigPayload>;
+      connectCodexOAuth: () => Promise<RuntimeConfigPayload>;
       onConfigChange: (listener: (config: RuntimeConfigPayload) => void) => () => void;
       onStateChange: (listener: (status: RuntimeStatusPayload) => void) => () => void;
     };

--- a/runtime/api-server/src/agent-runtime-config.test.ts
+++ b/runtime/api-server/src/agent-runtime-config.test.ts
@@ -1000,6 +1000,73 @@ test("projectAgentRuntimeConfig bypasses runtime proxy credentials for configure
   assert.equal(result.model_client.default_headers, null);
 });
 
+test("projectAgentRuntimeConfig resolves OpenAI Codex providers from runtime-config credentials", () => {
+  const root = makeTempDir("hb-agent-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = writeRuntimeConfigDocument(root, {
+    runtime: {
+      sandbox_id: "sandbox-from-runtime",
+      default_provider: "openai_codex",
+    },
+    providers: {
+      openai_codex: {
+        kind: "openai_compatible",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        api_key: "codex-access-token",
+        options: {
+          auth_mode: "codex_oauth",
+          refresh_token: "codex-refresh-token",
+          access_token_expires_at: "2099-01-01T00:00:00.000Z",
+        },
+      },
+    },
+    models: {
+      "openai_codex/gpt-5.4": {
+        provider_id: "openai_codex",
+        model_id: "gpt-5.4",
+      },
+    },
+  });
+
+  const result = projectAgentRuntimeConfig({
+    session_id: "session-1",
+    workspace_id: "workspace-1",
+    input_id: "input-1",
+    session_kind: "workspace_session",
+    harness_id: "pi",
+    browser_tools_available: false,
+    browser_tool_ids: [],
+    runtime_tool_ids: [],
+    workspace_command_ids: [],
+    runtime_exec_model_proxy_api_key: "hb-runtime-token",
+    runtime_exec_sandbox_id: "sandbox-from-exec-context",
+    runtime_exec_run_id: "run-1",
+    selected_model: "openai_codex/gpt-5.4",
+    default_provider_id: "holaboss_model_proxy",
+    session_mode: "code",
+    workspace_config_checksum: "checksum-1",
+    workspace_skill_ids: [],
+    default_tools: ["read"],
+    extra_tools: [],
+    resolved_mcp_tool_refs: [],
+    resolved_output_schemas: {},
+    agent: {
+      id: "workspace.general",
+      model: "gpt-5.2",
+      prompt: "You are concise.",
+    },
+  });
+
+  assert.equal(result.provider_id, "openai_codex");
+  assert.equal(result.model_id, "gpt-5.4");
+  assert.equal(result.model_client.api_key, "codex-access-token");
+  assert.equal(
+    result.model_client.base_url,
+    "https://chatgpt.com/backend-api/codex",
+  );
+  assert.equal(result.model_client.default_headers, null);
+});
+
 test("projectAgentRuntimeConfig keeps direct Anthropic providers on the native endpoint", () => {
   const root = makeTempDir("hb-agent-runtime-config-");
   process.env.HB_SANDBOX_ROOT = root;

--- a/runtime/api-server/src/agent-runtime-config.ts
+++ b/runtime/api-server/src/agent-runtime-config.ts
@@ -175,6 +175,7 @@ const KNOWN_DIRECT_PROVIDER_HOSTS = new Set([
 ]);
 const GEMINI_OPENAI_COMPAT_HOST = "generativelanguage.googleapis.com";
 const GEMINI_OPENAI_COMPAT_PATH = "/v1beta/openai";
+const OPENAI_CODEX_COMPAT_PATH = "/backend-api/codex";
 const LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<
   string,
   Record<string, string>
@@ -957,6 +958,9 @@ function shouldTreatAsDirectProviderBaseUrl(baseRoot: string): boolean {
         normalizedPath === "/v1beta" ||
         normalizedPath === GEMINI_OPENAI_COMPAT_PATH)
     ) {
+      return true;
+    }
+    if (normalizedPath.endsWith(OPENAI_CODEX_COMPAT_PATH)) {
       return true;
     }
     if (normalizedPath === "/v1") {

--- a/runtime/api-server/src/background-task-model.test.ts
+++ b/runtime/api-server/src/background-task-model.test.ts
@@ -138,6 +138,7 @@ test("background task model selection falls back to legacy provider background m
 test("background task default model suggestions use GPT-5.4 for managed and direct OpenAI providers", () => {
   assert.equal(defaultBackgroundTaskModelForProvider("holaboss_model_proxy"), "gpt-5.4");
   assert.equal(defaultBackgroundTaskModelForProvider("openai_direct"), "gpt-5.4");
+  assert.equal(defaultBackgroundTaskModelForProvider("openai_codex"), "gpt-5.4");
   assert.equal(defaultBackgroundTaskModelForProvider("openrouter_direct"), "openai/gpt-5.4");
 });
 

--- a/runtime/api-server/src/background-task-model.ts
+++ b/runtime/api-server/src/background-task-model.ts
@@ -12,6 +12,7 @@ const PROVIDER_ID_ALIASES: Record<string, string> = {
   holaboss: HOLABOSS_PROVIDER_ID,
   [HOLABOSS_PROVIDER_ID]: HOLABOSS_PROVIDER_ID,
   openai: "openai_direct",
+  openai_codex: "openai_codex",
   anthropic: "anthropic_direct",
   openrouter: "openrouter_direct",
   gemini: "gemini_direct",
@@ -35,6 +36,7 @@ const LEGACY_DIRECT_PROVIDER_MODEL_ALIASES: Record<
 const BACKGROUND_TASK_MODEL_DEFAULTS: Record<string, string | null> = {
   [HOLABOSS_PROVIDER_ID]: "gpt-5.4",
   openai_direct: "gpt-5.4",
+  openai_codex: "gpt-5.4",
   anthropic_direct: "claude-sonnet-4-6",
   openrouter_direct: "openai/gpt-5.4",
   gemini_direct: "gemini-2.5-flash",

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -1437,7 +1437,7 @@ test("buildPiProviderConfig uses OpenAI Responses API for direct GPT-5 models", 
   assert.equal(providerConfig.models[0]?.compat, undefined);
 });
 
-test("buildPiProviderConfig uses OpenAI Responses API for Codex OAuth GPT-5 models", () => {
+test("buildPiProviderConfig uses OpenAI Codex Responses API for Codex OAuth GPT-5 models", () => {
   const providerConfig = buildPiProviderConfig({
     ...baseRequest(),
     provider_id: "openai_codex",
@@ -1449,9 +1449,9 @@ test("buildPiProviderConfig uses OpenAI Responses API for Codex OAuth GPT-5 mode
     },
   });
 
-  assert.equal(providerConfig.api, "openai-responses");
+  assert.equal(providerConfig.api, "openai-codex-responses");
   assert.equal(providerConfig.baseUrl, "https://chatgpt.com/backend-api/codex");
-  assert.equal(providerConfig.models[0]?.api, "openai-responses");
+  assert.equal(providerConfig.models[0]?.api, "openai-codex-responses");
 });
 
 test("buildPiProviderConfig uses OpenAI Responses API for managed Holaboss GPT-5 models", () => {

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -1437,6 +1437,23 @@ test("buildPiProviderConfig uses OpenAI Responses API for direct GPT-5 models", 
   assert.equal(providerConfig.models[0]?.compat, undefined);
 });
 
+test("buildPiProviderConfig uses OpenAI Responses API for Codex OAuth GPT-5 models", () => {
+  const providerConfig = buildPiProviderConfig({
+    ...baseRequest(),
+    provider_id: "openai_codex",
+    model_id: "gpt-5.4",
+    model_client: {
+      model_proxy_provider: "openai_compatible",
+      api_key: "codex-access-token",
+      base_url: "https://chatgpt.com/backend-api/codex",
+    },
+  });
+
+  assert.equal(providerConfig.api, "openai-responses");
+  assert.equal(providerConfig.baseUrl, "https://chatgpt.com/backend-api/codex");
+  assert.equal(providerConfig.models[0]?.api, "openai-responses");
+});
+
 test("buildPiProviderConfig uses OpenAI Responses API for managed Holaboss GPT-5 models", () => {
   const providerConfig = buildPiProviderConfig({
     ...baseRequest(),

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3307,6 +3307,9 @@ function piApiForRequest(request: HarnessHostPiRequest): Api {
   if (shouldUseNativeGoogleProvider(request)) {
     return "google-generative-ai";
   }
+  if (shouldUseOpenAiCodexResponsesProvider(request)) {
+    return "openai-codex-responses";
+  }
   if (shouldUseOpenAiResponsesProvider(request)) {
     return "openai-responses";
   }
@@ -3317,6 +3320,12 @@ function shouldUseNativeGoogleProvider(request: HarnessHostPiRequest): boolean {
   const normalizedProvider = request.model_client.model_proxy_provider.trim().toLowerCase();
   const providerId = request.provider_id.trim().toLowerCase();
   return normalizedProvider === "google_compatible" && providerId === "gemini_direct";
+}
+
+function shouldUseOpenAiCodexResponsesProvider(request: HarnessHostPiRequest): boolean {
+  const normalizedProvider = request.model_client.model_proxy_provider.trim().toLowerCase();
+  const providerId = request.provider_id.trim().toLowerCase();
+  return normalizedProvider === "openai_compatible" && providerId === "openai_codex";
 }
 
 function normalizedPiModelId(request: Pick<HarnessHostPiRequest, "model_id">): string {
@@ -3345,7 +3354,6 @@ function shouldUseOpenAiResponsesProvider(request: HarnessHostPiRequest): boolea
   }
   if (
     providerId !== "openai_direct" &&
-    providerId !== "openai_codex" &&
     providerId !== "openai" &&
     providerId !== "holaboss_model_proxy" &&
     providerId !== "holaboss"

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3345,6 +3345,7 @@ function shouldUseOpenAiResponsesProvider(request: HarnessHostPiRequest): boolea
   }
   if (
     providerId !== "openai_direct" &&
+    providerId !== "openai_codex" &&
     providerId !== "openai" &&
     providerId !== "holaboss_model_proxy" &&
     providerId !== "holaboss"


### PR DESCRIPTION
## Summary
- add a dedicated `openai_codex` provider in the desktop auth UI with device-code OAuth against `auth.openai.com`
- persist and refresh Codex access tokens locally in Electron while keeping `openai_direct` unchanged
- route `openai_codex` GPT-5 traffic through Pi's dedicated `openai-codex-responses` transport and keep the Codex base URL intact
- add targeted tests for runtime resolution, background-task defaults, and harness routing

## Validation
- `npm --prefix desktop run typecheck`
- `node --import tsx --test src/agent-runtime-config.test.ts src/background-task-model.test.ts`
- `node --import tsx --test src/pi.test.ts`
- `npm run typecheck` in `runtime/harness-host`

## Notes
- no Supabase migrations
- no environment changes beyond existing desktop/runtime dependencies
- no screenshots included because the changes are provider auth and runtime wiring focused