### PR TITLE
fix: align harness registry browser tool expectations

### DIFF
--- a/runtime/api-server/src/harness-registry.test.ts
+++ b/runtime/api-server/src/harness-registry.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 
+import { DESKTOP_BROWSER_TOOL_IDS } from "../../harnesses/src/desktop-browser-tools.js";
 import {
   listRuntimeHarnessAdapters,
   normalizeHarnessId,
@@ -95,20 +96,7 @@ test("requireRuntimeHarnessPlugin stages browser tools only for workspace sessio
     }),
     {
       changed: false,
-      toolIds: [
-        "browser_navigate",
-        "browser_open_tab",
-        "browser_get_state",
-        "browser_click",
-        "browser_type",
-        "browser_press",
-        "browser_scroll",
-        "browser_back",
-        "browser_forward",
-        "browser_reload",
-        "browser_screenshot",
-        "browser_list_tabs"
-      ]
+      toolIds: [...DESKTOP_BROWSER_TOOL_IDS]
     }
   );
   assert.deepEqual(


### PR DESCRIPTION
## Context
The previous browser capability change added `browser_context_click`, but `runtime/api-server/src/harness-registry.test.ts` still asserted against a hand-maintained browser tool list. That left CI failing in the `runtime-api-server` job even though the runtime code was correct.

## What Changed
- update the harness registry browser staging test to use the shared `DESKTOP_BROWSER_TOOL_IDS` constant
- remove the stale hard-coded browser tool expectation that omitted `browser_context_click`
- keep the test aligned automatically with future browser tool additions

## Validation
- `npm run typecheck` in `runtime/api-server`
- `npm run test` in `runtime/api-server`

## Notes
- no runtime behavior change; this is a CI/test expectation fix only
- no Supabase or migration impact
