### PR TITLE
fix: break chat composer footer resize feedback loop

### DIFF
--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -117,13 +117,26 @@ test("chat composer footer wraps controls based on available pane width instead 
   );
   assert.match(
     source,
-    /const resizeObserver = new ResizeObserver\(\(\) => \{\s*syncComposerFooterLayout\(\);\s*\}\);/,
+    /const composerFooterLayoutSyncFrameRef = useRef<number \| null>\(null\);/,
+  );
+  assert.match(
+    source,
+    /const cancelComposerFooterLayoutSync = \(\) => \{[\s\S]*window\.cancelAnimationFrame\(composerFooterLayoutSyncFrameRef\.current\);[\s\S]*composerFooterLayoutSyncFrameRef\.current = null;[\s\S]*\};/,
+  );
+  assert.match(
+    source,
+    /const scheduleComposerFooterLayoutSync = \(\) => \{[\s\S]*window\.requestAnimationFrame\(\s*\(\) => \{[\s\S]*syncComposerFooterLayout\(\);[\s\S]*\},\s*\);[\s\S]*\};/,
+  );
+  assert.match(
+    source,
+    /const resizeObserver = new ResizeObserver\(\(\) => \{\s*scheduleComposerFooterLayoutSync\(\);\s*\}\);/,
   );
   assert.match(
     source,
     /const compactComposerControls =\s*showModelSelector &&[\s\S]*composerFooterLayout\.width > 0[\s\S]*composerFooterLayout\.actionsWidth > 0[\s\S]*composerFooterLayout\.width < fullFooterControlWidth/,
   );
   assert.doesNotMatch(source, /composerFooterLayout\.wraps/);
+  assert.doesNotMatch(source, /Array\.from\(footer\.children\)/);
   assert.match(
     source,
     /const compactModelControlWidth = compactComposerControls[\s\S]*COMPOSER_COMPACT_MODEL_CONTROL_MAX_WIDTH_PX[\s\S]*compactFooterControlWidth -[\s\S]*COMPOSER_COMPACT_THINKING_CONTROL_MIN_WIDTH_PX/,

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -9340,6 +9340,7 @@ function Composer({
   const [highlightedSlashIndex, setHighlightedSlashIndex] = useState(0);
   const composerFooterRef = useRef<HTMLDivElement | null>(null);
   const composerActionsRef = useRef<HTMLDivElement | null>(null);
+  const composerFooterLayoutSyncFrameRef = useRef<number | null>(null);
   const slashCommandMenuRef = useRef<HTMLDivElement | null>(null);
   const [composerFooterLayout, setComposerFooterLayout] = useState({
     width: 0,
@@ -9402,6 +9403,13 @@ function Composer({
       ?.selectedLabel ??
     modelOptions.find((option) => option.value === selectedModel)?.label ??
     resolvedModelLabel;
+  const cancelComposerFooterLayoutSync = () => {
+    if (composerFooterLayoutSyncFrameRef.current === null) {
+      return;
+    }
+    window.cancelAnimationFrame(composerFooterLayoutSyncFrameRef.current);
+    composerFooterLayoutSyncFrameRef.current = null;
+  };
   const syncComposerFooterLayout = () => {
     const footer = composerFooterRef.current;
     if (!footer) {
@@ -9425,6 +9433,19 @@ function Composer({
         : { width, actionsWidth },
     );
   };
+  // Coalesce ResizeObserver bursts so compact/full footer transitions do not
+  // synchronously re-enter render while the DOM is still settling.
+  const scheduleComposerFooterLayoutSync = () => {
+    if (composerFooterLayoutSyncFrameRef.current !== null) {
+      return;
+    }
+    composerFooterLayoutSyncFrameRef.current = window.requestAnimationFrame(
+      () => {
+        composerFooterLayoutSyncFrameRef.current = null;
+        syncComposerFooterLayout();
+      },
+    );
+  };
   useLayoutEffect(() => {
     const footer = composerFooterRef.current;
     if (!footer) {
@@ -9437,31 +9458,17 @@ function Composer({
     }
 
     const resizeObserver = new ResizeObserver(() => {
-      syncComposerFooterLayout();
+      scheduleComposerFooterLayoutSync();
     });
     resizeObserver.observe(footer);
     if (composerActionsRef.current) {
       resizeObserver.observe(composerActionsRef.current);
     }
-    Array.from(footer.children).forEach((child) => {
-      if (child instanceof HTMLElement) {
-        resizeObserver.observe(child);
-      }
-    });
     return () => {
       resizeObserver.disconnect();
+      cancelComposerFooterLayoutSync();
     };
-  }, [
-    noAvailableModels,
-    resolvedModelLabel,
-    runtimeDefaultModelAvailable,
-    selectedModel,
-    selectedModelOptionLabel,
-    selectedThinkingValue,
-    showModelSelector,
-    showThinkingValueSelector,
-    thinkingValues,
-  ]);
+  }, []);
   useEffect(() => {
     setHighlightedSlashIndex(0);
   }, [activeSlashRange?.query, filteredSlashCommands.length]);


### PR DESCRIPTION
## Context

This fixes a desktop renderer `Maximum update depth exceeded` loop in the `ChatPane` composer footer.

Sentry on release `holaboss-local@2026.420.1` showed new desktop renderer groups in the same `ChatPane` subtree after the previous partial fix:
- `HOLABOSS-DESKTOP-X`
- `HOLABOSS-DESKTOP-T`
- `HOLABOSS-DESKTOP-V`

The renderer stack maps back to the `Composer` footer measurement path in `desktop/src/components/panes/ChatPane.tsx`.

## What Changed

- coalesce composer footer `ResizeObserver` updates onto `requestAnimationFrame` to avoid re-entrant state updates during compact/full footer transitions
- stop observing every footer child and only observe the stable footer and actions containers
- extend the `ChatPane` regression assertion to cover the deferred footer sync path and narrower observer scope

## Validation

- `npm --prefix desktop run build:renderer`

## Linked Issues

- No GitHub issue was linked for this change
- Sentry: `HOLABOSS-DESKTOP-X`, `HOLABOSS-DESKTOP-T`, `HOLABOSS-DESKTOP-V`

## Screenshots / Logs

- UI-affecting change with no intentional visual delta
- Renderer build completed successfully after dependency install
