### PR TITLE
fix: harden desktop runtime error handling and health checks

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -777,6 +777,10 @@ const sessionRuntimeStateCache = new Map<
   string,
   Map<string, SessionRuntimeRecordPayload>
 >();
+const agentSessionCache = new Map<
+  string,
+  Map<string, AgentSessionRecordPayload>
+>();
 const userBrowserInterruptPrompts = new Set<string>();
 const reportedOperatorSurfaceContexts = new Map<
   string,
@@ -12671,6 +12675,22 @@ function cloneRuntimeStateRecord(
   };
 }
 
+function cachedRuntimeStateRecords(
+  workspaceId: string,
+): SessionRuntimeRecordPayload[] {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return [];
+  }
+  const workspaceRecords = sessionRuntimeStateCache.get(normalizedWorkspaceId);
+  if (!workspaceRecords) {
+    return [];
+  }
+  return Array.from(workspaceRecords.values()).map((record) =>
+    cloneRuntimeStateRecord(record),
+  );
+}
+
 function normalizeRuntimeStateRecord(
   record: SessionRuntimeRecordPayload,
 ): SessionRuntimeRecordPayload | null {
@@ -12726,6 +12746,92 @@ function cacheRuntimeStateRecords(
   }
   sessionRuntimeStateCache.set(normalizedWorkspaceId, workspaceRecords);
   return normalizedItems;
+}
+
+function cloneAgentSessionRecord(
+  record: AgentSessionRecordPayload,
+): AgentSessionRecordPayload {
+  return { ...record };
+}
+
+function normalizeAgentSessionRecord(
+  record: AgentSessionRecordPayload,
+): AgentSessionRecordPayload | null {
+  const workspaceId = record.workspace_id.trim();
+  const sessionId = browserSessionId(record.session_id);
+  if (!workspaceId || !sessionId) {
+    return null;
+  }
+  const now = utcNowIso();
+  return {
+    workspace_id: workspaceId,
+    session_id: sessionId,
+    kind: record.kind?.trim() || "session",
+    title: typeof record.title === "string" ? record.title : null,
+    parent_session_id: record.parent_session_id?.trim() || null,
+    source_proposal_id: record.source_proposal_id?.trim() || null,
+    created_by: record.created_by?.trim() || null,
+    created_at: record.created_at || now,
+    updated_at: record.updated_at || record.created_at || now,
+    archived_at: record.archived_at?.trim() || null,
+  };
+}
+
+function cacheAgentSessionRecords(
+  workspaceId: string,
+  items: AgentSessionRecordPayload[],
+): AgentSessionRecordPayload[] {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return [];
+  }
+  const workspaceRecords = new Map<string, AgentSessionRecordPayload>();
+  const normalizedItems: AgentSessionRecordPayload[] = [];
+  for (const item of items) {
+    const normalized = normalizeAgentSessionRecord({
+      ...item,
+      workspace_id: normalizedWorkspaceId,
+    });
+    if (!normalized) {
+      continue;
+    }
+    workspaceRecords.set(normalized.session_id, normalized);
+    normalizedItems.push(cloneAgentSessionRecord(normalized));
+  }
+  agentSessionCache.set(normalizedWorkspaceId, workspaceRecords);
+  return normalizedItems;
+}
+
+function upsertCachedAgentSessionRecord(
+  record: AgentSessionRecordPayload,
+): AgentSessionRecordPayload | null {
+  const normalized = normalizeAgentSessionRecord(record);
+  if (!normalized) {
+    return null;
+  }
+  let workspaceRecords = agentSessionCache.get(normalized.workspace_id);
+  if (!workspaceRecords) {
+    workspaceRecords = new Map<string, AgentSessionRecordPayload>();
+    agentSessionCache.set(normalized.workspace_id, workspaceRecords);
+  }
+  workspaceRecords.set(normalized.session_id, normalized);
+  return cloneAgentSessionRecord(normalized);
+}
+
+function cachedAgentSessionRecords(
+  workspaceId: string,
+): AgentSessionRecordPayload[] {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return [];
+  }
+  const workspaceRecords = agentSessionCache.get(normalizedWorkspaceId);
+  if (!workspaceRecords) {
+    return [];
+  }
+  return Array.from(workspaceRecords.values()).map((record) =>
+    cloneAgentSessionRecord(record),
+  );
 }
 
 function upsertCachedRuntimeStateRecord(
@@ -13901,20 +14007,30 @@ async function deleteWorkspace(
 async function listRuntimeStates(
   workspaceId: string,
 ): Promise<SessionRuntimeStateListResponsePayload> {
-  const response = await requestRuntimeJson<SessionRuntimeStateListResponsePayload>({
-    method: "GET",
-    path: `/api/v1/agent-sessions/by-workspace/${workspaceId}/runtime-states`,
-    params: {
-      limit: 100,
-      offset: 0,
-    },
-  });
-  const items = cacheRuntimeStateRecords(workspaceId, response.items ?? []);
-  return {
-    ...response,
-    items,
-    count: items.length,
-  };
+  try {
+    const response = await requestRuntimeJson<SessionRuntimeStateListResponsePayload>({
+      method: "GET",
+      path: `/api/v1/agent-sessions/by-workspace/${workspaceId}/runtime-states`,
+      params: {
+        limit: 100,
+        offset: 0,
+      },
+    });
+    const items = cacheRuntimeStateRecords(workspaceId, response.items ?? []);
+    return {
+      ...response,
+      items,
+      count: items.length,
+    };
+  } catch (error) {
+    if (isTransientRuntimeError(error)) {
+      const items = cachedRuntimeStateRecords(workspaceId);
+      if (items.length > 0) {
+        return { items, count: items.length };
+      }
+    }
+    throw error;
+  }
 }
 
 async function listAgentSessions(
@@ -13923,22 +14039,38 @@ async function listAgentSessions(
   if (!workspaceId.trim()) {
     return { items: [], count: 0 };
   }
-  return requestRuntimeJson<AgentSessionListResponsePayload>({
-    method: "GET",
-    path: "/api/v1/agent-sessions",
-    params: {
-      workspace_id: workspaceId,
-      include_archived: false,
-      limit: 100,
-      offset: 0,
-    },
-  });
+  try {
+    const response = await requestRuntimeJson<AgentSessionListResponsePayload>({
+      method: "GET",
+      path: "/api/v1/agent-sessions",
+      params: {
+        workspace_id: workspaceId,
+        include_archived: false,
+        limit: 100,
+        offset: 0,
+      },
+    });
+    const items = cacheAgentSessionRecords(workspaceId, response.items ?? []);
+    return {
+      ...response,
+      items,
+      count: items.length,
+    };
+  } catch (error) {
+    if (isTransientRuntimeError(error)) {
+      const items = cachedAgentSessionRecords(workspaceId);
+      if (items.length > 0) {
+        return { items, count: items.length };
+      }
+    }
+    throw error;
+  }
 }
 
 async function createAgentSession(
   payload: CreateAgentSessionPayload,
 ): Promise<CreateAgentSessionResponsePayload> {
-  return requestRuntimeJson<CreateAgentSessionResponsePayload>({
+  const response = await requestRuntimeJson<CreateAgentSessionResponsePayload>({
     method: "POST",
     path: "/api/v1/agent-sessions",
     payload: {
@@ -13950,6 +14082,10 @@ async function createAgentSession(
       created_by: payload.created_by ?? undefined,
     },
   });
+  if (response.session) {
+    upsertCachedAgentSessionRecord(response.session);
+  }
+  return response;
 }
 
 function isMissingSessionBindingError(error: unknown): boolean {
@@ -18712,6 +18848,7 @@ function destroyBrowserWorkspace(workspaceId: string) {
   workspace.userBrowserLock = null;
   workspace.agentSessionSpaces.clear();
   sessionRuntimeStateCache.delete(workspaceId);
+  agentSessionCache.delete(workspaceId);
   browserWorkspaces.delete(workspaceId);
 }
 

--- a/desktop/src/components/panes/BrowserPane.test.mjs
+++ b/desktop/src/components/panes/BrowserPane.test.mjs
@@ -118,3 +118,16 @@ test("browser pane only clears native browser bounds on suspend or unmount, not 
   assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*window\.setTimeout\(queueSync, 400\);[\s\S]*return \(\) => \{\s*observer\.disconnect\(\);[\s\S]*window\.cancelAnimationFrame\(rafId\);\s*\};\s*\}, \[layoutSyncKey, suspendNativeView\]\);/s);
   assert.match(source, /useEffect\(\(\) => \{\s*return \(\) => \{\s*void window\.electronAPI\.browser\.setBounds\(\{\s*x: 0,\s*y: 0,\s*width: 0,\s*height: 0,\s*\}\);\s*\};\s*\}, \[\]\);/s);
 });
+
+test("browser pane session-state polling keeps the last successful snapshot during transient runtime errors", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /} catch \{\s*\/\/ Preserve the most recent runtime state snapshot during transient\s*\/\/ runtime restarts instead of triggering an unhandled rejection\.\s*\}/s,
+  );
+  assert.match(
+    source,
+    /const refreshVisibleSessionState = \(\) => \{\s*if \(document\.visibilityState !== "visible"\) \{\s*return;\s*\}\s*void loadSessionState\(\);\s*\};/s,
+  );
+});

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -220,20 +220,34 @@ export function BrowserPane({
           return;
         }
         setRuntimeStatesBySessionId(runtimeStateIndex(runtimeStatesResponse.items));
+      } catch {
+        // Preserve the most recent runtime state snapshot during transient
+        // runtime restarts instead of triggering an unhandled rejection.
       } finally {
         requestInFlight = false;
       }
     };
 
