### PR TITLE
feat: expand sentry telemetry across desktop and runtime

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4,6 +4,17 @@ import * as Sentry from "@sentry/electron/main";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: !!process.env.SENTRY_DSN,
+  enableLogs: !!process.env.SENTRY_DSN,
+  attachScreenshot: !!process.env.SENTRY_DSN,
+  maxBreadcrumbs: 200,
+  integrations: [
+    Sentry.consoleLoggingIntegration({
+      levels: ["info", "warn", "error"],
+    }),
+  ],
+  beforeSend(event, hint) {
+    return enrichDesktopSentryEvent(event, hint);
+  },
 });
 
 import { electronClient } from "@better-auth/electron/client";
@@ -33,6 +44,7 @@ import {
   type IpcMainInvokeEvent,
   type OpenDialogOptions,
   type Session,
+  type WebContents,
 } from "electron";
 import {
   execFileSync,
@@ -93,6 +105,10 @@ import { ensureWorkspaceGitRepo } from "./workspace-git.js";
 const APP_DISPLAY_NAME = "Holaboss";
 const AUTH_CALLBACK_PROTOCOL = "ai.holaboss.app";
 const DESKTOP_LAUNCH_ID = randomUUID();
+Sentry.setTags({
+  desktop_launch_id: DESKTOP_LAUNCH_ID,
+  process_kind: "electron_main",
+});
 const verboseTelemetryEnabled =
   process.env.HOLABOSS_VERBOSE_TELEMETRY?.trim() === "1";
 const chromiumStderrLoggingEnabled =
@@ -821,6 +837,7 @@ let downloadsPopupWindow: BrowserWindow | null = null;
 let historyPopupWindow: BrowserWindow | null = null;
 let overflowPopupWindow: BrowserWindow | null = null;
 let addressSuggestionsPopupWindow: BrowserWindow | null = null;
+const unresponsiveDesktopWindows = new WeakSet<BrowserWindow>();
 let attachedBrowserTabView: BrowserView | null = null;
 let attachedAppSurfaceView: BrowserView | null = null;
 let currentTheme = "amber-minimal-light";
@@ -927,6 +944,82 @@ let appUpdateStatus: AppUpdateStatusPayload = {
   channel: "latest",
   preferredChannel: null,
 };
+
+function desktopWindowTelemetryRole(window: BrowserWindow | null | undefined): string {
+  if (!window) {
+    return "unknown";
+  }
+  if (window === mainWindow) {
+    return "main";
+  }
+  if (window === authPopupWindow) {
+    return "auth_popup";
+  }
+  if (window === downloadsPopupWindow) {
+    return "downloads_popup";
+  }
+  if (window === historyPopupWindow) {
+    return "history_popup";
+  }
+  if (window === overflowPopupWindow) {
+    return "overflow_popup";
+  }
+  if (window === addressSuggestionsPopupWindow) {
+    return "address_suggestions_popup";
+  }
+  return "browser_window";
+}
+
+function safeWebContentsUrl(contents: WebContents): string | null {
+  try {
+    return contents.getURL() || null;
+  } catch {
+    return null;
+  }
+}
+
+function addDesktopLifecycleBreadcrumb(
+  category: string,
+  message: string,
+  data?: Record<string, unknown>,
+) {
+  Sentry.addBreadcrumb({
+    category: `desktop.${category}`,
+    message,
+    level: "info",
+    data: data
+      ? (redactDesktopSentryValue(data) as Record<string, unknown>)
+      : undefined,
+  });
+}
+
+function captureDesktopLifecycleEvent(params: {
+  message: string;
+  level: Sentry.SeverityLevel;
+  fingerprint: string[];
+  tags?: Record<string, string | null | undefined>;
+  contexts?: Record<string, Record<string, unknown> | null | undefined>;
+}) {
+  Sentry.withScope((scope) => {
+    scope.setLevel(params.level);
+    scope.setFingerprint(params.fingerprint);
+    for (const [key, value] of Object.entries(params.tags ?? {})) {
+      const normalizedValue = value?.trim();
+      if (normalizedValue) {
+        scope.setTag(key, normalizedValue);
+      }
+    }
+    for (const [key, context] of Object.entries(params.contexts ?? {})) {
+      if (context) {
+        scope.setContext(
+          key,
+          redactDesktopSentryValue(context) as Record<string, unknown>,
+        );
+      }
+    }
+    Sentry.captureMessage(params.message);
+  });
+}
 
 // Port 5060 is SIP — blocked by Node.js fetch (undici "bad port").
 const RUNTIME_API_PORT_FALLBACK = 5160;
@@ -4961,6 +5054,279 @@ async function exportDesktopDiagnosticsBundle() {
   return result;
 }
 
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const SENTRY_RUNTIME_LOG_TAIL_BYTES = 64 * 1024;
+const SENTRY_RECENT_EVENT_LIMIT = 40;
+const SENTRY_RECENT_STATE_LIMIT = 20;
+const SENTRY_REDACTED_VALUE = "[REDACTED]";
+const SENTRY_SENSITIVE_KEY_PATTERNS = [
+  /token/i,
+  /secret/i,
+  /password/i,
+  /cookie/i,
+  /^authorization$/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i,
+  /refresh[_-]?token/i,
+  /access[_-]?token/i,
+];
+const SENTRY_SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
+  /((?:token|secret|password|cookie|authorization|api[_-]?key|private[_-]?key|refresh[_-]?token|access[_-]?token)[^:=\n\r]{0,64}[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const SENTRY_AUTHORIZATION_BEARER_PATTERN =
+  /(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,;]+(?:\s+[^\s,;]+)?/gi;
+
+function shouldRedactSentryKey(key: string): boolean {
+  const normalized = key.trim();
+  if (!normalized) {
+    return false;
+  }
+  return SENTRY_SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function redactDesktopSentryValue(value: unknown, keyName = ""): unknown {
+  if (shouldRedactSentryKey(keyName)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return SENTRY_REDACTED_VALUE;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactDesktopSentryValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        redactDesktopSentryValue(entry, key),
+      ]),
+    );
+  }
+  return value;
+}
+
+function redactDesktopSentryText(text: string): string {
+  return text
+    .replace(
+      SENTRY_AUTHORIZATION_BEARER_PATTERN,
+      `$1${SENTRY_REDACTED_VALUE}`,
+    )
+    .replace(
+      SENTRY_SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+      `$1${SENTRY_REDACTED_VALUE}`,
+    );
+}
+
+function addSentryHintAttachment(
+  hint: Sentry.EventHint | undefined,
+  attachment: NonNullable<Sentry.EventHint["attachments"]>[number] | null,
+) {
+  if (!hint || !attachment) {
+    return;
+  }
+  hint.attachments = [...(hint.attachments ?? []), attachment];
+}
+
+function runtimeSentryFileMetadata(filePath: string): Record<string, unknown> {
+  if (!filePath) {
+    return { path: null, exists: false };
+  }
+  try {
+    const stats = statSync(filePath);
+    return {
+      path: path.basename(filePath),
+      exists: true,
+      sizeBytes: stats.size,
+      modifiedAt: stats.mtime.toISOString(),
+    };
+  } catch {
+    return {
+      path: path.basename(filePath),
+      exists: false,
+    };
+  }
+}
+
+function readFileTail(filePath: string, maxBytes: number): string | null {
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+  const buffer = readFileSync(filePath);
+  const start = Math.max(0, buffer.length - maxBytes);
+  return buffer.subarray(start).toString("utf8");
+}
+
+function openRuntimeDiagnosticsDatabase(): Database.Database | null {
+  const dbPath = runtimeDatabasePath();
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  const database = new Database(dbPath, {
+    readonly: true,
+    fileMustExist: true,
+  });
+  database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+  return database;
+}
+
+function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {
+    captured_at: utcNowIso(),
+    desktop: {
+      launch_id: DESKTOP_LAUNCH_ID,
+      app_version: app.getVersion(),
+      pid: process.pid,
+      platform: process.platform,
+      arch: process.arch,
+      versions: {
+        chrome: process.versions.chrome,
+        electron: process.versions.electron,
+        node: process.versions.node,
+      },
+    },
+    runtime_status: runtimeStatus,
+    persisted_runtime_process: readPersistedRuntimeProcessState(),
+    files: {
+      runtime_db: runtimeSentryFileMetadata(runtimeDatabasePath()),
+      runtime_log: runtimeSentryFileMetadata(runtimeLogsPath()),
+      runtime_config: runtimeSentryFileMetadata(runtimeConfigPath()),
+    },
+  };
+
+  const database = openRuntimeDiagnosticsDatabase();
+  if (!database) {
+    return redactDesktopSentryValue(snapshot) as Record<string, unknown>;
+  }
+
+  try {
+    const readCount = (sql: string): number => {
+      const row = database.prepare(sql).get() as { count?: number } | undefined;
+      return Number(row?.count ?? 0);
+    };
+
+    snapshot.database = {
+      counts: {
+        active_sessions: readCount(
+          "SELECT COUNT(*) AS count FROM session_runtime_state WHERE status IN ('BUSY', 'QUEUED') OR current_input_id IS NOT NULL",
+        ),
+        active_terminal_sessions: readCount(
+          "SELECT COUNT(*) AS count FROM terminal_sessions WHERE status IN ('starting', 'running')",
+        ),
+        failed_app_builds: readCount(
+          "SELECT COUNT(*) AS count FROM app_builds WHERE status IN ('failed', 'running')",
+        ),
+        queued_inputs: readCount(
+          "SELECT COUNT(*) AS count FROM agent_session_inputs WHERE status IN ('queued', 'claimed')",
+        ),
+      },
+      recent_event_log: database.prepare(`
+        SELECT category, event, outcome, detail, created_at
+        FROM event_log
+        ORDER BY created_at DESC
+        LIMIT ?
+      `).all(SENTRY_RECENT_EVENT_LIMIT),
+      session_runtime_state: database.prepare(`
+        SELECT workspace_id, session_id, status, current_input_id, updated_at
+        FROM session_runtime_state
+        ORDER BY updated_at DESC
+        LIMIT ?
+      `).all(SENTRY_RECENT_STATE_LIMIT),
+      terminal_sessions: database.prepare(`
+        SELECT terminal_id, workspace_id, session_id, input_id, owner, status, title, command, last_activity_at
+        FROM terminal_sessions
+        ORDER BY last_activity_at DESC
+        LIMIT ?
+      `).all(SENTRY_RECENT_STATE_LIMIT),
+      app_builds: database.prepare(`
+        SELECT workspace_id, app_id, status, error, updated_at
+        FROM app_builds
+        WHERE status IN ('running', 'failed')
+        ORDER BY updated_at DESC
+        LIMIT ?
+      `).all(SENTRY_RECENT_STATE_LIMIT),
+    };
+  } catch (error) {
+    snapshot.database = {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    database.close();
+  }
+
+  return redactDesktopSentryValue(snapshot) as Record<string, unknown>;
+}
+
+function redactedRuntimeConfigAttachment() {
+  const configPath = runtimeConfigPath();
+  if (!existsSync(configPath)) {
+    return null;
+  }
+  let data = "";
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+    data = `${JSON.stringify(redactDesktopSentryValue(parsed), null, 2)}\n`;
+  } catch {
+    data = `${JSON.stringify(
+      {
+        error: "runtime-config.json could not be parsed for redaction.",
+      },
+      null,
+      2,
+    )}\n`;
+  }
+  return {
+    filename: "runtime-config.redacted.json",
+    data,
+    contentType: "application/json",
+  };
+}
+
+function runtimeLogTailAttachment() {
+  const tail = readFileTail(runtimeLogsPath(), SENTRY_RUNTIME_LOG_TAIL_BYTES);
+  if (!tail) {
+    return null;
+  }
+  return {
+    filename: "runtime-log-tail.txt",
+    data: redactDesktopSentryText(tail),
+    contentType: "text/plain",
+  };
+}
+
+function enrichDesktopSentryEvent(
+  event: Sentry.ErrorEvent,
+  hint: Sentry.EventHint | undefined,
+): Sentry.ErrorEvent {
+  if (event.request?.headers) {
+    delete event.request.headers.authorization;
+    delete event.request.headers.cookie;
+    delete event.request.headers["x-api-key"];
+  }
+  const diagnostics = readDesktopRuntimeDiagnosticsSnapshot();
+  const diagnosticsAttachment = {
+    filename: "desktop-runtime-diagnostics.json",
+    data: `${JSON.stringify(diagnostics, null, 2)}\n`,
+    contentType: "application/json",
+  };
+  addSentryHintAttachment(hint, diagnosticsAttachment);
+  addSentryHintAttachment(hint, runtimeLogTailAttachment());
+  addSentryHintAttachment(hint, redactedRuntimeConfigAttachment());
+  event.tags = {
+    ...(event.tags ?? {}),
+    desktop_launch_id: DESKTOP_LAUNCH_ID,
+    process_kind: "electron_main",
+  };
+  event.contexts = {
+    ...(event.contexts ?? {}),
+    desktop_process:
+      (diagnostics.desktop as Record<string, unknown> | undefined) ?? {},
+    embedded_runtime_status:
+      (diagnostics.runtime_status as Record<string, unknown> | undefined) ?? {},
+    embedded_runtime_files:
+      (diagnostics.files as Record<string, unknown> | undefined) ?? {},
+  };
+  return event;
+}
+
 function processIsAlive(pid: number) {
   if (!Number.isInteger(pid) || pid <= 0) {
     return false;
@@ -4990,7 +5356,7 @@ function utcNowIso() {
 
 function openRuntimeDatabase() {
   const database = new Database(runtimeDatabasePath());
-  database.pragma("journal_mode = WAL");
+  database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
   database.pragma("foreign_keys = ON");
   return database;
 }
@@ -5143,6 +5509,7 @@ async function bootstrapRuntimeDatabase() {
 
   const database = openRuntimeDatabase();
   try {
+    database.pragma("journal_mode = WAL");
     migrateLocalWorkspacesTable(database);
     migrateRuntimeInstallationStateTable(database);
     migrateRuntimeProcessStateTable(database);
@@ -5524,6 +5891,20 @@ function appendRuntimeEventLog(event: {
   outcome: string;
   detail?: string | null;
 }) {
+  Sentry.addBreadcrumb({
+    category: `runtime.${event.category}`,
+    message: event.event,
+    level:
+      event.outcome === "error"
+        ? "error"
+        : event.outcome === "success"
+          ? "info"
+          : "debug",
+    data: {
+      outcome: event.outcome,
+      detail: event.detail ?? null,
+    },
+  });
   const database = openRuntimeDatabase();
   try {
     database
@@ -8747,6 +9128,8 @@ async function exchangeDesktopRuntimeBinding(
 function emitAuthAuthenticated(user: AuthUserPayload) {
   pendingAuthUser = user;
   pendingAuthError = null;
+  const userId = authUserId(user);
+  Sentry.setUser(userId ? { id: userId } : null);
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send("auth:authenticated", user);
   }
@@ -8761,6 +9144,8 @@ function emitAuthAuthenticated(user: AuthUserPayload) {
 
 function emitAuthUserUpdated(user: AuthUserPayload | null) {
   pendingAuthUser = user;
+  const userId = authUserId(user);
+  Sentry.setUser(userId ? { id: userId } : null);
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send("auth:userUpdated", user);
   }
@@ -15871,6 +16256,10 @@ async function startEmbeddedRuntime() {
           SANDBOX_AGENT_HARNESS: harness,
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
           HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
+          HOLABOSS_RUNTIME_LOG_PATH: runtimeLogsPath(),
+          HOLABOSS_RUNTIME_CONFIG_PATH: runtimeConfigPath(),
+          HOLABOSS_DESKTOP_LAUNCH_ID: DESKTOP_LAUNCH_ID,
+          HOLABOSS_DESKTOP_APP_VERSION: app.getVersion(),
           HOLABOSS_DESKTOP_BROWSER_ENABLED: currentDesktopBrowserCapabilityConfig()
             .enabled
             ? "true"
@@ -21760,6 +22149,109 @@ if (!singleInstanceLock) {
     void handleAuthCallbackUrl(initialCallbackUrl);
   }
 }
+
+app.on("browser-window-created", (_event, window) => {
+  window.on("unresponsive", () => {
+    if (unresponsiveDesktopWindows.has(window)) {
+      return;
+    }
+    unresponsiveDesktopWindows.add(window);
+    captureDesktopLifecycleEvent({
+      message: "Electron window became unresponsive",
+      level: "warning",
+      fingerprint: [
+        "electron-window-unresponsive",
+        desktopWindowTelemetryRole(window),
+      ],
+      tags: {
+        desktop_window_role: desktopWindowTelemetryRole(window),
+      },
+      contexts: {
+        desktop_window: {
+          role: desktopWindowTelemetryRole(window),
+          title: window.getTitle() || null,
+          visible: window.isVisible(),
+          focused: window.isFocused(),
+          minimized: window.isMinimized(),
+          maximized: window.isMaximized(),
+        },
+      },
+    });
+  });
+
+  window.on("responsive", () => {
+    unresponsiveDesktopWindows.delete(window);
+    addDesktopLifecycleBreadcrumb(
+      "window",
+      "Browser window responsive again",
+      {
+        desktop_window_role: desktopWindowTelemetryRole(window),
+        title: window.getTitle() || null,
+      },
+    );
+  });
+});
+
+app.on("web-contents-created", (_event, contents) => {
+  const contentsType = contents.getType();
+  contents.on("render-process-gone", (_goneEvent, details) => {
+    const ownerWindow = BrowserWindow.fromWebContents(contents);
+    const ownerRole = desktopWindowTelemetryRole(ownerWindow);
+    captureDesktopLifecycleEvent({
+      message: "Electron renderer process gone",
+      level: "error",
+      fingerprint: [
+        "electron-render-process-gone",
+        contentsType,
+        details.reason,
+      ],
+      tags: {
+        desktop_window_role: ownerRole,
+        webcontents_type: contentsType,
+        render_process_reason: details.reason,
+      },
+      contexts: {
+        render_process: {
+          type: contentsType,
+          reason: details.reason,
+          exit_code: details.exitCode,
+          url: safeWebContentsUrl(contents),
+        },
+        desktop_window: ownerWindow
+          ? {
+              role: ownerRole,
+              title: ownerWindow.getTitle() || null,
+            }
+          : null,
+      },
+    });
+  });
+});
+
+app.on("child-process-gone", (_event, details) => {
+  captureDesktopLifecycleEvent({
+    message: "Electron child process gone",
+    level: "error",
+    fingerprint: [
+      "electron-child-process-gone",
+      details.type,
+      details.reason,
+    ],
+    tags: {
+      child_process_type: details.type,
+      child_process_reason: details.reason,
+    },
+    contexts: {
+      child_process: {
+        type: details.type,
+        reason: details.reason,
+        name: details.name ?? null,
+        service_name: details.serviceName ?? null,
+        exit_code: details.exitCode,
+      },
+    },
+  });
+});
 
 app.whenReady().then(async () => {
   if (process.platform === "darwin" && app.dock) {

--- a/desktop/electron/sentry-telemetry.test.mjs
+++ b/desktop/electron/sentry-telemetry.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const RENDERER_PATH = new URL("../src/main.tsx", import.meta.url);
+const ERROR_BOUNDARY_PATH = new URL(
+  "../src/components/ui/ErrorBoundary.tsx",
+  import.meta.url,
+);
+const RENDERER_SENTRY_PATH = new URL(
+  "../src/lib/rendererSentry.ts",
+  import.meta.url,
+);
+const APP_SHELL_PATH = new URL(
+  "../src/components/layout/AppShell.tsx",
+  import.meta.url,
+);
+const CHAT_PANE_PATH = new URL(
+  "../src/components/panes/ChatPane.tsx",
+  import.meta.url,
+);
+
+test("desktop main sentry init adds diagnostics enrichment and runtime env wiring", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(source, /enableLogs:\s*!!process\.env\.SENTRY_DSN/);
+  assert.match(source, /attachScreenshot:\s*!!process\.env\.SENTRY_DSN/);
+  assert.match(
+    source,
+    /consoleLoggingIntegration\(\{\s*levels:\s*\["info", "warn", "error"\]/,
+  );
+  assert.match(source, /beforeSend\(event, hint\)\s*\{\s*return enrichDesktopSentryEvent\(event, hint\);/);
+  assert.match(source, /filename:\s*"desktop-runtime-diagnostics\.json"/);
+  assert.match(source, /filename:\s*"runtime-log-tail\.txt"/);
+  assert.match(source, /filename:\s*"runtime-config\.redacted\.json"/);
+  assert.match(source, /HOLABOSS_RUNTIME_LOG_PATH:\s*runtimeLogsPath\(\)/);
+  assert.match(source, /HOLABOSS_RUNTIME_CONFIG_PATH:\s*runtimeConfigPath\(\)/);
+  assert.match(source, /HOLABOSS_DESKTOP_LAUNCH_ID:\s*DESKTOP_LAUNCH_ID/);
+  assert.match(source, /app\.on\("web-contents-created"/);
+  assert.match(source, /render-process-gone/);
+  assert.match(source, /app\.on\("child-process-gone"/);
+  assert.match(source, /app\.on\("browser-window-created"/);
+  assert.match(source, /window\.on\("unresponsive"/);
+});
+
+test("renderer sentry wiring captures logs and adds renderer crash context", async () => {
+  const [
+    rendererSource,
+    errorBoundarySource,
+    rendererSentrySource,
+    appShellSource,
+    chatPaneSource,
+  ] = await Promise.all([
+    readFile(RENDERER_PATH, "utf8"),
+    readFile(ERROR_BOUNDARY_PATH, "utf8"),
+    readFile(RENDERER_SENTRY_PATH, "utf8"),
+    readFile(APP_SHELL_PATH, "utf8"),
+    readFile(CHAT_PANE_PATH, "utf8"),
+  ]);
+
+  assert.match(rendererSource, /enableLogs:\s*true/);
+  assert.match(rendererSource, /maxBreadcrumbs:\s*200/);
+  assert.match(
+    rendererSource,
+    /consoleLoggingIntegration\(\{\s*levels:\s*\["warn", "error"\]/,
+  );
+  assert.match(rendererSource, /eventLoopBlockIntegration\(\{\s*threshold:\s*2000/);
+  assert.match(rendererSource, /beforeSend\(event, hint\)\s*\{\s*return enrichRendererSentryEvent\(event, hint\);/);
+  assert.match(rendererSource, /Sentry\.setTag\("process_kind", "electron_renderer"\)/);
+  assert.match(rendererSentrySource, /filename:\s*"renderer-diagnostics\.json"/);
+  assert.match(rendererSentrySource, /process_kind:\s*"electron_renderer"/);
+  assert.match(appShellSource, /useRendererSentrySection\("app_shell", appShellSentryState\)/);
+  assert.match(appShellSource, /pushRendererSentryActivity\("runtime", "renderer runtime status changed"/);
+  assert.match(chatPaneSource, /useRendererSentrySection\("chat_pane", chatPaneSentryState\)/);
+  assert.match(chatPaneSource, /pushRendererSentryActivity\("chat", "chat error surfaced"/);
+  assert.match(errorBoundarySource, /surface:\s*"renderer_error_boundary"/);
+  assert.match(errorBoundarySource, /page_url:\s*window\.location\.href/);
+});

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -27,6 +27,10 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UpdateReminder } from "@/components/ui/UpdateReminder";
 import { type ExplorerAttachmentDragPayload } from "@/lib/attachmentDrag";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
+import {
+  pushRendererSentryActivity,
+  useRendererSentrySection,
+} from "@/lib/rendererSentry";
 import { getWorkspaceAppDefinition } from "@/lib/workspaceApps";
 import {
   useWorkspaceDesktop,
@@ -242,6 +246,66 @@ type ReportedOperatorSurfaceContext = {
   active_surface_id: string | null;
   surfaces: OperatorSurfacePayload[];
 };
+
+function summarizeAppShellView(
+  view: AgentView | SpaceDisplayView,
+): Record<string, unknown> {
+  switch (view.type) {
+    case "app":
+      return {
+        type: view.type,
+        app_id: view.appId,
+        path: view.path ?? null,
+        resource_id: view.resourceId ?? null,
+        view_id: view.view ?? null,
+      };
+    case "internal":
+      return {
+        type: view.type,
+        surface: view.surface,
+        resource_id: view.resourceId ?? null,
+      };
+    default:
+      return {
+        type: view.type,
+      };
+  }
+}
+
+function summarizeRuntimeStatusForSentry(
+  runtimeStatus: RuntimeStatusPayload | null,
+): Record<string, unknown> | null {
+  if (!runtimeStatus) {
+    return null;
+  }
+  return {
+    status: runtimeStatus.status,
+    available: runtimeStatus.available,
+    pid: runtimeStatus.pid,
+    harness: runtimeStatus.harness ?? null,
+    desktop_browser_ready: runtimeStatus.desktopBrowserReady,
+    last_error: runtimeStatus.lastError || null,
+  };
+}
+
+function summarizeAppUpdateStatusForSentry(
+  status: AppUpdateStatusPayload | null,
+): Record<string, unknown> | null {
+  if (!status) {
+    return null;
+  }
+  return {
+    supported: status.supported,
+    checking: status.checking,
+    available: status.available,
+    downloaded: status.downloaded,
+    current_version: status.currentVersion,
+    latest_version: status.latestVersion ?? null,
+    channel: status.channel,
+    preferred_channel: status.preferredChannel ?? null,
+    error: status.error || null,
+  };
+}
 
 function nonEmptySurfaceText(value: string | null | undefined): string {
   return (value ?? "").trim();
@@ -3126,6 +3190,146 @@ function AppShellContent() {
       }),
     [activeShellView, agentView, spaceDisplayView],
   );
+  const appShellSentryState = useMemo(
+    () => ({
+      selected_workspace_id: selectedWorkspaceId || null,
+      active_shell_view: activeShellView,
+      active_chat_session_id: activeChatSessionId || null,
+      agent_view: summarizeAppShellView(agentView),
+      space_display_view: summarizeAppShellView(spaceDisplayView),
+      space_layout: {
+        explorer_mode: spaceExplorerMode,
+        explorer_collapsed: spaceExplorerCollapsed,
+        browser_space: spaceBrowserSpace,
+        visibility: spaceVisibility,
+      },
+      workspace: {
+        count: workspaces.length,
+        has_selected_workspace: Boolean(selectedWorkspace),
+        has_hydrated_workspace_list: hasHydratedWorkspaceList,
+        apps_ready: workspaceAppsReady,
+        blocking_reason: workspaceBlockingReason || null,
+        error_message: workspaceErrorMessage || null,
+        onboarding_mode_active: onboardingModeActive,
+      },
+      runtime_status: summarizeRuntimeStatusForSentry(runtimeStatus),
+      operations: {
+        drawer_open: operationsDrawerOpen,
+        active_tab: activeOperationsTab,
+      },
+      dialogs: {
+        workspace_switcher_open: workspaceSwitcherOpen,
+        settings_open: settingsDialogOpen,
+        publish_open: publishOpen,
+        create_workspace_open: createWorkspacePanelOpen,
+        workspace_apps_open: workspaceAppsDialogOpen,
+        task_proposal_details_open: taskProposalDetailsDialogOpen,
+      },
+      notifications: {
+        total: notifications.length,
+        toast_count: effectiveToastNotifications.length,
+        task_proposal_count: taskProposals.length,
+      },
+      proactive: {
+        workspace_enabled: proactiveWorkspaceEnabled,
+        loading_workspace_enabled: isLoadingProactiveWorkspaceEnabled,
+        updating_workspace_enabled: isUpdatingProactiveWorkspaceEnabled,
+        loading_status: isLoadingProactiveStatus,
+        has_status: Boolean(proactiveStatus),
+        error:
+          proactiveTaskProposalsError || proactiveHeartbeatError || null,
+      },
+      app_update: summarizeAppUpdateStatusForSentry(effectiveAppUpdateStatus),
+      operator_surface: reportedOperatorSurfaceContext
+        ? {
+            active_surface_id:
+              reportedOperatorSurfaceContext.active_surface_id ?? null,
+            surface_count: reportedOperatorSurfaceContext.surfaces.length,
+          }
+        : null,
+    }),
+    [
+      activeChatSessionId,
+      activeOperationsTab,
+      activeShellView,
+      agentView,
+      createWorkspacePanelOpen,
+      effectiveAppUpdateStatus,
+      effectiveToastNotifications.length,
+      hasHydratedWorkspaceList,
+      isLoadingProactiveStatus,
+      isLoadingProactiveWorkspaceEnabled,
+      isUpdatingProactiveWorkspaceEnabled,
+      notifications.length,
+      onboardingModeActive,
+      operationsDrawerOpen,
+      proactiveHeartbeatError,
+      proactiveStatus,
+      proactiveTaskProposalsError,
+      proactiveWorkspaceEnabled,
+      publishOpen,
+      reportedOperatorSurfaceContext,
+      runtimeStatus,
+      selectedWorkspace,
+      selectedWorkspaceId,
+      settingsDialogOpen,
+      spaceBrowserSpace,
+      spaceDisplayView,
+      spaceExplorerCollapsed,
+      spaceExplorerMode,
+      spaceVisibility,
+      taskProposalDetailsDialogOpen,
+      taskProposals.length,
+      workspaceAppsDialogOpen,
+      workspaceAppsReady,
+      workspaceBlockingReason,
+      workspaceErrorMessage,
+      workspaceSwitcherOpen,
+      workspaces.length,
+    ],
+  );
+  useRendererSentrySection("app_shell", appShellSentryState);
+
+  useEffect(() => {
+    pushRendererSentryActivity("workspace", "selected workspace changed", {
+      selected_workspace_id: selectedWorkspaceId || null,
+      has_selected_workspace: Boolean(selectedWorkspace),
+    });
+  }, [selectedWorkspace, selectedWorkspaceId]);
+
+  useEffect(() => {
+    pushRendererSentryActivity("navigation", "app shell view changed", {
+      active_shell_view: activeShellView,
+      agent_view_type: agentView.type,
+      space_display_type: spaceDisplayView.type,
+      space_explorer_mode: spaceExplorerMode,
+      space_browser_space: spaceBrowserSpace,
+    });
+  }, [
+    activeShellView,
+    agentView.type,
+    spaceBrowserSpace,
+    spaceDisplayView.type,
+    spaceExplorerMode,
+  ]);
+
+  useEffect(() => {
+    pushRendererSentryActivity("runtime", "renderer runtime status changed", {
+      status: runtimeStatus?.status ?? "unknown",
+      available: runtimeStatus?.available ?? false,
+      last_error: runtimeStatus?.lastError || null,
+    });
+  }, [runtimeStatus?.available, runtimeStatus?.lastError, runtimeStatus?.status]);
+
+  useEffect(() => {
+    if (!activeChatSessionId) {
+      return;
+    }
+    pushRendererSentryActivity("chat", "active chat session changed", {
+      selected_workspace_id: selectedWorkspaceId || null,
+      session_id: activeChatSessionId,
+    });
+  }, [activeChatSessionId, selectedWorkspaceId]);
 
   useEffect(() => {
     if (!selectedWorkspaceId || spaceDisplayView.type !== "internal") {

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -165,6 +165,58 @@ test("chat composer footer wraps controls based on available pane width instead 
   assert.doesNotMatch(source, /sm:w-\[208px\]/);
 });
 
+test("chat pane defers scroll metrics updates out of resize and scroll callbacks", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const chatScrollMetricsSyncFrameRef = useRef<number \| null>\(null\);/,
+  );
+  assert.match(
+    source,
+    /const chatScrollMetricsSyncTargetRef = useRef<HTMLDivElement \| null>\(null\);/,
+  );
+  assert.match(
+    source,
+    /const cancelChatScrollMetricsSync = \(\) => \{[\s\S]*window\.cancelAnimationFrame\(chatScrollMetricsSyncFrameRef\.current\);[\s\S]*chatScrollMetricsSyncTargetRef\.current = null;[\s\S]*\};/,
+  );
+  assert.match(
+    source,
+    /const scheduleChatScrollMetricsSync = \(\s*container\?: HTMLDivElement \| null,\s*\) => \{[\s\S]*window\.requestAnimationFrame\(\(\) => \{[\s\S]*syncChatScrollMetrics\(target\);[\s\S]*\}\);[\s\S]*\};/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\s*\(\) => \(\) => \{[\s\S]*clearChatScrollbarDragState\(\);[\s\S]*cancelChatScrollMetricsSync\(\);[\s\S]*\},\s*\[\],\s*\);/,
+  );
+  assert.match(
+    source,
+    /const resizeObserver = new ResizeObserver\(\(\) => \{\s*scheduleChatScrollMetricsSync\(container\);\s*\}\);/,
+  );
+  assert.match(source, /scheduleChatScrollMetricsSync\(currentTarget\);/);
+  assert.doesNotMatch(
+    source,
+    /const resizeObserver = new ResizeObserver\(\(\) => \{\s*syncChatScrollMetrics\(container\);\s*\}\);/,
+  );
+  assert.doesNotMatch(source, /syncChatScrollMetrics\(currentTarget\);/);
+});
+
+test("chat pane blocks overlapping older-history loads before state commits", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /function setIsLoadingOlderHistoryState\(nextValue: boolean\)/,
+  );
+  assert.match(
+    source,
+    /isLoadingHistory \|\|\s*isLoadingOlderHistoryRef\.current \|\|\s*pendingHistoryPrependRestoreRef\.current \|\|/,
+  );
+  assert.match(
+    source,
+    /setIsLoadingOlderHistoryState\(true\);[\s\S]*finally \{[\s\S]*setIsLoadingOlderHistoryState\(false\);[\s\S]*isLoadingOlderHistoryRef\.current = false;/,
+  );
+});
+
 test("chat composer switches model and thinking selectors into icon-led compact triggers", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -61,6 +61,10 @@ import {
   useDesktopAuthSession,
 } from "@/lib/auth/authClient";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
+import {
+  pushRendererSentryActivity,
+  useRendererSentrySection,
+} from "@/lib/rendererSentry";
 import { preferredSessionId } from "@/lib/sessionRouting";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
@@ -3236,6 +3240,8 @@ export function ChatPane({
   const composerIsComposingRef = useRef(false);
   const shouldAutoScrollRef = useRef(true);
   const lastChatScrollTopRef = useRef(0);
+  const chatScrollMetricsSyncFrameRef = useRef<number | null>(null);
+  const chatScrollMetricsSyncTargetRef = useRef<HTMLDivElement | null>(null);
   const chatScrollbarDragStateRef = useRef<ChatScrollbarDragState | null>(null);
   const chatScrollbarBodyUserSelectRef = useRef<string | null>(null);
   const chatScrollbarBodyCursorRef = useRef<string | null>(null);
@@ -3253,6 +3259,7 @@ export function ChatPane({
     scrollHeight: number;
     scrollTop: number;
   } | null>(null);
+  const isLoadingOlderHistoryRef = useRef(false);
   const seenMainDebugKeysRef = useRef<Set<string>>(new Set());
   const selectedWorkspaceRef = useRef<WorkspaceRecordPayload | null>(null);
   const isOnboardingVariant = variant === "onboarding";
@@ -3424,6 +3431,11 @@ export function ChatPane({
     setIsHistoryViewportPending(false);
   }
 
+  function setIsLoadingOlderHistoryState(nextValue: boolean) {
+    isLoadingOlderHistoryRef.current = nextValue;
+    setIsLoadingOlderHistory(nextValue);
+  }
+
   function resetLiveTurn() {
     liveAssistantSegmentsRef.current = [];
     liveAssistantTextRef.current = "";
@@ -3442,7 +3454,7 @@ export function ChatPane({
     setCurrentTodoPlan(null);
     setLoadedHistoryMessageCount(0);
     setTotalHistoryMessageCount(0);
-    setIsLoadingOlderHistory(false);
+    setIsLoadingOlderHistoryState(false);
     setArtifactBrowserOpen(false);
     setArtifactBrowserFilter("all");
     setMemoryProposalAction(null);
@@ -3836,7 +3848,7 @@ export function ChatPane({
     setMessages(page.renderedMessages);
     setLoadedHistoryMessageCount(page.history.count);
     setTotalHistoryMessageCount(page.history.total);
-    setIsLoadingOlderHistory(false);
+    setIsLoadingOlderHistoryState(false);
     pendingHistoryPrependRestoreRef.current = null;
     setChatErrorMessage(page.warnings.join(" "));
     resetLiveTurn();
@@ -3948,7 +3960,8 @@ export function ChatPane({
       !sessionId ||
       !workspaceId ||
       isLoadingHistory ||
-      isLoadingOlderHistory ||
+      isLoadingOlderHistoryRef.current ||
+      pendingHistoryPrependRestoreRef.current ||
       loadedHistoryMessageCount >= totalHistoryMessageCount
     ) {
       return;
@@ -3962,7 +3975,7 @@ export function ChatPane({
       };
     }
     shouldAutoScrollRef.current = false;
-    setIsLoadingOlderHistory(true);
+    setIsLoadingOlderHistoryState(true);
 
     try {
       const page = await loadSessionHistoryPage({
@@ -4002,8 +4015,10 @@ export function ChatPane({
       }
     } finally {
       if (isSessionHistoryTargetActive(sessionId, workspaceId)) {
-        setIsLoadingOlderHistory(false);
+        setIsLoadingOlderHistoryState(false);
+        return;
       }
+      isLoadingOlderHistoryRef.current = false;
     }
   }
 
@@ -4269,6 +4284,39 @@ export function ChatPane({
     });
   }
 
+  const cancelChatScrollMetricsSync = () => {
+    if (chatScrollMetricsSyncFrameRef.current !== null) {
+      window.cancelAnimationFrame(chatScrollMetricsSyncFrameRef.current);
+      chatScrollMetricsSyncFrameRef.current = null;
+    }
+    chatScrollMetricsSyncTargetRef.current = null;
+  };
+
+  const scheduleChatScrollMetricsSync = (
+    container?: HTMLDivElement | null,
+  ) => {
+    if (container) {
+      chatScrollMetricsSyncTargetRef.current = container;
+    } else if (chatScrollMetricsSyncTargetRef.current === null) {
+      chatScrollMetricsSyncTargetRef.current = messagesRef.current;
+    }
+
+    if (chatScrollMetricsSyncTargetRef.current === null) {
+      return;
+    }
+    if (chatScrollMetricsSyncFrameRef.current !== null) {
+      return;
+    }
+
+    chatScrollMetricsSyncFrameRef.current = window.requestAnimationFrame(() => {
+      chatScrollMetricsSyncFrameRef.current = null;
+      const target =
+        chatScrollMetricsSyncTargetRef.current ?? messagesRef.current;
+      chatScrollMetricsSyncTargetRef.current = null;
+      syncChatScrollMetrics(target);
+    });
+  };
+
   function clearChatScrollbarDragState() {
     chatScrollbarDragStateRef.current = null;
     if (typeof document === "undefined") {
@@ -4307,7 +4355,8 @@ export function ChatPane({
 
     shouldAutoScrollRef.current = false;
     container.scrollTop = nextScrollTop;
-    syncChatScrollMetrics(container);
+    lastChatScrollTopRef.current = nextScrollTop;
+    scheduleChatScrollMetricsSync(container);
   }
 
   function handleChatScrollbarPointerDown(
@@ -4449,7 +4498,8 @@ export function ChatPane({
     const scrollHeightDelta =
       container.scrollHeight - pendingRestore.scrollHeight;
     container.scrollTop = pendingRestore.scrollTop + scrollHeightDelta;
-    syncChatScrollMetrics(container);
+    lastChatScrollTopRef.current = container.scrollTop;
+    scheduleChatScrollMetricsSync(container);
   }, [messages]);
 
   useLayoutEffect(() => {
@@ -4467,7 +4517,8 @@ export function ChatPane({
       top: container.scrollHeight,
       behavior: "auto",
     });
-    syncChatScrollMetrics(container);
+    lastChatScrollTopRef.current = container.scrollTop;
+    scheduleChatScrollMetricsSync(container);
 
     const frameId = window.requestAnimationFrame(() => {
       if (historyViewportGenerationRef.current !== restoreGeneration) {
@@ -4485,7 +4536,13 @@ export function ChatPane({
     selectedWorkspaceRef.current = selectedWorkspace;
   }, [selectedWorkspace]);
 
-  useEffect(() => clearChatScrollbarDragState, []);
+  useEffect(
+    () => () => {
+      clearChatScrollbarDragState();
+      cancelChatScrollMetricsSync();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!isResponding) {
@@ -6676,6 +6733,185 @@ export function ChatPane({
   const showLowBalanceWarning =
     usesHostedManagedCredits && isLowBalance && !isOutOfCredits;
   const showOutOfCreditsWarning = usesHostedManagedCredits && isOutOfCredits;
+  const chatPaneSentryState = useMemo(
+    () => ({
+      workspace_id: selectedWorkspaceId || null,
+      session_id: activeSessionId || null,
+      variant,
+      signed_in: isSignedIn,
+      workspace_ready: Boolean(selectedWorkspace) && workspaceAppsReady,
+      workspace_blocking_reason: workspaceBlockingReason || null,
+      runtime_default_model: runtimeConfig?.defaultModel ?? null,
+      session_metrics: {
+        available_session_count: availableSessions.length,
+        active_queued_input_count: activeQueuedSessionInputs.length,
+        message_count: messages.length,
+        session_output_count: sessionOutputs.length,
+        live_segment_count: liveAssistantSegments.length,
+        live_execution_item_count: liveExecutionItems.length,
+        todo_phase_count: displayedTodoPlan?.phases.length ?? 0,
+      },
+      composer: {
+        input_length: input.length,
+        quoted_skill_count: quotedSkillIds.length,
+        pending_attachment_count: pendingAttachments.length,
+        disabled: composerDisabled,
+        disabled_reason: composerDisabledReason || null,
+        attachment_gate_message: attachmentGateMessage || null,
+        pending_image_input_unsupported_message:
+          pendingImageInputUnsupportedMessage || null,
+      },
+      activity: {
+        is_loading_history: isLoadingHistory,
+        is_loading_older_history: isLoadingOlderHistory,
+        is_history_viewport_pending: isHistoryViewportPending,
+        is_responding: isResponding,
+        is_submitting_message: isSubmittingMessage,
+        is_pause_pending: isPausePending,
+        live_agent_status: liveAgentStatus || null,
+        chat_error_message: chatErrorMessage || null,
+        artifact_browser_open: artifactBrowserOpen,
+        todo_panel_expanded: displayedTodoPanelExpanded,
+      },
+      model_selection: {
+        selected_model: effectiveChatModelPreference || null,
+        resolved_model: resolvedChatModel || null,
+        selected_model_label: selectedModelDisplayLabel || null,
+        thinking_value: effectiveThinkingValue,
+        supports_reasoning: selectedModelSupportsReasoning,
+        supports_image_input: selectedModelSupportsImageInput,
+      },
+      browser_state: {
+        space: visibleBrowserState.space,
+        active_tab_id: visibleBrowserState.activeTabId || null,
+        tab_count: visibleBrowserState.tabs.length,
+        user_tab_count: visibleBrowserState.tabCounts.user,
+        agent_tab_count: visibleBrowserState.tabCounts.agent,
+        session_id: visibleBrowserState.sessionId || null,
+        control_mode: visibleBrowserState.controlMode,
+        control_session_id: visibleBrowserState.controlSessionId || null,
+        lifecycle_state: visibleBrowserState.lifecycleState ?? null,
+      },
+      billing: {
+        low_balance: showLowBalanceWarning,
+        out_of_credits: showOutOfCreditsWarning,
+        uses_hosted_managed_credits: usesHostedManagedCredits,
+      },
+    }),
+    [
+      activeQueuedSessionInputs.length,
+      activeSessionId,
+      artifactBrowserOpen,
+      attachmentGateMessage,
+      availableSessions.length,
+      chatErrorMessage,
+      composerDisabled,
+      composerDisabledReason,
+      displayedTodoPanelExpanded,
+      displayedTodoPlan,
+      effectiveChatModelPreference,
+      effectiveThinkingValue,
+      input.length,
+      isLoadingHistory,
+      isLoadingOlderHistory,
+      isHistoryViewportPending,
+      isPausePending,
+      isResponding,
+      isSignedIn,
+      isSubmittingMessage,
+      liveAgentStatus,
+      liveAssistantSegments.length,
+      liveExecutionItems.length,
+      messages.length,
+      pendingAttachments.length,
+      pendingImageInputUnsupportedMessage,
+      quotedSkillIds.length,
+      resolvedChatModel,
+      runtimeConfig?.defaultModel,
+      selectedModelDisplayLabel,
+      selectedModelSupportsImageInput,
+      selectedModelSupportsReasoning,
+      selectedWorkspace,
+      selectedWorkspaceId,
+      sessionOutputs.length,
+      showLowBalanceWarning,
+      showOutOfCreditsWarning,
+      variant,
+      visibleBrowserState,
+      usesHostedManagedCredits,
+      workspaceAppsReady,
+      workspaceBlockingReason,
+    ],
+  );
+  useRendererSentrySection("chat_pane", chatPaneSentryState);
+
+  useEffect(() => {
+    pushRendererSentryActivity("chat", "chat session changed", {
+      workspace_id: selectedWorkspaceId || null,
+      session_id: activeSessionId || null,
+    });
+  }, [activeSessionId, selectedWorkspaceId]);
+
+  useEffect(() => {
+    pushRendererSentryActivity("chat", "chat model selection changed", {
+      session_id: activeSessionId || null,
+      selected_model: effectiveChatModelPreference || null,
+      resolved_model: resolvedChatModel || null,
+      thinking_value: effectiveThinkingValue,
+    });
+  }, [
+    activeSessionId,
+    effectiveChatModelPreference,
+    effectiveThinkingValue,
+    resolvedChatModel,
+  ]);
+
+  useEffect(() => {
+    if (!chatErrorMessage) {
+      return;
+    }
+    pushRendererSentryActivity("chat", "chat error surfaced", {
+      session_id: activeSessionId || null,
+      workspace_id: selectedWorkspaceId || null,
+      message: chatErrorMessage,
+    });
+  }, [activeSessionId, chatErrorMessage, selectedWorkspaceId]);
+
+  useEffect(() => {
+    pushRendererSentryActivity("chat", "chat activity state changed", {
+      session_id: activeSessionId || null,
+      is_responding: isResponding,
+      is_submitting_message: isSubmittingMessage,
+      is_pause_pending: isPausePending,
+      live_agent_status: liveAgentStatus || null,
+    });
+  }, [
+    activeSessionId,
+    isPausePending,
+    isResponding,
+    isSubmittingMessage,
+    liveAgentStatus,
+  ]);
+
+  useEffect(() => {
+    pushRendererSentryActivity("browser", "chat browser state changed", {
+      session_id: activeSessionId || null,
+      browser_space: visibleBrowserState.space,
+      tab_count: visibleBrowserState.tabs.length,
+      control_mode: visibleBrowserState.controlMode,
+      browser_session_id: visibleBrowserState.sessionId || null,
+      control_session_id: visibleBrowserState.controlSessionId || null,
+      lifecycle_state: visibleBrowserState.lifecycleState ?? null,
+    });
+  }, [
+    activeSessionId,
+    visibleBrowserState.controlMode,
+    visibleBrowserState.controlSessionId,
+    visibleBrowserState.lifecycleState,
+    visibleBrowserState.sessionId,
+    visibleBrowserState.space,
+    visibleBrowserState.tabs.length,
+  ]);
 
   useEffect(() => {
     if (!effectiveChatModelPreference) {
@@ -6752,6 +6988,7 @@ export function ChatPane({
 
   useEffect(() => {
     if (!hasMessages) {
+      cancelChatScrollMetricsSync();
       setChatScrollMetrics({
         scrollTop: 0,
         scrollHeight: 0,
@@ -6760,7 +6997,7 @@ export function ChatPane({
       return;
     }
 
-    syncChatScrollMetrics();
+    scheduleChatScrollMetricsSync();
 
     const container = messagesRef.current;
     if (!container) {
@@ -6768,7 +7005,7 @@ export function ChatPane({
     }
 
     const resizeObserver = new ResizeObserver(() => {
-      syncChatScrollMetrics(container);
+      scheduleChatScrollMetricsSync(container);
     });
     resizeObserver.observe(container);
 
@@ -7032,11 +7269,12 @@ export function ChatPane({
               }}
               onScroll={(event) => {
                 const { currentTarget } = event;
-                const scrolledUp =
-                  currentTarget.scrollTop < lastChatScrollTopRef.current;
+                const nextScrollTop = currentTarget.scrollTop;
+                const scrolledUp = nextScrollTop < lastChatScrollTopRef.current;
+                lastChatScrollTopRef.current = nextScrollTop;
                 const nearBottom = isNearChatBottom(currentTarget);
                 shouldAutoScrollRef.current = scrolledUp ? false : nearBottom;
-                syncChatScrollMetrics(currentTarget);
+                scheduleChatScrollMetricsSync(currentTarget);
                 if (
                   currentTarget.scrollTop <=
                   CHAT_HISTORY_TOP_LOAD_THRESHOLD_PX

--- a/desktop/src/components/ui/ErrorBoundary.tsx
+++ b/desktop/src/components/ui/ErrorBoundary.tsx
@@ -26,6 +26,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("[ErrorBoundary]", error, info.componentStack);
     Sentry.captureException(error, {
+      tags: {
+        surface: "renderer_error_boundary",
+      },
+      extra: {
+        page_url: window.location.href,
+      },
       contexts: { react: { componentStack: info.componentStack } },
     });
   }

--- a/desktop/src/lib/rendererSentry.ts
+++ b/desktop/src/lib/rendererSentry.ts
@@ -1,0 +1,227 @@
+import * as Sentry from "@sentry/electron/renderer";
+import { useEffect } from "react";
+
+const MAX_RENDERER_SENTRY_ACTIVITY = 40;
+const RENDERER_SENTRY_REDACTED_VALUE = "[REDACTED]";
+const RENDERER_SENSITIVE_KEY_PATTERNS = [
+  /token/i,
+  /secret/i,
+  /password/i,
+  /cookie/i,
+  /^authorization$/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i,
+  /refresh[_-]?token/i,
+  /access[_-]?token/i,
+];
+const RENDERER_SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
+  /((?:token|secret|password|cookie|authorization|api[_-]?key|private[_-]?key|refresh[_-]?token|access[_-]?token)[^:=\n\r]{0,64}[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const RENDERER_AUTHORIZATION_BEARER_PATTERN =
+  /(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,;]+(?:\s+[^\s,;]+)?/gi;
+
+interface RendererSentryActivity {
+  at: string;
+  category: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+const rendererSentrySections = new Map<string, Record<string, unknown>>();
+const rendererSentryActivity: RendererSentryActivity[] = [];
+
+function shouldRedactRendererSentryKey(key: string): boolean {
+  const normalized = key.trim();
+  if (!normalized) {
+    return false;
+  }
+  return RENDERER_SENSITIVE_KEY_PATTERNS.some((pattern) =>
+    pattern.test(normalized),
+  );
+}
+
+export function redactRendererSentryValue(
+  value: unknown,
+  keyName = "",
+): unknown {
+  if (shouldRedactRendererSentryKey(keyName)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return RENDERER_SENTRY_REDACTED_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRendererSentryValue(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        redactRendererSentryValue(entry, key),
+      ]),
+    );
+  }
+
+  if (typeof value === "string") {
+    return value
+      .replace(
+        RENDERER_AUTHORIZATION_BEARER_PATTERN,
+        `$1${RENDERER_SENTRY_REDACTED_VALUE}`,
+      )
+      .replace(
+        RENDERER_SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+        `$1${RENDERER_SENTRY_REDACTED_VALUE}`,
+      );
+  }
+
+  return value;
+}
+
+function rendererLocationSnapshot(): Record<string, unknown> {
+  return {
+    href: window.location.href,
+    origin: window.location.origin,
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+    title: document.title,
+    visibility_state: document.visibilityState,
+    focused: document.hasFocus(),
+    online: navigator.onLine,
+    user_agent: navigator.userAgent,
+    language: navigator.language,
+  };
+}
+
+function buildRendererSentrySnapshot(): Record<string, unknown> {
+  return {
+    captured_at: new Date().toISOString(),
+    location: rendererLocationSnapshot(),
+    sections: Object.fromEntries(rendererSentrySections.entries()),
+    recent_activity: [...rendererSentryActivity],
+  };
+}
+
+function addRendererSentryHintAttachment(
+  hint: Sentry.EventHint | undefined,
+  attachment: NonNullable<Sentry.EventHint["attachments"]>[number] | null,
+) {
+  if (!hint || !attachment) {
+    return;
+  }
+  hint.attachments = [...(hint.attachments ?? []), attachment];
+}
+
+function normalizeRendererTagValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value.trim() || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+export function setRendererSentrySection(
+  name: string,
+  value: Record<string, unknown> | null | undefined,
+): void {
+  if (!value) {
+    rendererSentrySections.delete(name);
+    return;
+  }
+  rendererSentrySections.set(
+    name,
+    redactRendererSentryValue(value) as Record<string, unknown>,
+  );
+}
+
+export function clearRendererSentrySection(name: string): void {
+  rendererSentrySections.delete(name);
+}
+
+export function useRendererSentrySection(
+  name: string,
+  value: Record<string, unknown> | null | undefined,
+): void {
+  useEffect(() => {
+    setRendererSentrySection(name, value);
+    return () => {
+      clearRendererSentrySection(name);
+    };
+  }, [name, value]);
+}
+
+export function pushRendererSentryActivity(
+  category: string,
+  message: string,
+  data?: Record<string, unknown>,
+): void {
+  const sanitizedData = data
+    ? (redactRendererSentryValue(data) as Record<string, unknown>)
+    : undefined;
+  rendererSentryActivity.push({
+    at: new Date().toISOString(),
+    category,
+    message,
+    data: sanitizedData,
+  });
+  if (rendererSentryActivity.length > MAX_RENDERER_SENTRY_ACTIVITY) {
+    rendererSentryActivity.splice(
+      0,
+      rendererSentryActivity.length - MAX_RENDERER_SENTRY_ACTIVITY,
+    );
+  }
+  Sentry.addBreadcrumb({
+    category: `renderer.${category}`,
+    message,
+    level: "info",
+    data: sanitizedData,
+  });
+}
+
+export function enrichRendererSentryEvent(
+  event: Sentry.ErrorEvent,
+  hint: Sentry.EventHint | undefined,
+): Sentry.ErrorEvent {
+  const snapshot = buildRendererSentrySnapshot();
+  addRendererSentryHintAttachment(hint, {
+    filename: "renderer-diagnostics.json",
+    data: `${JSON.stringify(snapshot, null, 2)}\n`,
+    contentType: "application/json",
+  });
+
+  const appShellState =
+    (snapshot.sections as Record<string, Record<string, unknown> | undefined>)
+      .app_shell ?? null;
+  const chatPaneState =
+    (snapshot.sections as Record<string, Record<string, unknown> | undefined>)
+      .chat_pane ?? null;
+  const selectedWorkspaceId =
+    normalizeRendererTagValue(appShellState?.selected_workspace_id) ??
+    normalizeRendererTagValue(chatPaneState?.workspace_id);
+  const activeSessionId = normalizeRendererTagValue(chatPaneState?.session_id);
+
+  event.tags = {
+    ...(event.tags ?? {}),
+    process_kind: "electron_renderer",
+    ...(selectedWorkspaceId
+      ? { selected_workspace_id: selectedWorkspaceId }
+      : {}),
+    ...(activeSessionId ? { active_session_id: activeSessionId } : {}),
+  };
+  event.contexts = {
+    ...(event.contexts ?? {}),
+    renderer_location:
+      (snapshot.location as Record<string, unknown> | undefined) ?? {},
+    renderer_state: {
+      sections: snapshot.sections,
+      recent_activity: snapshot.recent_activity,
+    },
+  };
+  return event;
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -2,7 +2,46 @@ import * as Sentry from "@sentry/electron/renderer";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import {
+  enrichRendererSentryEvent,
+  pushRendererSentryActivity,
+} from "./lib/rendererSentry";
 
-Sentry.init();
+Sentry.init({
+  enableLogs: true,
+  maxBreadcrumbs: 200,
+  integrations: [
+    Sentry.consoleLoggingIntegration({
+      levels: ["warn", "error"],
+    }),
+    Sentry.eventLoopBlockIntegration({
+      threshold: 2000,
+    }),
+  ],
+  beforeSend(event, hint) {
+    return enrichRendererSentryEvent(event, hint);
+  },
+});
+Sentry.setTag("process_kind", "electron_renderer");
+pushRendererSentryActivity("lifecycle", "renderer initialized", {
+  pathname: window.location.pathname,
+  search: window.location.search,
+});
+window.addEventListener("online", () => {
+  pushRendererSentryActivity("connectivity", "renderer went online", {
+    online: true,
+  });
+});
+window.addEventListener("offline", () => {
+  pushRendererSentryActivity("connectivity", "renderer went offline", {
+    online: false,
+  });
+});
+document.addEventListener("visibilitychange", () => {
+  pushRendererSentryActivity("visibility", "renderer visibility changed", {
+    visibility_state: document.visibilityState,
+    focused: document.hasFocus(),
+  });
+});
 
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -65,6 +65,7 @@ import {
   type RecallEmbeddingBackfillWorkerLike,
   RuntimeRecallEmbeddingBackfillWorker,
 } from "./recall-embedding-backfill-worker.js";
+import { captureRuntimeException } from "./runtime-sentry.js";
 import {
   AppLifecycleExecutorError,
   appBuildHasCompletedSetup,
@@ -2126,7 +2127,11 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   const browserToolService = options.browserToolService ?? new DesktopBrowserToolService();
   const terminalSessionManager =
     options.terminalSessionManager === undefined
-      ? new TerminalSessionManager({ store, logger: app.log })
+      ? new TerminalSessionManager({
+        store,
+        logger: app.log,
+        captureRuntimeException,
+      })
       : options.terminalSessionManager;
   const integrationService = new RuntimeIntegrationService(store);
   const honoBaseUrl = process.env.HOLABOSS_AUTH_BASE_URL ?? "";

--- a/runtime/api-server/src/index.ts
+++ b/runtime/api-server/src/index.ts
@@ -1,20 +1,66 @@
 import * as Sentry from "@sentry/node";
 import { setTimeout as sleep } from "node:timers/promises";
+import { buildRuntimeSentryDiagnostics } from "./runtime-sentry.js";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: !!process.env.SENTRY_DSN,
+  enableLogs: !!process.env.SENTRY_DSN,
   release: process.env.HOLABOSS_RUNTIME_VERSION,
   environment: process.env.SENTRY_ENVIRONMENT ?? "production",
-  beforeSend(event) {
+  maxBreadcrumbs: 200,
+  integrations: [
+    Sentry.pinoIntegration({
+      log: {
+        levels: ["info", "warn", "error", "fatal"],
+      },
+      error: {
+        levels: ["error", "fatal"],
+        handled: true,
+      },
+    }),
+    Sentry.consoleLoggingIntegration({
+      levels: ["warn", "error"],
+    }),
+  ],
+  beforeSend(event, hint) {
     if (event.request?.headers) {
       delete event.request.headers["authorization"];
       delete event.request.headers["cookie"];
       delete event.request.headers["x-api-key"];
     }
+    const diagnostics = buildRuntimeSentryDiagnostics();
+    event.contexts = {
+      ...(event.contexts ?? {}),
+      ...diagnostics.contexts,
+    };
+    const attachments = diagnostics.attachments.map((attachment) => ({
+      filename: attachment.filename,
+      data: attachment.data,
+      contentType: attachment.contentType,
+    }));
+    if (hint && attachments.length > 0) {
+      hint.attachments = [...(hint.attachments ?? []), ...attachments];
+    }
     return event;
   },
 });
+
+Sentry.setTags({
+  runtime_surface:
+    process.env.HOLABOSS_EMBEDDED_RUNTIME === "1"
+      ? "desktop_embedded"
+      : "standalone",
+  runtime_workflow_backend:
+    process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND ?? "unknown",
+});
+
+if (process.env.HOLABOSS_DESKTOP_LAUNCH_ID?.trim()) {
+  Sentry.setTag(
+    "desktop_launch_id",
+    process.env.HOLABOSS_DESKTOP_LAUNCH_ID.trim(),
+  );
+}
 
 import { buildRuntimeApiServer } from "./app.js";
 

--- a/runtime/api-server/src/runtime-sentry.test.ts
+++ b/runtime/api-server/src/runtime-sentry.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  buildRuntimeSentryDiagnostics,
+  redactRuntimeSentryText,
+  redactRuntimeSentryValue,
+} from "./runtime-sentry.js";
+
+const tempDirs: string[] = [];
+const ENV_KEYS = [
+  "HOLABOSS_RUNTIME_DB_PATH",
+  "HOLABOSS_RUNTIME_LOG_PATH",
+  "HOLABOSS_RUNTIME_CONFIG_PATH",
+  "HOLABOSS_RUNTIME_VERSION",
+  "HOLABOSS_DESKTOP_LAUNCH_ID",
+];
+
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+test("runtime sentry diagnostics redact config and log attachments", () => {
+  const root = makeTempDir("hb-runtime-sentry-");
+  const runtimeDbPath = path.join(root, "runtime.db");
+  const runtimeLogPath = path.join(root, "runtime.log");
+  const runtimeConfigPath = path.join(root, "runtime-config.json");
+
+  fs.writeFileSync(runtimeDbPath, "");
+  fs.writeFileSync(
+    runtimeLogPath,
+    'token=abc123\ncookie=session-secret\nnormal line\n',
+    "utf8",
+  );
+  fs.writeFileSync(
+    runtimeConfigPath,
+    JSON.stringify({
+      runtime: {
+        auth_token: "secret-token",
+      },
+      providers: {
+        openai: {
+          api_key: "sk-live",
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  process.env.HOLABOSS_RUNTIME_DB_PATH = runtimeDbPath;
+  process.env.HOLABOSS_RUNTIME_LOG_PATH = runtimeLogPath;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = runtimeConfigPath;
+  process.env.HOLABOSS_RUNTIME_VERSION = "holaboss-desktop-2026.420.1";
+  process.env.HOLABOSS_DESKTOP_LAUNCH_ID = "launch-123";
+
+  const diagnostics = buildRuntimeSentryDiagnostics();
+  const configAttachment = diagnostics.attachments.find(
+    (attachment) => attachment.filename === "runtime-config.redacted.json",
+  );
+  const logAttachment = diagnostics.attachments.find(
+    (attachment) => attachment.filename === "runtime-log-tail.txt",
+  );
+  const snapshotAttachment = diagnostics.attachments.find(
+    (attachment) => attachment.filename === "runtime-diagnostics.json",
+  );
+
+  assert.ok(configAttachment);
+  assert.equal(configAttachment?.contentType, "application/json");
+  assert.match(String(configAttachment?.data ?? ""), /\[REDACTED\]/);
+  assert.doesNotMatch(String(configAttachment?.data ?? ""), /secret-token|sk-live/);
+
+  assert.ok(logAttachment);
+  assert.match(String(logAttachment?.data ?? ""), /\[REDACTED\]/);
+  assert.doesNotMatch(String(logAttachment?.data ?? ""), /abc123|session-secret/);
+
+  assert.ok(snapshotAttachment);
+  assert.match(String(snapshotAttachment?.data ?? ""), /launch-123/);
+  assert.equal(
+    diagnostics.contexts.runtime_process?.desktop_launch_id,
+    "launch-123",
+  );
+});
+
+test("runtime sentry redaction helpers scrub secret-shaped values", () => {
+  assert.equal(
+    redactRuntimeSentryText("authorization=Bearer super-secret"),
+    "authorization=[REDACTED]",
+  );
+  assert.deepEqual(
+    redactRuntimeSentryValue({
+      access_token: "secret",
+      nested: {
+        refresh_token: "secret-2",
+      },
+    }),
+    {
+      access_token: "[REDACTED]",
+      nested: {
+        refresh_token: "[REDACTED]",
+      },
+    },
+  );
+});

--- a/runtime/api-server/src/runtime-sentry.ts
+++ b/runtime/api-server/src/runtime-sentry.ts
@@ -1,6 +1,31 @@
 import * as Sentry from "@sentry/node";
+import fs from "node:fs";
+import path from "node:path";
 
 type RuntimeSentryLevel = "fatal" | "error" | "warning" | "log" | "info" | "debug";
+const RUNTIME_SENTRY_LOG_TAIL_BYTES = 64 * 1024;
+const REDACTED_VALUE = "[REDACTED]";
+const SENSITIVE_KEY_PATTERNS = [
+  /token/i,
+  /secret/i,
+  /password/i,
+  /cookie/i,
+  /^authorization$/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i,
+  /refresh[_-]?token/i,
+  /access[_-]?token/i,
+];
+const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
+  /((?:token|secret|password|cookie|authorization|api[_-]?key|private[_-]?key|refresh[_-]?token|access[_-]?token)[^:=\n\r]{0,64}[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const AUTHORIZATION_BEARER_PATTERN =
+  /(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,;]+(?:\s+[^\s,;]+)?/gi;
+
+export interface RuntimeSentryAttachment {
+  filename: string;
+  data: string | Uint8Array;
+  contentType?: string;
+}
 
 export interface RuntimeSentryCaptureOptions {
   error: unknown;
@@ -9,6 +34,7 @@ export interface RuntimeSentryCaptureOptions {
   extras?: Record<string, unknown>;
   contexts?: Record<string, Record<string, unknown> | null | undefined>;
   fingerprint?: string[];
+  attachments?: RuntimeSentryAttachment[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -35,6 +61,50 @@ function jsonValue(value: unknown): unknown {
   return value === undefined ? null : String(value);
 }
 
+function shouldRedactKey(key: string): boolean {
+  const normalized = key.trim();
+  if (!normalized) {
+    return false;
+  }
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function redactRuntimeSentryValue(
+  value: unknown,
+  keyName = "",
+): unknown {
+  if (shouldRedactKey(keyName)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return REDACTED_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRuntimeSentryValue(entry));
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        redactRuntimeSentryValue(entry, key),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+export function redactRuntimeSentryText(text: string): string {
+  return text
+    .replace(AUTHORIZATION_BEARER_PATTERN, `$1${REDACTED_VALUE}`)
+    .replace(
+      SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+      `$1${REDACTED_VALUE}`,
+    );
+}
+
 function normalizeTagValue(value: unknown): string | null {
   if (value === null || value === undefined) {
     return null;
@@ -57,6 +127,139 @@ function normalizeError(value: unknown): Error {
       ? value
       : JSON.stringify(jsonValue(value)) ?? "Unknown runtime error";
   return new Error(message);
+}
+
+function envPath(name: string): string {
+  return process.env[name]?.trim() || "";
+}
+
+function safeStat(filePath: string): Record<string, unknown> {
+  if (!filePath) {
+    return {
+      path: null,
+      exists: false,
+    };
+  }
+  try {
+    const stats = fs.statSync(filePath);
+    return {
+      path: path.basename(filePath),
+      exists: true,
+      sizeBytes: stats.size,
+      modifiedAt: stats.mtime.toISOString(),
+    };
+  } catch {
+    return {
+      path: path.basename(filePath),
+      exists: false,
+    };
+  }
+}
+
+function readFileTail(filePath: string, maxBytes: number): string | null {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null;
+  }
+  const buffer = fs.readFileSync(filePath);
+  const start = Math.max(0, buffer.length - maxBytes);
+  return buffer.subarray(start).toString("utf8");
+}
+
+function runtimeSentrySnapshot(): Record<string, unknown> {
+  const runtimeDbPath = envPath("HOLABOSS_RUNTIME_DB_PATH");
+  const runtimeLogPath = envPath("HOLABOSS_RUNTIME_LOG_PATH");
+  const runtimeConfigPath = envPath("HOLABOSS_RUNTIME_CONFIG_PATH");
+  return {
+    captured_at: new Date().toISOString(),
+    runtime: {
+      embedded_runtime: process.env.HOLABOSS_EMBEDDED_RUNTIME === "1",
+      workflow_backend: process.env.HOLABOSS_RUNTIME_WORKFLOW_BACKEND ?? null,
+      runtime_version: process.env.HOLABOSS_RUNTIME_VERSION ?? null,
+      sentry_environment: process.env.SENTRY_ENVIRONMENT ?? null,
+      desktop_launch_id: process.env.HOLABOSS_DESKTOP_LAUNCH_ID ?? null,
+      desktop_app_version: process.env.HOLABOSS_DESKTOP_APP_VERSION ?? null,
+      pid: process.pid,
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      cwd: process.cwd(),
+    },
+    files: {
+      runtime_db: safeStat(runtimeDbPath),
+      runtime_log: safeStat(runtimeLogPath),
+      runtime_config: safeStat(runtimeConfigPath),
+    },
+  };
+}
+
+function redactedRuntimeConfigAttachment(): RuntimeSentryAttachment | null {
+  const runtimeConfigPath = envPath("HOLABOSS_RUNTIME_CONFIG_PATH");
+  if (!runtimeConfigPath || !fs.existsSync(runtimeConfigPath)) {
+    return null;
+  }
+
+  let data = "";
+  try {
+    const rawDocument = fs.readFileSync(runtimeConfigPath, "utf8");
+    const parsed = JSON.parse(rawDocument) as unknown;
+    data = `${JSON.stringify(redactRuntimeSentryValue(parsed), null, 2)}\n`;
+  } catch {
+    data = `${JSON.stringify(
+      {
+        error: "runtime-config.json could not be parsed for redaction.",
+      },
+      null,
+      2,
+    )}\n`;
+  }
+
+  return {
+    filename: "runtime-config.redacted.json",
+    data,
+    contentType: "application/json",
+  };
+}
+
+function runtimeLogTailAttachment(): RuntimeSentryAttachment | null {
+  const runtimeLogPath = envPath("HOLABOSS_RUNTIME_LOG_PATH");
+  const tail = readFileTail(runtimeLogPath, RUNTIME_SENTRY_LOG_TAIL_BYTES);
+  if (!tail) {
+    return null;
+  }
+  return {
+    filename: "runtime-log-tail.txt",
+    data: redactRuntimeSentryText(tail),
+    contentType: "text/plain",
+  };
+}
+
+export function buildRuntimeSentryDiagnostics(): {
+  attachments: RuntimeSentryAttachment[];
+  contexts: Record<string, Record<string, unknown>>;
+} {
+  const snapshot = runtimeSentrySnapshot();
+  const attachments: RuntimeSentryAttachment[] = [
+    {
+      filename: "runtime-diagnostics.json",
+      data: `${JSON.stringify(snapshot, null, 2)}\n`,
+      contentType: "application/json",
+    },
+  ];
+  const logTailAttachment = runtimeLogTailAttachment();
+  if (logTailAttachment) {
+    attachments.push(logTailAttachment);
+  }
+  const configAttachment = redactedRuntimeConfigAttachment();
+  if (configAttachment) {
+    attachments.push(configAttachment);
+  }
+  return {
+    attachments,
+    contexts: {
+      runtime_process: jsonValue(snapshot.runtime) as Record<string, unknown>,
+      runtime_files: jsonValue(snapshot.files) as Record<string, unknown>,
+    },
+  };
 }
 
 export function captureRuntimeException(
@@ -83,6 +286,13 @@ export function captureRuntimeException(
       if (value && Object.keys(value).length > 0) {
         scope.setContext(key, jsonValue(value) as Record<string, unknown>);
       }
+    }
+    for (const attachment of options.attachments ?? []) {
+      scope.addAttachment({
+        filename: attachment.filename,
+        data: attachment.data,
+        contentType: attachment.contentType,
+      });
     }
     Sentry.captureException(error);
   });

--- a/runtime/api-server/src/terminal-session-manager.test.ts
+++ b/runtime/api-server/src/terminal-session-manager.test.ts
@@ -8,6 +8,7 @@ import { afterEach, test } from "node:test";
 import { RuntimeStateStore } from "@holaboss/runtime-state-store";
 
 import { TerminalSessionManager } from "./terminal-session-manager.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 
 const tempDirs: string[] = [];
 
@@ -235,6 +236,69 @@ test("terminal session manager reconciles stale running sessions on startup", as
   assert.equal(stale.status, "interrupted");
   assert.deepEqual(events.map((event) => event.eventType), ["exit"]);
   assert.equal(events[0]?.payload.reason, "runtime_restarted");
+
+  await manager.close();
+  store.close();
+});
+
+test("terminal session manager captures output persistence failures instead of crashing", async () => {
+  const root = makeTempDir("hb-terminal-session-manager-sentry-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  fs.mkdirSync(workspaceDir(root, "workspace-1"), { recursive: true });
+
+  const appendTerminalSessionEvent = store.appendTerminalSessionEvent.bind(store);
+  store.appendTerminalSessionEvent = ((params) => {
+    if (params.eventType === "output") {
+      throw new Error("database is locked");
+    }
+    return appendTerminalSessionEvent(params);
+  }) as typeof store.appendTerminalSessionEvent;
+
+  let currentPty: FakePtyProcess | null = null;
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+  const manager = new TerminalSessionManager({
+    store,
+    captureRuntimeException(capture) {
+      sentryCaptures.push(capture);
+    },
+    spawnImpl: () => {
+      currentPty = new FakePtyProcess();
+      return currentPty;
+    },
+  });
+  await manager.start();
+
+  const session = await manager.createSession({
+    workspaceId: "workspace-1",
+    command: testCommand(),
+  });
+
+  const ptyProcess = requirePty(currentPty);
+  assert.doesNotThrow(() => {
+    ptyProcess.emitData("terminal-ready\n");
+  });
+
+  await waitFor(() => manager.getSession({ terminalId: session.terminalId })?.status === "closed");
+
+  assert.equal(sentryCaptures.length, 1);
+  assert.equal(
+    sentryCaptures[0]?.tags?.failure_kind,
+    "sqlite_database_locked",
+  );
+  assert.equal(
+    sentryCaptures[0]?.tags?.terminal_event_type,
+    "output",
+  );
+  assert.equal(ptyProcess.killCalls[0], "SIGTERM");
 
   await manager.close();
   store.close();

--- a/runtime/api-server/src/terminal-session-manager.ts
+++ b/runtime/api-server/src/terminal-session-manager.ts
@@ -14,6 +14,7 @@ import * as pty from "node-pty";
 
 import { buildRunnerEnv } from "./runner-worker.js";
 import { shellCommandInvocation } from "./runtime-shell.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 
 interface LoggerLike {
   info?(payload: unknown, message?: string): void;
@@ -26,6 +27,7 @@ interface LiveTerminalSession {
   ptyProcess: TerminalSessionPtyProcess;
   finalized: boolean;
   requestedClose: boolean;
+  closingForPersistenceFailure: boolean;
   lastKnownStatus: TerminalSessionStatus;
 }
 
@@ -62,6 +64,9 @@ export interface TerminalSessionManagerLike {
 export interface TerminalSessionManagerOptions {
   store: RuntimeStateStore;
   logger?: LoggerLike;
+  captureRuntimeException?: (
+    options: RuntimeSentryCaptureOptions,
+  ) => void;
   maxActiveSessions?: number;
   maxActiveSessionsPerWorkspace?: number;
   spawnImpl?: (
@@ -139,6 +144,14 @@ function requireTerminalSession(
   return record;
 }
 
+function terminalSessionFailureKind(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/database is locked/i.test(message)) {
+    return "sqlite_database_locked";
+  }
+  return "terminal_session_persistence_failed";
+}
+
 export class TerminalSessionManagerError extends Error {
   readonly statusCode: number;
   readonly code: string;
@@ -167,7 +180,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       statuses: ["starting", "running"],
     });
     for (const session of staleSessions) {
-      const event = this.options.store.appendTerminalSessionEvent({
+      const event = this.appendTerminalSessionEventWithCapture({
         terminalId: session.terminalId,
         eventType: "exit",
         payload: {
@@ -178,8 +191,19 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
         status: "interrupted",
         exitCode: session.exitCode,
         endedAt: utcNowIso(),
+      }, {
+        surface: "startup_reconcile",
+        workspace_id: session.workspaceId,
+        session_id: session.sessionId,
+        input_id: session.inputId,
+        owner: session.owner,
+        title: session.title,
+        command: session.command,
+        cwd: session.cwd,
       });
-      this.emit(event);
+      if (event) {
+        this.emit(event);
+      }
     }
   }
 
@@ -293,20 +317,41 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       ptyProcess,
       finalized: false,
       requestedClose: false,
+      closingForPersistenceFailure: false,
       lastKnownStatus: "running",
     };
     this.liveSessions.set(record.terminalId, live);
 
     ptyProcess.onData((data) => {
-      if (live.finalized) {
+      if (live.finalized || live.closingForPersistenceFailure) {
         return;
       }
-      const event = this.options.store.appendTerminalSessionEvent({
+      const event = this.appendTerminalSessionEventWithCapture({
         terminalId: record.terminalId,
         eventType: "output",
         payload: { data },
+      }, {
+        surface: "pty_data",
+        workspace_id: record.workspaceId,
+        session_id: record.sessionId,
+        input_id: record.inputId,
+        owner: record.owner,
+        title: record.title,
+        command: record.command,
+        cwd: record.cwd,
+        data_bytes: Buffer.byteLength(data),
       });
-      this.emit(event);
+      if (event) {
+        this.emit(event);
+        return;
+      }
+      live.closingForPersistenceFailure = true;
+      live.requestedClose = true;
+      try {
+        live.ptyProcess.kill();
+      } catch {
+        // ignore
+      }
     });
 
     ptyProcess.onExit(({ exitCode, signal }) => {
@@ -472,18 +517,72 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     }
     live.finalized = true;
     this.liveSessions.delete(live.terminalId);
-    const event = this.options.store.appendTerminalSessionEvent({
+    const event = this.appendTerminalSessionEventWithCapture({
       terminalId: live.terminalId,
       eventType: params.eventType,
       payload: params.payload,
       status: params.status,
       exitCode: params.exitCode,
       endedAt: utcNowIso(),
+    }, {
+      surface: "pty_exit",
+      status: params.status,
+      requested_close: live.requestedClose,
+      closing_for_persistence_failure: live.closingForPersistenceFailure,
     });
-    this.emit(event);
+    if (event) {
+      this.emit(event);
+    }
   }
 
   private emit(event: TerminalSessionEventRecord): void {
     this.emitter.emit(eventChannel(event.terminalId), event);
+  }
+
+  private appendTerminalSessionEventWithCapture(
+    params: Parameters<RuntimeStateStore["appendTerminalSessionEvent"]>[0],
+    context: Record<string, unknown>,
+  ): TerminalSessionEventRecord | null {
+    try {
+      return this.options.store.appendTerminalSessionEvent(params);
+    } catch (error) {
+      const failureKind = terminalSessionFailureKind(error);
+      this.options.logger?.error?.(
+        {
+          terminalId: params.terminalId,
+          eventType: params.eventType,
+          failureKind,
+          err: error instanceof Error ? error.message : String(error),
+        },
+        "terminal session event persistence failed",
+      );
+      this.options.captureRuntimeException?.({
+        error,
+        level: "error",
+        tags: {
+          surface: "terminal_session_manager",
+          failure_kind: failureKind,
+          terminal_event_type: params.eventType,
+        },
+        fingerprint: [
+          "terminal-session-manager",
+          failureKind,
+          params.eventType,
+        ],
+        contexts: {
+          terminal_session: {
+            terminal_id: params.terminalId,
+            status: params.status ?? null,
+            exit_code: params.exitCode ?? null,
+            ended_at: params.endedAt ?? null,
+            ...context,
+          },
+        },
+        extras: {
+          payload: params.payload,
+        },
+      });
+      return null;
+    }
   }
 }

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -4743,6 +4743,7 @@ export class RuntimeStateStore {
     fs.mkdirSync(path.dirname(this.dbPath), { recursive: true });
     const db = new Database(this.dbPath);
     db.pragma("journal_mode = WAL");
+    db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
     this.#vectorIndexSupported = this.tryLoadVectorExtension(db);
     this.ensureRuntimeDbSchema(db);


### PR DESCRIPTION
## Summary

- expand Sentry telemetry across Electron main, renderer, and runtime with redacted diagnostics attachments, renderer state snapshots, screenshot and hang coverage, and crash lifecycle breadcrumbs so desktop failures are debuggable from Sentry without diagnose zips in most cases
- harden two concrete high-noise failures found in Sentry: add a SQLite busy timeout plus runtime capture for terminal persistence failures, and break the recurring ChatPane maximum-update-depth loop by deferring scroll-metric sync and blocking overlapping history loads

## Validation

- [x] `node --test desktop/electron/sentry-telemetry.test.mjs`
- [x] `node --test --test-name-pattern 'chat pane defers scroll metrics updates out of resize and scroll callbacks|chat pane blocks overlapping older-history loads before state commits' desktop/src/components/panes/ChatPane.test.mjs`
- [x] `npm run typecheck` in `desktop`
- [x] `npm run build` in `desktop`
- [x] `npm run typecheck` in `runtime/api-server`
- [x] `node --import tsx --test src/runtime-sentry.test.ts src/terminal-session-manager.test.ts` in `runtime/api-server`
- [x] `npm run test` in `runtime/api-server`

## Risks

- Sentry events now carry more attachments and opt-in screenshots when `SENTRY_DSN` is enabled, which increases telemetry volume and privacy sensitivity for tester environments
- diagnostics are still snapshot-based and cannot cover power loss, hard kills, or failures that occur before the app can flush telemetry

## Docs

- [ ] docs updated if setup, packaging, or public behavior changed
