### PR TITLE
fix: harden runtime failure handling and desktop restart behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,10 @@ jobs:
           node-version: "24"
 
       - name: Build Linux runtime bundle
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          HOLABOSS_RUNTIME_VERSION: ${{ env.RELEASE_TAG }}
         run: bash runtime/deploy/package_linux_runtime.sh out/runtime-linux
 
       - name: Upload runtime Sentry source maps
@@ -345,6 +349,10 @@ jobs:
             desktop/package-lock.json
 
       - name: Build macOS runtime bundle
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          HOLABOSS_RUNTIME_VERSION: ${{ env.RELEASE_TAG }}
         run: bash runtime/deploy/package_macos_runtime.sh out/runtime-macos
 
       - name: Upload runtime Sentry source maps
@@ -664,6 +672,8 @@ jobs:
           WIN_CSC_LINK: ${{ env.WINDOWS_CERTIFICATE }}
           WIN_CSC_KEY_PASSWORD: ${{ env.WINDOWS_CERTIFICATE_PASSWORD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          HOLABOSS_RUNTIME_VERSION: ${{ env.RELEASE_TAG }}
         run: |
           if (-not $env:WINDOWS_CERTIFICATE -or -not $env:WINDOWS_CERTIFICATE_PASSWORD) {
             throw "Windows desktop release requires WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD so the public installer is code-signed."

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -802,6 +802,10 @@ const filePreviewWatchSubscriptions = new Map<
 let runtimeProcess: ChildProcessWithoutNullStreams | null = null;
 const intentionallyStoppedRuntimeProcesses =
   new WeakSet<ChildProcessWithoutNullStreams>();
+const DEFERRED_RUNTIME_RESTART_POLL_MS = 5_000;
+let deferredRuntimeRestartTimer: NodeJS.Timeout | null = null;
+let deferredRuntimeRestartReason: string | null = null;
+let deferredRuntimeRestartInFlight = false;
 let appQuitCleanupPromise: Promise<void> | null = null;
 let appQuitCleanupFinished = false;
 let pendingAuthUser: AuthUserPayload | null = null;
@@ -7909,15 +7913,157 @@ function runtimeConfigRestartRequired(
   return false;
 }
 
+function normalizeDeferredRuntimeRestartReason(reason: string): string {
+  const normalized = reason.trim();
+  return normalized || "unspecified";
+}
+
+function listRuntimeRestartBlockingSessions(): Array<{
+  workspaceId: string;
+  sessionId: string;
+  status: string;
+  currentInputId: string | null;
+}> {
+  const database = openRuntimeDatabase();
+  try {
+    const rows = database
+      .prepare(
+        `
+        SELECT
+          workspace_id,
+          session_id,
+          status,
+          current_input_id
+        FROM session_runtime_state
+        WHERE status IN ('BUSY', 'QUEUED')
+           OR current_input_id IS NOT NULL
+        ORDER BY updated_at DESC
+      `,
+      )
+      .all() as Array<{
+      workspace_id: string;
+      session_id: string;
+      status: string;
+      current_input_id: string | null;
+    }>;
+    return rows
+      .map((row) => ({
+        workspaceId: row.workspace_id.trim(),
+        sessionId: row.session_id.trim(),
+        status: row.status.trim(),
+        currentInputId:
+          typeof row.current_input_id === "string" &&
+          row.current_input_id.trim()
+            ? row.current_input_id.trim()
+            : null,
+      }))
+      .filter((row) => row.workspaceId && row.sessionId);
+  } finally {
+    database.close();
+  }
+}
+
+function runtimeRestartBlockerDetail(
+  blockers: Array<{
+    workspaceId: string;
+    sessionId: string;
+    status: string;
+    currentInputId: string | null;
+  }>,
+): string {
+  return blockers
+    .map((blocker) =>
+      [
+        blocker.workspaceId,
+        blocker.sessionId,
+        blocker.status,
+        blocker.currentInputId ?? "-",
+      ].join(":"),
+    )
+    .join(",");
+}
+
+function clearDeferredRuntimeRestartWatcher(): void {
+  if (!deferredRuntimeRestartTimer) {
+    return;
+  }
+  clearInterval(deferredRuntimeRestartTimer);
+  deferredRuntimeRestartTimer = null;
+}
+
+async function maybeRunDeferredRuntimeRestart(): Promise<boolean> {
+  const reason = deferredRuntimeRestartReason;
+  if (!reason || deferredRuntimeRestartInFlight) {
+    return false;
+  }
+  const healthy = await isRuntimeHealthy(runtimeBaseUrl());
+  const blockers = healthy ? listRuntimeRestartBlockingSessions() : [];
+  if (blockers.length > 0) {
+    return false;
+  }
+
+  deferredRuntimeRestartInFlight = true;
+  deferredRuntimeRestartReason = null;
+  clearDeferredRuntimeRestartWatcher();
+  appendRuntimeEventLog({
+    category: "runtime",
+    event: "embedded_runtime.restart_resumed",
+    outcome: "start",
+    detail: `reason=${normalizeDeferredRuntimeRestartReason(reason)}`,
+  });
+  try {
+    await stopEmbeddedRuntime();
+    void startEmbeddedRuntime();
+    return true;
+  } finally {
+    deferredRuntimeRestartInFlight = false;
+  }
+}
+
+function ensureDeferredRuntimeRestartWatcher(): void {
+  if (deferredRuntimeRestartTimer) {
+    return;
+  }
+  deferredRuntimeRestartTimer = setInterval(() => {
+    void maybeRunDeferredRuntimeRestart();
+  }, DEFERRED_RUNTIME_RESTART_POLL_MS);
+  deferredRuntimeRestartTimer.unref();
+}
+
+async function restartEmbeddedRuntimeSafely(
+  reason: string,
+): Promise<"restarted" | "deferred"> {
+  const normalizedReason = normalizeDeferredRuntimeRestartReason(reason);
+  const healthy = await isRuntimeHealthy(runtimeBaseUrl());
+  const blockers = healthy ? listRuntimeRestartBlockingSessions() : [];
+  if (blockers.length > 0) {
+    deferredRuntimeRestartReason = normalizedReason;
+    ensureDeferredRuntimeRestartWatcher();
+    appendRuntimeEventLog({
+      category: "runtime",
+      event: "embedded_runtime.restart_deferred",
+      outcome: "deferred",
+      detail: `reason=${normalizedReason} blockers=${runtimeRestartBlockerDetail(blockers)}`,
+    });
+    return "deferred";
+  }
+
+  deferredRuntimeRestartReason = null;
+  clearDeferredRuntimeRestartWatcher();
+  await stopEmbeddedRuntime();
+  void startEmbeddedRuntime();
+  return "restarted";
+}
+
 async function restartEmbeddedRuntimeIfNeeded(
   current: Record<string, string>,
   next: Record<string, string>,
+  reason = "runtime_config_update",
 ): Promise<boolean> {
   if (!runtimeConfigRestartRequired(current, next)) {
     return false;
   }
-  await stopEmbeddedRuntime();
-  void startEmbeddedRuntime();
+  await restartEmbeddedRuntimeSafely(reason);
   return true;
 }
 
@@ -8035,8 +8181,7 @@ async function setRuntimeConfigDocument(
   await syncDesktopBrowserCapabilityConfig();
 
   if (shouldRestartRuntime) {
-    await stopEmbeddedRuntime();
-    void startEmbeddedRuntime();
+    await restartEmbeddedRuntimeSafely("runtime_config_document");
   }
 
   const config = await getRuntimeConfig();
@@ -9179,7 +9324,11 @@ async function clearRuntimeBindingSecrets(reason: string): Promise<void> {
   lastRuntimeBindingRefreshAtMs = 0;
   lastRuntimeBindingRefreshUserId = "";
   clearTransientRuntimeBindingRefreshFailure();
-  await restartEmbeddedRuntimeIfNeeded(currentConfig, nextConfig);
+  await restartEmbeddedRuntimeIfNeeded(
+    currentConfig,
+    nextConfig,
+    "runtime_binding_invalidate",
+  );
   await emitRuntimeConfig();
   appendRuntimeEventLog({
     category: "auth",
@@ -9261,7 +9410,11 @@ async function provisionRuntimeBindingForAuthenticatedUser(
         controlPlaneBaseUrl: DESKTOP_CONTROL_PLANE_BASE_URL,
       });
       await syncRuntimeModelCatalogFromBinding(binding);
-      await restartEmbeddedRuntimeIfNeeded(currentConfig, nextConfig);
+      await restartEmbeddedRuntimeIfNeeded(
+        currentConfig,
+        nextConfig,
+        "runtime_binding_provision",
+      );
       await emitRuntimeConfig();
       await syncRuntimeUserProfileFromAuth(user);
 
@@ -21391,8 +21544,8 @@ app.whenReady().then(async () => {
     refreshRuntimeStatus(),
   );
   handleTrustedIpc("runtime:restart", ["main"], async () => {
-    await stopEmbeddedRuntime();
-    return startEmbeddedRuntime();
+    await restartEmbeddedRuntimeSafely("manual_restart");
+    return refreshRuntimeStatus();
   });
   handleTrustedIpc("auth:getUser", ["main", "auth-popup"], async () =>
     getAuthenticatedUser(),
@@ -21472,7 +21625,11 @@ app.whenReady().then(async () => {
     async (_event, payload: RuntimeConfigUpdatePayload) => {
       const currentConfig = await readRuntimeConfigFile();
       const nextConfig = await writeRuntimeConfigFile(payload);
-      await restartEmbeddedRuntimeIfNeeded(currentConfig, nextConfig);
+      await restartEmbeddedRuntimeIfNeeded(
+        currentConfig,
+        nextConfig,
+        "runtime_config_update",
+      );
       const config = await getRuntimeConfig();
       await emitRuntimeConfig(config);
       return config;
@@ -21630,7 +21787,11 @@ app.whenReady().then(async () => {
         controlPlaneBaseUrl: DESKTOP_CONTROL_PLANE_BASE_URL,
       });
       await syncRuntimeModelCatalogFromBinding(binding);
-      await restartEmbeddedRuntimeIfNeeded(currentConfig, nextConfig);
+      await restartEmbeddedRuntimeIfNeeded(
+        currentConfig,
+        nextConfig,
+        "runtime_binding_exchange_manual",
+      );
       const config = await getRuntimeConfig();
       await emitRuntimeConfig(config);
       return config;

--- a/desktop/electron/runtime-restart-deferral.test.mjs
+++ b/desktop/electron/runtime-restart-deferral.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("desktop runtime restart guard checks runtime-state blockers before stopping the embedded runtime", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+  const restartGuardSection =
+    source.match(
+      /function normalizeDeferredRuntimeRestartReason[\s\S]*?async function restartEmbeddedRuntimeIfNeeded\(/,
+    )?.[0] ?? "";
+
+  assert.match(
+    restartGuardSection,
+    /FROM session_runtime_state[\s\S]*WHERE status IN \('BUSY', 'QUEUED'\)[\s\S]*OR current_input_id IS NOT NULL/,
+  );
+  assert.match(
+    restartGuardSection,
+    /const healthy = await isRuntimeHealthy\(runtimeBaseUrl\(\)\);[\s\S]*const blockers = healthy \? listRuntimeRestartBlockingSessions\(\) : \[\];/,
+  );
+  assert.match(
+    restartGuardSection,
+    /event: "embedded_runtime\.restart_deferred"[\s\S]*outcome: "deferred"/,
+  );
+  assert.match(
+    restartGuardSection,
+    /event: "embedded_runtime\.restart_resumed"[\s\S]*outcome: "start"/,
+  );
+  assert.match(
+    restartGuardSection,
+    /await stopEmbeddedRuntime\(\);[\s\S]*void startEmbeddedRuntime\(\);/,
+  );
+});
+
+test("desktop runtime routes config and manual restarts through the deferred restart guard", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /async function restartEmbeddedRuntimeIfNeeded\([\s\S]*await restartEmbeddedRuntimeSafely\(reason\);[\s\S]*return true;/,
+  );
+  assert.match(
+    source,
+    /if \(shouldRestartRuntime\) \{[\s\S]*await restartEmbeddedRuntimeSafely\("runtime_config_document"\);[\s\S]*\}/,
+  );
+  assert.match(
+    source,
+    /handleTrustedIpc\("runtime:restart", \["main"\], async \(\) => \{[\s\S]*await restartEmbeddedRuntimeSafely\("manual_restart"\);[\s\S]*return refreshRuntimeStatus\(\);[\s\S]*\}\);/,
+  );
+});

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -12,6 +12,7 @@ import {
   registerWorkspaceAgentRunStarted,
 } from "./claimed-input-executor.js";
 import type { MemoryServiceLike } from "./memory.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 import type { PiContextUsage } from "./session-checkpoint.js";
 
 const tempDirs: string[] = [];
@@ -1321,6 +1322,62 @@ test("claimed input fails when runner becomes idle after run_started", async () 
   assert.ok(turnResult);
   assert.equal(turnResult.status, "failed");
   assert.equal(turnResult.stopReason, "RunnerCommandError");
+
+  store.close();
+});
+
+test("claimed input reports synthesized runner timeouts to Sentry", async () => {
+  const store = makeStore("hb-claimed-input-sentry-timeout-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" },
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    captureRuntimeExceptionFn: (capture) => {
+      sentryCaptures.push(capture);
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "runner command timed out",
+        returnCode: 124,
+        sawTerminal: false,
+      };
+    },
+  });
+
+  assert.equal(sentryCaptures.length, 1);
+  assert.equal(sentryCaptures[0]?.tags?.failure_kind, "runner_timeout");
+  assert.equal(sentryCaptures[0]?.tags?.surface, "claimed_input_executor");
+  assert.equal(
+    sentryCaptures[0]?.contexts?.claimed_input?.input_id,
+    queued.inputId,
+  );
 
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -23,6 +23,7 @@ const ORIGINAL_ENV = {
     process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S,
   HB_SANDBOX_ROOT: process.env.HB_SANDBOX_ROOT,
   HOLABOSS_RUNTIME_CONFIG_PATH: process.env.HOLABOSS_RUNTIME_CONFIG_PATH,
+  HOLABOSS_HARNESS_RUN_TIMEOUT_S: process.env.HOLABOSS_HARNESS_RUN_TIMEOUT_S,
 };
 
 function test(
@@ -64,6 +65,12 @@ afterEach(() => {
   } else {
     process.env.HOLABOSS_RUNTIME_CONFIG_PATH =
       ORIGINAL_ENV.HOLABOSS_RUNTIME_CONFIG_PATH;
+  }
+  if (ORIGINAL_ENV.HOLABOSS_HARNESS_RUN_TIMEOUT_S === undefined) {
+    delete process.env.HOLABOSS_HARNESS_RUN_TIMEOUT_S;
+  } else {
+    process.env.HOLABOSS_HARNESS_RUN_TIMEOUT_S =
+      ORIGINAL_ENV.HOLABOSS_HARNESS_RUN_TIMEOUT_S;
   }
 });
 
@@ -759,6 +766,60 @@ test("claimed input renews its claim lease while the runner is still healthy", a
   assert.ok(claimedUntilDuringRun);
   assert.notEqual(claimedUntilDuringRun, claimedUntilBefore);
   assert.ok(Date.parse(claimedUntilDuringRun) > Date.parse(claimedUntilBefore));
+
+  store.close();
+});
+
+test("claimed input passes the harness timeout through to the outer runner watchdog", async () => {
+  process.env.HOLABOSS_HARNESS_RUN_TIMEOUT_S = "45";
+
+  const store = makeStore("hb-claimed-input-harness-timeout-payload-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" },
+  });
+  let seenHarnessTimeout: number | null = null;
+
+  await processClaimedInput({
+    store,
+    record: queued,
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      seenHarnessTimeout =
+        typeof payload.harness_timeout_seconds === "number"
+          ? payload.harness_timeout_seconds
+          : null;
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 2,
+        event_type: "run_completed",
+        payload: { status: "ok" },
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true,
+      };
+    },
+  });
+
+  assert.equal(seenHarnessTimeout, 45);
 
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -18,6 +18,7 @@ import { resolveProductRuntimeConfig } from "./runtime-config.js";
 import {
   normalizeHarnessId,
   resolveRuntimeHarnessAdapter,
+  resolveRuntimeHarnessPlugin,
 } from "./harness-registry.js";
 import type { MemoryServiceLike } from "./memory.js";
 import { createBackgroundTaskMemoryModelClient } from "./background-task-model.js";
@@ -1271,6 +1272,17 @@ export async function processClaimedInput(params: {
       runtimeBinding,
     });
 
+    const harnessTimeoutSeconds =
+      resolveRuntimeHarnessPlugin(harness)?.timeoutSeconds({
+        request: {
+          workspace_id: record.workspaceId,
+          session_id: record.sessionId,
+          session_kind: sessionKind,
+          input_id: record.inputId,
+          instruction,
+        },
+      }) ?? null;
+
     const payload: Record<string, unknown> = {
       workspace_id: record.workspaceId,
       session_id: record.sessionId,
@@ -1281,6 +1293,7 @@ export async function processClaimedInput(params: {
       context: runtimeContext,
       model: record.payload.model ?? null,
       thinking_value: record.payload.thinking_value ?? null,
+      harness_timeout_seconds: harnessTimeoutSeconds,
       debug: false,
     };
     const memoryWritebackModelContext = writebackModelContext({

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -20,6 +20,7 @@ import {
   resolveRuntimeHarnessAdapter,
   resolveRuntimeHarnessPlugin,
 } from "./harness-registry.js";
+import { captureRuntimeException } from "./runtime-sentry.js";
 import type { MemoryServiceLike } from "./memory.js";
 import { createBackgroundTaskMemoryModelClient } from "./background-task-model.js";
 import {
@@ -1090,6 +1091,7 @@ export async function processClaimedInput(params: {
   relayRunEventFn?: typeof registerWorkspaceAgentRunEvent;
   enqueueSessionCheckpointJobFn?: typeof enqueueSessionCheckpointJob;
   waitForSessionCheckpointCompletionFn?: typeof waitForSessionCheckpointCompletion;
+  captureRuntimeExceptionFn?: typeof captureRuntimeException;
   abortSignal?: AbortSignal;
 }): Promise<void> {
   const { store, record } = params;
@@ -1282,6 +1284,40 @@ export async function processClaimedInput(params: {
           instruction,
         },
       }) ?? null;
+    const captureClaimedInputFailure = (
+      failureKind: string,
+      message: string,
+      extra: Record<string, unknown> = {},
+    ) => {
+      (
+        params.captureRuntimeExceptionFn ?? captureRuntimeException
+      )({
+        error: new Error(message),
+        level: "error",
+        fingerprint: ["runtime", "claimed_input", failureKind, harness],
+        tags: {
+          surface: "claimed_input_executor",
+          failure_kind: failureKind,
+          harness,
+          session_kind: sessionKind,
+        },
+        contexts: {
+          claimed_input: {
+            workspace_id: record.workspaceId,
+            session_id: record.sessionId,
+            input_id: record.inputId,
+            run_id: runId,
+            harness_session_id: checkpointHarnessSessionId,
+            selected_model: selectedModel,
+          },
+        },
+        extras: {
+          last_sequence: lastSequence,
+          harness_timeout_seconds: harnessTimeoutSeconds,
+          ...extra,
+        },
+      });
+    };
 
     const payload: Record<string, unknown> = {
       workspace_id: record.workspaceId,
@@ -1708,6 +1744,19 @@ export async function processClaimedInput(params: {
             payload: failurePayload,
             createdAt: failedAt,
           };
+          captureClaimedInputFailure(
+            execution.abortReason === "claim_expired"
+              ? "claim_expired"
+              : "runner_aborted",
+            String(failurePayload.message ?? "runner aborted before terminal event"),
+            {
+              abort_reason: execution.abortReason,
+              return_code: execution.returnCode,
+              stderr: execution.stderr,
+              saw_terminal: execution.sawTerminal,
+              skipped_lines: execution.skippedLines.slice(0, 5),
+            },
+          );
           terminalStatus = "ERROR";
           lastError = failurePayload;
           completedAt = failedAt;
@@ -1747,6 +1796,22 @@ export async function processClaimedInput(params: {
           payload: failurePayload,
           createdAt: new Date().toISOString(),
         };
+        captureClaimedInputFailure(
+          execution.returnCode !== 0
+            ? execution.stderr.trim() === "runner command timed out"
+              ? "runner_timeout"
+              : execution.stderr.includes("became idle")
+                ? "runner_idle_timeout"
+                : "runner_command_error"
+            : "runner_missing_terminal",
+          String(failurePayload.message ?? "runner ended before terminal event"),
+          {
+            return_code: execution.returnCode,
+            stderr: execution.stderr,
+            saw_terminal: execution.sawTerminal,
+            skipped_lines: execution.skippedLines.slice(0, 5),
+          },
+        );
         terminalStatus = "ERROR";
         lastError = failurePayload;
         completedAt = new Date().toISOString();

--- a/runtime/api-server/src/index.ts
+++ b/runtime/api-server/src/index.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { setTimeout as sleep } from "node:timers/promises";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -17,6 +18,28 @@ Sentry.init({
 
 import { buildRuntimeApiServer } from "./app.js";
 
+const SENTRY_FLUSH_TIMEOUT_MS = 2_000;
+const SHUTDOWN_TIMEOUT_MS = 2_000;
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  switch (signal) {
+    case "SIGINT":
+      return 130;
+    case "SIGTERM":
+      return 143;
+    default:
+      return 0;
+  }
+}
+
+async function flushSentry(): Promise<void> {
+  try {
+    await Sentry.flush(SENTRY_FLUSH_TIMEOUT_MS);
+  } catch {
+    // Best-effort during process shutdown.
+  }
+}
+
 async function main(): Promise<void> {
   const port = Number.parseInt(
     process.env.SANDBOX_RUNTIME_API_PORT ??
@@ -32,11 +55,39 @@ async function main(): Promise<void> {
       "0.0.0.0"
     ).trim() || "0.0.0.0";
   const app = buildRuntimeApiServer({ logger: true });
+  let shuttingDown = false;
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    void (async () => {
+      try {
+        await Promise.race([
+          app.close().catch(() => undefined),
+          sleep(SHUTDOWN_TIMEOUT_MS),
+        ]);
+      } finally {
+        await flushSentry();
+        process.exit(signalExitCode(signal));
+      }
+    })();
+  };
+
+  process.once("SIGINT", () => {
+    shutdown("SIGINT");
+  });
+  process.once("SIGTERM", () => {
+    shutdown("SIGTERM");
+  });
 
   try {
     await app.listen({ port, host });
   } catch (error) {
     app.log.error(error);
+    Sentry.captureException(error);
+    await flushSentry();
     process.exit(1);
   }
 }

--- a/runtime/api-server/src/queue-worker.test.ts
+++ b/runtime/api-server/src/queue-worker.test.ts
@@ -9,6 +9,7 @@ import { RuntimeStateStore } from "@holaboss/runtime-state-store";
 
 import { buildRuntimeApiServer } from "./app.js";
 import { RuntimeQueueWorker } from "./queue-worker.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 
 const tempDirs: string[] = [];
 
@@ -243,9 +244,13 @@ test("runtime queue worker marks claimed input failed when delegated execution r
     priority: 1,
     payload: { text: "hello" }
   });
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
 
   const worker = new RuntimeQueueWorker({
     store,
+    captureRuntimeException: (capture) => {
+      sentryCaptures.push(capture);
+    },
     executeClaimedInput: async () => {
       throw new Error("delegated execution failed");
     }
@@ -266,6 +271,12 @@ test("runtime queue worker marks claimed input failed when delegated execution r
   assert.ok(runtimeState);
   assert.equal(runtimeState.status, "ERROR");
   assert.deepEqual(runtimeState.lastError, { message: "delegated execution failed" });
+  assert.equal(sentryCaptures.length, 1);
+  assert.equal(sentryCaptures[0]?.tags?.failure_kind, "claimed_input_exception");
+  assert.equal(
+    sentryCaptures[0]?.contexts?.claimed_input?.input_id,
+    queued.inputId,
+  );
 
   store.close();
 });

--- a/runtime/api-server/src/queue-worker.ts
+++ b/runtime/api-server/src/queue-worker.ts
@@ -5,6 +5,7 @@ import { type RuntimeStateStore, type SessionInputRecord, utcNowIso } from "@hol
 import { processClaimedInput } from "./claimed-input-executor.js";
 import type { MemoryServiceLike } from "./memory.js";
 import { buildRunCompletedEvent, buildRunFailedEvent } from "./runner-worker.js";
+import { captureRuntimeException } from "./runtime-sentry.js";
 
 const DEFAULT_CLAIMED_BY = "sandbox-agent-ts-worker";
 const DEFAULT_LEASE_SECONDS = 300;
@@ -36,6 +37,7 @@ export interface RuntimeQueueWorkerOptions {
   memoryService?: MemoryServiceLike | null;
   wakeDurableMemoryWorker?: (() => void) | null;
   executeClaimedInput?: (record: SessionInputRecord, options?: { signal?: AbortSignal }) => Promise<void>;
+  captureRuntimeException?: typeof captureRuntimeException;
   claimedBy?: string;
   leaseSeconds?: number;
   pollIntervalMs?: number;
@@ -55,6 +57,7 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
   readonly #store: RuntimeStateStore;
   readonly #logger: RuntimeQueueWorkerOptions["logger"];
   readonly #executeClaimedInput: (record: SessionInputRecord, options?: { signal?: AbortSignal }) => Promise<void>;
+  readonly #captureRuntimeException: typeof captureRuntimeException;
   readonly #claimedBy: string;
   readonly #leaseSeconds: number;
   readonly #pollIntervalMs: number;
@@ -75,6 +78,8 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
     this.#store = options.store;
     this.#logger = options.logger;
     this.#claimedBy = options.claimedBy ?? DEFAULT_CLAIMED_BY;
+    this.#captureRuntimeException =
+      options.captureRuntimeException ?? captureRuntimeException;
     this.#executeClaimedInput =
       options.executeClaimedInput ??
       ((record, executionOptions) =>
@@ -208,6 +213,25 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
         await this.#executeClaimedInput(record, { signal: controller.signal });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        this.#captureRuntimeException({
+          error,
+          level: "error",
+          fingerprint: ["runtime", "queue_worker", "claimed_input_exception"],
+          tags: {
+            surface: "queue_worker",
+            failure_kind: "claimed_input_exception",
+          },
+          contexts: {
+            claimed_input: {
+              workspace_id: record.workspaceId,
+              session_id: record.sessionId,
+              input_id: record.inputId,
+            },
+          },
+          extras: {
+            claimed_by: this.#claimedBy,
+          },
+        });
         this.#logger?.error?.("TS queue worker failed to process claimed input", {
           inputId: record.inputId,
           workspaceId: record.workspaceId,
@@ -290,6 +314,28 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
       });
       const hasTerminal = events.some((event) => TERMINAL_EVENT_TYPES.has(event.eventType));
       if (!hasTerminal) {
+        this.#captureRuntimeException({
+          error: new Error(
+            "claimed input lease expired before the runner emitted a terminal event",
+          ),
+          level: "error",
+          fingerprint: ["runtime", "queue_worker", "claim_expired"],
+          tags: {
+            surface: "queue_worker",
+            failure_kind: "claim_expired",
+          },
+          contexts: {
+            claimed_input: {
+              workspace_id: record.workspaceId,
+              session_id: record.sessionId,
+              input_id: record.inputId,
+            },
+          },
+          extras: {
+            active_run_present: Boolean(activeRun),
+            output_event_count: events.length,
+          },
+        });
         const failure = buildRunFailedEvent({
           sessionId: record.sessionId,
           inputId: record.inputId,

--- a/runtime/api-server/src/runner-worker.test.ts
+++ b/runtime/api-server/src/runner-worker.test.ts
@@ -19,6 +19,7 @@ const ORIGINAL_ENV = {
   SANDBOX_AGENT_TASK_PROPOSAL_RUN_TIMEOUT_S: process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_TIMEOUT_S,
   SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S: process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S,
   SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S: process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S,
+  SANDBOX_AGENT_RUN_POST_START_GRACE_S: process.env.SANDBOX_AGENT_RUN_POST_START_GRACE_S,
   SANDBOX_AGENT_RUNNER_HEARTBEAT_MS: process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS,
   SANDBOX_RUNTIME_API_URL: process.env.SANDBOX_RUNTIME_API_URL,
   SANDBOX_RUNTIME_API_HOST: process.env.SANDBOX_RUNTIME_API_HOST,
@@ -57,6 +58,11 @@ afterEach(() => {
     delete process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S;
   } else {
     process.env.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S = ORIGINAL_ENV.SANDBOX_AGENT_TASK_PROPOSAL_RUN_IDLE_TIMEOUT_S;
+  }
+  if (ORIGINAL_ENV.SANDBOX_AGENT_RUN_POST_START_GRACE_S === undefined) {
+    delete process.env.SANDBOX_AGENT_RUN_POST_START_GRACE_S;
+  } else {
+    process.env.SANDBOX_AGENT_RUN_POST_START_GRACE_S = ORIGINAL_ENV.SANDBOX_AGENT_RUN_POST_START_GRACE_S;
   }
   if (ORIGINAL_ENV.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS === undefined) {
     delete process.env.SANDBOX_AGENT_RUNNER_HEARTBEAT_MS;
@@ -355,6 +361,34 @@ test("native runner executor keeps silent runs alive with invisible runner heart
 
   assert.deepEqual(
     events.map((event) => event.event_type),
+    ["run_started", "run_completed"]
+  );
+});
+
+test("executeRunnerRequest gives a started harness its own timeout budget before the outer watchdog kills it", async () => {
+  process.env.SANDBOX_AGENT_RUN_TIMEOUT_S = "1";
+  process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S = "10";
+  process.env.SANDBOX_AGENT_RUN_POST_START_GRACE_S = "0";
+
+  setNodeRunnerTemplate([
+    "setTimeout(() => {",
+    "  process.stdout.write(JSON.stringify({ session_id: 'session-1', input_id: 'input-1', sequence: 1, event_type: 'run_started', payload: { instruction_preview: 'hello' } }) + '\\n');",
+    "}, 500);",
+    "setTimeout(() => {",
+    "  process.stdout.write(JSON.stringify({ session_id: 'session-1', input_id: 'input-1', sequence: 2, event_type: 'run_completed', payload: { status: 'success' } }) + '\\n');",
+    "}, 1500);"
+  ]);
+
+  const execution = await executeRunnerRequest(
+    payload({ harness_timeout_seconds: 2 }),
+    {}
+  );
+
+  assert.equal(execution.stderr, "");
+  assert.equal(execution.returnCode, 0);
+  assert.equal(execution.sawTerminal, true);
+  assert.deepEqual(
+    execution.events.map((event) => event.event_type),
     ["run_started", "run_completed"]
   );
 });

--- a/runtime/api-server/src/runner-worker.ts
+++ b/runtime/api-server/src/runner-worker.ts
@@ -16,6 +16,7 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 5000;
 const DEFAULT_RUN_TIMEOUT_SECONDS = 1800;
 const DEFAULT_IDLE_TIMEOUT_SECONDS = 900;
 const DEFAULT_TASK_PROPOSAL_RUN_TIMEOUT_SECONDS = 7200;
+const DEFAULT_POST_START_TIMEOUT_GRACE_SECONDS = 60;
 
 export interface RunnerExecutorLike {
   run(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
@@ -180,6 +181,29 @@ function runnerHeartbeatIntervalMs(): number {
     min: 50,
     max: 60_000,
   });
+}
+
+function postStartTimeoutGraceSeconds(): number {
+  return secondsFromEnv(
+    "SANDBOX_AGENT_RUN_POST_START_GRACE_S",
+    DEFAULT_POST_START_TIMEOUT_GRACE_SECONDS,
+    { min: 0, max: 600 }
+  );
+}
+
+function harnessTimeoutSeconds(payload: Record<string, unknown>): number | null {
+  const raw = payload.harness_timeout_seconds;
+  const parsed =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? Number.parseInt(raw, 10)
+        : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const normalized = Math.max(0, Math.min(Math.trunc(parsed), 7200));
+  return normalized > 0 ? normalized : null;
 }
 
 function normalizeRuntimeApiHost(value: string): string {
@@ -432,14 +456,26 @@ export async function executeRunnerRequest(
 
   const timeoutMs = runnerTimeoutSeconds(payload) * 1000;
   const idleTimeoutMs = runnerIdleTimeoutSeconds(payload) * 1000;
+  const postStartHarnessTimeoutSeconds = harnessTimeoutSeconds(payload);
+  const postStartTimeoutGraceMs = postStartTimeoutGraceSeconds() * 1000;
   let timedOut = false;
   let idleTimedOut = false;
   let sawTerminal = false;
   let aborted = false;
-  const timeout = setTimeout(() => {
-    timedOut = true;
-    killChildProcess(child, "SIGKILL");
-  }, timeoutMs);
+  let timeout: NodeJS.Timeout | null = null;
+  let hardDeadlineAtMs = Date.now() + timeoutMs;
+  let postStartDeadlineApplied = false;
+  const scheduleHardTimeoutAt = (deadlineAtMs: number) => {
+    hardDeadlineAtMs = deadlineAtMs;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timedOut = true;
+      killChildProcess(child, "SIGKILL");
+    }, Math.max(1, hardDeadlineAtMs - Date.now()));
+  };
+  scheduleHardTimeoutAt(hardDeadlineAtMs);
   let idleTimeout: NodeJS.Timeout | null = null;
   const resetIdleTimeout = () => {
     if (idleTimeout) {
@@ -505,6 +541,19 @@ export async function executeRunnerRequest(
           }
           resetIdleTimeout();
           events.push(parsed);
+          if (
+            parsed.event_type === "run_started" &&
+            !postStartDeadlineApplied &&
+            postStartHarnessTimeoutSeconds !== null
+          ) {
+            postStartDeadlineApplied = true;
+            scheduleHardTimeoutAt(
+              Math.max(
+                hardDeadlineAtMs,
+                Date.now() + postStartHarnessTimeoutSeconds * 1000 + postStartTimeoutGraceMs
+              )
+            );
+          }
           if (options.onEvent) {
             await options.onEvent(parsed);
           }
@@ -523,7 +572,9 @@ export async function executeRunnerRequest(
       skippedLines.push(stdoutBuffer.trim());
     }
   } finally {
-    clearTimeout(timeout);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
     if (idleTimeout) {
       clearTimeout(idleTimeout);
     }

--- a/runtime/api-server/src/runtime-sentry.ts
+++ b/runtime/api-server/src/runtime-sentry.ts
@@ -1,0 +1,89 @@
+import * as Sentry from "@sentry/node";
+
+type RuntimeSentryLevel = "fatal" | "error" | "warning" | "log" | "info" | "debug";
+
+export interface RuntimeSentryCaptureOptions {
+  error: unknown;
+  level?: RuntimeSentryLevel;
+  tags?: Record<string, unknown>;
+  extras?: Record<string, unknown>;
+  contexts?: Record<string, Record<string, unknown> | null | undefined>;
+  fingerprint?: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function jsonValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => jsonValue(item));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, jsonValue(item)]),
+    );
+  }
+  return value === undefined ? null : String(value);
+}
+
+function normalizeTagValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value.trim() || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  const message =
+    typeof value === "string"
+      ? value
+      : JSON.stringify(jsonValue(value)) ?? "Unknown runtime error";
+  return new Error(message);
+}
+
+export function captureRuntimeException(
+  options: RuntimeSentryCaptureOptions,
+): void {
+  const error = normalizeError(options.error);
+  Sentry.withScope((scope) => {
+    if (options.level) {
+      scope.setLevel(options.level);
+    }
+    if (Array.isArray(options.fingerprint) && options.fingerprint.length > 0) {
+      scope.setFingerprint(options.fingerprint.filter((item) => item.trim()));
+    }
+    for (const [key, value] of Object.entries(options.tags ?? {})) {
+      const normalized = normalizeTagValue(value);
+      if (normalized) {
+        scope.setTag(key, normalized);
+      }
+    }
+    for (const [key, value] of Object.entries(options.extras ?? {})) {
+      scope.setExtra(key, jsonValue(value));
+    }
+    for (const [key, value] of Object.entries(options.contexts ?? {})) {
+      if (value && Object.keys(value).length > 0) {
+        scope.setContext(key, jsonValue(value) as Record<string, unknown>);
+      }
+    }
+    Sentry.captureException(error);
+  });
+}

--- a/runtime/api-server/src/session-checkpoint.test.ts
+++ b/runtime/api-server/src/session-checkpoint.test.ts
@@ -584,7 +584,7 @@ test("session checkpoint records not_compacted when PI reports a compaction no-o
   }
 });
 
-test("session checkpoint treats provider 422 summarization failures as a soft no-op", async () => {
+test("session checkpoint treats provider 422 summarization failures as a soft no-op and records compaction diagnostics", async () => {
   const { store, root } = makeStore("hb-session-checkpoint-soft-422-");
   const sessions = new Map<string, FakeSessionState>();
   const sessionOps = createFakeSessionOps(sessions);
@@ -664,7 +664,31 @@ test("session checkpoint treats provider 422 summarization failures as a soft no
       record: queued!,
       sessionOps,
       runPiSessionCompactionFn: async () => {
-        throw new Error("Summarization failed: 422 status code (no body)");
+        const error = new Error("Summarization failed: 422 status code (no body)") as Error & {
+          commandResult?: Record<string, unknown>;
+        };
+        error.commandResult = {
+          compacted: false,
+          session_file: liveSessionFile,
+          diagnostics: {
+            preparation: {
+              status: "ready",
+              is_split_turn: true,
+              first_kept_entry_id: "entry-2",
+            },
+            compaction_end: {
+              error_message:
+                "Compaction failed: Turn prefix summarization failed: 422 status code (no body)",
+            },
+          },
+          error: {
+            name: "APIError",
+            message: "Summarization failed: 422 status code (no body)",
+            status_code: 422,
+            provider_message: "422 status code (no body)",
+          },
+        };
+        throw error;
       },
     });
 
@@ -685,6 +709,35 @@ test("session checkpoint treats provider 422 summarization failures as a soft no
         updatedJob?.payload.checkpoint_result as { outcome?: string } | undefined
       )?.outcome,
       "soft_provider_422",
+    );
+    assert.deepEqual(
+      (
+        updatedJob?.payload.checkpoint_result as
+          | { compaction?: Record<string, unknown> | null }
+          | undefined
+      )?.compaction,
+      {
+        session_file: liveSessionFile,
+        reason: null,
+        diagnostics: {
+          preparation: {
+            status: "ready",
+            is_split_turn: true,
+            first_kept_entry_id: "entry-2",
+          },
+          compaction_end: {
+            error_message:
+              "Compaction failed: Turn prefix summarization failed: 422 status code (no body)",
+          },
+        },
+        result: null,
+        error: {
+          name: "APIError",
+          message: "Summarization failed: 422 status code (no body)",
+          status_code: 422,
+          provider_message: "422 status code (no body)",
+        },
+      },
     );
   } finally {
     store.close();

--- a/runtime/api-server/src/session-checkpoint.test.ts
+++ b/runtime/api-server/src/session-checkpoint.test.ts
@@ -11,6 +11,7 @@ import {
   enqueueSessionCheckpointJob,
   processSessionCheckpointJob,
 } from "./session-checkpoint.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 
 interface FakeSessionEntry {
   id: string;
@@ -658,11 +659,15 @@ test("session checkpoint treats provider 422 summarization failures as a soft no
       sessionOps,
     });
     assert.ok(queued);
+    const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
 
     await processSessionCheckpointJob({
       store,
       record: queued!,
       sessionOps,
+      captureRuntimeExceptionFn: (capture) => {
+        sentryCaptures.push(capture);
+      },
       runPiSessionCompactionFn: async () => {
         const error = new Error("Summarization failed: 422 status code (no body)") as Error & {
           commandResult?: Record<string, unknown>;
@@ -709,6 +714,13 @@ test("session checkpoint treats provider 422 summarization failures as a soft no
         updatedJob?.payload.checkpoint_result as { outcome?: string } | undefined
       )?.outcome,
       "soft_provider_422",
+    );
+    assert.equal(sentryCaptures.length, 1);
+    assert.equal(sentryCaptures[0]?.tags?.failure_kind, "soft_provider_422");
+    assert.equal(sentryCaptures[0]?.tags?.surface, "session_checkpoint");
+    assert.equal(
+      sentryCaptures[0]?.contexts?.session_checkpoint?.input_id,
+      "input-soft-422",
     );
     assert.deepEqual(
       (

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -33,7 +33,10 @@ interface SessionCheckpointJobPayload {
 interface PiCompactionCommandResult {
   compacted: boolean;
   session_file: string;
+  result?: Record<string, unknown> | null;
   reason?: string | null;
+  diagnostics?: Record<string, unknown> | null;
+  error?: Record<string, unknown> | null;
 }
 
 type SessionCheckpointResultOutcome =
@@ -56,6 +59,15 @@ interface SessionCheckpointResultRecord {
   reason?: string | null;
   merged?: boolean;
   boundary_written?: boolean;
+  compaction?: SessionCheckpointCompactionRecord | null;
+}
+
+interface SessionCheckpointCompactionRecord {
+  session_file: string | null;
+  reason: string | null;
+  diagnostics: Record<string, unknown> | null;
+  result: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
 }
 
 type ResolveRuntimeModelClientFn = typeof resolveRuntimeModelClient;
@@ -138,6 +150,30 @@ function requiredRecord(value: unknown, fieldName: string): Record<string, unkno
     throw new Error(`${fieldName} must be an object`);
   }
   return value;
+}
+
+function jsonValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => jsonValue(item));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, jsonValue(item)]),
+    );
+  }
+  return value === undefined ? null : String(value);
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function runtimeRootDir(): string {
@@ -224,6 +260,7 @@ function recordSessionCheckpointResult(params: {
   reason?: string | null;
   merged?: boolean;
   boundaryWritten?: boolean;
+  compaction?: SessionCheckpointCompactionRecord | null;
 }): void {
   const nextPayload = {
     ...(isRecord(params.record.payload) ? params.record.payload : {}),
@@ -238,6 +275,7 @@ function recordSessionCheckpointResult(params: {
           params.outcome === "merged_without_boundary"),
       boundary_written:
         params.boundaryWritten ?? (params.outcome === "merged"),
+      compaction: params.compaction ?? null,
     } satisfies SessionCheckpointResultRecord,
   };
   params.store.updatePostRunJob(params.record.jobId, {
@@ -430,26 +468,94 @@ async function runPiSessionCompaction(requestPayload: Record<string, unknown>): 
     child.once("error", reject);
     child.once("close", (code) => resolve(code ?? 0));
   });
-  if (exitCode !== 0) {
-    throw new Error(stderr.trim() || `compact-pi-session exited with code ${exitCode}`);
-  }
-
   const responseLine = stdout
     .trim()
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
     .at(-1);
+  if (!responseLine && exitCode !== 0) {
+    throw new Error(stderr.trim() || `compact-pi-session exited with code ${exitCode}`);
+  }
   if (!responseLine) {
     throw new Error("compact-pi-session did not return a result");
   }
   const parsed = JSON.parse(responseLine) as unknown;
-  const result = requiredRecord(parsed, "compact-pi-session response");
+  const result = decodePiCompactionCommandResult(parsed);
+  if (result.error) {
+    const error = new Error(
+      nonEmptyString(result.error.message) ??
+        (stderr.trim() || `compact-pi-session exited with code ${exitCode || 1}`),
+    );
+    error.name =
+      nonEmptyString(result.error.name) ?? "PiSessionCompactionCommandError";
+    Object.assign(error, {
+      commandResult: result,
+      exitCode,
+      stderr: stderr.trim() || null,
+    });
+    throw error;
+  }
+  if (exitCode !== 0) {
+    const error = new Error(stderr.trim() || `compact-pi-session exited with code ${exitCode}`);
+    Object.assign(error, {
+      commandResult: result,
+      exitCode,
+      stderr: stderr.trim() || null,
+    });
+    throw error;
+  }
+  return result;
+}
+
+function decodePiCompactionCommandResult(value: unknown): PiCompactionCommandResult {
+  const result = requiredRecord(value, "compact-pi-session response");
   return {
     compacted: Boolean(result.compacted),
     session_file: nonEmptyString(result.session_file) ?? "",
+    result: isRecord(result.result) ? result.result : null,
     reason: nonEmptyString(result.reason),
+    diagnostics: isRecord(result.diagnostics) ? result.diagnostics : null,
+    error: isRecord(result.error) ? result.error : null,
   };
+}
+
+function summarizeCheckpointCompactionResult(
+  result: PiCompactionCommandResult | null | undefined,
+): SessionCheckpointCompactionRecord | null {
+  if (!result) {
+    return null;
+  }
+  const compactedResult = isRecord(result.result) ? result.result : null;
+  const summary = nonEmptyString(compactedResult?.summary);
+  return {
+    session_file: nonEmptyString(result.session_file),
+    reason: nonEmptyString(result.reason),
+    diagnostics: isRecord(result.diagnostics)
+      ? (jsonValue(result.diagnostics) as Record<string, unknown>)
+      : null,
+    result: compactedResult
+      ? {
+          first_kept_entry_id: nonEmptyString(compactedResult.firstKeptEntryId),
+          tokens_before: finiteNumberOrNull(compactedResult.tokensBefore),
+          summary_length: summary ? summary.length : null,
+          summary_preview: summary ? summary.slice(0, 240) : null,
+          details: jsonValue(compactedResult.details),
+        }
+      : null,
+    error: isRecord(result.error)
+      ? (jsonValue(result.error) as Record<string, unknown>)
+      : null,
+  };
+}
+
+function compactionResultFromError(
+  error: unknown,
+): PiCompactionCommandResult | null {
+  if (!isRecord(error) || !isRecord(error.commandResult)) {
+    return null;
+  }
+  return decodePiCompactionCommandResult(error.commandResult);
 }
 
 function maybeDeleteFile(filePath: string): void {
@@ -693,6 +799,7 @@ export async function processSessionCheckpointJob(params: {
       persisted_harness_session_id: compactedSessionPath,
       timeout_seconds: 0,
     });
+    const compaction = summarizeCheckpointCompactionResult(result);
     if (!result.compacted) {
       maybeDeleteFile(compactedSessionPath);
       recordSessionCheckpointResult({
@@ -700,6 +807,7 @@ export async function processSessionCheckpointJob(params: {
         record: params.record,
         outcome: "not_compacted",
         reason: result.reason ?? null,
+        compaction,
       });
       return;
     }
@@ -770,6 +878,7 @@ export async function processSessionCheckpointJob(params: {
         outcome: "merged",
         merged: true,
         boundaryWritten: true,
+        compaction,
       });
       return;
     }
@@ -780,15 +889,20 @@ export async function processSessionCheckpointJob(params: {
       merged: true,
       boundaryWritten: false,
       detail: "live session was compacted but no turn result was available to write a boundary",
+      compaction,
     });
   } catch (error) {
     maybeDeleteFile(compactedSessionPath);
+    const compaction = summarizeCheckpointCompactionResult(
+      compactionResultFromError(error),
+    );
     if (isSoftCheckpointCompactionError(error)) {
       recordSessionCheckpointResult({
         store: params.store,
         record: params.record,
         outcome: "soft_provider_422",
         detail: error instanceof Error ? error.message : String(error),
+        compaction,
       });
       return;
     }
@@ -797,6 +911,7 @@ export async function processSessionCheckpointJob(params: {
       record: params.record,
       outcome: "error",
       detail: error instanceof Error ? error.message : String(error),
+      compaction,
     });
     throw error;
   }

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -9,6 +9,7 @@ import type { PostRunJobRecord, RuntimeStateStore } from "@holaboss/runtime-stat
 
 import { resolveRuntimeModelClient } from "./agent-runtime-config.js";
 import { buildRunnerEnv } from "./runner-worker.js";
+import { captureRuntimeException } from "./runtime-sentry.js";
 import { writeTurnCompactionBoundary } from "./turn-memory-writeback.js";
 
 export const SESSION_CHECKPOINT_JOB_TYPE = "session_checkpoint";
@@ -705,6 +706,7 @@ export async function processSessionCheckpointJob(params: {
   ) => Promise<PiCompactionCommandResult>;
   resolveRuntimeModelClientFn?: ResolveRuntimeModelClientFn;
   sessionOps?: SessionCheckpointSessionOps;
+  captureRuntimeExceptionFn?: typeof captureRuntimeException;
 }): Promise<void> {
   if (params.record.jobType !== SESSION_CHECKPOINT_JOB_TYPE) {
     throw new Error(`unsupported session checkpoint job type: ${params.record.jobType}`);
@@ -896,6 +898,42 @@ export async function processSessionCheckpointJob(params: {
     const compaction = summarizeCheckpointCompactionResult(
       compactionResultFromError(error),
     );
+    (
+      params.captureRuntimeExceptionFn ?? captureRuntimeException
+    )({
+      error,
+      level: isSoftCheckpointCompactionError(error) ? "warning" : "error",
+      fingerprint: [
+        "runtime",
+        "session_checkpoint",
+        isSoftCheckpointCompactionError(error) ? "soft_provider_422" : "error",
+        payload.harness,
+      ],
+      tags: {
+        surface: "session_checkpoint",
+        failure_kind: isSoftCheckpointCompactionError(error)
+          ? "soft_provider_422"
+          : "error",
+        harness: payload.harness,
+      },
+      contexts: {
+        session_checkpoint: {
+          workspace_id: params.record.workspaceId,
+          session_id: params.record.sessionId,
+          input_id: params.record.inputId,
+          job_id: params.record.jobId,
+          harness: payload.harness,
+          base_harness_session_id: payload.base_harness_session_id,
+          base_leaf_id: payload.base_leaf_id,
+          base_latest_compaction_id: payload.base_latest_compaction_id,
+        },
+      },
+      extras: {
+        detail: error instanceof Error ? error.message : String(error),
+        context_usage: payload.context_usage,
+        compaction,
+      },
+    });
     if (isSoftCheckpointCompactionError(error)) {
       recordSessionCheckpointResult({
         store: params.store,

--- a/runtime/api-server/tsup.config.ts
+++ b/runtime/api-server/tsup.config.ts
@@ -1,5 +1,15 @@
 import { defineConfig } from "tsup";
 
+const sentryEnv = {
+  ...(process.env.SENTRY_DSN ? { SENTRY_DSN: process.env.SENTRY_DSN } : {}),
+  ...(process.env.SENTRY_ENVIRONMENT
+    ? { SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT }
+    : {}),
+  ...(process.env.HOLABOSS_RUNTIME_VERSION
+    ? { HOLABOSS_RUNTIME_VERSION: process.env.HOLABOSS_RUNTIME_VERSION }
+    : {}),
+};
+
 export default defineConfig({
   entry: [
     "src/index.ts",
@@ -18,6 +28,7 @@ export default defineConfig({
   target: "node20",
   sourcemap: true,
   dts: true,
+  env: sentryEnv,
   outExtension() {
     return {
       js: ".mjs"

--- a/runtime/harness-host/src/index.ts
+++ b/runtime/harness-host/src/index.ts
@@ -50,7 +50,7 @@ export async function runHarnessHostCli(
     const result = await compactPiSession(request);
     const stdout = deps.stdout ?? process.stdout;
     stdout.write(`${JSON.stringify(result)}\n`);
-    return 0;
+    return result.error ? 1 : 0;
   }
 
   const resolvePluginByCommand = deps.resolvePluginByCommand ?? requireHarnessHostPluginByCommand;

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -2356,7 +2356,87 @@ test("compactPiSession returns a structured result for successful snapshot compa
       modifiedFiles: ["src/pi.ts"],
     },
   });
+  assert.equal(result.reason, null);
+  assert.equal(result.diagnostics, null);
+  assert.equal(result.error, null);
   assert.equal(disposed, true);
+});
+
+test("compactPiSession returns structured error diagnostics for snapshot compaction failures", async () => {
+  let listener: ((event: unknown) => void) | undefined;
+  const result = await compactPiSession(baseRequest(), {
+    createSession: async () => ({
+      session: {
+        subscribe(nextListener: (event: unknown) => void) {
+          listener = nextListener;
+          return () => {
+            listener = undefined;
+          };
+        },
+        async compact() {
+          listener?.({
+            type: "compaction_start",
+            reason: "manual",
+          });
+          listener?.({
+            type: "compaction_end",
+            reason: "manual",
+            result: undefined,
+            aborted: false,
+            willRetry: false,
+            errorMessage:
+              "Compaction failed: Turn prefix summarization failed: 422 status code (no body)",
+          });
+          const error = new Error(
+            "Turn prefix summarization failed: 422 status code (no body)",
+          ) as Error & {
+            status?: number;
+            error?: Record<string, unknown>;
+          };
+          error.name = "APIError";
+          error.status = 422;
+          error.error = {
+            type: "invalid_request_error",
+            message: "422 status code (no body)",
+          };
+          throw error;
+        },
+      } as never,
+      sessionFile: "/tmp/pi-session.jsonl",
+      mcpToolMetadata: new Map(),
+      skillMetadataByAlias: new Map(),
+      dispose: async () => {},
+    }),
+  });
+
+  assert.equal(result.compacted, false);
+  assert.equal(result.reason, null);
+  assert.equal(result.result, null);
+  assert.deepEqual(result.diagnostics, {
+    compaction_start: {
+      type: "compaction_start",
+      reason: "manual",
+    },
+    compaction_end: {
+      type: "compaction_end",
+      reason: "manual",
+      aborted: false,
+      will_retry: false,
+      error_message:
+        "Compaction failed: Turn prefix summarization failed: 422 status code (no body)",
+      result: null,
+    },
+  });
+  assert.equal(result.error?.name, "APIError");
+  assert.equal(
+    result.error?.message,
+    "Turn prefix summarization failed: 422 status code (no body)",
+  );
+  assert.equal(result.error?.status_code, 422);
+  assert.equal(
+    result.error?.provider_message,
+    "422 status code (no body)",
+  );
 });
 
 test("buildPiPromptPayload inlines native images, extracts common document formats, and falls back for binary files", async () => {

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import JSZip from "jszip";
 import {
@@ -50,6 +51,8 @@ export interface PiCompactionCommandResult {
   session_file: string;
   result?: JsonObject | null;
   reason?: string | null;
+  diagnostics?: JsonObject | null;
+  error?: JsonObject | null;
 }
 
 export type PiEventMapperState = {
@@ -72,9 +75,36 @@ export interface PiDeps {
   createSession: (request: HarnessHostPiRequest) => Promise<PiSessionHandle>;
 }
 
-type PiInternalCompactionSession = AgentSession & {
+type PiInternalCompactionSession = {
   _checkCompaction?: (assistantMessage: unknown, skipAbortedCheck?: boolean) => Promise<void>;
 };
+
+type PiCompactionDiagnosticsSession = AgentSession & {
+  sessionManager?: {
+    getBranch?: () => unknown[];
+    getLeafId?: () => string | null;
+  };
+  settingsManager?: {
+    getCompactionSettings?: () => unknown;
+  };
+  model?: {
+    provider?: unknown;
+    id?: unknown;
+    contextWindow?: unknown;
+  };
+  getContextUsage?: () => unknown;
+  subscribe?: (listener: (event: AgentSessionEvent) => void) => (() => void) | void;
+};
+
+type PiPrepareCompactionResult = {
+  firstKeptEntryId?: unknown;
+  messagesToSummarize?: unknown;
+  turnPrefixMessages?: unknown;
+  isSplitTurn?: unknown;
+  tokensBefore?: unknown;
+  previousSummary?: unknown;
+  settings?: unknown;
+} | null;
 
 type PiThinkingLevel =
   | "minimal"
@@ -115,6 +145,9 @@ const PI_TODO_WRITE_OPS_TEXT =
 const PI_TODO_WRITE_ALIAS_WARNING =
   "Do not invent alias op names such as `replace_all`, `update_task`, or `set_status`.";
 const require = createRequire(import.meta.url);
+let cachedPrepareCompactionFnPromise:
+  | Promise<((entries: unknown[], settings: unknown) => PiPrepareCompactionResult) | null>
+  | null = null;
 
 type PiTodoStatus = (typeof PI_TODO_STATUSES)[number];
 
@@ -746,6 +779,256 @@ function jsonValue(value: unknown): JsonValue {
 
 function jsonObject(value: Record<string, unknown>): JsonObject {
   return JSON.parse(JSON.stringify(value)) as JsonObject;
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function summarizeCompactionBranchEntry(entry: unknown): JsonObject | null {
+  if (!isRecord(entry)) {
+    return null;
+  }
+  const message = isRecord(entry.message) ? entry.message : null;
+  return {
+    id: optionalTrimmedString(entry.id),
+    parent_id: optionalTrimmedString(entry.parentId),
+    type: optionalTrimmedString(entry.type),
+    timestamp: optionalTrimmedString(entry.timestamp),
+    role: optionalTrimmedString(message?.role),
+    custom_type: optionalTrimmedString(entry.customType),
+    first_kept_entry_id: optionalTrimmedString(entry.firstKeptEntryId),
+  };
+}
+
+function latestCompactionBranchEntry(branch: unknown[]): Record<string, unknown> | null {
+  for (let index = branch.length - 1; index >= 0; index -= 1) {
+    const entry = branch[index];
+    if (isRecord(entry) && entry.type === "compaction") {
+      return entry;
+    }
+  }
+  return null;
+}
+
+async function loadPrepareCompactionFn():
+  Promise<((entries: unknown[], settings: unknown) => PiPrepareCompactionResult) | null> {
+  if (cachedPrepareCompactionFnPromise) {
+    return cachedPrepareCompactionFnPromise;
+  }
+  cachedPrepareCompactionFnPromise = (async () => {
+    try {
+      const packageEntry = require.resolve("@mariozechner/pi-coding-agent");
+      const modulePath = path.join(
+        path.dirname(packageEntry),
+        "core",
+        "compaction",
+        "compaction.js",
+      );
+      const module = (await import(pathToFileURL(modulePath).href)) as {
+        prepareCompaction?: (entries: unknown[], settings: unknown) => PiPrepareCompactionResult;
+      };
+      return typeof module.prepareCompaction === "function"
+        ? module.prepareCompaction
+        : null;
+    } catch {
+      return null;
+    }
+  })();
+  return cachedPrepareCompactionFnPromise;
+}
+
+function summarizeCompactionPreparation(
+  preparation: PiPrepareCompactionResult,
+  branch: unknown[],
+): JsonObject {
+  if (!preparation || !isRecord(preparation)) {
+    return {
+      status: "none",
+    };
+  }
+  const firstKeptEntryId = optionalTrimmedString(preparation.firstKeptEntryId);
+  const firstKeptEntryIndex = firstKeptEntryId
+    ? branch.findIndex(
+        (entry) => isRecord(entry) && optionalTrimmedString(entry.id) === firstKeptEntryId,
+      )
+    : -1;
+  const firstKeptEntry =
+    firstKeptEntryIndex >= 0 ? summarizeCompactionBranchEntry(branch[firstKeptEntryIndex]) : null;
+  const previousEntry =
+    firstKeptEntryIndex > 0
+      ? summarizeCompactionBranchEntry(branch[firstKeptEntryIndex - 1])
+      : null;
+  return {
+    status: "ready",
+    first_kept_entry_id: firstKeptEntryId,
+    first_kept_entry_index: firstKeptEntryIndex >= 0 ? firstKeptEntryIndex : null,
+    first_kept_entry: firstKeptEntry,
+    previous_entry: previousEntry,
+    is_split_turn:
+      typeof preparation.isSplitTurn === "boolean" ? preparation.isSplitTurn : null,
+    tokens_before: finiteNumberOrNull(preparation.tokensBefore),
+    messages_to_summarize_count: Array.isArray(preparation.messagesToSummarize)
+      ? preparation.messagesToSummarize.length
+      : null,
+    turn_prefix_message_count: Array.isArray(preparation.turnPrefixMessages)
+      ? preparation.turnPrefixMessages.length
+      : null,
+    previous_summary_length:
+      typeof preparation.previousSummary === "string"
+        ? preparation.previousSummary.length
+        : null,
+    settings: isRecord(preparation.settings)
+      ? jsonObject(preparation.settings)
+      : null,
+  };
+}
+
+async function collectPiCompactionDiagnostics(
+  session: PiCompactionDiagnosticsSession,
+): Promise<JsonObject | null> {
+  const branch = session.sessionManager?.getBranch?.();
+  if (!Array.isArray(branch)) {
+    return null;
+  }
+  const latestCompaction = latestCompactionBranchEntry(branch);
+  const diagnostics: Record<string, unknown> = {
+    branch_entry_count: branch.length,
+    leaf_id: session.sessionManager?.getLeafId?.() ?? null,
+    branch_tail: branch.slice(-6).map((entry) => summarizeCompactionBranchEntry(entry)),
+    latest_compaction: latestCompaction
+      ? {
+          id: optionalTrimmedString(latestCompaction.id),
+          first_kept_entry_id: optionalTrimmedString(latestCompaction.firstKeptEntryId),
+          timestamp: optionalTrimmedString(latestCompaction.timestamp),
+        }
+      : null,
+    model: session.model
+      ? {
+          provider: optionalTrimmedString(session.model.provider),
+          id: optionalTrimmedString(session.model.id),
+          context_window: finiteNumberOrNull(session.model.contextWindow),
+        }
+      : null,
+    context_usage: jsonValue(session.getContextUsage?.() ?? null),
+  };
+
+  const settings = session.settingsManager?.getCompactionSettings?.();
+  if (isRecord(settings)) {
+    diagnostics.compaction_settings = jsonObject(settings);
+  }
+
+  const prepareCompaction = await loadPrepareCompactionFn();
+  if (!prepareCompaction || !settings) {
+    diagnostics.preparation = {
+      status: prepareCompaction ? "unavailable_settings" : "unavailable_helper",
+    };
+    return jsonObject(diagnostics);
+  }
+
+  try {
+    diagnostics.preparation = summarizeCompactionPreparation(
+      prepareCompaction(branch, settings),
+      branch,
+    );
+  } catch (error) {
+    diagnostics.preparation = {
+      status: "error",
+      message: sdkErrorMessage(error, "Failed to compute compaction preparation"),
+    };
+  }
+  return jsonObject(diagnostics);
+}
+
+function summarizeCompactionEventResult(value: unknown): JsonObject | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const summary = optionalTrimmedString(value.summary);
+  return {
+    first_kept_entry_id: optionalTrimmedString(value.firstKeptEntryId),
+    tokens_before: finiteNumberOrNull(value.tokensBefore),
+    summary_length: summary ? summary.length : null,
+    details: isRecord(value.details) ? jsonObject(value.details) : jsonValue(value.details),
+  };
+}
+
+function summarizeCompactionEvent(event: AgentSessionEvent): JsonObject | null {
+  if (event.type === "compaction_start") {
+    return {
+      type: "compaction_start",
+      reason: optionalTrimmedString(event.reason),
+    };
+  }
+  if (event.type === "compaction_end") {
+    return {
+      type: "compaction_end",
+      reason: optionalTrimmedString(event.reason),
+      aborted: typeof event.aborted === "boolean" ? event.aborted : null,
+      will_retry: typeof event.willRetry === "boolean" ? event.willRetry : null,
+      error_message: optionalTrimmedString(event.errorMessage),
+      result: summarizeCompactionEventResult(event.result),
+    };
+  }
+  return null;
+}
+
+function withCompactionEventDiagnostics(
+  diagnostics: JsonObject | null,
+  compactionStart: JsonObject | null,
+  compactionEnd: JsonObject | null,
+): JsonObject | null {
+  if (!diagnostics && !compactionStart && !compactionEnd) {
+    return null;
+  }
+  const next: Record<string, unknown> = diagnostics ? { ...diagnostics } : {};
+  if (compactionStart) {
+    next.compaction_start = compactionStart;
+  }
+  if (compactionEnd) {
+    next.compaction_end = compactionEnd;
+  }
+  return jsonObject(next);
+}
+
+function summarizePiCompactionError(
+  error: unknown,
+  compactionEnd: JsonObject | null,
+): JsonObject {
+  const record = isRecord(error) ? error : null;
+  return {
+    name:
+      (error instanceof Error && error.name.trim()) ||
+      optionalTrimmedString(record?.name) ||
+      "Error",
+    message: sdkErrorMessage(error, "Pi compaction failed"),
+    provider_message:
+      extractProviderErrorMessage(record?.error ?? record?.body ?? record?.cause ?? error) ??
+      sdkErrorMessage(error, "Pi compaction failed"),
+    status_code:
+      finiteNumberOrNull(record?.status) ?? finiteNumberOrNull(record?.statusCode),
+    code:
+      optionalTrimmedString(record?.code) ??
+      optionalTrimmedString(record?.error && isRecord(record.error) ? record.error.code : null),
+    type:
+      optionalTrimmedString(record?.type) ??
+      optionalTrimmedString(record?.error && isRecord(record.error) ? record.error.type : null),
+    param:
+      optionalTrimmedString(record?.param) ??
+      optionalTrimmedString(record?.error && isRecord(record.error) ? record.error.param : null),
+    request_id:
+      optionalTrimmedString(record?.request_id) ??
+      optionalTrimmedString(record?.requestId),
+    headers: isRecord(record?.headers) ? jsonObject(stringRecord(record.headers)) : null,
+    error: isRecord(record?.error) ? jsonObject(record.error) : jsonValue(record?.error),
+    body: isRecord(record?.body) ? jsonObject(record.body) : jsonValue(record?.body),
+    cause: isRecord(record?.cause) ? jsonObject(record.cause) : jsonValue(record?.cause),
+    stack_preview:
+      error instanceof Error && typeof error.stack === "string"
+        ? error.stack.split("\n").slice(0, 8).join("\n")
+        : null,
+    compaction_end: compactionEnd,
+  };
 }
 
 function stringRecord(value: unknown): Record<string, string> {
@@ -4263,14 +4546,14 @@ function defaultPiDeps(): PiDeps {
   };
 }
 
-function suppressPiPostRunAutoCompaction(session: PiInternalCompactionSession): void {
-  const originalCheckCompaction = session._checkCompaction;
+function suppressPiPostRunAutoCompaction(session: AgentSession): void {
+  const internalSession = session as unknown as PiInternalCompactionSession;
+  const originalCheckCompaction = internalSession._checkCompaction;
   if (typeof originalCheckCompaction !== "function") {
     return;
   }
 
-  session._checkCompaction = async function (
-    this: PiInternalCompactionSession,
+  internalSession._checkCompaction = async function (
     assistantMessage: unknown,
     skipAbortedCheck = true,
   ): Promise<void> {
@@ -4292,7 +4575,7 @@ export async function runPi(request: HarnessHostPiRequest, deps: PiDeps = defaul
   };
 
   const handle = await deps.createSession(request);
-  suppressPiPostRunAutoCompaction(handle.session as PiInternalCompactionSession);
+  suppressPiPostRunAutoCompaction(handle.session);
   const requestedThinking = requestedPiThinkingLevel(request) ?? "off";
   (
     handle.session as AgentSession & {
@@ -4415,6 +4698,19 @@ export async function compactPiSession(
   deps: PiDeps = defaultPiDeps(),
 ): Promise<PiCompactionCommandResult> {
   const handle = await deps.createSession(request);
+  const session = handle.session as PiCompactionDiagnosticsSession;
+  const diagnostics = await collectPiCompactionDiagnostics(session);
+  let compactionStart: JsonObject | null = null;
+  let compactionEnd: JsonObject | null = null;
+  const unsubscribe = session.subscribe?.((event) => {
+    if (event.type === "compaction_start") {
+      compactionStart = summarizeCompactionEvent(event);
+      return;
+    }
+    if (event.type === "compaction_end") {
+      compactionEnd = summarizeCompactionEvent(event);
+    }
+  });
   try {
     const result = await handle.session.compact();
     return {
@@ -4422,6 +4718,12 @@ export async function compactPiSession(
       session_file: handle.sessionFile,
       result: jsonObject(JSON.parse(JSON.stringify(result)) as Record<string, unknown>),
       reason: null,
+      diagnostics: withCompactionEventDiagnostics(
+        diagnostics,
+        compactionStart,
+        compactionEnd,
+      ),
+      error: null,
     };
   } catch (error) {
     const reason = compactionNoOpReason(error);
@@ -4431,10 +4733,28 @@ export async function compactPiSession(
         session_file: handle.sessionFile,
         result: null,
         reason,
+        diagnostics: withCompactionEventDiagnostics(
+          diagnostics,
+          compactionStart,
+          compactionEnd,
+        ),
+        error: null,
       };
     }
-    throw error;
+    return {
+      compacted: false,
+      session_file: handle.sessionFile,
+      result: null,
+      reason: null,
+      diagnostics: withCompactionEventDiagnostics(
+        diagnostics,
+        compactionStart,
+        compactionEnd,
+      ),
+      error: summarizePiCompactionError(error, compactionEnd),
+    };
   } finally {
+    unsubscribe?.();
     await handle.dispose();
   }
 }


### PR DESCRIPTION
## Summary

- defer embedded runtime restarts while any session is `BUSY`, `QUEUED`, or still has a `current_input_id` so desktop does not SIGTERM active runs during overflow compaction and trigger the unreleased lease-expiry path
- re-arm the outer runner watchdog after `run_started` using the selected harness timeout plus grace so the hard kill becomes a backstop instead of racing a live harness
- record structured PI checkpoint compaction diagnostics, including preparation state, emitted compaction events, and provider error metadata, so future `422` failures are diagnosable from the bundle
- send claimed-input, queue-worker, and session-checkpoint failures to Sentry, flush on normal runtime shutdown, and wire runtime Sentry env vars through release CI so `holaboss-runtime` gets the same kind of background-worker visibility as desktop

## Validation

- [x] `node --test desktop/electron/runtime-restart-deferral.test.mjs desktop/electron/runtime-lifecycle-lock.test.mjs`
- [x] `node --import tsx --test src/runner-worker.test.ts src/claimed-input-executor.test.ts`
- [x] `node --import tsx --test src/claimed-input-executor.test.ts src/queue-worker.test.ts src/session-checkpoint.test.ts`
- [x] `node --import tsx --test src/pi.test.ts`
- [x] `node --import tsx --test src/session-checkpoint.test.ts`
- [x] `npm run typecheck` in `runtime/api-server`
- [x] `npm run build` in `runtime/api-server`
- [x] `npm run typecheck` in `runtime/harness-host`
- [ ] `npm run desktop:typecheck`
- [ ] `npm run runtime:test`

## Risks

- embedded runtime restarts triggered by config or binding changes now wait for active session blockers to clear, so new runtime config can take effect slightly later than before
- runtime background failures will now emit to Sentry; release packaging must continue passing the runtime Sentry env vars so events land in `holaboss-runtime`
- no migrations or schema changes

## Docs

- [ ] docs updated if setup, packaging, or public behavior changed