+    const refreshVisibleSessionState = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      void loadSessionState();
+    };
+
     void loadSessionState();
     const intervalId = window.setInterval(
-      () => void loadSessionState(),
+      refreshVisibleSessionState,
       BROWSER_SESSION_POLL_INTERVAL_MS,
     );
+    window.addEventListener("focus", refreshVisibleSessionState);
+    document.addEventListener("visibilitychange", refreshVisibleSessionState);
 
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshVisibleSessionState);
+      document.removeEventListener("visibilitychange", refreshVisibleSessionState);
     };
   }, [selectedWorkspaceId]);
 

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -121,8 +121,9 @@ test("chat composer footer wraps controls based on available pane width instead 
   );
   assert.match(
     source,
-    /const compactComposerControls =\s*showModelSelector &&[\s\S]*composerFooterLayout\.wraps[\s\S]*composerFooterLayout\.width < fullFooterControlWidth/,
+    /const compactComposerControls =\s*showModelSelector &&[\s\S]*composerFooterLayout\.width > 0[\s\S]*composerFooterLayout\.actionsWidth > 0[\s\S]*composerFooterLayout\.width < fullFooterControlWidth/,
   );
+  assert.doesNotMatch(source, /composerFooterLayout\.wraps/);
   assert.match(
     source,
     /const compactModelControlWidth = compactComposerControls[\s\S]*COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX[\s\S]*compactFooterControlWidth -[\s\S]*COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX/,

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -9344,7 +9344,6 @@ function Composer({
   const [composerFooterLayout, setComposerFooterLayout] = useState({
     width: 0,
     actionsWidth: 0,
-    wraps: false,
   });
   const noAvailableModels =
     !runtimeDefaultModelAvailable &&
@@ -9419,19 +9418,11 @@ function Composer({
     const actionsWidth = Math.round(
       composerActionsRef.current?.getBoundingClientRect().width ?? 0,
     );
-    const visibleRowOffsets = Array.from(footer.children)
-      .filter(
-        (child): child is HTMLElement =>
-          child instanceof HTMLElement && child.offsetParent !== null,
-      )
-      .map((child) => child.offsetTop);
-    const wraps = new Set(visibleRowOffsets).size > 1;
     setComposerFooterLayout((current) =>
       current.width === width &&
-      current.actionsWidth === actionsWidth &&
-      current.wraps === wraps
+      current.actionsWidth === actionsWidth
         ? current
-        : { width, actionsWidth, wraps },
+        : { width, actionsWidth },
     );
   };
   useLayoutEffect(() => {
@@ -9533,10 +9524,9 @@ function Composer({
   );
   const compactComposerControls =
     showModelSelector &&
-    (composerFooterLayout.wraps ||
-      (composerFooterLayout.width > 0 &&
-        composerFooterLayout.actionsWidth > 0 &&
-        composerFooterLayout.width < fullFooterControlWidth));
+    composerFooterLayout.width > 0 &&
+    composerFooterLayout.actionsWidth > 0 &&
+    composerFooterLayout.width < fullFooterControlWidth;
   const compactModelControlWidth = compactComposerControls
     ? Math.min(
         COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX,

--- a/desktop/src/components/panes/useWorkspaceBrowser.test.mjs
+++ b/desktop/src/components/panes/useWorkspaceBrowser.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "useWorkspaceBrowser.ts");
+
+test("workspace browser session polling tolerates transient runtime errors and only refreshes while visible", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /} catch \{\s*\/\/ Keep the last successful browser session snapshot during transient\s*\/\/ runtime hiccups instead of surfacing an unhandled rejection\.\s*\}/s,
+  );
+  assert.match(
+    source,
+    /const refreshVisibleSessionState = \(\) => \{\s*if \(document\.visibilityState !== "visible"\) \{\s*return;\s*\}\s*void loadSessionState\(\);\s*\};/s,
+  );
+  assert.match(source, /window\.addEventListener\("focus", refreshVisibleSessionState\);/);
+  assert.match(
+    source,
+    /document\.addEventListener\("visibilitychange", refreshVisibleSessionState\);/,
+  );
+  assert.match(
+    source,
+    /window\.removeEventListener\("focus", refreshVisibleSessionState\);/,
+  );
+  assert.match(
+    source,
+    /document\.removeEventListener\("visibilitychange", refreshVisibleSessionState\);/,
+  );
+});

--- a/desktop/src/components/panes/useWorkspaceBrowser.ts
+++ b/desktop/src/components/panes/useWorkspaceBrowser.ts
@@ -186,20 +186,34 @@ export function useWorkspaceBrowser(
         }
         setAgentSessions(sessionsResponse.items);
         setRuntimeStatesBySessionId(runtimeStateIndex(runtimeStatesResponse.items));
+      } catch {
+        // Keep the last successful browser session snapshot during transient
+        // runtime hiccups instead of surfacing an unhandled rejection.
       } finally {
         requestInFlight = false;
       }
     };
 
+    const refreshVisibleSessionState = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      void loadSessionState();
+    };
+
     void loadSessionState();
     const intervalId = window.setInterval(
-      () => void loadSessionState(),
+      refreshVisibleSessionState,
       BROWSER_SESSION_POLL_INTERVAL_MS,
     );
+    window.addEventListener("focus", refreshVisibleSessionState);
+    document.addEventListener("visibilitychange", refreshVisibleSessionState);
 
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshVisibleSessionState);
+      document.removeEventListener("visibilitychange", refreshVisibleSessionState);
     };
   }, [options?.includeSessions, selectedWorkspaceId]);
 

