### PR TITLE
fix: capture embedding request diagnostics in runtime sentry

### DIFF
--- a/runtime/api-server/src/memory-model-client.test.ts
+++ b/runtime/api-server/src/memory-model-client.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 
-import { queryMemoryModelJson } from "./memory-model-client.js";
+import {
+  queryMemoryModelEmbedding,
+  queryMemoryModelJson,
+} from "./memory-model-client.js";
 
 const ORIGINAL_FETCH = globalThis.fetch;
 type RecordedCall = { url: string; headers: HeadersInit | undefined; body: Record<string, unknown> | null };
@@ -148,4 +151,183 @@ test("queryMemoryModelJson uses Anthropic native messages with strict JSON promp
   assert.equal(recordedCall.body?.model, "claude-sonnet-4-6");
   assert.equal(recordedCall.body?.system, "Return JSON.");
   assert.deepEqual(recordedCall.body?.messages, [{ role: "user", content: "Hello" }]);
+});
+
+test("queryMemoryModelEmbedding uses OpenAI-compatible embeddings", async () => {
+  let call: RecordedCall | null = null;
+  globalThis.fetch = (async (input, init) => {
+    call = {
+      url: String(input),
+      headers: init?.headers,
+      body:
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : null,
+    };
+    return new Response(
+      JSON.stringify({
+        data: [
+          {
+            embedding: [0.25, 0.5, 0.75],
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  const embedding = await queryMemoryModelEmbedding(
+    {
+      baseUrl: "https://runtime.example/api/v1/model-proxy/openai/v1",
+      apiKey: "token-embedding",
+      modelId: "text-embedding-3-small",
+      apiStyle: "openai_compatible",
+    },
+    {
+      input: "Remember this workspace fact.",
+    },
+  );
+
+  assert.ok(embedding);
+  assert.deepEqual(Array.from(embedding ?? []), [0.25, 0.5, 0.75]);
+  assert.ok(call);
+  const recordedCall = call as RecordedCall;
+  assert.equal(
+    recordedCall.url,
+    "https://runtime.example/api/v1/model-proxy/openai/v1/embeddings",
+  );
+  assert.equal(
+    (recordedCall.headers as Record<string, string>).Authorization,
+    "Bearer token-embedding",
+  );
+  assert.deepEqual(recordedCall.body, {
+    model: "text-embedding-3-small",
+    input: "Remember this workspace fact.",
+    encoding_format: "float",
+  });
+});
+
+test("queryMemoryModelEmbedding captures redacted Sentry diagnostics on upstream failure", async () => {
+  const captures: Array<Record<string, unknown>> = [];
+  const embeddingInput =
+    "remember authorization=Bearer secret-token and workspace facts";
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: "upstream failed",
+        api_key: "sk-secret",
+      }),
+      {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      },
+    )) as typeof fetch;
+
+  const embedding = await queryMemoryModelEmbedding(
+    {
+      baseUrl: "https://runtime.example/api/v1/model-proxy/openai/v1",
+      apiKey: "token-embedding",
+      modelId: "text-embedding-3-small",
+      apiStyle: "openai_compatible",
+      defaultHeaders: {
+        "X-API-Key": "proxy-secret",
+        "X-Holaboss-User-Id": "user-1",
+        "X-Holaboss-Sandbox-Id": "desktop:sandbox-1",
+        "X-Holaboss-Session-Id": "session-1",
+        "X-Holaboss-Workspace-Id": "workspace-1",
+        "X-Holaboss-Input-Id": "input-1",
+      },
+    },
+    {
+      input: embeddingInput,
+    },
+    {
+      captureException(capture) {
+        captures.push(capture as unknown as Record<string, unknown>);
+      },
+    },
+  );
+
+  assert.equal(embedding, null);
+  assert.equal(captures.length, 1);
+  const capture = captures[0] as {
+    tags?: Record<string, unknown>;
+    contexts?: Record<string, Record<string, unknown>>;
+    attachments?: Array<{ filename: string; data: string | Uint8Array }>;
+  };
+  assert.equal(capture.tags?.surface, "memory_model_embedding");
+  assert.equal(capture.tags?.failure_kind, "upstream_non_ok");
+  assert.equal(capture.tags?.response_status, 502);
+  assert.equal(
+    capture.contexts?.memory_model_embedding_request?.workspace_id,
+    "workspace-1",
+  );
+  assert.equal(
+    capture.contexts?.memory_model_embedding_request?.session_id,
+    "session-1",
+  );
+  assert.equal(
+    capture.contexts?.memory_model_embedding_request?.input_id,
+    "input-1",
+  );
+  assert.equal(
+    capture.contexts?.memory_model_embedding_request?.model,
+    "text-embedding-3-small",
+  );
+  assert.equal(
+    capture.contexts?.memory_model_embedding_response?.status,
+    502,
+  );
+  const requestAttachment = capture.attachments?.find(
+    (attachment) => attachment.filename === "embedding-request.json",
+  );
+  const responseAttachment = capture.attachments?.find(
+    (attachment) => attachment.filename === "embedding-response.json",
+  );
+  assert.ok(requestAttachment);
+  assert.ok(responseAttachment);
+  const requestPayload = JSON.parse(String(requestAttachment?.data)) as Record<
+    string,
+    unknown
+  >;
+  const responsePayload = JSON.parse(String(responseAttachment?.data)) as Record<
+    string,
+    unknown
+  >;
+  assert.equal(requestPayload.endpoint, "https://runtime.example/api/v1/model-proxy/openai/v1/embeddings");
+  assert.deepEqual(requestPayload.headers, {
+    "Content-Type": "application/json",
+    "X-Holaboss-Input-Id": "input-1",
+    "X-Holaboss-Sandbox-Id": "desktop:sandbox-1",
+    "X-Holaboss-Session-Id": "session-1",
+    "X-Holaboss-User-Id": "user-1",
+    "X-Holaboss-Workspace-Id": "workspace-1",
+  });
+  assert.equal(
+    (requestPayload.body as Record<string, unknown>).model,
+    "text-embedding-3-small",
+  );
+  assert.equal(
+    (requestPayload.body as Record<string, unknown>).encoding_format,
+    "float",
+  );
+  assert.equal(
+    (requestPayload.body as Record<string, unknown>).input_length,
+    embeddingInput.length,
+  );
+  assert.match(
+    String((requestPayload.body as Record<string, unknown>).input_preview),
+    /\[REDACTED\]/,
+  );
+  assert.equal(responsePayload.status, 502);
+  assert.equal(responsePayload.content_type, "application/json");
+  assert.doesNotMatch(
+    String(responsePayload.body_preview),
+    /sk-secret/,
+  );
+  assert.match(String(responsePayload.body_preview), /\[REDACTED\]/);
 });

--- a/runtime/api-server/src/memory-model-client.ts
+++ b/runtime/api-server/src/memory-model-client.ts
@@ -1,5 +1,20 @@
 import { createHash } from "node:crypto";
 
+import {
+  captureRuntimeException,
+  redactRuntimeSentryText,
+  redactRuntimeSentryValue,
+  type RuntimeSentryCaptureOptions,
+} from "./runtime-sentry.js";
+
+const MEMORY_MODEL_EMBEDDING_INPUT_PREVIEW_CHARS = 8_192;
+const MEMORY_MODEL_EMBEDDING_RESPONSE_PREVIEW_CHARS = 4_096;
+const MEMORY_MODEL_SENSITIVE_HEADER_NAMES = new Set([
+  "authorization",
+  "cookie",
+  "x-api-key",
+]);
+
 export interface MemoryModelClientConfig {
   baseUrl: string;
   apiKey: string;
@@ -17,6 +32,10 @@ export interface MemoryModelJsonQuery {
 export interface MemoryModelEmbeddingQuery {
   input: string;
   timeoutMs?: number;
+}
+
+interface QueryMemoryModelEmbeddingOptions {
+  captureException?: (options: RuntimeSentryCaptureOptions) => void;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -84,6 +103,18 @@ function parseJsonObjectCandidate(text: string): Record<string, unknown> | null 
   try {
     const parsed = JSON.parse(fenced[1]);
     return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonValueCandidate(text: string): unknown | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
   } catch {
     return null;
   }
@@ -158,6 +189,193 @@ export function modelCallFingerprint(params: {
       })
     )
     .digest("hex");
+}
+
+function textFingerprint(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function headerValue(
+  headers: Record<string, string>,
+  headerName: string,
+): string {
+  const normalizedHeaderName = headerName.trim().toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.trim().toLowerCase() === normalizedHeaderName) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function sentrySafeHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers)
+      .filter(([key, value]) => {
+        if (!value.trim()) {
+          return false;
+        }
+        return !MEMORY_MODEL_SENSITIVE_HEADER_NAMES.has(
+          key.trim().toLowerCase(),
+        );
+      })
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+  );
+}
+
+function sentryTextPreview(
+  text: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  return {
+    text: `${text.slice(0, maxChars)}\n...[truncated]`,
+    truncated: true,
+  };
+}
+
+function responseTextForSentry(text: string): string {
+  const parsed = parseJsonValueCandidate(text);
+  if (parsed !== null) {
+    return `${JSON.stringify(redactRuntimeSentryValue(parsed), null, 2)}\n`;
+  }
+  return redactRuntimeSentryText(text);
+}
+
+function captureEmbeddingFailure(params: {
+  captureException?: (options: RuntimeSentryCaptureOptions) => void;
+  error: unknown;
+  failureKind:
+    | "request_exception"
+    | "upstream_non_ok"
+    | "invalid_json"
+    | "invalid_payload";
+  endpoint: string;
+  headers: Record<string, string>;
+  requestBody: {
+    model: string;
+    input: string;
+    encoding_format: "float";
+  };
+  responseStatus?: number;
+  responseContentType?: string;
+  responseText?: string;
+}): void {
+  const inputPreview = sentryTextPreview(
+    redactRuntimeSentryText(params.requestBody.input),
+    MEMORY_MODEL_EMBEDDING_INPUT_PREVIEW_CHARS,
+  );
+  const safeHeaders = sentrySafeHeaders(params.headers);
+  const normalizedResponseText = params.responseText ?? "";
+  const formattedResponseText = normalizedResponseText
+    ? responseTextForSentry(normalizedResponseText)
+    : "";
+  const responsePreview = formattedResponseText
+    ? sentryTextPreview(
+        formattedResponseText,
+        MEMORY_MODEL_EMBEDDING_RESPONSE_PREVIEW_CHARS,
+      )
+    : null;
+  const requestContext = {
+    endpoint: params.endpoint,
+    model: params.requestBody.model,
+    encoding_format: params.requestBody.encoding_format,
+    workspace_id:
+      headerValue(params.headers, "x-holaboss-workspace-id") || null,
+    session_id: headerValue(params.headers, "x-holaboss-session-id") || null,
+    input_id: headerValue(params.headers, "x-holaboss-input-id") || null,
+    sandbox_id: headerValue(params.headers, "x-holaboss-sandbox-id") || null,
+    user_id: headerValue(params.headers, "x-holaboss-user-id") || null,
+    input_length: params.requestBody.input.length,
+    input_sha256: textFingerprint(params.requestBody.input),
+    input_truncated: inputPreview.truncated,
+  };
+  const attachments: RuntimeSentryCaptureOptions["attachments"] = [
+    {
+      filename: "embedding-request.json",
+      data: `${JSON.stringify(
+        {
+          endpoint: params.endpoint,
+          headers: safeHeaders,
+          body: {
+            model: params.requestBody.model,
+            input_preview: inputPreview.text,
+            input_length: params.requestBody.input.length,
+            input_sha256: textFingerprint(params.requestBody.input),
+            input_truncated: inputPreview.truncated,
+            encoding_format: params.requestBody.encoding_format,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      contentType: "application/json",
+    },
+  ];
+  const responseContext =
+    params.responseStatus !== undefined ||
+    params.responseContentType ||
+    normalizedResponseText
+      ? {
+          status: params.responseStatus ?? null,
+          content_type: params.responseContentType || null,
+          body_length: normalizedResponseText.length,
+          body_sha256: normalizedResponseText
+            ? textFingerprint(normalizedResponseText)
+            : null,
+          body_truncated: responsePreview?.truncated ?? false,
+        }
+      : null;
+  if (responseContext) {
+    attachments.push({
+      filename: "embedding-response.json",
+      data: `${JSON.stringify(
+        {
+          status: params.responseStatus ?? null,
+          content_type: params.responseContentType || null,
+          body_length: normalizedResponseText.length,
+          body_sha256: normalizedResponseText
+            ? textFingerprint(normalizedResponseText)
+            : null,
+          body_truncated: responsePreview?.truncated ?? false,
+          body_preview: responsePreview?.text ?? "",
+        },
+        null,
+        2,
+      )}\n`,
+      contentType: "application/json",
+    });
+  }
+  (params.captureException ?? captureRuntimeException)({
+    error: params.error,
+    level: "error",
+    tags: {
+      surface: "memory_model_embedding",
+      failure_kind: params.failureKind,
+      embedding_model: params.requestBody.model,
+      ...(params.responseStatus !== undefined
+        ? { response_status: params.responseStatus }
+        : {}),
+    },
+    contexts: {
+      memory_model_embedding_request: requestContext,
+      ...(responseContext
+        ? { memory_model_embedding_response: responseContext }
+        : {}),
+    },
+    fingerprint: [
+      "memory-model-embedding",
+      params.failureKind,
+      params.responseStatus !== undefined
+        ? String(params.responseStatus)
+        : params.requestBody.model,
+    ],
+    attachments,
+  });
 }
 
 export async function queryMemoryModelJson(
@@ -252,7 +470,8 @@ export async function queryMemoryModelJson(
 
 export async function queryMemoryModelEmbedding(
   config: MemoryModelClientConfig,
-  query: MemoryModelEmbeddingQuery
+  query: MemoryModelEmbeddingQuery,
+  options: QueryMemoryModelEmbeddingOptions = {},
 ): Promise<Float32Array | null> {
   const baseUrl = config.baseUrl.trim().replace(/\/+$/, "");
   const modelId = normalizeOpenAiModelId(config.modelId);
@@ -280,25 +499,73 @@ export async function queryMemoryModelEmbedding(
   if (!hasExplicitAuthHeader(headers) && config.apiKey.trim()) {
     headers.Authorization = `Bearer ${config.apiKey.trim()}`;
   }
+  const endpoint = `${baseUrl}/embeddings`;
+  const requestBody = {
+    model: modelId,
+    input: normalizedInput,
+    encoding_format: "float" as const,
+  };
   const controller = new AbortController();
   const timeoutMs = Math.max(1000, Math.min(query.timeoutMs ?? 7000, 20000));
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(`${baseUrl}/embeddings`, {
+    const response = await fetch(endpoint, {
       method: "POST",
       headers,
       signal: controller.signal,
-      body: JSON.stringify({
-        model: modelId,
-        input: normalizedInput,
-        encoding_format: "float",
-      }),
+      body: JSON.stringify(requestBody),
     });
+    const responseText = await response.text().catch(() => "");
+    const responseContentType = firstNonEmptyString(
+      response.headers.get("content-type"),
+    );
     if (!response.ok) {
+      captureEmbeddingFailure({
+        captureException: options.captureException,
+        error: new Error(
+          `Memory model embedding request failed with status ${response.status}`,
+        ),
+        failureKind: "upstream_non_ok",
+        endpoint,
+        headers,
+        requestBody,
+        responseStatus: response.status,
+        responseContentType,
+        responseText,
+      });
       return null;
     }
-    const payload = await response.json().catch(() => null);
+    const payload = parseJsonValueCandidate(responseText);
+    if (payload === null) {
+      captureEmbeddingFailure({
+        captureException: options.captureException,
+        error: new Error(
+          "Memory model embedding response was not valid JSON",
+        ),
+        failureKind: "invalid_json",
+        endpoint,
+        headers,
+        requestBody,
+        responseStatus: response.status,
+        responseContentType,
+        responseText,
+      });
+      return null;
+    }
     if (!isRecord(payload) || !Array.isArray(payload.data) || payload.data.length === 0 || !isRecord(payload.data[0])) {
+      captureEmbeddingFailure({
+        captureException: options.captureException,
+        error: new Error(
+          "Memory model embedding response did not contain a usable embedding payload",
+        ),
+        failureKind: "invalid_payload",
+        endpoint,
+        headers,
+        requestBody,
+        responseStatus: response.status,
+        responseContentType,
+        responseText,
+      });
       return null;
     }
     const embedding = Array.isArray(payload.data[0].embedding) ? payload.data[0].embedding : [];
@@ -306,10 +573,31 @@ export async function queryMemoryModelEmbedding(
       .map((value) => (typeof value === "number" ? value : Number(value)))
       .filter((value) => Number.isFinite(value));
     if (values.length === 0) {
+      captureEmbeddingFailure({
+        captureException: options.captureException,
+        error: new Error(
+          "Memory model embedding response contained no numeric embedding values",
+        ),
+        failureKind: "invalid_payload",
+        endpoint,
+        headers,
+        requestBody,
+        responseStatus: response.status,
+        responseContentType,
+        responseText,
+      });
       return null;
     }
     return new Float32Array(values);
-  } catch {
+  } catch (error) {
+    captureEmbeddingFailure({
+      captureException: options.captureException,
+      error,
+      failureKind: "request_exception",
+      endpoint,
+      headers,
+      requestBody,
+    });
     return null;
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Context
This change makes embedding-call failures reconstructable in Sentry from the runtime caller side.

When `/embeddings` fails, the runtime now captures redacted request and response diagnostics instead of just returning `null`, so we can see the selected model, Holaboss workspace/session identifiers, a stable input fingerprint, and upstream response metadata without exposing secrets.

## What Changed
- capture redacted `embedding-request.json` and `embedding-response.json` attachments for outbound embedding failures
- include structured Sentry tags and contexts for model, workspace, session, input, status, and response metadata
- keep the successful embedding path and request shape unchanged
- add focused tests for the embedding request path and the new failure telemetry

## Validation
- `node --import tsx --test src/memory-model-client.test.ts`
- `npm run typecheck` in `runtime/api-server`
- `npm test` in `runtime/api-server`
- `npm run typecheck` in `runtime/state-store`

## Notes
- only the runtime API server files are included in this PR; unrelated local desktop edits were left out of the commit
