### PR TITLE
fix: stabilize chat composer draft hydration across workspace switches

### DIFF
--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -696,6 +696,14 @@ test("chat pane exposes an in-pane session dropdown for switching agent sessions
   );
   assert.match(
     source,
+    /const draftHydrationWorkspaceIdRef = useRef\(\(selectedWorkspaceId \|\| ""\)\.trim\(\)\);/,
+  );
+  assert.match(
+    source,
+    /const skipNextComposerDraftPublishRef = useRef\(false\);/,
+  );
+  assert.match(
+    source,
     /const localSessionOpenRequestRef =\s*useRef<ChatPaneSessionOpenRequest \| null>\(null\);/,
   );
   assert.match(source, /const effectiveSessionOpenRequest =\s*sessionOpenRequest \?\? localSessionOpenRequest;/);
@@ -705,11 +713,11 @@ test("chat pane exposes an in-pane session dropdown for switching agent sessions
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*setInput\(\(current\) =>\s*current === composerDraftText \? current : composerDraftText,\s*\);\s*\}, \[composerDraftText\]\);/,
+    /useEffect\(\(\) => \{\s*const normalizedWorkspaceId = \(selectedWorkspaceId \|\| ""\)\.trim\(\);\s*if \(draftHydrationWorkspaceIdRef\.current === normalizedWorkspaceId\) \{\s*return;\s*\}\s*draftHydrationWorkspaceIdRef\.current = normalizedWorkspaceId;\s*skipNextComposerDraftPublishRef\.current = true;\s*setInput\(\(current\) =>\s*current === composerDraftText \? current : composerDraftText,\s*\);\s*\}, \[composerDraftText, selectedWorkspaceId\]\);/,
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*onComposerDraftTextChange\?\.\(input\);\s*\}, \[input, onComposerDraftTextChange\]\);/,
+    /useEffect\(\(\) => \{\s*if \(skipNextComposerDraftPublishRef\.current\) \{\s*skipNextComposerDraftPublishRef\.current = false;\s*return;\s*\}\s*onComposerDraftTextChange\?\.\(input\);\s*\}, \[input, onComposerDraftTextChange\]\);/,
   );
   assert.match(source, /function setLocalSessionOpenRequestState\(/);
   assert.match(source, /function sessionStatusIndicator\(statusLabel: string\)/);
@@ -833,11 +841,19 @@ test("chat pane mirrors composer draft text from shell state", async () => {
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*setInput\(\(current\) =>\s*current === composerDraftText \? current : composerDraftText,\s*\);\s*\}, \[composerDraftText\]\);/,
+    /const draftHydrationWorkspaceIdRef = useRef\(\(selectedWorkspaceId \|\| ""\)\.trim\(\)\);/,
   );
   assert.match(
     source,
-    /useEffect\(\(\) => \{\s*onComposerDraftTextChange\?\.\(input\);\s*\}, \[input, onComposerDraftTextChange\]\);/,
+    /const skipNextComposerDraftPublishRef = useRef\(false\);/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*const normalizedWorkspaceId = \(selectedWorkspaceId \|\| ""\)\.trim\(\);\s*if \(draftHydrationWorkspaceIdRef\.current === normalizedWorkspaceId\) \{\s*return;\s*\}\s*draftHydrationWorkspaceIdRef\.current = normalizedWorkspaceId;\s*skipNextComposerDraftPublishRef\.current = true;\s*setInput\(\(current\) =>\s*current === composerDraftText \? current : composerDraftText,\s*\);\s*\}, \[composerDraftText, selectedWorkspaceId\]\);/,
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\) => \{\s*if \(skipNextComposerDraftPublishRef\.current\) \{\s*skipNextComposerDraftPublishRef\.current = false;\s*return;\s*\}\s*onComposerDraftTextChange\?\.\(input\);\s*\}, \[input, onComposerDraftTextChange\]\);/,
   );
 });
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -3273,6 +3273,8 @@ export function ChatPane({
   const localSessionOpenRequestRef =
     useRef<ChatPaneSessionOpenRequest | null>(null);
   const draftParentSessionIdRef = useRef<string | null>(null);
+  const draftHydrationWorkspaceIdRef = useRef((selectedWorkspaceId || "").trim());
+  const skipNextComposerDraftPublishRef = useRef(false);
   const liveAssistantSegmentsRef = useRef<ChatAssistantSegment[]>([]);
   const liveAssistantTextRef = useRef("");
   const liveExecutionItemsRef = useRef<ChatExecutionTimelineItem[]>([]);
@@ -4622,12 +4624,22 @@ export function ChatPane({
   }, [selectedWorkspaceId]);
 
   useEffect(() => {
+    const normalizedWorkspaceId = (selectedWorkspaceId || "").trim();
+    if (draftHydrationWorkspaceIdRef.current === normalizedWorkspaceId) {
+      return;
+    }
+    draftHydrationWorkspaceIdRef.current = normalizedWorkspaceId;
+    skipNextComposerDraftPublishRef.current = true;
     setInput((current) =>
       current === composerDraftText ? current : composerDraftText,
     );
-  }, [composerDraftText]);
+  }, [composerDraftText, selectedWorkspaceId]);
 
   useEffect(() => {
+    if (skipNextComposerDraftPublishRef.current) {
+      skipNextComposerDraftPublishRef.current = false;
+      return;
+    }
     onComposerDraftTextChange?.(input);
   }, [input, onComposerDraftTextChange]);
 


### PR DESCRIPTION
## Context

A tester reported the desktop chat composer flashing and refusing input. The issue was not captured in Sentry, but the draft mirroring path in `ChatPane` could publish stale textarea state back into the newly selected workspace during workspace/view transitions.

## Changes

- hydrate the chat composer from shell-scoped draft state only when the selected workspace changes
- skip the next outward draft publish after workspace hydration so stale textarea text is not written into the new workspace bucket
- add chat pane regressions covering the workspace hydration guard and skipped publish path

## Validation

- `node --test --test-name-pattern "chat pane mirrors composer draft text from shell state|app shell passes workspace-scoped chat composer drafts into the chat pane|app shell passes new session requests into the chat pane selector" src/components/panes/ChatPane.test.mjs src/components/layout/AppShell.test.mjs`
- `npm run typecheck`

## Notes

- I did not rerun the full `ChatPane.test.mjs` file because this branch already has unrelated baseline failures in that broader source-structure suite.