--- a/runtime/api-server/src/app-lifecycle-worker.test.ts
+++ b/runtime/api-server/src/app-lifecycle-worker.test.ts
@@ -10,6 +10,7 @@ import { RuntimeStateStore } from "@holaboss/runtime-state-store";
 import {
   AppLifecycleExecutorError,
   findComposeCommand,
+  isAppHealthy,
   RuntimeAppLifecycleExecutor,
   shutdownComposeTargets,
   startComposeAppTarget,
@@ -36,9 +37,51 @@ function makeSpawnStub(handlers: Record<string, { code: number }>) {
     queueMicrotask(() => {
       child.emit("close", handler.code);
     });
-    return child;
+  return child;
   }) as typeof import("node:child_process").spawn;
 }
+
+test("isAppHealthy probes only the configured healthcheck target", async () => {
+  const urls: string[] = [];
+  const resolvedApp = {
+    appId: "gmail",
+    mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
+    mcpTools: [],
+    healthCheck: { target: "mcp" as const, path: "/mcp/health", timeoutS: 30, intervalS: 1 },
+    envContract: [],
+    integrations: [],
+    startCommand: "",
+    baseDir: "apps/gmail",
+    lifecycle: { setup: "", start: "npm run start", stop: "npm run stop" }
+  };
+
+  const fetchImpl = (async (input: string | URL | Request) => {
+    urls.push(typeof input === "string" ? input : input.toString());
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+
+  const mcpHealthy = await isAppHealthy({
+    resolvedApp,
+    httpPort: 18080,
+    mcpPort: 13100,
+    fetchImpl
+  });
+  assert.equal(mcpHealthy, true);
+  assert.deepEqual(urls, ["http://localhost:13100/mcp/health"]);
+
+  urls.length = 0;
+  const apiHealthy = await isAppHealthy({
+    resolvedApp: {
+      ...resolvedApp,
+      healthCheck: { ...resolvedApp.healthCheck, target: "api", path: "/healthz" }
+    },
+    httpPort: 18080,
+    mcpPort: 13100,
+    fetchImpl
+  });
+  assert.equal(apiHealthy, true);
+  assert.deepEqual(urls, ["http://localhost:18080/healthz"]);
+});
 
 test("findComposeCommand prefers docker compose when available", async () => {
   const spawnStub = makeSpawnStub({
@@ -501,7 +544,7 @@ test("startShellLifecycleAppTarget runs lifecycle.setup before lifecycle.start",
   ]);
 });
 
-test("startShellLifecycleAppTarget requires both app HTTP and MCP health checks", async () => {
+test("startShellLifecycleAppTarget honors an explicit API health check target without probing MCP", async () => {
   const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "hb-shell-app-both-health-"));
   let started = false;
   const spawnStub = ((command: string, args?: readonly string[]) => {
@@ -525,36 +568,34 @@ test("startShellLifecycleAppTarget requires both app HTTP and MCP health checks"
     return child;
   }) as typeof import("node:child_process").spawn;
 
-  await assert.rejects(
-    () =>
-      startShellLifecycleAppTarget({
-        appId: "app-a",
-        appDir,
-        resolvedApp: {
-          appId: "app-a",
-          mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
-          mcpTools: [],
-          healthCheck: { path: "/health", timeoutS: 0.1, intervalS: 0.01 },
-          envContract: [],
-          startCommand: "",
-          baseDir: "apps/app-a",
-          lifecycle: { setup: "", start: "npm run start", stop: "npm run stop" }
-        },
-        httpPort: 18081,
-        mcpPort: 13101,
-        spawnImpl: spawnStub,
-        fetchImpl: (async (input: string | URL | RequestInfo) => {
-          if (!started) {
-            throw new Error("app not started yet");
-          }
-          if (String(input).includes("/health")) {
-            return new Response("", { status: 200 });
-          }
-          return new Response("", { status: 503 });
-        }) as typeof fetch
-      }),
-    /did not become healthy/
-  );
+  const result = await startShellLifecycleAppTarget({
+    appId: "app-a",
+    appDir,
+    resolvedApp: {
+      appId: "app-a",
+      mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
+      mcpTools: [],
+      healthCheck: { target: "api", path: "/health", timeoutS: 0.1, intervalS: 0.01 },
+      envContract: [],
+      startCommand: "",
+      baseDir: "apps/app-a",
+      lifecycle: { setup: "", start: "npm run start", stop: "npm run stop" }
+    },
+    httpPort: 18081,
+    mcpPort: 13101,
+    spawnImpl: spawnStub,
+    fetchImpl: (async (input: string | URL | RequestInfo) => {
+      if (!started) {
+        throw new Error("app not started yet");
+      }
+      if (String(input) === "http://localhost:18081/health") {
+        return new Response("", { status: 200 });
+      }
+      return new Response("", { status: 503 });
+    }) as typeof fetch
+  });
+
+  assert.equal(result.status, "started");
 });
 
 test("startShellLifecycleAppTarget coalesces concurrent starts for the same app", async () => {

--- a/runtime/api-server/src/app-lifecycle-worker.ts
+++ b/runtime/api-server/src/app-lifecycle-worker.ts
@@ -692,9 +692,19 @@ function healthProbeUrls(params: {
   httpPort: number;
   mcpPort: number;
 }): Array<{ kind: "http" | "mcp"; url: string }> {
+  if (params.resolvedApp.healthCheck.target === "api") {
+    return [
+      {
+        kind: "http",
+        url: `http://localhost:${params.httpPort}${params.resolvedApp.healthCheck.path}`
+      }
+    ];
+  }
   return [
-    { kind: "http", url: `http://localhost:${params.httpPort}/` },
-    { kind: "mcp", url: `http://localhost:${params.mcpPort}${params.resolvedApp.healthCheck.path}` }
+    {
+      kind: "mcp",
+      url: `http://localhost:${params.mcpPort}${params.resolvedApp.healthCheck.path}`
+    }
   ];
 }
 

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -3249,7 +3249,12 @@ test("app lifecycle routes delegate to the lifecycle executor and uninstall upda
         appId: "app-b",
         mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
         mcpTools: [],
-        healthCheck: { path: "/health", timeoutS: 60, intervalS: 5 },
+        healthCheck: {
+          path: "/health",
+          timeoutS: 60,
+          intervalS: 5,
+          target: "mcp"
+        },
         envContract: [],
         integrations: undefined,
         startCommand: "",
@@ -3266,7 +3271,12 @@ test("app lifecycle routes delegate to the lifecycle executor and uninstall upda
         appId: "app-b",
         mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
         mcpTools: [],
-        healthCheck: { path: "/health", timeoutS: 60, intervalS: 5 },
+        healthCheck: {
+          path: "/health",
+          timeoutS: 60,
+          intervalS: 5,
+          target: "mcp"
+        },
         envContract: [],
         integrations: undefined,
         startCommand: "",
@@ -3283,7 +3293,12 @@ test("app lifecycle routes delegate to the lifecycle executor and uninstall upda
         appId: "app-b",
         mcp: { transport: "http-sse", port: 4100, path: "/mcp" },
         mcpTools: [],
-        healthCheck: { path: "/health", timeoutS: 60, intervalS: 5 },
+        healthCheck: {
+          path: "/health",
+          timeoutS: 60,
+          intervalS: 5,
+          target: "mcp"
+        },
         envContract: [],
         integrations: undefined,
         startCommand: "",

--- a/runtime/api-server/src/resolved-app-bootstrap-shared.ts
+++ b/runtime/api-server/src/resolved-app-bootstrap-shared.ts
@@ -102,6 +102,8 @@ export function parseResolvedApplicationRuntimePayload(value: unknown): Resolved
     },
     mcpTools: optionalStringList(payload.mcp_tools),
     healthCheck: {
+      target:
+        optionalString(healthCheck.target) === "api" ? "api" : "mcp",
       path: requiredString(healthCheck.path, "resolved_application.health_check.path"),
       timeoutS,
       intervalS

--- a/runtime/api-server/src/workspace-apps.ts
+++ b/runtime/api-server/src/workspace-apps.ts
@@ -35,6 +35,7 @@ export type ResolvedApplicationRuntime = {
   };
   mcpTools: string[];
   healthCheck: {
+    target?: "api" | "mcp";
     path: string;
     timeoutS: number;
     intervalS: number;
@@ -247,6 +248,12 @@ export function parseResolvedAppRuntime(
     (t): t is string => typeof t === "string" && t.trim().length > 0
   );
   const healthchecks = isRecord(loaded.healthchecks) ? loaded.healthchecks : null;
+  const preferredHealthcheckTarget =
+    healthchecks && isRecord(healthchecks.mcp)
+      ? "mcp"
+      : healthchecks && isRecord(healthchecks.api)
+        ? "api"
+        : "mcp";
   const preferredHealthcheck =
     (healthchecks && (isRecord(healthchecks.mcp) ? healthchecks.mcp : null)) ||
     (healthchecks && (isRecord(healthchecks.api) ? healthchecks.api : null)) ||
@@ -266,6 +273,7 @@ export function parseResolvedAppRuntime(
     },
     mcpTools,
     healthCheck: {
+      target: preferredHealthcheckTarget,
       path: preferredHealthcheck && typeof preferredHealthcheck.path === "string" ? preferredHealthcheck.path : "/health",
       timeoutS:
         preferredHealthcheck && preferredHealthcheck.timeout_s !== undefined && !Number.isNaN(Number(preferredHealthcheck.timeout_s))

--- a/runtime/api-server/src/workspace-runtime-plan.test.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.test.ts
@@ -327,6 +327,42 @@ integrations:
   ]);
 });
 
+test("parseResolvedAppRuntime preserves the selected healthcheck target", () => {
+  const mcpResolved = parseResolvedAppRuntime(
+    `
+app_id: gmail
+mcp:
+  port: 3099
+healthchecks:
+  mcp:
+    path: /mcp/health
+    timeout_s: 30
+    interval_s: 1
+`,
+    "gmail",
+    "apps/gmail/app.runtime.yaml"
+  );
+  assert.equal(mcpResolved.healthCheck.target, "mcp");
+  assert.equal(mcpResolved.healthCheck.path, "/mcp/health");
+
+  const apiResolved = parseResolvedAppRuntime(
+    `
+app_id: gmail
+mcp:
+  port: 3099
+healthchecks:
+  api:
+    path: /healthz
+    timeout_s: 45
+    interval_s: 2
+`,
+    "gmail",
+    "apps/gmail/app.runtime.yaml"
+  );
+  assert.equal(apiResolved.healthCheck.target, "api");
+  assert.equal(apiResolved.healthCheck.path, "/healthz");
+});
+
 test("parseResolvedAppRuntime rejects unknown credential_source values", () => {
   assert.throws(
     () =>

--- a/runtime/api-server/src/workspace-runtime-plan.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.ts
@@ -86,6 +86,7 @@ export type ResolvedApplication = {
     path: string;
   };
   health_check: {
+    target?: "api" | "mcp";
     path: string;
     timeout_s: number;
     interval_s: number;
@@ -852,6 +853,12 @@ function parseAppRuntimeYaml(rawYaml: string, declaredAppId: string, configPath:
     });
   }
   const configDir = configPath.includes("/") ? configPath.slice(0, configPath.lastIndexOf("/")) : ".";
+  const preferredHealthcheckTarget =
+    healthchecks && isRecord(healthchecks.mcp)
+      ? "mcp"
+      : healthchecks && isRecord(healthchecks.api)
+        ? "api"
+        : "mcp";
 
   return {
     app_id: declaredAppId,
@@ -861,6 +868,7 @@ function parseAppRuntimeYaml(rawYaml: string, declaredAppId: string, configPath:
       path: typeof mcp.path === "string" ? mcp.path : "/mcp"
     },
     health_check: {
+      target: preferredHealthcheckTarget,
       path: preferredHealthcheck && typeof preferredHealthcheck.path === "string" ? preferredHealthcheck.path : "/health",
       timeout_s:
         preferredHealthcheck &&


### PR DESCRIPTION
## Context

This PR fixes the desktop/runtime code paths behind the current `holaboss-desktop` Sentry issue clusters instead of resolving them operationally in Sentry only.

It targets these failure classes:
- `Maximum update depth exceeded`
- `workspace:listAgentSessions` timeout / `ECONNRESET`
- `App 'gmail' did not become healthy within 30s`

## What Changed

- remove the ChatPane composer footer layout feedback loop that could repeatedly flip layout state and trigger React update-depth failures
- harden renderer polling in the workspace browser and browser pane so transient IPC/runtime failures do not surface as unhandled promise rejections
- cache runtime state and agent session snapshots in the Electron main process and fall back to cached values on transient runtime errors
- preserve the configured app health-check target (`api` vs `mcp`) through runtime plan compilation and resolved bootstrap parsing
- honor that explicit health-check target in the lifecycle worker so API-targeted apps are not forced through MCP health probes
- add targeted regression tests for workspace polling behavior and runtime health-check selection

## Validation

- `npm --prefix desktop run build:renderer`
- `npm --prefix desktop run typecheck`
- `node --test desktop/src/components/panes/useWorkspaceBrowser.test.mjs desktop/src/components/panes/BrowserPane.test.mjs`
- `cd runtime/api-server && node --import tsx --test src/app-lifecycle-worker.test.ts src/workspace-runtime-plan.test.ts`
- `npm --prefix runtime/api-server run typecheck`

## Notes

- no Supabase or migration changes
- no environment changes required
- `desktop/src/components/panes/ChatPane.test.mjs` has unrelated pre-existing stale assertions, so validation on the composer-footer fix was targeted rather than a full-file green run
