### PR TITLE
chore(desktop): UX cleanup across settings, runtime status, and panes

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -288,7 +288,7 @@ const DEV_SHELL_CSP = [
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: http: https:",
   "font-src 'self' data:",
-  "connect-src 'self' http://localhost:* ws://localhost:* https: wss:",
+  "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss:",
   "worker-src 'self' blob:",
   // App surfaces are rendered in renderer iframes and resolve to local
   // runtime ports such as http://localhost:38090 during development.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -864,8 +864,7 @@
     "../sdk/app-sdk/node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "../sdk/app-sdk/node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -976,7 +975,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1717,7 +1715,6 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1933,7 +1930,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -2444,8 +2440,7 @@
     "../sdk/app-sdk/node_modules/openapi-types": {
       "version": "12.1.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "../sdk/app-sdk/node_modules/openapi3-ts": {
       "version": "4.5.0",
@@ -2714,7 +2709,6 @@
       "version": "19.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2859,7 +2853,6 @@
       "version": "1.0.0-rc.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3316,7 +3309,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3421,7 +3413,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3806,7 +3797,6 @@
     "../sdk/app-sdk/node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3833,7 +3823,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4248,7 +4237,6 @@
     "node_modules/@better-auth/core": {
       "version": "1.5.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -4366,12 +4354,10 @@
     },
     "node_modules/@better-auth/utils": {
       "version": "0.3.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "peer": true
+      "version": "1.1.21"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -4854,6 +4840,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4873,6 +4860,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4887,6 +4875,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4899,8 +4888,30 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -5896,6 +5907,7 @@
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6064,7 +6076,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6082,7 +6093,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -6093,7 +6103,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6452,7 +6461,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6467,7 +6475,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -6483,7 +6490,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7857,7 +7863,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7913,18 +7918,19 @@
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8025,7 +8031,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8051,7 +8056,6 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8590,7 +8594,6 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8698,7 +8701,6 @@
     "node_modules/better-auth": {
       "version": "1.5.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -8802,7 +8804,6 @@
     "node_modules/better-call": {
       "version": "1.3.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -8822,7 +8823,6 @@
       "version": "12.8.0",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8904,7 +8904,6 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8945,7 +8944,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8963,6 +8961,7 @@
     "node_modules/bson": {
       "version": "7.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -9609,7 +9608,6 @@
     "node_modules/conf": {
       "version": "15.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -9828,7 +9826,8 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10016,7 +10015,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10043,7 +10041,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10093,7 +10090,6 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10153,7 +10149,6 @@
       "version": "26.8.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -10349,7 +10344,6 @@
     "node_modules/eciesjs/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -10392,7 +10386,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -10581,6 +10574,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10599,6 +10593,7 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10745,7 +10740,6 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10754,7 +10748,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10803,7 +10796,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11677,7 +11669,6 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -11694,7 +11685,6 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.7.4",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -11706,7 +11696,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11775,7 +11764,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11871,7 +11859,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12377,7 +12364,6 @@
     "node_modules/jose": {
       "version": "6.2.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12434,7 +12420,6 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -12522,7 +12507,6 @@
     "node_modules/kysely": {
       "version": "0.28.14",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -12983,7 +12967,6 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13259,7 +13242,8 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -14088,6 +14072,7 @@
     "node_modules/mongodb-connection-string-url": {
       "version": "7.0.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -14208,7 +14193,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -14439,7 +14423,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14915,6 +14898,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14930,6 +14914,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -15202,7 +15187,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15210,7 +15194,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15499,7 +15482,6 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -15721,7 +15703,6 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15772,7 +15753,6 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16273,7 +16253,6 @@
       "version": "2.8.7",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -16339,13 +16318,13 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -16672,6 +16651,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16849,6 +16829,7 @@
     "node_modules/tr46": {
       "version": "5.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -17017,7 +16998,6 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -17064,7 +17044,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17397,7 +17376,6 @@
     "node_modules/vite": {
       "version": "8.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17528,6 +17506,7 @@
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -17535,6 +17514,7 @@
     "node_modules/whatwg-url": {
       "version": "14.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -17642,7 +17622,6 @@
     "node_modules/yaml": {
       "version": "2.8.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17767,7 +17746,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -12,6 +12,8 @@
         "@better-auth/electron": "^1.5.5",
         "@fontsource-variable/inter": "^5.2.8",
         "@holaboss/app-sdk": "file:../sdk/app-sdk",
+        "@iconify-json/catppuccin": "^1.2.17",
+        "@iconify/react": "^6.0.2",
         "@sentry/electron": "^7.11.0",
         "@tailwindcss/vite": "^4.2.1",
         "archiver": "^7.0.1",
@@ -862,7 +864,8 @@
     "../sdk/app-sdk/node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "../sdk/app-sdk/node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -973,6 +976,7 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1713,6 +1717,7 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1928,6 +1933,7 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -2438,7 +2444,8 @@
     "../sdk/app-sdk/node_modules/openapi-types": {
       "version": "12.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "../sdk/app-sdk/node_modules/openapi3-ts": {
       "version": "4.5.0",
@@ -2707,6 +2714,7 @@
       "version": "19.2.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2851,6 +2859,7 @@
       "version": "1.0.0-rc.12",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3307,6 +3316,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3411,6 +3421,7 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3795,6 +3806,7 @@
     "../sdk/app-sdk/node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3821,6 +3833,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4235,6 +4248,7 @@
     "node_modules/@better-auth/core": {
       "version": "1.5.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -4352,10 +4366,12 @@
     },
     "node_modules/@better-auth/utils": {
       "version": "0.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21"
+      "version": "1.1.21",
+      "peer": true
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -4838,7 +4854,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4858,7 +4873,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4873,7 +4887,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4886,30 +4899,8 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -5525,6 +5516,36 @@
         "hono": "^4"
       }
     },
+    "node_modules/@iconify-json/catppuccin": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@iconify-json/catppuccin/-/catppuccin-1.2.17.tgz",
+      "integrity": "sha512-l1pFOADEUlw+j7V+yfFzBowdE4deeMuI4amqfKaN+7uTI9B0Ho24C86DitQk5zb62NkEM9poOyfuG7WS2bw6jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
+      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
       "license": "MIT",
@@ -5875,7 +5896,6 @@
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6044,6 +6064,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6061,6 +6082,7 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -6071,6 +6093,7 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6429,6 +6452,7 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6443,6 +6467,7 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -6458,6 +6483,7 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7831,6 +7857,7 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7886,19 +7913,18 @@
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7999,6 +8025,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8024,6 +8051,7 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8562,6 +8590,7 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8669,6 +8698,7 @@
     "node_modules/better-auth": {
       "version": "1.5.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -8772,6 +8802,7 @@
     "node_modules/better-call": {
       "version": "1.3.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -8791,6 +8822,7 @@
       "version": "12.8.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8872,6 +8904,7 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8912,6 +8945,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8929,7 +8963,6 @@
     "node_modules/bson": {
       "version": "7.2.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -9576,6 +9609,7 @@
     "node_modules/conf": {
       "version": "15.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -9794,8 +9828,7 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -9983,6 +10016,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10009,6 +10043,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10058,6 +10093,7 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10117,6 +10153,7 @@
       "version": "26.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -10312,6 +10349,7 @@
     "node_modules/eciesjs/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -10354,6 +10392,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -10542,7 +10581,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10561,7 +10599,6 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10708,6 +10745,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10716,6 +10754,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10764,6 +10803,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11637,6 +11677,7 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -11653,6 +11694,7 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -11664,6 +11706,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11732,6 +11775,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11827,6 +11871,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12332,6 +12377,7 @@
     "node_modules/jose": {
       "version": "6.2.2",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12388,6 +12434,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -12475,6 +12522,7 @@
     "node_modules/kysely": {
       "version": "0.28.14",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -12935,6 +12983,7 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13210,8 +13259,7 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -14040,7 +14088,6 @@
     "node_modules/mongodb-connection-string-url": {
       "version": "7.0.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -14161,6 +14208,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -14391,6 +14439,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14866,7 +14915,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14882,7 +14930,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -15155,6 +15202,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15162,6 +15210,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15450,6 +15499,7 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -15671,6 +15721,7 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15721,6 +15772,7 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16221,6 +16273,7 @@
       "version": "2.8.7",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -16286,13 +16339,13 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -16619,7 +16672,6 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16797,7 +16849,6 @@
     "node_modules/tr46": {
       "version": "5.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -16966,6 +17017,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -17012,6 +17064,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17344,6 +17397,7 @@
     "node_modules/vite": {
       "version": "8.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17474,7 +17528,6 @@
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -17482,7 +17535,6 @@
     "node_modules/whatwg-url": {
       "version": "14.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -17590,6 +17642,7 @@
     "node_modules/yaml": {
       "version": "2.8.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17714,6 +17767,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -60,6 +60,8 @@
     "@better-auth/electron": "^1.5.5",
     "@fontsource-variable/inter": "^5.2.8",
     "@holaboss/app-sdk": "file:../sdk/app-sdk",
+    "@iconify-json/catppuccin": "^1.2.17",
+    "@iconify/react": "^6.0.2",
     "@sentry/electron": "^7.11.0",
     "@tailwindcss/vite": "^4.2.1",
     "archiver": "^7.0.1",

--- a/desktop/src/components/billing/BillingSettingsPanel.test.mjs
+++ b/desktop/src/components/billing/BillingSettingsPanel.test.mjs
@@ -9,12 +9,12 @@ test("billing settings panel renders a standalone billing page", async () => {
 
   assert.match(source, /BillingSummaryCard/);
   assert.match(source, /useDesktopBilling/);
-  assert.match(source, /Hosted credits and managed usage for this desktop account\./);
   assert.match(source, /void refresh\(\);/);
-  assert.match(source, /Refreshing\.\.\./);
-  assert.match(source, /"Refreshing\.\.\." : "Refresh"/);
+  assert.match(source, /aria-label=\{isLoading \? "Refreshing usage" : "Refresh usage"\}/);
+  assert.match(source, /\{isLoading \? "Refreshing\.\.\." : "Refresh"\}/);
   assert.match(source, /Usage record/);
   assert.match(source, /Reactivate/);
+  assert.doesNotMatch(source, /Hosted credits and managed usage for this desktop account\./);
   assert.doesNotMatch(source, /Website usage & billing/);
   assert.doesNotMatch(source, /Billing overview/);
   assert.doesNotMatch(source, /Holaboss credits apply to managed desktop usage only\./);

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpRight,
   ChevronRight,
   Gift,
+  RefreshCw,
   ShoppingCart,
   Sparkles,
   UserCog,
@@ -12,6 +13,11 @@ import {
 } from "lucide-react";
 import { BillingSummaryCard } from "@/components/billing/BillingSummaryCard";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
 
 // ============================================================================
@@ -233,7 +239,7 @@ function UsageRow({ item }: { item: UsageItem }) {
   const subtitle = resolveUsageSubtitle(item);
 
   return (
-    <div className="flex items-center justify-between gap-3 py-2">
+    <div className="flex items-center justify-between gap-3 py-3">
       <div className="flex min-w-0 items-center gap-2.5">
         <div
           className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${
@@ -294,7 +300,7 @@ function UsageGroupRow({
     <div>
       {/* Group header */}
       <div
-        className="flex cursor-pointer items-center justify-between gap-3 py-2 transition-colors hover:bg-accent/30"
+        className="flex cursor-pointer items-center justify-between gap-3 py-3 transition-colors hover:bg-accent/30"
         onClick={onToggle}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -422,17 +428,66 @@ export function BillingSettingsPanel() {
         links={links}
         isLoading={isLoading}
         error={error}
-        onRefresh={() => void refresh()}
+        onRefresh={() => {
+          void refresh();
+        }}
       />
+
       <section className="grid gap-2 rounded-[24px] border border-border/40 bg-card/40 px-4 py-3">
-        <div className="text-lg font-semibold text-foreground">
-          Usage record
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-lg font-semibold text-foreground">
+            Usage record
+          </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={isLoading ? "Refreshing usage" : "Refresh usage"}
+                  onClick={() => {
+                    void refresh();
+                  }}
+                  disabled={isLoading}
+                />
+              }
+            >
+              <RefreshCw
+                size={14}
+                className={isLoading ? "animate-spin" : ""}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {isLoading ? "Refreshing..." : "Refresh"}
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <div className="divide-y divide-border/30">
-          {groups.length === 0 ? (
+          {isLoading && groups.length === 0 ? (
+            <div
+              role="status"
+              aria-busy="true"
+              aria-label="Loading usage"
+              className="py-1"
+            >
+              {[80, 96, 64].map((w) => (
+                <div key={w} className="flex items-center gap-2.5 py-3">
+                  <span className="h-7 w-7 shrink-0 animate-pulse rounded-full bg-muted-foreground/20" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span
+                      className="h-3 animate-pulse rounded bg-muted-foreground/20"
+                      style={{ width: `${w}%` }}
+                    />
+                    <span className="h-2.5 w-32 animate-pulse rounded bg-muted-foreground/20" />
+                  </div>
+                  <span className="h-3 w-10 shrink-0 animate-pulse rounded bg-muted-foreground/20" />
+                </div>
+              ))}
+            </div>
+          ) : groups.length === 0 ? (
             <div className="py-3 text-sm text-muted-foreground">
-              {isLoading ? "Loading usage..." : "No usage yet."}
+              No usage yet.
             </div>
           ) : (
             groups.map((group) => (

--- a/desktop/src/components/billing/BillingSummaryCard.tsx
+++ b/desktop/src/components/billing/BillingSummaryCard.tsx
@@ -60,12 +60,69 @@ export function BillingSummaryCard({
   error = null,
   onRefresh,
 }: BillingSummaryCardProps) {
+  if (isLoading) {
+    return (
+      <section
+        role="status"
+        aria-busy="true"
+        aria-label="Loading billing summary"
+        className="rounded-xl border border-border/40 px-4 py-4"
+      >
+        {/* Header skeleton */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="h-4 w-24 animate-pulse rounded bg-muted-foreground/20" />
+            <span className="h-5 w-20 animate-pulse rounded-full bg-muted-foreground/20" />
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {onRefresh ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Refresh billing"
+                onClick={onRefresh}
+                disabled
+              >
+                <RefreshCw size={13} className="animate-spin" />
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Stats grid skeleton */}
+        <div className="mt-4 border-t border-border/40 pt-4">
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <div>
+              <span className="block h-6 w-16 animate-pulse rounded bg-muted-foreground/20" />
+              <span className="mt-1 block h-3 w-12 animate-pulse rounded bg-muted-foreground/20" />
+            </div>
+            <div className="text-right">
+              <span className="ml-auto block h-6 w-14 animate-pulse rounded bg-muted-foreground/20" />
+              <span className="mt-1 ml-auto block h-3 w-12 animate-pulse rounded bg-muted-foreground/20" />
+            </div>
+          </div>
+
+          {/* Bottom stats skeleton */}
+          <div className="mt-3 grid gap-1.5 border-t border-border/30 pt-3">
+            {[72, 56, 64].map((w) => (
+              <div key={w} className="flex items-center justify-between">
+                <span
+                  className="h-3 animate-pulse rounded bg-muted-foreground/20"
+                  style={{ width: `${w}px` }}
+                />
+                <span className="h-3 w-10 animate-pulse rounded bg-muted-foreground/20" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   const hasOverview = Boolean(overview);
-  const creditsValue = isLoading
-    ? "..."
-    : hasOverview
-      ? (overview?.creditsBalance ?? 0).toLocaleString()
-      : "—";
+  const creditsValue = hasOverview
+    ? (overview?.creditsBalance ?? 0).toLocaleString()
+    : "—";
 
   const timelineLabel = billingTimelineLabel(overview);
 
@@ -75,9 +132,9 @@ export function BillingSummaryCard({
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <span className="truncate text-sm font-semibold text-foreground">
-            {isLoading ? "Loading..." : overview?.planName || "Free"}
+            {overview?.planName || "Free"}
           </span>
-          {!isLoading && timelineLabel !== "Billing managed on web" ? (
+          {timelineLabel !== "Billing managed on web" ? (
             <Badge variant="outline" className="shrink-0 text-muted-foreground">
               {timelineLabel}
             </Badge>
@@ -91,39 +148,32 @@ export function BillingSummaryCard({
               size="icon-sm"
               aria-label="Refresh billing"
               onClick={onRefresh}
-              disabled={isLoading}
             >
-              <RefreshCw size={13} className={isLoading ? "animate-spin" : ""} />
+              <RefreshCw size={13} />
             </Button>
           ) : null}
-          {!isLoading ? (
-            <>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => openBillingLink(links?.billingPageUrl)}
-              >
-                Manage
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => openBillingLink(links?.addCreditsUrl)}
-              >
-                Add credits
-              </Button>
-            </>
-          ) : null}
+          <Button
+            variant="ghost"
+            onClick={() => openBillingLink(links?.billingPageUrl)}
+          >
+            Manage
+          </Button>
+          <Button
+            onClick={() => openBillingLink(links?.addCreditsUrl)}
+          >
+            Add credits
+          </Button>
         </div>
       </div>
 
       {error ? (
-        <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+        <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
           {error.message}
         </div>
       ) : null}
 
-      {!isLoading && !hasOverview && !error ? (
-        <div className="mt-3 rounded-md border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+      {!hasOverview && !error ? (
+        <div className="mt-3 rounded-md border border-border/40 px-3 py-2 text-sm text-muted-foreground">
           Sign in to view billing details.
         </div>
       ) : null}
@@ -134,7 +184,7 @@ export function BillingSummaryCard({
             <div className="text-lg font-semibold tabular-nums text-foreground">
               {creditsValue}
             </div>
-            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1 text-sm text-muted-foreground">
               <span>Credits</span>
               <Popover>
                 <PopoverTrigger
@@ -166,11 +216,11 @@ export function BillingSummaryCard({
             <div className="text-lg font-semibold tabular-nums text-foreground">
               {overview?.monthlyCreditsIncluded?.toLocaleString() ?? "—"}
             </div>
-            <div className="text-xs text-muted-foreground">Monthly</div>
+            <div className="text-sm text-muted-foreground">Monthly</div>
           </div>
         </div>
 
-        <div className="mt-3 grid gap-1.5 border-t border-border/30 pt-3 text-xs text-muted-foreground">
+        <div className="mt-3 grid gap-1.5 border-t border-border/30 pt-3 text-sm text-muted-foreground">
           <div className="flex items-center justify-between">
             <span>Total allocated</span>
             <span className="tabular-nums text-foreground">

--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface CreditsPillProps {
@@ -14,6 +14,20 @@ export function CreditsPill({
   isLowBalance = false,
   onClick,
 }: CreditsPillProps) {
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-busy="true"
+        aria-label="Loading credits balance"
+        className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border/55 px-2.5"
+      >
+        <span className="size-3 animate-pulse rounded-full bg-muted-foreground/20" />
+        <span className="h-3 w-10 animate-pulse rounded bg-muted-foreground/20" />
+      </div>
+    );
+  }
+
   return (
     <Button
       type="button"
@@ -27,13 +41,9 @@ export function CreditsPill({
       }`}
       aria-label="Open credits and billing details"
     >
-      {isLoading ? (
-        <Loader2 size={13} className="animate-spin" />
-      ) : (
-        <Sparkles size={13} className="opacity-80" />
-      )}
+      <Sparkles className="opacity-80" />
       <span className="font-medium tabular-nums">
-        {isLoading ? "..." : (balance ?? 0).toLocaleString()}
+        {(balance ?? 0).toLocaleString()}
       </span>
     </Button>
   );

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import {
   OperationsInboxPane,
   type OperationsDrawerTab,
 } from "@/components/layout/OperationsDrawer";
+import { RuntimeStatusIndicator } from "@/components/layout/RuntimeStatusIndicator";
 import { SettingsDialog } from "@/components/layout/SettingsDialog";
 import { TopTabsBar } from "@/components/layout/TopTabsBar";
 import { WorkspaceAppsDialog } from "@/components/layout/WorkspaceAppsDialog";
@@ -348,7 +349,9 @@ function isPathWithin(parentPath: string, targetPath: string) {
 function buildReportedSurfaceFromInternalView(params: {
   owner: OperatorSurfaceOwner;
   active: boolean;
-  view: Extract<AgentView, { type: "internal" }> | Extract<SpaceDisplayView, { type: "internal" }>;
+  view:
+    | Extract<AgentView, { type: "internal" }>
+    | Extract<SpaceDisplayView, { type: "internal" }>;
 }): OperatorSurfacePayload | null {
   const resourceId = nonEmptySurfaceText(params.view.resourceId);
   const ownerLabel = params.owner === "user" ? "User" : "Agent";
@@ -391,7 +394,9 @@ function buildReportedSurfaceFromInternalView(params: {
 function buildReportedSurfaceFromAppView(params: {
   owner: OperatorSurfaceOwner;
   active: boolean;
-  view: Extract<AgentView, { type: "app" }> | Extract<SpaceDisplayView, { type: "app" }>;
+  view:
+    | Extract<AgentView, { type: "app" }>
+    | Extract<SpaceDisplayView, { type: "app" }>;
 }): OperatorSurfacePayload {
   const resourceId = nonEmptySurfaceText(params.view.resourceId);
   const routePath = nonEmptySurfaceText(params.view.path);
@@ -460,7 +465,8 @@ function buildReportedOperatorSurfaceContext(params: {
     return null;
   }
 
-  const activeSurface = surfaces.find((surface) => surface.active) ?? surfaces[0];
+  const activeSurface =
+    surfaces.find((surface) => surface.active) ?? surfaces[0];
   return {
     active_surface_id: activeSurface?.surface_id ?? null,
     surfaces,
@@ -586,8 +592,7 @@ function buildTaskProposalToastNotification(params: {
     cronjob_id: null,
     source_type: "task_proposal",
     source_label: "Task proposals",
-    title:
-      proposalCount === 1 ? "Task proposal ready" : "Task proposals ready",
+    title: proposalCount === 1 ? "Task proposal ready" : "Task proposals ready",
     message:
       proposalCount === 1
         ? `"${firstProposalName}" is ready to review in the inbox${workspaceQualifier}.`
@@ -1146,8 +1151,7 @@ function AppShellContent() {
   const [publishOpen, setPublishOpen] = useState(false);
   const [createWorkspacePanelOpen, setCreateWorkspacePanelOpen] =
     useState(false);
-  const [workspaceAppsDialogOpen, setWorkspaceAppsDialogOpen] =
-    useState(false);
+  const [workspaceAppsDialogOpen, setWorkspaceAppsDialogOpen] = useState(false);
   const [
     createWorkspacePanelAnchorWorkspaceId,
     setCreateWorkspacePanelAnchorWorkspaceId,
@@ -1161,10 +1165,15 @@ function AppShellContent() {
   } | null>(null);
   const [chatSessionOpenRequest, setChatSessionOpenRequest] =
     useState<ChatSessionOpenRequest | null>(null);
-  const [chatBrowserJumpRequestKeysBySessionId, setChatBrowserJumpRequestKeysBySessionId] =
-    useState<Record<string, number>>({});
-  const [chatComposerDraftTextByWorkspace, setChatComposerDraftTextByWorkspace] =
-    useState<Record<string, string>>({});
+  const [
+    chatBrowserJumpRequestKeysBySessionId,
+    setChatBrowserJumpRequestKeysBySessionId,
+  ] = useState<Record<string, number>>({});
+  const [browserDisplayFlashNonce, setBrowserDisplayFlashNonce] = useState(0);
+  const [
+    chatComposerDraftTextByWorkspace,
+    setChatComposerDraftTextByWorkspace,
+  ] = useState<Record<string, string>>({});
   const [chatComposerPrefillRequest, setChatComposerPrefillRequest] =
     useState<ChatComposerPrefillRequest | null>(null);
   const [chatExplorerAttachmentRequest, setChatExplorerAttachmentRequest] =
@@ -2130,8 +2139,17 @@ function AppShellContent() {
         .setActiveWorkspace(selectedWorkspaceId, "agent", normalizedSessionId)
         .catch(() => undefined);
       consumeChatBrowserJumpRequest(normalizedSessionId, requestKey);
+      setBrowserDisplayFlashNonce((current) => current + 1);
     },
     [consumeChatBrowserJumpRequest, revealBrowserPane, selectedWorkspaceId],
+  );
+
+  const hasPendingAgentJump = useMemo(
+    () =>
+      Object.values(chatBrowserJumpRequestKeysBySessionId).some(
+        (value) => value > 0,
+      ),
+    [chatBrowserJumpRequestKeysBySessionId],
   );
 
   const activeChatBrowserJumpRequest = useMemo(() => {
@@ -2805,36 +2823,36 @@ function AppShellContent() {
     [],
   );
 
-  const handleOpenAutomationRunSession = useCallback((
-    sessionId: string,
-    workspaceId?: string | null,
-  ) => {
-    const normalizedSessionId = sessionId.trim();
-    const normalizedWorkspaceId =
-      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
-    if (!normalizedSessionId) {
-      return;
-    }
-    if (!normalizedWorkspaceId) {
-      return;
-    }
+  const handleOpenAutomationRunSession = useCallback(
+    (sessionId: string, workspaceId?: string | null) => {
+      const normalizedSessionId = sessionId.trim();
+      const normalizedWorkspaceId =
+        workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
+      if (!normalizedSessionId) {
+        return;
+      }
+      if (!normalizedWorkspaceId) {
+        return;
+      }
 
-    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
-      setSelectedWorkspaceId(normalizedWorkspaceId);
-    }
+      if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+        setSelectedWorkspaceId(normalizedWorkspaceId);
+      }
 
-    setActiveShellView("space");
-    setSpaceVisibility((previous) => ({
-      ...previous,
-      agent: true,
-    }));
-    setAgentView({ type: "chat" });
-    setChatSessionJumpRequest({
-      sessionId: normalizedSessionId,
-      requestKey: Date.now(),
-    });
-    setChatFocusRequestKey((current) => current + 1);
-  }, [selectedWorkspaceId, setSelectedWorkspaceId]);
+      setActiveShellView("space");
+      setSpaceVisibility((previous) => ({
+        ...previous,
+        agent: true,
+      }));
+      setAgentView({ type: "chat" });
+      setChatSessionJumpRequest({
+        sessionId: normalizedSessionId,
+        requestKey: Date.now(),
+      });
+      setChatFocusRequestKey((current) => current + 1);
+    },
+    [selectedWorkspaceId, setSelectedWorkspaceId],
+  );
 
   const nextChatSessionOpenRequestKey = useCallback(() => {
     chatSessionOpenRequestKeyRef.current += 1;
@@ -2851,87 +2869,91 @@ function AppShellContent() {
     return chatExplorerAttachmentRequestKeyRef.current;
   }, []);
 
-  const handleCreateScheduleInChat = useCallback((workspaceId?: string | null) => {
-    const normalizedWorkspaceId =
-      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
-    if (!normalizedWorkspaceId) {
-      return;
-    }
+  const handleCreateScheduleInChat = useCallback(
+    (workspaceId?: string | null) => {
+      const normalizedWorkspaceId =
+        workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
+      if (!normalizedWorkspaceId) {
+        return;
+      }
 
-    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
-      setSelectedWorkspaceId(normalizedWorkspaceId);
-    }
+      if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+        setSelectedWorkspaceId(normalizedWorkspaceId);
+      }
 
-    setActiveShellView("space");
-    setSpaceVisibility((previous) => ({
-      ...previous,
-      agent: true,
-    }));
-    setAgentView({ type: "chat" });
-    setChatSessionJumpRequest(null);
-    setChatSessionOpenRequest({
-      sessionId: "",
-      mode: "draft",
-      parentSessionId: null,
-      requestKey: nextChatSessionOpenRequestKey(),
-    });
-    setChatComposerPrefillRequest({
-      text: "Create a cronjob for ",
-      requestKey: nextChatComposerPrefillRequestKey(),
-      mode: "replace",
-    });
-    setChatFocusRequestKey((current) => current + 1);
-  }, [
-    nextChatComposerPrefillRequestKey,
-    nextChatSessionOpenRequestKey,
-    selectedWorkspaceId,
-    setSelectedWorkspaceId,
-  ]);
+      setActiveShellView("space");
+      setSpaceVisibility((previous) => ({
+        ...previous,
+        agent: true,
+      }));
+      setAgentView({ type: "chat" });
+      setChatSessionJumpRequest(null);
+      setChatSessionOpenRequest({
+        sessionId: "",
+        mode: "draft",
+        parentSessionId: null,
+        requestKey: nextChatSessionOpenRequestKey(),
+      });
+      setChatComposerPrefillRequest({
+        text: "Create a cronjob for ",
+        requestKey: nextChatComposerPrefillRequestKey(),
+        mode: "replace",
+      });
+      setChatFocusRequestKey((current) => current + 1);
+    },
+    [
+      nextChatComposerPrefillRequestKey,
+      nextChatSessionOpenRequestKey,
+      selectedWorkspaceId,
+      setSelectedWorkspaceId,
+    ],
+  );
 
-  const handleEditScheduleInChat = useCallback((
-    job: CronjobRecordPayload,
-    workspaceId?: string | null,
-  ) => {
-    const normalizedWorkspaceId =
-      workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
-    if (!normalizedWorkspaceId) {
-      return;
-    }
+  const handleEditScheduleInChat = useCallback(
+    (job: CronjobRecordPayload, workspaceId?: string | null) => {
+      const normalizedWorkspaceId =
+        workspaceId?.trim() || selectedWorkspaceId?.trim() || "";
+      if (!normalizedWorkspaceId) {
+        return;
+      }
 
-    if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
-      setSelectedWorkspaceId(normalizedWorkspaceId);
-    }
+      if (normalizedWorkspaceId !== (selectedWorkspaceId?.trim() || "")) {
+        setSelectedWorkspaceId(normalizedWorkspaceId);
+      }
 
-    const jobName =
-      job.name?.trim() || job.description?.trim() || "Untitled schedule";
-    const instruction = job.instruction?.trim() || job.description?.trim() || "";
-    setActiveShellView("space");
-    setSpaceVisibility((previous) => ({
-      ...previous,
-      agent: true,
-    }));
-    setAgentView({ type: "chat" });
-    setChatSessionJumpRequest(null);
-    setChatSessionOpenRequest({
-      sessionId: "",
-      mode: "draft",
-      parentSessionId: null,
-      requestKey: nextChatSessionOpenRequestKey(),
-    });
-    setChatComposerPrefillRequest({
-      text:
-        `Edit cronjob "${jobName}" (id: ${job.id}). Current cron: ${job.cron}. ` +
-        `Current instruction: ${instruction}\n\nUpdate it to: `,
-      requestKey: nextChatComposerPrefillRequestKey(),
-      mode: "replace",
-    });
-    setChatFocusRequestKey((current) => current + 1);
-  }, [
-    nextChatComposerPrefillRequestKey,
-    nextChatSessionOpenRequestKey,
-    selectedWorkspaceId,
-    setSelectedWorkspaceId,
-  ]);
+      const jobName =
+        job.name?.trim() || job.description?.trim() || "Untitled schedule";
+      const instruction =
+        job.instruction?.trim() || job.description?.trim() || "";
+      setActiveShellView("space");
+      setSpaceVisibility((previous) => ({
+        ...previous,
+        agent: true,
+      }));
+      setAgentView({ type: "chat" });
+      setChatSessionJumpRequest(null);
+      setChatSessionOpenRequest({
+        sessionId: "",
+        mode: "draft",
+        parentSessionId: null,
+        requestKey: nextChatSessionOpenRequestKey(),
+      });
+      setChatComposerPrefillRequest({
+        text:
+          `Edit cronjob "${jobName}" (id: ${job.id}). Current cron: ${job.cron}. ` +
+          `Current instruction: ${instruction}\n\nUpdate it to: `,
+        requestKey: nextChatComposerPrefillRequestKey(),
+        mode: "replace",
+      });
+      setChatFocusRequestKey((current) => current + 1);
+    },
+    [
+      nextChatComposerPrefillRequestKey,
+      nextChatSessionOpenRequestKey,
+      selectedWorkspaceId,
+      setSelectedWorkspaceId,
+    ],
+  );
 
   const handleCreateSession = useCallback(
     (request?: {
@@ -3064,7 +3086,8 @@ function AppShellContent() {
         return;
       }
       if (
-        (displayView.surface === "document" || displayView.surface === "file") &&
+        (displayView.surface === "document" ||
+          displayView.surface === "file") &&
         displayView.resourceId?.trim()
       ) {
         setFileExplorerFocusRequest({
@@ -3147,7 +3170,9 @@ function AppShellContent() {
         ) {
           return current;
         }
-        if (!isPathWithin(normalizedDeletedPath, current.resourceId?.trim() ?? "")) {
+        if (
+          !isPathWithin(normalizedDeletedPath, current.resourceId?.trim() ?? "")
+        ) {
           return current;
         }
         return { type: "chat" };
@@ -3160,7 +3185,9 @@ function AppShellContent() {
         ) {
           return current;
         }
-        if (!isPathWithin(normalizedDeletedPath, current.resourceId?.trim() ?? "")) {
+        if (
+          !isPathWithin(normalizedDeletedPath, current.resourceId?.trim() ?? "")
+        ) {
           return current;
         }
         if (selectedWorkspaceId) {
@@ -3172,7 +3199,10 @@ function AppShellContent() {
       });
 
       setFileExplorerFocusRequest((current) => {
-        if (!current?.path || !isPathWithin(normalizedDeletedPath, current.path)) {
+        if (
+          !current?.path ||
+          !isPathWithin(normalizedDeletedPath, current.path)
+        ) {
           return current;
         }
         return null;
@@ -3362,7 +3392,11 @@ function AppShellContent() {
     const nextDisplayView = lastDisplayView ?? spaceDisplayView;
     setSpaceDisplayView(nextDisplayView);
     syncFileExplorerFocusWithDisplayView(nextDisplayView);
-  }, [selectedWorkspaceId, spaceDisplayView, syncFileExplorerFocusWithDisplayView]);
+  }, [
+    selectedWorkspaceId,
+    spaceDisplayView,
+    syncFileExplorerFocusWithDisplayView,
+  ]);
 
   const restoreLastSpaceAppDisplayView = useCallback(() => {
     if (!selectedWorkspaceId) {
@@ -3440,34 +3474,31 @@ function AppShellContent() {
     };
   }, [reportedOperatorSurfaceContext, selectedWorkspaceId]);
 
-  const handleSyncAgentOperationFileDisplay = useCallback(
-    (path: string) => {
-      const targetPath = path.trim();
-      if (!targetPath) {
-        return;
-      }
+  const handleSyncAgentOperationFileDisplay = useCallback((path: string) => {
+    const targetPath = path.trim();
+    if (!targetPath) {
+      return;
+    }
 
-      setActiveShellView("space");
-      setSpaceExplorerMode("files");
-      setSpaceExplorerCollapsed(false);
-      setSpaceVisibility((previous) => ({
-        ...previous,
-        agent: true,
-        files: true,
-      }));
-      setAgentView({ type: "chat" });
-      setSpaceDisplayView({
-        type: "internal",
-        surface: "file",
-        resourceId: targetPath,
-      });
-      setFileExplorerFocusRequest({
-        path: targetPath,
-        requestKey: Date.now(),
-      });
-    },
-    [],
-  );
+    setActiveShellView("space");
+    setSpaceExplorerMode("files");
+    setSpaceExplorerCollapsed(false);
+    setSpaceVisibility((previous) => ({
+      ...previous,
+      agent: true,
+      files: true,
+    }));
+    setAgentView({ type: "chat" });
+    setSpaceDisplayView({
+      type: "internal",
+      surface: "file",
+      resourceId: targetPath,
+    });
+    setFileExplorerFocusRequest({
+      path: targetPath,
+      requestKey: Date.now(),
+    });
+  }, []);
 
   const handleOpenWorkspaceOutput = useCallback(
     (output: WorkspaceOutputRecordPayload) => {
@@ -3578,10 +3609,9 @@ function AppShellContent() {
     runtimeStatus,
     workspaceBlockingReason || workspaceErrorMessage,
   );
-  const bootstrapErrorMessage =
-    !hasHydratedWorkspaceList
-      ? runtimeStartupBlockedMessage(runtimeStatus, workspaceErrorMessage)
-      : "";
+  const bootstrapErrorMessage = !hasHydratedWorkspaceList
+    ? runtimeStartupBlockedMessage(runtimeStatus, workspaceErrorMessage)
+    : "";
   const hydratedRuntimeErrorMessage =
     hasHydratedWorkspaceList &&
     runtimeStartupBlockedDetail &&
@@ -3682,7 +3712,9 @@ function AppShellContent() {
           <MissingWorkspacePane
             workspaceName={selectedWorkspace.name}
             workspacePath={selectedWorkspace.workspace_path ?? null}
-            onRelocate={() => chooseWorkspaceRelocationFolder(selectedWorkspace.id)}
+            onRelocate={() =>
+              chooseWorkspaceRelocationFolder(selectedWorkspace.id)
+            }
             onDeleteRecord={async () => {
               await deleteWorkspace(selectedWorkspace.id);
             }}
@@ -3721,7 +3753,9 @@ function AppShellContent() {
           onJumpToSessionBrowser={handleJumpToSessionBrowser}
           onOpenInbox={handleOpenInboxPane}
           inboxUnreadCount={unreadTaskProposalCount}
-          onRequestCreateSession={(request) => void handleCreateSession(request)}
+          onRequestCreateSession={(request) =>
+            void handleCreateSession(request)
+          }
           composerDraftText={
             selectedWorkspaceId
               ? (chatComposerDraftTextByWorkspace[selectedWorkspaceId] ?? "")
@@ -3823,6 +3857,7 @@ function AppShellContent() {
           browserSpace={spaceBrowserSpace}
           suspendNativeView={shouldSuspendBrowserNativeView}
           layoutSyncKey={spaceDisplayLayoutSyncKey}
+          jumpPulseKey={browserDisplayFlashNonce}
           embedded
         />
       );
@@ -3875,6 +3910,7 @@ function AppShellContent() {
   }, [
     activeApp,
     activeAppId,
+    browserDisplayFlashNonce,
     handleMissingInternalResource,
     handleOpenLinkInNewAppBrowserTab,
     hasSelectedWorkspace,
@@ -3883,6 +3919,7 @@ function AppShellContent() {
     showOperationsDrawer,
     spaceAgentPaneWidth,
     spaceBrowserSpace,
+    spaceDisplayLayoutSyncKey,
     spaceDisplayView,
     spaceExplorerCollapsed,
     spaceExplorerMode,
@@ -4210,6 +4247,18 @@ function AppShellContent() {
         />
 
         {hasWorkspaces ? (
+          <div className="pointer-events-none absolute bottom-2 left-2 z-20 sm:bottom-4 sm:left-4">
+            <RuntimeStatusIndicator
+              status={runtimeStatus}
+              onClick={() => {
+                setSettingsDialogSection("providers");
+                setSettingsDialogOpen(true);
+              }}
+            />
+          </div>
+        ) : null}
+
+        {hasWorkspaces ? (
           <div className={titleBarContainerClassName}>
             <TopTabsBar
               integratedTitleBar={hasIntegratedTitleBar}
@@ -4268,20 +4317,20 @@ function AppShellContent() {
                               <div className="flex shrink-0 items-center gap-2 border-b border-border/45 px-3 py-2.5">
                                 <Tabs
                                   value={spaceExplorerMode}
-                                    onValueChange={(value) => {
-                                      const mode = value as SpaceExplorerMode;
-                                      setSpaceExplorerMode(mode);
-                                      if (mode === "browser") {
-                                        setSpaceDisplayView({
-                                          type: "browser",
-                                        });
-                                      } else if (mode === "applications") {
-                                        restoreLastSpaceAppDisplayView();
-                                      } else {
-                                        restoreLastSpaceFileDisplayView();
-                                      }
-                                    }}
-                                    className="min-w-0 flex-1"
+                                  onValueChange={(value) => {
+                                    const mode = value as SpaceExplorerMode;
+                                    setSpaceExplorerMode(mode);
+                                    if (mode === "browser") {
+                                      setSpaceDisplayView({
+                                        type: "browser",
+                                      });
+                                    } else if (mode === "applications") {
+                                      restoreLastSpaceAppDisplayView();
+                                    } else {
+                                      restoreLastSpaceFileDisplayView();
+                                    }
+                                  }}
+                                  className="min-w-0 flex-1"
                                 >
                                   <TabsList className="w-full">
                                     <TabsTrigger
@@ -4316,7 +4365,9 @@ function AppShellContent() {
                                 <Button
                                   variant="ghost"
                                   size="icon-sm"
-                                  onClick={() => setSpaceExplorerCollapsed(true)}
+                                  onClick={() =>
+                                    setSpaceExplorerCollapsed(true)
+                                  }
                                   aria-label="Collapse explorer"
                                 >
                                   <PanelLeftClose />
@@ -4376,6 +4427,7 @@ function AppShellContent() {
                                     onActivateDisplay={() =>
                                       setSpaceDisplayView({ type: "browser" })
                                     }
+                                    hasPendingAgentJump={hasPendingAgentJump}
                                   />
                                 ) : null}
                               </div>

--- a/desktop/src/components/layout/RuntimeStatusIndicator.tsx
+++ b/desktop/src/components/layout/RuntimeStatusIndicator.tsx
@@ -1,0 +1,67 @@
+interface RuntimeStatusIndicatorProps {
+  status: RuntimeStatusPayload | null;
+  onClick?: () => void;
+}
+
+function runtimeStatusVisual(status: RuntimeStatus | undefined): {
+  dotClass: string;
+  label: string;
+} {
+  switch (status) {
+    case "running":
+      return { dotClass: "bg-success", label: "Runtime running" };
+    case "starting":
+      return {
+        dotClass: "animate-pulse bg-warning",
+        label: "Runtime starting",
+      };
+    case "error":
+      return { dotClass: "bg-destructive", label: "Runtime error" };
+    case "missing":
+      return { dotClass: "bg-destructive", label: "Runtime missing" };
+    case "stopped":
+      return {
+        dotClass: "bg-muted-foreground/60",
+        label: "Runtime stopped",
+      };
+    case "disabled":
+      return {
+        dotClass: "bg-muted-foreground/40",
+        label: "Runtime disabled",
+      };
+    default:
+      return {
+        dotClass: "bg-muted-foreground/40",
+        label: "Runtime unknown",
+      };
+  }
+}
+
+export function RuntimeStatusIndicator({
+  status,
+  onClick,
+}: RuntimeStatusIndicatorProps) {
+  if (!status) {
+    return null;
+  }
+
+  const { dotClass, label } = runtimeStatusVisual(status.status);
+  const detail = status.lastError.trim();
+  const hoverText = detail || label;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={hoverText}
+      className="pointer-events-auto flex h-6 items-center gap-1.5 rounded-full border border-border/40 bg-background/70 px-2.5 text-[11px] font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground"
+    >
+      <span
+        className={`size-1.5 rounded-full ${dotClass}`}
+        aria-hidden="true"
+      />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/desktop/src/components/layout/SettingsDialog.test.mjs
+++ b/desktop/src/components/layout/SettingsDialog.test.mjs
@@ -20,10 +20,10 @@ test("settings dialog includes an automations section with a workspace selector"
   assert.match(source, /toolbarLeading=\{/);
   assert.match(source, /<Select\s+value=\{automationsWorkspaceId \|\| undefined\}/);
   assert.match(source, /onValueChange=\{\(value\) =>\s*setAutomationsWorkspaceId\(value \?\? ""\)\s*\}/);
-  assert.match(source, /<SelectTrigger className="min-w-\[220px\] rounded-full border-border\/40 bg-background\/80 px-3\.5 text-sm shadow-none sm:w-\[280px\]">/);
-  assert.match(source, /<SelectValue placeholder="Select workspace">/);
-  assert.match(source, /\{\(value: string \| null\) =>/);
-  assert.match(source, /workspaces\.find\(\(workspace\) => workspace\.id === value\)\?\.name/);
+  assert.match(source, /<SelectTrigger className="w-56">/);
+  assert.match(source, /<FolderKanban\s+size=\{14\}/);
+  assert.match(source, /placeholder=\{\s*workspaces\.length === 0\s*\? "No workspaces available"\s*: "Select workspace"\s*\}/);
+  assert.doesNotMatch(source, /<SelectTrigger className="min-w-\[220px\] rounded-full/);
   assert.match(source, /<AutomationsPane[\s\S]*workspaceId=\{automationsWorkspaceId \|\| null\}[\s\S]*showHeader=\{false\}[\s\S]*toolbarLeading=\{/);
   assert.match(source, /onEditSchedule=\{\(job\) => \{/);
   assert.match(source, /onEditAutomationSchedule\(automationsWorkspaceId, job\);/);

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import {
   CreditCard,
   ExternalLink,
   FileArchive,
+  FolderKanban,
   Globe,
   Info,
   Loader2,
@@ -400,7 +401,7 @@ export function SettingsDialog({
                   key={id}
                   type="button"
                   onClick={() => onSectionChange(id)}
-                  className={`flex h-8 items-center gap-2.5 rounded-lg px-2.5 text-left text-[13px] transition-colors ${
+                  className={`flex h-9 items-center gap-2.5 rounded-lg px-2.5 text-left text-sm transition-colors ${
                     active
                       ? "bg-sidebar-accent text-sidebar-accent-foreground"
                       : "text-sidebar-foreground/72 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
@@ -416,7 +417,7 @@ export function SettingsDialog({
 
         <section className="flex min-h-0 min-w-0 flex-col overflow-hidden">
           <header className="flex items-center justify-between gap-4 border-b border-border/35 px-6 py-4">
-            <div className="text-base font-semibold text-foreground">
+            <div className="text-lg font-semibold text-foreground">
               {titleForSection(activeSection)}
             </div>
 
@@ -456,9 +457,9 @@ export function SettingsDialog({
             ) : null}
 
             {activeSection === "settings" ? (
-              <div className="grid gap-5">
+              <div className="grid gap-6">
                 <section>
-                  <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                  <div className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
                     App
                   </div>
 
@@ -587,7 +588,7 @@ export function SettingsDialog({
                 </section>
 
                 <section>
-                  <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                  <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                     Appearance
                   </div>
 
@@ -633,7 +634,7 @@ export function SettingsDialog({
                           </div>
 
                           <div className="mt-2.5 flex items-center justify-between gap-2">
-                            <span className="text-[13px] font-medium text-foreground">
+                            <span className="text-sm font-medium text-foreground">
                               {prettifyThemeLabel(themeOption)}
                             </span>
                             {selected ? (
@@ -667,17 +668,20 @@ export function SettingsDialog({
                       }
                       disabled={workspaces.length === 0}
                     >
-                      <SelectTrigger className="min-w-[220px] rounded-full border-border/40 bg-background/80 px-3.5 text-sm shadow-none sm:w-[280px]">
-                        <SelectValue placeholder="Select workspace">
-                          {(value: string | null) =>
-                            value
-                              ? workspaces.find((workspace) => workspace.id === value)?.name ??
-                                "Select workspace"
+                      <SelectTrigger className="w-56">
+                        <FolderKanban
+                          size={14}
+                          className="text-muted-foreground"
+                        />
+                        <SelectValue
+                          placeholder={
+                            workspaces.length === 0
+                              ? "No workspaces available"
                               : "Select workspace"
                           }
-                        </SelectValue>
+                        />
                       </SelectTrigger>
-                      <SelectContent align="end">
+                      <SelectContent>
                         {workspaces.map((workspace) => (
                           <SelectItem key={workspace.id} value={workspace.id}>
                             {workspace.name}
@@ -711,7 +715,7 @@ export function SettingsDialog({
             {activeSection === "about" ? (
               <div className="grid max-w-[720px] gap-6">
                 <section>
-                  <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                  <div className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
                     Links
                   </div>
 
@@ -741,7 +745,7 @@ export function SettingsDialog({
                 </section>
 
                 <section>
-                  <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                  <div className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
                     Diagnostics
                   </div>
                   <div className="mt-4 rounded-xl border border-border/35 bg-background/70 px-4 py-4">

--- a/desktop/src/components/layout/TopTabsBar.test.mjs
+++ b/desktop/src/components/layout/TopTabsBar.test.mjs
@@ -57,7 +57,8 @@ test("top tabs bar renders custom compact window controls for Windows title bar 
   assert.doesNotMatch(source, /onOpenMarketplace\?: \(\) => void;/);
   assert.doesNotMatch(source, /isMarketplaceActive\?: boolean;/);
   assert.doesNotMatch(source, /LayoutGrid/);
-  assert.match(source, /render=\{<Button variant="outline" size="icon" className="relative rounded-lg" \/>\}/);
+  assert.match(source, /render=\{<Button variant="outline" size="icon" className="rounded-lg" \/>\}/);
+  assert.doesNotMatch(source, /absolute -right-0\.5 -top-0\.5 size-2 rounded-full ring-2 ring-background/);
   assert.match(source, /window\.electronAPI\.ui\.getWindowState\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.minimizeWindow\(\)/);
   assert.match(source, /window\.electronAPI\.ui\.closeWindow\(\)/);

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -95,7 +95,6 @@ export function TopTabsBar({
     deletingWorkspaceId,
     workspaceErrorMessage,
     deleteWorkspace,
-    runtimeStatus,
   } = useWorkspaceDesktop();
 
   const onDeleteWorkspace = async (workspace: WorkspaceRecordPayload) => {
@@ -367,20 +366,9 @@ export function TopTabsBar({
           <DropdownMenu>
             <DropdownMenuTrigger
               ref={userButtonRef}
-              render={<Button variant="outline" size="icon" className="relative rounded-lg" />}
+              render={<Button variant="outline" size="icon" className="rounded-lg" />}
             >
               <User2 />
-              <span
-                className={`absolute -right-0.5 -top-0.5 size-2 rounded-full ring-2 ring-background ${
-                  runtimeStatus?.status === "running"
-                    ? "bg-success"
-                    : runtimeStatus?.status === "starting"
-                      ? "animate-pulse bg-warning"
-                      : runtimeStatus?.status === "error"
-                        ? "bg-destructive"
-                        : "bg-muted-foreground/40"
-                }`}
-              />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={8} className="w-52">
               <DropdownMenuGroup>

--- a/desktop/src/components/panes/AutomationsPane.test.mjs
+++ b/desktop/src/components/panes/AutomationsPane.test.mjs
@@ -92,7 +92,7 @@ test("scheduled rows use a kebab menu for run, edit, and delete actions", async 
   assert.match(source, /const handleEdit = \(job: CronjobRecordPayload\) => \{/);
   assert.match(source, /if \(onEditSchedule\) \{\s*onEditSchedule\(job\);\s*return;\s*\}/);
   assert.match(source, /Actions for \$\{jobTitle\(job\)\}/);
-  assert.match(source, /<MoreHorizontal size=\{20\} \/>/);
+  assert.match(source, /<MoreHorizontal size=\{16\} \/>/);
   assert.match(source, /<Pencil size=\{16\} \/>/);
   assert.match(source, /Run now/);
   assert.match(source, /Edit/);
@@ -106,17 +106,10 @@ test("new schedule button uses the shared primary button style", async () => {
   assert.doesNotMatch(source, /bg-foreground/);
 });
 
-test("embedded automations toolbar uses the shared compact control height", async () => {
+test("automations toolbar uses shadcn Tabs primitive instead of custom pill buttons", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /theme-subtle-surface mt-5 inline-flex items-center rounded-full border border-border\/45 bg-muted\/40 p-1/);
-  assert.match(source, /min-w-\[124px\] rounded-full px-4 text-sm font-semibold/);
-  assert.doesNotMatch(source, /h-9 min-w-\[132px\]/);
-});
-
-test("automation tabs keep a distinct hover state instead of blending into the track", async () => {
-  const source = await readFile(sourcePath, "utf8");
-
-  assert.match(source, /bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground/);
-  assert.match(source, /text-muted-foreground hover:bg-background\/70 hover:text-foreground/);
+  assert.match(source, /from "@\/components\/ui\/tabs"/);
+  assert.match(source, /<TabsTrigger value="scheduled">/);
+  assert.match(source, /<TabsTrigger value="completed">/);
 });

--- a/desktop/src/components/panes/AutomationsPane.test.mjs
+++ b/desktop/src/components/panes/AutomationsPane.test.mjs
@@ -24,7 +24,7 @@ test("scheduled tab toggle updates cronjob enabled state", async () => {
 
   assert.match(source, /await window\.electronAPI\.workspace\.updateCronjob\(job\.id, \{\s*enabled: !job\.enabled,\s*\}\);/);
   assert.match(source, /setCronjobs\(\(previous\) =>\s*previous\.map\(\(item\) => \(item\.id === updated\.id \? updated : item\)\),\s*\);/);
-  assert.match(source, /aria-label=\{job\.enabled \? "Disable schedule" : "Enable schedule"\}/);
+  assert.match(source, /aria-label=\{\s*job\.enabled\s*\?\s*"Disable schedule"\s*:\s*"Enable schedule"\s*\}/);
 });
 
 test("scheduled rows expose a run-now action for each automation", async () => {
@@ -41,7 +41,7 @@ test("post-action refresh preserves the current banner and suppresses transient 
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(source, /interface RefreshDataOptions \{\s*preserveStatusMessage\?: boolean;\s*suppressErrors\?: boolean;\s*\}/);
-  assert.match(source, /const refreshData = useCallback\(async \(options\?: RefreshDataOptions\) => \{/);
+  assert.match(source, /const refreshData = useCallback\(\s*async \(options\?: RefreshDataOptions\) => \{/);
   assert.match(source, /if \(!preserveStatusMessage\) \{\s*setStatusMessage\(""\);\s*\}/);
   assert.match(source, /if \(!suppressErrors\) \{\s*setStatusTone\("error"\);\s*setStatusMessage\(normalizeErrorMessage\(error\)\);\s*\}/);
   assert.match(source, /void refreshData\(\{\s*preserveStatusMessage: true,\s*suppressErrors: true,\s*\}\);/);

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -1,8 +1,23 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
-import { Clock3, Loader2, MoreHorizontal, Pencil, Play, Plus, Trash2 } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  Clock3,
+  MoreHorizontal,
+  Pencil,
+  Play,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PaneCard } from "@/components/ui/PaneCard";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -110,7 +125,7 @@ function jobKindLabel(job: CronjobRecordPayload): string {
 function jobKindClassName(job: CronjobRecordPayload): string {
   const channel = jobDeliveryChannel(job);
   if (channel === "system_notification") {
-    return "border-[rgba(192,158,93,0.32)] bg-[rgba(250,244,227,0.92)] text-[rgba(114,86,34,0.96)]";
+    return "border-amber-300/40 bg-amber-400/10 text-amber-200";
   }
   if (channel === "session_run") {
     return "border-primary/25 bg-primary/10 text-primary";
@@ -215,68 +230,77 @@ export function AutomationsPane({
     setStatusMessage(message);
   };
 
-  const refreshData = useCallback(async (options?: RefreshDataOptions) => {
-    const preserveStatusMessage = options?.preserveStatusMessage ?? false;
-    const suppressErrors = options?.suppressErrors ?? false;
+  const refreshData = useCallback(
+    async (options?: RefreshDataOptions) => {
+      const preserveStatusMessage = options?.preserveStatusMessage ?? false;
+      const suppressErrors = options?.suppressErrors ?? false;
 
-    if (!activeWorkspaceId) {
-      setCronjobs([]);
-      setCompletedRuns([]);
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      const [cronjobsResponse, sessionsResponse, runtimeStatesResponse] =
-        await Promise.all([
-          window.electronAPI.workspace.listCronjobs(activeWorkspaceId),
-          window.electronAPI.workspace.listAgentSessions(activeWorkspaceId),
-          window.electronAPI.workspace.listRuntimeStates(activeWorkspaceId),
-        ]);
-
-      setCronjobs(cronjobsResponse.jobs);
-
-      const runtimeStateBySessionId = new Map(
-        runtimeStatesResponse.items.map((item) => [item.session_id, item]),
-      );
-
-      const nextCompletedRuns = sessionsResponse.items
-        .filter((session) => session.kind.trim().toLowerCase() === "cronjob")
-        .map((session) => {
-          const runtimeState = runtimeStateBySessionId.get(session.session_id);
-          const status = (runtimeState?.status || "IDLE").trim().toUpperCase();
-          const completedAt =
-            runtimeState?.updated_at || session.updated_at || session.created_at;
-          return {
-            sessionId: session.session_id,
-            title: session.title?.trim() || "Cronjob run",
-            completedAt,
-            status,
-            errorDetail: runtimeStateErrorMessage(runtimeState?.last_error),
-          };
-        })
-        .filter((run) => isTerminalRunStatus(run.status))
-        .sort((left, right) => {
-          const leftRaw = Date.parse(left.completedAt);
-          const rightRaw = Date.parse(right.completedAt);
-          const leftTs = Number.isNaN(leftRaw) ? 0 : leftRaw;
-          const rightTs = Number.isNaN(rightRaw) ? 0 : rightRaw;
-          return rightTs - leftTs;
-        });
-
-      setCompletedRuns(nextCompletedRuns);
-      if (!preserveStatusMessage) {
-        setStatusMessage("");
+      if (!activeWorkspaceId) {
+        setCronjobs([]);
+        setCompletedRuns([]);
+        return;
       }
-    } catch (error) {
-      if (!suppressErrors) {
-        setStatusTone("error");
-        setStatusMessage(normalizeErrorMessage(error));
+
+      setIsLoading(true);
+      try {
+        const [cronjobsResponse, sessionsResponse, runtimeStatesResponse] =
+          await Promise.all([
+            window.electronAPI.workspace.listCronjobs(activeWorkspaceId),
+            window.electronAPI.workspace.listAgentSessions(activeWorkspaceId),
+            window.electronAPI.workspace.listRuntimeStates(activeWorkspaceId),
+          ]);
+
+        setCronjobs(cronjobsResponse.jobs);
+
+        const runtimeStateBySessionId = new Map(
+          runtimeStatesResponse.items.map((item) => [item.session_id, item]),
+        );
+
+        const nextCompletedRuns = sessionsResponse.items
+          .filter((session) => session.kind.trim().toLowerCase() === "cronjob")
+          .map((session) => {
+            const runtimeState = runtimeStateBySessionId.get(
+              session.session_id,
+            );
+            const status = (runtimeState?.status || "IDLE")
+              .trim()
+              .toUpperCase();
+            const completedAt =
+              runtimeState?.updated_at ||
+              session.updated_at ||
+              session.created_at;
+            return {
+              sessionId: session.session_id,
+              title: session.title?.trim() || "Cronjob run",
+              completedAt,
+              status,
+              errorDetail: runtimeStateErrorMessage(runtimeState?.last_error),
+            };
+          })
+          .filter((run) => isTerminalRunStatus(run.status))
+          .sort((left, right) => {
+            const leftRaw = Date.parse(left.completedAt);
+            const rightRaw = Date.parse(right.completedAt);
+            const leftTs = Number.isNaN(leftRaw) ? 0 : leftRaw;
+            const rightTs = Number.isNaN(rightRaw) ? 0 : rightRaw;
+            return rightTs - leftTs;
+          });
+
+        setCompletedRuns(nextCompletedRuns);
+        if (!preserveStatusMessage) {
+          setStatusMessage("");
+        }
+      } catch (error) {
+        if (!suppressErrors) {
+          setStatusTone("error");
+          setStatusMessage(normalizeErrorMessage(error));
+        }
+      } finally {
+        setIsLoading(false);
       }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [activeWorkspaceId]);
+    },
+    [activeWorkspaceId],
+  );
 
   useEffect(() => {
     void refreshData();
@@ -376,9 +400,7 @@ export function AutomationsPane({
     <>
       <div className="relative min-h-0 flex-1 overflow-auto">
         <div className="mx-auto flex min-h-full max-w-5xl flex-col px-6 py-6">
-          <div
-            className="flex flex-wrap items-center justify-between gap-4"
-          >
+          <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="min-w-0">
               {showHeader ? (
                 <div>
@@ -386,7 +408,8 @@ export function AutomationsPane({
                     Automations
                   </h1>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Manage recurring schedules and review completed automation runs.
+                    Manage recurring schedules and review completed automation
+                    runs.
                   </p>
                 </div>
               ) : toolbarLeading ? (
@@ -405,57 +428,82 @@ export function AutomationsPane({
             </Button>
           </div>
 
-          <div className="theme-subtle-surface mt-5 inline-flex items-center rounded-full border border-border/45 bg-muted/40 p-1">
-            <div className="inline-flex items-center gap-1">
-              <Button
-                type="button"
-                variant={activeTab === "scheduled" ? "secondary" : "ghost"}
-                size="default"
-                onClick={() => setActiveTab("scheduled")}
-                className={`min-w-[124px] rounded-full px-4 text-sm font-semibold ${
-                  activeTab === "scheduled"
-                    ? "bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground"
-                    : "text-muted-foreground hover:bg-background/70 hover:text-foreground"
-                }`}
-              >
-                Scheduled
-              </Button>
-              <Button
-                type="button"
-                variant={activeTab === "completed" ? "secondary" : "ghost"}
-                size="default"
-                onClick={() => setActiveTab("completed")}
-                className={`min-w-[124px] rounded-full px-4 text-sm font-semibold ${
-                  activeTab === "completed"
-                    ? "bg-background text-foreground shadow-sm hover:bg-background hover:text-foreground"
-                    : "text-muted-foreground hover:bg-background/70 hover:text-foreground"
-                }`}
-              >
-                Completed
-              </Button>
-            </div>
-          </div>
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as "scheduled" | "completed")}
+            className="mt-5"
+          >
+            <TabsList>
+              <TabsTrigger value="scheduled">Scheduled</TabsTrigger>
+              <TabsTrigger value="completed">Completed</TabsTrigger>
+            </TabsList>
+          </Tabs>
 
           {statusMessage ? (
             <div className="mt-4">
-              <div className={`rounded-xl border px-3 py-2 text-xs ${statusClassName}`}>
+              <div
+                className={`rounded-xl border px-3 py-2 text-sm ${statusClassName}`}
+              >
                 {statusMessage}
               </div>
             </div>
           ) : null}
 
-          <div className="mt-5 min-h-0 flex-1 overflow-hidden rounded-[24px] border border-border/40 bg-background/70">
+          <div className="mt-5 min-h-0 flex-1 overflow-hidden rounded-2xl border border-border/40 bg-background/70">
             {!activeWorkspaceId ? (
               <EmptyState message={emptyWorkspaceMessage} />
-            ) : isLoading && scheduledJobs.length === 0 && completedRuns.length === 0 ? (
-              <EmptyState message="Loading automations..." />
+            ) : isLoading &&
+              scheduledJobs.length === 0 &&
+              completedRuns.length === 0 ? (
+              <div
+                role="status"
+                aria-busy="true"
+                aria-label="Loading automations"
+                className="flex h-full min-h-0 flex-col"
+              >
+                <div className="shrink-0 border-b border-border/30 px-4 py-4 sm:px-5">
+                  <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    <span>Title</span>
+                    <span>Schedule at</span>
+                    <span>Status</span>
+                    <span />
+                  </div>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  {[
+                    { titleW: "w-36", scheduleW: "w-28" },
+                    { titleW: "w-48", scheduleW: "w-32" },
+                    { titleW: "w-40", scheduleW: "w-24" },
+                    { titleW: "w-44", scheduleW: "w-36" },
+                  ].map((row, index) => (
+                    <div
+                      key={index}
+                      className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border/20 px-4 py-4 sm:px-5"
+                    >
+                      <div className="flex flex-col gap-1.5 pr-2">
+                        <span
+                          className={`h-4 ${row.titleW} animate-pulse rounded bg-muted-foreground/20`}
+                        />
+                        <span className="h-2.5 w-16 animate-pulse rounded bg-muted/40" />
+                      </div>
+                      <span
+                        className={`h-4 ${row.scheduleW} animate-pulse rounded bg-muted-foreground/20`}
+                      />
+                      <span className="h-5 w-9 animate-pulse rounded-full bg-muted-foreground/20" />
+                      <div className="flex justify-end">
+                        <span className="size-7 animate-pulse rounded-md bg-muted-foreground/20" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             ) : activeTab === "scheduled" ? (
               scheduledJobs.length === 0 ? (
                 <EmptyState message="No scheduled tasks in this workspace." />
               ) : (
                 <div className="flex h-full min-h-0 flex-col">
                   <div className="shrink-0 border-b border-border/30 px-4 py-4 sm:px-5">
-                    <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/75">
+                    <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
                       <span>Title</span>
                       <span>Schedule at</span>
                       <span>Status</span>
@@ -469,10 +517,10 @@ export function AutomationsPane({
                       return (
                         <div
                           key={job.id}
-                          className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border/20 px-4 py-4 transition-colors hover:bg-accent/20 sm:px-5"
+                          className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border/20 px-4 py-4 transition-colors hover:bg-accent sm:px-5"
                         >
                           <div className="min-w-0 pr-2">
-                            <div className="truncate text-[18px] font-medium tracking-[-0.02em] text-foreground">
+                            <div className="truncate text-sm font-medium text-foreground">
                               {jobTitle(job)}
                             </div>
                             {jobKindLabel(job) !== "Automation" ? (
@@ -486,56 +534,52 @@ export function AutomationsPane({
                               </div>
                             ) : null}
                             {job.last_error ? (
-                              <div className="mt-1 truncate text-xs text-destructive/85">
+                              <div className="mt-1 truncate text-xs text-destructive">
                                 {job.last_error}
                               </div>
                             ) : null}
                           </div>
 
-                          <div className="truncate text-[18px] tracking-[-0.02em] text-muted-foreground">
+                          <div className="truncate text-sm text-muted-foreground">
                             {scheduleAtLabel(job)}
                           </div>
 
                           <div>
-                            <button
-                              type="button"
+                            <Switch
+                              checked={job.enabled}
+                              onCheckedChange={() =>
+                                void handleToggleEnabled(job)
+                              }
                               disabled={isBusy}
-                              onClick={() => void handleToggleEnabled(job)}
-                              aria-label={job.enabled ? "Disable schedule" : "Enable schedule"}
-                              className={`relative inline-flex h-[34px] w-[52px] items-center rounded-full border transition-colors ${
+                              aria-label={
                                 job.enabled
-                                  ? "border-primary/40 bg-primary/85"
-                                  : "border-border/60 bg-muted/75"
-                              } disabled:cursor-not-allowed disabled:opacity-45`}
-                            >
-                              <span
-                                className={`size-5 rounded-full bg-background shadow-sm transition-transform ${
-                                  job.enabled
-                                    ? "translate-x-7"
-                                    : "translate-x-1"
-                                }`}
-                              />
-                              {isBusy ? (
-                                <span className="absolute inset-0 grid place-items-center">
-                                  <Loader2 size={11} className="animate-spin text-muted-foreground" />
-                                </span>
-                              ) : null}
-                            </button>
+                                  ? "Disable schedule"
+                                  : "Enable schedule"
+                              }
+                            />
                           </div>
 
                           <div className="flex justify-end">
                             <DropdownMenu>
                               <DropdownMenuTrigger
-                                aria-label={`Actions for ${jobTitle(job)}`}
-                                className="grid size-10 place-items-center rounded-2xl border border-border/30 bg-muted/30 text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
+                                render={
+                                  <Button
+                                    variant="ghost"
+                                    size="icon-sm"
+                                    aria-label={`Actions for ${jobTitle(job)}`}
+                                  />
+                                }
                               >
-                                <MoreHorizontal size={20} />
+                                <MoreHorizontal size={16} />
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" sideOffset={8} className="w-48 rounded-[20px] p-1.5">
+                              <DropdownMenuContent
+                                align="end"
+                                sideOffset={8}
+                                className="w-48"
+                              >
                                 <DropdownMenuItem
                                   onClick={() => void handleRunNow(job)}
                                   disabled={isBusy}
-                                  className="min-h-11 rounded-[14px] text-base"
                                 >
                                   <Play size={16} />
                                   Run now
@@ -543,7 +587,6 @@ export function AutomationsPane({
                                 <DropdownMenuItem
                                   onClick={() => handleEdit(job)}
                                   disabled={isBusy}
-                                  className="min-h-11 rounded-[14px] text-base"
                                 >
                                   <Pencil size={16} />
                                   Edit
@@ -552,7 +595,6 @@ export function AutomationsPane({
                                   onClick={() => void handleDelete(job)}
                                   disabled={isBusy}
                                   variant="destructive"
-                                  className="min-h-11 rounded-[14px] text-base"
                                 >
                                   <Trash2 size={16} />
                                   Delete
@@ -571,7 +613,7 @@ export function AutomationsPane({
             ) : (
               <div className="flex h-full min-h-0 flex-col">
                 <div className="shrink-0 border-b border-border/30 px-4 py-4 sm:px-5">
-                  <div className="grid grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/75">
+                  <div className="grid grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     <span>Title</span>
                     <span>Completed at</span>
                     <span>Status</span>
@@ -585,20 +627,20 @@ export function AutomationsPane({
                       type="button"
                       disabled={!onOpenRunSession}
                       onClick={() => onOpenRunSession?.(run.sessionId)}
-                      className="grid w-full grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 border-b border-border/20 px-4 py-4 text-left transition-colors hover:bg-accent/20 disabled:cursor-default disabled:hover:bg-transparent sm:px-5"
+                      className="grid w-full grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 border-b border-border/20 px-4 py-4 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent sm:px-5"
                     >
                       <div className="min-w-0">
-                        <div className="truncate text-[18px] font-medium tracking-[-0.02em] text-foreground">
+                        <div className="truncate text-sm font-medium text-foreground">
                           {run.title}
                         </div>
                         {run.errorDetail ? (
-                          <div className="mt-0.5 truncate text-xs text-destructive/90">
+                          <div className="mt-0.5 truncate text-xs text-destructive">
                             {run.errorDetail}
                           </div>
                         ) : null}
                       </div>
 
-                      <div className="truncate text-[18px] tracking-[-0.02em] text-muted-foreground">
+                      <div className="truncate text-sm text-muted-foreground">
                         {formatAbsoluteTimestamp(run.completedAt)}
                       </div>
 
@@ -633,8 +675,10 @@ function EmptyState({ message }: { message: string }) {
     <div className="flex h-full w-full items-center justify-center p-6 text-center">
       <div className="max-w-lg">
         <Clock3 size={20} className="mx-auto text-muted-foreground" />
-        <div className="mt-3 text-sm font-medium text-foreground">No tasks to show</div>
-        <div className="mt-1 text-xs text-muted-foreground">{message}</div>
+        <div className="mt-3 text-sm font-medium text-foreground">
+          No tasks to show
+        </div>
+        <div className="mt-1 text-sm text-muted-foreground">{message}</div>
       </div>
     </div>
   );

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -1431,9 +1431,21 @@ test("chat pane offers an explicit jump-to-browser CTA instead of auto-switching
   );
   assert.doesNotMatch(source, /showLiveAssistantTurn \|\|\s*showSessionBrowserJumpCta/);
   assert.doesNotMatch(source, /This session started using its browser\./);
-  assert.match(source, /Jump to browser/);
+  assert.match(source, /View in agent browser/);
   assert.match(
     source,
-    /<AssistantTurn[\s\S]*statusAccessory=\{\s*showSessionBrowserJumpCta\s*\?\s*\(/,
+    /const sessionBrowserJumpCta = showSessionBrowserJumpCta \? \(/,
+  );
+  assert.match(
+    source,
+    /statusAccessory=\{sessionBrowserJumpCta\}/,
+  );
+  assert.match(
+    source,
+    /footerAccessory=\{\s*message\.id === lastCompletedAssistantMessageId\s*\?\s*sessionBrowserJumpCta\s*:\s*null\s*\}/,
+  );
+  assert.match(
+    source,
+    /const lastCompletedAssistantMessageId = useMemo\(/,
   );
 });

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -19,17 +19,24 @@ import {
   AlertTriangle,
   ArrowRight,
   ArrowUp,
+  ArrowUpRight,
   Cable,
   Check,
   ChevronDown,
   Clock3,
   CornerDownLeft,
   Copy,
+  File as FileIcon,
+  FileCode2,
+  FileSpreadsheet,
   FileText,
+  FileType,
   Folder,
+  Globe,
   Image as ImageIcon,
   Inbox,
   Lightbulb,
+  Link2,
   Loader2,
   Paperclip,
   PencilLine,
@@ -268,7 +275,9 @@ function pendingAttachmentIsImage(attachment: PendingAttachment): boolean {
   );
 }
 
-function supportsImageInput(inputModalities?: readonly string[] | null): boolean {
+function supportsImageInput(
+  inputModalities?: readonly string[] | null,
+): boolean {
   if (!Array.isArray(inputModalities) || inputModalities.length === 0) {
     return true;
   }
@@ -360,8 +369,7 @@ const CHAT_MODEL_STORAGE_KEY = "holaboss-chat-model-v1";
 const CHAT_THINKING_STORAGE_KEY = "holaboss-chat-thinking-v1";
 const CHAT_MODEL_USE_RUNTIME_DEFAULT = "__runtime_default__";
 const CHAT_SERIALIZED_SKILL_COMMAND_PATTERN = /^\/([A-Za-z0-9_-]+)$/;
-const QUEUED_MESSAGES_PREVIEW_EVENT =
-  "holaboss:queued-messages-preview-change";
+const QUEUED_MESSAGES_PREVIEW_EVENT = "holaboss:queued-messages-preview-change";
 const TODO_PREVIEW_EVENT = "holaboss:todo-preview-change";
 const LEGACY_UNAVAILABLE_CHAT_MODELS = new Set(["openai/gpt-5.2-mini"]);
 const DEPRECATED_CHAT_MODELS = new Set([
@@ -515,7 +523,9 @@ function normalizeStoredChatThinkingPreferences(
     }
     return Object.fromEntries(
       Object.entries(parsed)
-        .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+        .filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        )
         .map(([key, rawValue]) => [key.trim(), rawValue.trim()])
         .filter(([key, rawValue]) => Boolean(key) && Boolean(rawValue)),
     );
@@ -640,7 +650,8 @@ function buildComposerSlashCommandOptions(
       command: `/${skill.skill_id}`,
       label: skill.title,
       description: skill.summary,
-      searchText: `${skill.skill_id} ${skill.title} ${skill.summary}`.toLowerCase(),
+      searchText:
+        `${skill.skill_id} ${skill.title} ${skill.summary}`.toLowerCase(),
       skillId: skill.skill_id,
     }))
     .sort((left, right) => left.command.localeCompare(right.command));
@@ -795,11 +806,11 @@ function normalizeChatAttachment(value: unknown): ChatAttachment | null {
       ? "image"
       : value.kind === "folder"
         ? "folder"
-      : value.kind === "file"
-        ? "file"
-        : mimeType.startsWith("image/")
-          ? "image"
-          : "file";
+        : value.kind === "file"
+          ? "file"
+          : mimeType.startsWith("image/")
+            ? "image"
+            : "file";
 
   if (!id || !name || !mimeType || !workspacePath) {
     return null;
@@ -859,10 +870,7 @@ function appendAssistantOutputSegment(
   }
   const next = [...segments];
   const previous = next[next.length - 1];
-  if (
-    previous?.kind === "output" &&
-    (previous.tone ?? "default") === tone
-  ) {
+  if (previous?.kind === "output" && (previous.tone ?? "default") === tone) {
     next[next.length - 1] = {
       ...previous,
       text: `${previous.text}${text}`,
@@ -1159,7 +1167,9 @@ function normalizeClipboardAttachmentFile(file: File, index: number): File {
   });
 }
 
-function clipboardFilesFromDataTransfer(dataTransfer: DataTransfer | null): File[] {
+function clipboardFilesFromDataTransfer(
+  dataTransfer: DataTransfer | null,
+): File[] {
   if (!dataTransfer) {
     return [];
   }
@@ -1581,7 +1591,9 @@ function phaseHasRemainingTodoTasks(phase: ChatTodoPhase) {
 }
 
 function visibleTodoPhases(phases: ChatTodoPhase[]) {
-  const activePhases = phases.filter((phase) => phaseHasRemainingTodoTasks(phase));
+  const activePhases = phases.filter((phase) =>
+    phaseHasRemainingTodoTasks(phase),
+  );
   if (activePhases.length > 0) {
     return activePhases;
   }
@@ -1900,7 +1912,11 @@ function normalizeQueuedSessionInputPreviewEntries(
   entries: unknown,
 ): QueuedSessionInputPreviewDescriptor[] {
   const rawEntries =
-    typeof entries === "string" ? [entries] : Array.isArray(entries) ? entries : [];
+    typeof entries === "string"
+      ? [entries]
+      : Array.isArray(entries)
+        ? entries
+        : [];
   const normalized: QueuedSessionInputPreviewDescriptor[] = [];
   rawEntries.forEach((entry, index) => {
     if (typeof entry === "string") {
@@ -1927,8 +1943,8 @@ function normalizeQueuedSessionInputPreviewEntries(
     const attachments = Array.isArray(payload.attachments)
       ? payload.attachments
           .map((attachment) => normalizeChatAttachment(attachment))
-          .filter(
-            (attachment): attachment is ChatAttachment => Boolean(attachment),
+          .filter((attachment): attachment is ChatAttachment =>
+            Boolean(attachment),
           )
       : [];
     normalized.push({
@@ -1968,7 +1984,8 @@ function defaultTodoPlanPreview(): ChatTodoPlan {
             id: "task-research-2",
             content: "Pull the latest account context before replying",
             status: "in_progress",
-            details: "Waiting on the current run to finish before the follow-up can start.",
+            details:
+              "Waiting on the current run to finish before the follow-up can start.",
           },
         ],
       },
@@ -2203,7 +2220,9 @@ function syncableWorkspacePathFromRecord(
     }
   }
   for (const [key, candidate] of Object.entries(value)) {
-    if (!/(?:^|_)(?:path|file|filepath|filename|target|destination)$/i.test(key)) {
+    if (
+      !/(?:^|_)(?:path|file|filepath|filename|target|destination)$/i.test(key)
+    ) {
       continue;
     }
     const match = normalizeWorkspaceFileSyncPath(candidate);
@@ -2733,7 +2752,8 @@ function mergeTraceStep(
   const incomingIsNewer =
     incoming.order > existing.order ||
     (incoming.order === existing.order &&
-      traceStepStatusRank(incoming.status) >= traceStepStatusRank(existing.status));
+      traceStepStatusRank(incoming.status) >=
+        traceStepStatusRank(existing.status));
   const preferred = incomingIsNewer ? incoming : existing;
   const fallback = incomingIsNewer ? existing : incoming;
 
@@ -2741,7 +2761,8 @@ function mergeTraceStep(
     ...fallback,
     ...preferred,
     order: Math.min(existing.order, incoming.order),
-    details: preferred.details.length > 0 ? preferred.details : fallback.details,
+    details:
+      preferred.details.length > 0 ? preferred.details : fallback.details,
   };
 }
 
@@ -2760,10 +2781,7 @@ function appendExecutionTimelineThinkingDelta(
       ...lastItem,
       text: `${lastItem.text}${delta}`,
     };
-    return [
-      ...previous.slice(0, -1),
-      nextItem,
-    ];
+    return [...previous.slice(0, -1), nextItem];
   }
 
   const nextItem: ChatExecutionTimelineItem = {
@@ -2772,10 +2790,7 @@ function appendExecutionTimelineThinkingDelta(
     text: delta,
     order,
   };
-  return [
-    ...previous,
-    nextItem,
-  ];
+  return [...previous, nextItem];
 }
 
 function upsertExecutionTimelineTraceItem(
@@ -2792,7 +2807,9 @@ function upsertExecutionTimelineTraceItem(
       step,
       order: step.order,
     };
-    return [...previous, nextItem].sort((left, right) => left.order - right.order);
+    return [...previous, nextItem].sort(
+      (left, right) => left.order - right.order,
+    );
   }
 
   return previous.map((item, index) =>
@@ -2825,7 +2842,9 @@ function finalizeExecutionTimelineTraceItems(
 function traceStepsFromExecutionItems(items: ChatExecutionTimelineItem[]) {
   return items
     .filter(
-      (item): item is Extract<ChatExecutionTimelineItem, { kind: "trace_step" }> =>
+      (
+        item,
+      ): item is Extract<ChatExecutionTimelineItem, { kind: "trace_step" }> =>
         item.kind === "trace_step",
     )
     .map((item) => item.step);
@@ -3270,8 +3289,9 @@ export function ChatPane({
   const lastHandledComposerPrefillRequestKeyRef = useRef(0);
   const lastHandledExplorerAttachmentRequestKeyRef = useRef(0);
   const consumedSessionOpenRequestKeysRef = useRef<Set<number>>(new Set());
-  const localSessionOpenRequestRef =
-    useRef<ChatPaneSessionOpenRequest | null>(null);
+  const localSessionOpenRequestRef = useRef<ChatPaneSessionOpenRequest | null>(
+    null,
+  );
   const draftParentSessionIdRef = useRef<string | null>(null);
   const draftHydrationWorkspaceIdRef = useRef((selectedWorkspaceId || "").trim());
   const skipNextComposerDraftPublishRef = useRef(false);
@@ -3338,10 +3358,7 @@ export function ChatPane({
         ) => ChatPaneSessionOpenRequest | null),
   ) {
     setLocalSessionOpenRequest((current) => {
-      const resolved =
-        typeof next === "function"
-          ? next(current)
-          : next;
+      const resolved = typeof next === "function" ? next(current) : next;
       localSessionOpenRequestRef.current = resolved;
       return resolved;
     });
@@ -3471,7 +3488,10 @@ export function ChatPane({
     shouldAutoScrollRef.current = true;
   }
 
-  function isSessionHistoryTargetActive(sessionId: string, workspaceId: string) {
+  function isSessionHistoryTargetActive(
+    sessionId: string,
+    workspaceId: string,
+  ) {
     return (
       activeSessionIdRef.current === sessionId &&
       (selectedWorkspaceRef.current?.id || "").trim() === workspaceId
@@ -3493,8 +3513,9 @@ export function ChatPane({
     }
     terminalEventTypeByInputIdRef.current.set(normalizedInputId, eventType);
     while (terminalEventTypeByInputIdRef.current.size > 64) {
-      const oldestInputId =
-        terminalEventTypeByInputIdRef.current.keys().next().value;
+      const oldestInputId = terminalEventTypeByInputIdRef.current
+        .keys()
+        .next().value;
       if (typeof oldestInputId !== "string") {
         break;
       }
@@ -3594,7 +3615,8 @@ export function ChatPane({
               nextMessage.text = "";
               nextMessage.executionItems = undefined;
             } else if (restoredAssistantState.executionItems) {
-              nextMessage.executionItems = restoredAssistantState.executionItems;
+              nextMessage.executionItems =
+                restoredAssistantState.executionItems;
             }
             if (
               !nextMessage.text &&
@@ -3625,7 +3647,9 @@ export function ChatPane({
           const restoredAssistantState = assistantHistoryStateFromOutputEvents(
             outputEventsByInputId.get(userInputId) ?? [],
           );
-          const turnOutputs = sortOutputs(outputsByInputId.get(userInputId) ?? []);
+          const turnOutputs = sortOutputs(
+            outputsByInputId.get(userInputId) ?? [],
+          );
           const turnMemoryProposals = sortMemoryUpdateProposals(
             memoryProposalsByInputId.get(userInputId) ?? [],
           );
@@ -3633,20 +3657,21 @@ export function ChatPane({
             id: `assistant-${userInputId}`,
             role: "assistant",
             text:
-              restoredAssistantState.segments || !restoredAssistantState.failureText
+              restoredAssistantState.segments ||
+              !restoredAssistantState.failureText
                 ? ""
                 : restoredAssistantState.failureText,
             tone:
-              restoredAssistantState.segments || !restoredAssistantState.failureText
+              restoredAssistantState.segments ||
+              !restoredAssistantState.failureText
                 ? "default"
                 : "error",
             createdAt:
               restoredAssistantState.terminalCreatedAt || nextMessage.createdAt,
             segments: restoredAssistantState.segments,
-            executionItems:
-              restoredAssistantState.segments
-                ? undefined
-                : restoredAssistantState.executionItems,
+            executionItems: restoredAssistantState.segments
+              ? undefined
+              : restoredAssistantState.executionItems,
             outputs: turnOutputs.length > 0 ? turnOutputs : undefined,
             memoryProposals:
               turnMemoryProposals.length > 0 ? turnMemoryProposals : undefined,
@@ -3698,9 +3723,7 @@ export function ChatPane({
       history.messages,
       params.order,
     );
-    const assistantInputIds = turnInputIdsFromHistoryMessages(
-      historyMessages,
-    );
+    const assistantInputIds = turnInputIdsFromHistoryMessages(historyMessages);
     if (assistantInputIds.length === 0) {
       return {
         history,
@@ -3750,7 +3773,10 @@ export function ChatPane({
         }
         if (outputListResult.status !== "fulfilled") {
           auxiliaryHistoryWarnings.push(
-            optionalHistoryLoadErrorMessage("Artifacts", outputListResult.reason),
+            optionalHistoryLoadErrorMessage(
+              "Artifacts",
+              outputListResult.reason,
+            ),
           );
         }
         if (memoryProposalListResult.status !== "fulfilled") {
@@ -4110,8 +4136,7 @@ export function ChatPane({
     }
 
     const hasOutputSegment = nextSegments.some(
-      (segment) =>
-        segment.kind === "output" && Boolean(segment.text.trim()),
+      (segment) => segment.kind === "output" && Boolean(segment.text.trim()),
     );
     if (options?.fallbackText && !hasOutputSegment) {
       nextSegments = appendAssistantOutputSegment(
@@ -4573,9 +4598,8 @@ export function ChatPane({
       }
       requestInFlight = true;
       try {
-        const result = await window.electronAPI.workspace.listSkills(
-          selectedWorkspaceId,
-        );
+        const result =
+          await window.electronAPI.workspace.listSkills(selectedWorkspaceId);
         if (cancelled) {
           return;
         }
@@ -5718,6 +5742,16 @@ export function ChatPane({
     ) {
       return;
     }
+    if (
+      browserJumpRequest &&
+      activeSessionIdRef.current &&
+      browserJumpRequest.sessionId === activeSessionIdRef.current
+    ) {
+      onBrowserJumpRequestConsumed?.(
+        browserJumpRequest.sessionId,
+        browserJumpRequest.requestKey,
+      );
+    }
     if (usesHostedManagedCredits) {
       if (isOutOfCredits) {
         setChatErrorMessage("You're out of credits for managed usage.");
@@ -6052,9 +6086,10 @@ export function ChatPane({
       if (!queueOntoActiveRun) {
         const activeStreamId = activeStreamIdRef.current;
         if (activeStreamId) {
-          await closeStreamWithReason(activeStreamId, "send_message_error").catch(
-            () => undefined,
-          );
+          await closeStreamWithReason(
+            activeStreamId,
+            "send_message_error",
+          ).catch(() => undefined);
         }
       }
       setChatErrorMessage(normalizeErrorMessage(error));
@@ -6153,12 +6188,14 @@ export function ChatPane({
       throw new Error("Only queued messages can be edited.");
     }
 
-    const updated = await window.electronAPI.workspace.updateQueuedSessionInput({
-      workspace_id: item.workspaceId,
-      session_id: item.sessionId,
-      input_id: item.inputId,
-      text: serializedText,
-    });
+    const updated = await window.electronAPI.workspace.updateQueuedSessionInput(
+      {
+        workspace_id: item.workspaceId,
+        session_id: item.sessionId,
+        input_id: item.inputId,
+        text: serializedText,
+      },
+    );
 
     setQueuedSessionInputs((current) =>
       current.map((currentItem) =>
@@ -6282,8 +6319,9 @@ export function ChatPane({
     };
 
     void window.electronAPI.browser.getState().then(applyVisibleBrowserState);
-    const unsubscribe =
-      window.electronAPI.browser.onStateChange(applyVisibleBrowserState);
+    const unsubscribe = window.electronAPI.browser.onStateChange(
+      applyVisibleBrowserState,
+    );
 
     return () => {
       mounted = false;
@@ -6321,7 +6359,10 @@ export function ChatPane({
   };
 
   const jumpToSessionBrowser = () => {
-    if (!browserJumpRequest || browserJumpRequest.sessionId !== activeSessionId) {
+    if (
+      !browserJumpRequest ||
+      browserJumpRequest.sessionId !== activeSessionId
+    ) {
       return;
     }
     onJumpToSessionBrowser?.(
@@ -6370,15 +6411,28 @@ export function ChatPane({
       );
   const visibleAgentBrowserSessionId =
     visibleBrowserState.space === "agent"
-      ? visibleBrowserState.controlSessionId || visibleBrowserState.sessionId || ""
+      ? visibleBrowserState.controlSessionId ||
+        visibleBrowserState.sessionId ||
+        ""
       : "";
   const showSessionBrowserJumpCta = Boolean(
     browserJumpRequest &&
-      activeSessionId &&
-      browserJumpRequest.sessionId === activeSessionId &&
-      (visibleBrowserState.space !== "agent" ||
-        visibleAgentBrowserSessionId !== activeSessionId),
+    activeSessionId &&
+    browserJumpRequest.sessionId === activeSessionId &&
+    (visibleBrowserState.space !== "agent" ||
+      visibleAgentBrowserSessionId !== activeSessionId),
   );
+  const sessionBrowserJumpCta = showSessionBrowserJumpCta ? (
+    <button
+      type="button"
+      onClick={jumpToSessionBrowser}
+      className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground/80 transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:bg-accent/50 focus-visible:text-foreground"
+    >
+      <Globe size={12} className="opacity-80" />
+      <span>View in agent browser</span>
+      <ArrowUpRight size={12} className="opacity-80" />
+    </button>
+  ) : null;
   const renderedLiveAssistantSegments = liveAssistantSegmentsForRender(
     liveAssistantSegments,
     liveExecutionItems,
@@ -6389,6 +6443,18 @@ export function ChatPane({
     liveAssistantSegments.length > 0 ||
     Boolean(liveAssistantText) ||
     liveExecutionItems.length > 0;
+  const lastCompletedAssistantMessageId = useMemo(() => {
+    if (showLiveAssistantTurn) {
+      return null;
+    }
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const candidate = messages[index];
+      if (candidate && candidate.role !== "user") {
+        return candidate.id;
+      }
+    }
+    return null;
+  }, [messages, showLiveAssistantTurn]);
   const queuedSessionInputPreview = useQueuedSessionInputPreview({
     workspaceId: selectedWorkspaceId,
     sessionId: activeSessionId,
@@ -6465,7 +6531,9 @@ export function ChatPane({
   const availableWorkspaceSkillMap = useMemo(
     () =>
       new Map(
-        availableWorkspaceSkills.map((skill) => [skill.skill_id, skill] as const),
+        availableWorkspaceSkills.map(
+          (skill) => [skill.skill_id, skill] as const,
+        ),
       ),
     [availableWorkspaceSkills],
   );
@@ -6668,8 +6736,8 @@ export function ChatPane({
     ? selectedConfiguredModel.reasoning === true
     : Boolean(selectedFallbackModelMetadata?.reasoning);
   const selectedInputModalities = selectedConfiguredModel
-    ? selectedConfiguredModel.inputModalities ?? []
-    : selectedFallbackModelMetadata?.inputModalities ?? [];
+    ? (selectedConfiguredModel.inputModalities ?? [])
+    : (selectedFallbackModelMetadata?.inputModalities ?? []);
   const selectedModelDisplayLabel = selectedConfiguredModel
     ? runtimeModelDisplayLabel(selectedConfiguredModel)
     : selectedFallbackModelMetadata?.label?.trim() ||
@@ -6679,10 +6747,10 @@ export function ChatPane({
   );
   const selectedThinkingValues = selectedConfiguredModel
     ? runtimeModelThinkingValues(selectedConfiguredModel)
-    : selectedFallbackModelMetadata?.thinkingValues ?? [];
+    : (selectedFallbackModelMetadata?.thinkingValues ?? []);
   const selectedDefaultThinkingValue = selectedConfiguredModel
     ? selectedConfiguredModel.defaultThinkingValue?.trim() || null
-    : selectedFallbackModelMetadata?.defaultThinkingValue ?? null;
+    : (selectedFallbackModelMetadata?.defaultThinkingValue ?? null);
   const selectedStoredThinkingValue = resolvedChatModel
     ? (chatThinkingPreferences[resolvedChatModel] ?? "").trim()
     : "";
@@ -6696,7 +6764,7 @@ export function ChatPane({
           : selectedDefaultThinkingValue &&
               selectedThinkingValues.includes(selectedDefaultThinkingValue)
             ? selectedDefaultThinkingValue
-            : selectedThinkingValues[0] ?? null;
+            : (selectedThinkingValues[0] ?? null);
   const showThinkingValueSelector =
     !isOnboardingVariant &&
     selectedModelSupportsReasoning &&
@@ -6738,8 +6806,9 @@ export function ChatPane({
     (isSubmittingMessage ? "Submitting message..." : "");
   const composerDisabled = Boolean(composerDisabledReason);
   const pendingImageInputUnsupportedMessage =
-    pendingAttachments.some((attachment) => pendingAttachmentIsImage(attachment)) &&
-    !selectedModelSupportsImageInput
+    pendingAttachments.some((attachment) =>
+      pendingAttachmentIsImage(attachment),
+    ) && !selectedModelSupportsImageInput
       ? `${imageInputUnsupportedMessage(selectedModelDisplayLabel)} Remove the attached image or switch models.`
       : "";
   const showLowBalanceWarning =
@@ -7288,8 +7357,7 @@ export function ChatPane({
                 shouldAutoScrollRef.current = scrolledUp ? false : nearBottom;
                 scheduleChatScrollMetricsSync(currentTarget);
                 if (
-                  currentTarget.scrollTop <=
-                  CHAT_HISTORY_TOP_LOAD_THRESHOLD_PX
+                  currentTarget.scrollTop <= CHAT_HISTORY_TOP_LOAD_THRESHOLD_PX
                 ) {
                   void loadOlderSessionHistory();
                 }
@@ -7299,7 +7367,7 @@ export function ChatPane({
               {hasMessages ? (
                 <div
                   ref={messagesContentRef}
-                  className={`flex min-w-0 w-full flex-col gap-7 px-6 pb-3 pt-5 ${
+                  className={`flex min-w-0 w-full flex-col gap-6 px-6 pb-3 pt-5 ${
                     showHistoryRestoreScreen ? "invisible" : ""
                   }`}
                 >
@@ -7367,6 +7435,11 @@ export function ChatPane({
                         collapsedTraceByStepId={collapsedTraceByStepId}
                         onToggleTraceStep={toggleTraceStep}
                         onLinkClick={onOpenLinkInBrowser}
+                        footerAccessory={
+                          message.id === lastCompletedAssistantMessageId
+                            ? sessionBrowserJumpCta
+                            : null
+                        }
                       />
                     ),
                   )}
@@ -7398,20 +7471,7 @@ export function ChatPane({
                       onToggleTraceStep={toggleTraceStep}
                       onLinkClick={onOpenLinkInBrowser}
                       live
-                      statusAccessory={
-                        showSessionBrowserJumpCta ? (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={jumpToSessionBrowser}
-                            className="rounded-full"
-                          >
-                            <span>Jump to browser</span>
-                            <ArrowRight size={13} />
-                          </Button>
-                        ) : null
-                      }
+                      statusAccessory={sessionBrowserJumpCta}
                       status={
                         liveAgentStatus || (isResponding ? "Working" : "")
                       }
@@ -7455,8 +7515,8 @@ export function ChatPane({
                           isResponding={isResponding}
                           pausePending={isPausePending}
                           pauseDisabled={
-                            pendingInputIdRef.current === STREAM_ATTACH_PENDING ||
-                            isSubmittingMessage
+                            pendingInputIdRef.current ===
+                              STREAM_ATTACH_PENDING || isSubmittingMessage
                           }
                           disabled={composerDisabled}
                           disabledReason={composerDisabledReason}
@@ -7566,9 +7626,9 @@ export function ChatPane({
               className={`shrink-0 px-6 pb-5 pt-3 ${
                 showHistoryRestoreScreen ? "invisible" : ""
               }`}
-          >
-            <form onSubmit={onSubmit} className="w-full">
-              <div className="space-y-3">
+            >
+              <form onSubmit={onSubmit} className="w-full">
+                <div className="space-y-3">
                   <QueuedSessionInputRail
                     items={displayedQueuedSessionInputs}
                     onEditItem={updateQueuedSessionInputText}
@@ -7593,7 +7653,9 @@ export function ChatPane({
                       runtimeDefaultModelLabel={runtimeDefaultModel}
                       modelOptions={availableChatModelOptions}
                       modelOptionGroups={availableChatModelOptionGroups}
-                      runtimeDefaultModelAvailable={runtimeDefaultModelAvailable}
+                      runtimeDefaultModelAvailable={
+                        runtimeDefaultModelAvailable
+                      }
                       selectedThinkingValue={effectiveThinkingValue}
                       thinkingValues={selectedThinkingValues}
                       showThinkingValueSelector={showThinkingValueSelector}
@@ -7619,7 +7681,9 @@ export function ChatPane({
                       onAttachmentInputChange={onAttachmentInputChange}
                       onPause={pauseCurrentRun}
                       onAddDroppedFiles={appendPendingLocalFiles}
-                      onAddExplorerAttachments={appendPendingExplorerAttachments}
+                      onAddExplorerAttachments={
+                        appendPendingExplorerAttachments
+                      }
                       onSelectSlashCommand={(command) => {
                         if (command.kind === "skill") {
                           addQuotedSkill(command.skillId);
@@ -7942,7 +8006,7 @@ function UserTurn({
 
   return (
     <div className="group/user-turn flex min-w-0 justify-end">
-      <div className="flex min-w-0 max-w-[420px] flex-col items-end gap-2 sm:max-w-[560px] lg:max-w-[680px]">
+      <div className="flex min-w-0 max-w-[420px] flex-col items-end gap-1 sm:max-w-[560px] lg:max-w-[680px]">
         {parsedQuotedSkills.skillIds.length > 0 ? (
           <div className="flex max-w-full flex-wrap justify-end gap-2">
             {parsedQuotedSkills.skillIds.map((skillId) => (
@@ -7957,7 +8021,7 @@ function UserTurn({
           </div>
         ) : null}
         {parsedQuotedSkills.body ? (
-          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full rounded-[18px] border px-4 py-3 text-foreground/95">
+          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full rounded-[20px] px-[18px] py-2.5 text-foreground/95">
             <SimpleMarkdown
               className="chat-markdown chat-user-markdown max-w-full"
               onLinkClick={onLinkClick}
@@ -7970,7 +8034,7 @@ function UserTurn({
           <AttachmentList attachments={attachments} className="justify-end" />
         ) : null}
         {canCopy || timeLabel ? (
-          <div className="flex min-h-6 items-center justify-end gap-2 pr-1 text-[11px] text-muted-foreground/72 opacity-0 pointer-events-none transition duration-150 group-hover/user-turn:opacity-100 group-hover/user-turn:pointer-events-auto group-focus-within/user-turn:opacity-100 group-focus-within/user-turn:pointer-events-auto">
+          <div className="flex items-center justify-end gap-2 pr-1 text-[11px] text-muted-foreground/72 opacity-0 pointer-events-none transition duration-150 group-hover/user-turn:opacity-100 group-hover/user-turn:pointer-events-auto group-focus-within/user-turn:opacity-100 group-focus-within/user-turn:pointer-events-auto">
             {canCopy ? (
               <Button
                 type="button"
@@ -8226,6 +8290,7 @@ function AssistantTurn({
   status = "",
   live = false,
   statusAccessory = null,
+  footerAccessory = null,
 }: {
   label: string;
   mode: string;
@@ -8256,6 +8321,7 @@ function AssistantTurn({
   status?: string;
   live?: boolean;
   statusAccessory?: ReactNode;
+  footerAccessory?: ReactNode;
 }) {
   const normalizedStatus = status.replace(/\.+$/, "").trim();
   const renderedSegments =
@@ -8283,12 +8349,8 @@ function AssistantTurn({
           ]
         : [];
   const showStatusPlaceholder =
-    live &&
-    Boolean(normalizedStatus) &&
-    renderedSegments.length === 0;
-  const showWorkingStatusLine =
-    live &&
-    renderedSegments.length > 0;
+    live && Boolean(normalizedStatus) && renderedSegments.length === 0;
+  const showWorkingStatusLine = live && renderedSegments.length > 0;
   const renderStatusLine = (nextLabel: string, className = "") => {
     if (!statusAccessory) {
       return <LiveStatusLine label={nextLabel} className={className} />;
@@ -8353,13 +8415,17 @@ function AssistantTurn({
           ),
         )}
 
-        {showWorkingStatusLine ? (
-          renderStatusLine(
-            "Working",
-            renderedSegments.some((segment) => segment.kind === "execution")
-              ? "mt-1"
-              : "",
-          )
+        {showWorkingStatusLine
+          ? renderStatusLine(
+              "Working",
+              renderedSegments.some((segment) => segment.kind === "execution")
+                ? "mt-1"
+                : "",
+            )
+          : null}
+
+        {footerAccessory ? (
+          <div className="mt-2 flex justify-start">{footerAccessory}</div>
         ) : null}
 
         {memoryProposals.length > 0 ? (
@@ -8388,19 +8454,202 @@ function AssistantTurn({
   );
 }
 
+type OutputVisualKind =
+  | "spreadsheet"
+  | "document"
+  | "pdf"
+  | "code"
+  | "image"
+  | "link"
+  | "app"
+  | "file";
+
+const SPREADSHEET_EXTENSIONS = new Set([
+  "xlsx",
+  "xls",
+  "xlsm",
+  "xlsb",
+  "ods",
+  "csv",
+  "tsv",
+]);
+const PDF_EXTENSIONS = new Set(["pdf"]);
+const CODE_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "c",
+  "cpp",
+  "h",
+  "cs",
+  "php",
+  "swift",
+  "kt",
+  "sh",
+  "json",
+  "yml",
+  "yaml",
+  "toml",
+  "xml",
+  "sql",
+  "css",
+  "scss",
+]);
+const DOCUMENT_EXTENSIONS = new Set([
+  "md",
+  "mdx",
+  "markdown",
+  "txt",
+  "doc",
+  "docx",
+  "rtf",
+  "odt",
+  "html",
+  "htm",
+]);
+
+function outputFileExtension(
+  output: WorkspaceOutputRecordPayload,
+): string {
+  const metadataExt = outputMetadataString(output, "extension");
+  if (metadataExt) {
+    return metadataExt.replace(/^\./, "").toLowerCase();
+  }
+  const fromTitle = output.title?.trim() ?? "";
+  const dotIndex = fromTitle.lastIndexOf(".");
+  if (dotIndex > 0 && dotIndex < fromTitle.length - 1) {
+    return fromTitle.slice(dotIndex + 1).toLowerCase();
+  }
+  return "";
+}
+
+function outputVisualKind(
+  output: WorkspaceOutputRecordPayload,
+): OutputVisualKind {
+  const filter = outputBrowserFilterForOutput(output);
+  if (filter === "apps") {
+    return "app";
+  }
+  if (filter === "images") {
+    return "image";
+  }
+  if (filter === "links") {
+    return "link";
+  }
+
+  const extension = outputFileExtension(output);
+  if (extension) {
+    if (SPREADSHEET_EXTENSIONS.has(extension)) {
+      return "spreadsheet";
+    }
+    if (PDF_EXTENSIONS.has(extension)) {
+      return "pdf";
+    }
+    if (CODE_EXTENSIONS.has(extension)) {
+      return "code";
+    }
+    if (DOCUMENT_EXTENSIONS.has(extension)) {
+      return "document";
+    }
+  }
+
+  if (filter === "code") {
+    return "code";
+  }
+  const category = outputMetadataString(output, "category");
+  if (category === "spreadsheet") {
+    return "spreadsheet";
+  }
+  if (category === "document") {
+    return "document";
+  }
+  return "file";
+}
+
+function outputVisualTheme(kind: OutputVisualKind): {
+  Icon: typeof FileText;
+  tileClass: string;
+  iconClass: string;
+} {
+  switch (kind) {
+    case "spreadsheet":
+      return {
+        Icon: FileSpreadsheet,
+        tileClass:
+          "bg-emerald-500/12 ring-1 ring-inset ring-emerald-500/20",
+        iconClass: "text-emerald-600 dark:text-emerald-400",
+      };
+    case "pdf":
+      return {
+        Icon: FileType,
+        tileClass: "bg-rose-500/12 ring-1 ring-inset ring-rose-500/20",
+        iconClass: "text-rose-600 dark:text-rose-400",
+      };
+    case "document":
+      return {
+        Icon: FileText,
+        tileClass: "bg-sky-500/12 ring-1 ring-inset ring-sky-500/20",
+        iconClass: "text-sky-600 dark:text-sky-400",
+      };
+    case "code":
+      return {
+        Icon: FileCode2,
+        tileClass:
+          "bg-violet-500/12 ring-1 ring-inset ring-violet-500/20",
+        iconClass: "text-violet-600 dark:text-violet-400",
+      };
+    case "image":
+      return {
+        Icon: ImageIcon,
+        tileClass:
+          "bg-amber-500/12 ring-1 ring-inset ring-amber-500/20",
+        iconClass: "text-amber-600 dark:text-amber-400",
+      };
+    case "link":
+      return {
+        Icon: Link2,
+        tileClass: "bg-blue-500/12 ring-1 ring-inset ring-blue-500/20",
+        iconClass: "text-blue-600 dark:text-blue-400",
+      };
+    case "app":
+      return {
+        Icon: Waypoints,
+        tileClass: "bg-primary/12 ring-1 ring-inset ring-primary/20",
+        iconClass: "text-primary",
+      };
+    default:
+      return {
+        Icon: FileIcon,
+        tileClass: "bg-muted ring-1 ring-inset ring-border/50",
+        iconClass: "text-muted-foreground",
+      };
+  }
+}
+
 function OutputArtifactIcon({
   output,
+  size = "md",
 }: {
   output: WorkspaceOutputRecordPayload;
+  size?: "sm" | "md";
 }) {
-  const filter = outputBrowserFilterForOutput(output);
-  if (filter === "images") {
-    return <ImageIcon size={16} className="shrink-0 text-primary/72" />;
-  }
-  if (filter === "apps") {
-    return <Waypoints size={16} className="shrink-0 text-primary/72" />;
-  }
-  return <FileText size={16} className="shrink-0 text-primary/72" />;
+  const kind = outputVisualKind(output);
+  const { Icon, tileClass, iconClass } = outputVisualTheme(kind);
+  const tileSize = size === "sm" ? "size-7" : "size-9";
+  const iconSize = size === "sm" ? 14 : 16;
+  return (
+    <div
+      className={`grid ${tileSize} shrink-0 place-items-center rounded-[10px] ${tileClass}`}
+    >
+      <Icon size={iconSize} className={iconClass} />
+    </div>
+  );
 }
 
 function HistoryRestoreSkeleton() {
@@ -8467,18 +8716,22 @@ function AssistantTurnOutputs({
           key={output.id}
           type="button"
           onClick={() => onOpenOutput?.(output)}
-          className="flex max-w-[360px] items-center gap-3 rounded-xl border border-border/50 bg-card px-3.5 py-2.5 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:hover:bg-card"
+          className="group flex max-w-[380px] items-center gap-3 rounded-xl border border-border/45 bg-card px-3 py-2.5 text-left transition-colors hover:border-border/70 hover:bg-accent/50 disabled:cursor-default disabled:hover:border-border/45 disabled:hover:bg-card"
           disabled={!onOpenOutput}
         >
           <OutputArtifactIcon output={output} />
           <div className="min-w-0 flex-1">
-            <div className="truncate text-[13px] font-medium text-foreground">
+            <div className="truncate text-sm font-medium tracking-[-0.005em] text-foreground">
               {output.title || "Untitled artifact"}
             </div>
-            <div className="text-[11px] text-muted-foreground">
+            <div className="truncate text-xs text-muted-foreground/85">
               {outputSecondaryLabel(output)}
             </div>
           </div>
+          <ArrowUpRight
+            size={14}
+            className="shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground/70"
+          />
         </button>
       ))}
 
@@ -8486,10 +8739,12 @@ function AssistantTurnOutputs({
         <button
           type="button"
           onClick={onOpenAllArtifacts}
-          className="flex max-w-[360px] items-center gap-3 rounded-xl border border-border/50 px-3.5 py-2.5 text-left text-muted-foreground transition-colors hover:bg-accent"
+          className="flex max-w-[380px] items-center gap-3 rounded-xl border border-dashed border-border/50 px-3 py-2 text-left text-muted-foreground transition-colors hover:border-border/80 hover:bg-accent/40 hover:text-foreground"
         >
-          <FileText size={15} className="shrink-0" />
-          <span className="text-[13px]">
+          <div className="grid size-7 shrink-0 place-items-center rounded-[9px] bg-muted text-muted-foreground">
+            <Folder size={14} />
+          </div>
+          <span className="text-xs">
             View all artifacts ({sessionOutputs.length})
           </span>
         </button>
@@ -9430,7 +9685,9 @@ function ThinkingValueSelect({
   if (thinkingValues.length === 0 || !selectedThinkingValue) {
     return null;
   }
-  const selectedThinkingLabel = displayThinkingValueLabel(selectedThinkingValue);
+  const selectedThinkingLabel = displayThinkingValueLabel(
+    selectedThinkingValue,
+  );
   const compactLabelMinWidth = 52 + selectedThinkingLabel.length * 7;
   const showCompactLabel =
     !compact ||
@@ -9454,9 +9711,7 @@ function ThinkingValueSelect({
         }`}
       >
         <span className="truncate">{displayThinkingValueLabel(value)}</span>
-        {active ? (
-          <Check size={13} className="shrink-0 text-primary" />
-        ) : null}
+        {active ? <Check size={13} className="shrink-0 text-primary" /> : null}
       </button>
     );
   };
@@ -9533,7 +9788,9 @@ function ThinkingValueSelect({
         <div className="border-b border-border/40 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
           Reasoning effort
         </div>
-        <div className="py-1">{thinkingValues.map((value) => renderOption(value))}</div>
+        <div className="py-1">
+          {thinkingValues.map((value) => renderOption(value))}
+        </div>
       </PopoverContent>
     </Popover>
   );
@@ -9761,8 +10018,7 @@ function Composer({
       document.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [activeSlashCommandKey, showSlashCommandMenu]);
-  const visibleFooterControlCount =
-    1 + (showThinkingValueSelector ? 1 : 0) + 1;
+  const visibleFooterControlCount = 1 + (showThinkingValueSelector ? 1 : 0) + 1;
   const fullPrimaryControlWidth = showModelSelector
     ? noAvailableModels
       ? COMPOSER_FULL_PROVIDER_SETUP_WIDTH_PX
@@ -9854,16 +10110,17 @@ function Composer({
     if (showSlashCommandMenu) {
       if (event.key === "ArrowDown" && filteredSlashCommands.length > 0) {
         event.preventDefault();
-        setHighlightedSlashIndex((current) =>
-          (current + 1) % filteredSlashCommands.length,
+        setHighlightedSlashIndex(
+          (current) => (current + 1) % filteredSlashCommands.length,
         );
         return;
       }
       if (event.key === "ArrowUp" && filteredSlashCommands.length > 0) {
         event.preventDefault();
-        setHighlightedSlashIndex((current) =>
-          (current - 1 + filteredSlashCommands.length) %
-          filteredSlashCommands.length,
+        setHighlightedSlashIndex(
+          (current) =>
+            (current - 1 + filteredSlashCommands.length) %
+            filteredSlashCommands.length,
         );
         return;
       }
@@ -10062,10 +10319,7 @@ function Composer({
                   key={skill.skillId}
                   className="inline-flex max-w-full items-center gap-2 rounded-full border border-primary/20 bg-primary/8 px-3 py-1.5 text-[11px] text-foreground/88"
                 >
-                  <Sparkles
-                    size={12}
-                    className="text-primary/80"
-                  />
+                  <Sparkles size={12} className="text-primary/80" />
                   <span className="truncate">{skill.title}</span>
                   <button
                     type="button"
@@ -10143,7 +10397,9 @@ function Composer({
                         className="shrink-0 text-muted-foreground"
                       />
                       <span className="truncate">
-                        {compactComposerControls ? "Providers" : "Set up providers"}
+                        {compactComposerControls
+                          ? "Providers"
+                          : "Set up providers"}
                       </span>
                     </span>
                     <ArrowRight
@@ -10198,7 +10454,9 @@ function Composer({
                 disabled={disabled}
                 compact={compactComposerControls}
                 compactWidth={
-                  compactComposerControls ? compactThinkingControlWidth : undefined
+                  compactComposerControls
+                    ? compactThinkingControlWidth
+                    : undefined
                 }
                 onThinkingValueChange={onThinkingValueChange}
               />

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -11,26 +11,17 @@ import {
   AtSign,
   ArrowLeft,
   ChevronRight,
-  FileArchive,
-  FileAudio2,
-  FileBadge2,
-  FileCode2,
-  FileCog,
-  FileImage,
-  FileJson,
-  FileSpreadsheet,
-  FileText,
-  FileVideoCamera,
-  Folder,
   Loader2,
   MoreHorizontal,
   Plus,
   Save,
   Search,
-  Shield,
   Star,
-  type LucideIcon,
 } from "lucide-react";
+import { Icon as IconifyIcon, addCollection } from "@iconify/react";
+import catppuccinCollection from "@iconify-json/catppuccin/icons.json";
+
+addCollection(catppuccinCollection as Parameters<typeof addCollection>[0]);
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import {
   areTablePreviewSheetsEqual,
@@ -39,6 +30,7 @@ import {
 } from "@/components/panes/SpreadsheetEditor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PaneCard } from "@/components/ui/PaneCard";
 import {
   DropdownMenu,
@@ -162,8 +154,7 @@ let explorerClipboardEntry: ExplorerClipboardEntry | null = null;
 type TextPreviewMode = "edit" | "preview";
 
 type ExplorerIconDescriptor = {
-  Icon: LucideIcon;
-  className: string;
+  name: string;
 };
 
 type FileExplorerContextMenuState = {
@@ -230,7 +221,10 @@ type ExplorerExternalDropDataTransferItem = DataTransferItem & {
 };
 
 function joinExplorerImportPath(parentPath: string, name: string) {
-  const trimmedName = name.trim().replace(/[\\/]+/g, "/").replace(/^\/+|\/+$/g, "");
+  const trimmedName = name
+    .trim()
+    .replace(/[\\/]+/g, "/")
+    .replace(/^\/+|\/+$/g, "");
   if (!parentPath) {
     return trimmedName;
   }
@@ -268,9 +262,7 @@ async function readExternalDropDirectoryEntries(
   return entries;
 }
 
-async function readExternalDropFile(
-  entry: FileSystemFileEntry,
-) {
+async function readExternalDropFile(entry: FileSystemFileEntry) {
   return new Promise<File>((resolve, reject) => {
     entry.file(resolve, (error) => {
       reject(error ?? new Error(`Failed to read ${entry.name}.`));
@@ -306,7 +298,10 @@ async function collectDroppedExternalEntriesFromEntry(
   ];
   for (const childEntry of childEntries) {
     importedEntries.push(
-      ...(await collectDroppedExternalEntriesFromEntry(childEntry, relativePath)),
+      ...(await collectDroppedExternalEntriesFromEntry(
+        childEntry,
+        relativePath,
+      )),
     );
   }
   return importedEntries;
@@ -335,10 +330,14 @@ function hasExternalExplorerDropData(dataTransfer: DataTransfer | null) {
     return true;
   }
 
-  return Array.from(dataTransfer.items ?? []).some((item) => item.kind === "file");
+  return Array.from(dataTransfer.items ?? []).some(
+    (item) => item.kind === "file",
+  );
 }
 
-async function collectDroppedExternalEntries(dataTransfer: DataTransfer | null) {
+async function collectDroppedExternalEntries(
+  dataTransfer: DataTransfer | null,
+) {
   if (!dataTransfer) {
     return [];
   }
@@ -432,97 +431,110 @@ function getFileExtension(fileName: string) {
 function getExplorerIconDescriptor(
   targetName: string,
   isDirectory: boolean,
+  isExpanded = false,
 ): ExplorerIconDescriptor {
   if (isDirectory) {
-    return {
-      Icon: Folder,
-      className: "text-primary",
-    };
+    return { name: isExpanded ? "folder-open" : "folder" };
   }
 
   const normalizedFileName = getComparableFileName(targetName);
   const extension = getFileExtension(normalizedFileName);
 
-  if (SPECIAL_POLICY_FILENAMES.has(normalizedFileName)) {
-    return {
-      Icon: Shield,
-      className: "text-cyan-700 dark:text-cyan-300",
-    };
+  if (normalizedFileName === "package.json") return { name: "npm" };
+  if (normalizedFileName === "package-lock.json") return { name: "lock" };
+  if (normalizedFileName === "bun.lockb" || normalizedFileName === "bun.lock") {
+    return { name: "bun" };
   }
+  if (normalizedFileName === "pnpm-lock.yaml") return { name: "pnpm" };
+  if (
+    normalizedFileName === ".gitignore" ||
+    normalizedFileName === ".gitattributes"
+  ) {
+    return { name: "git" };
+  }
+  if (normalizedFileName === "dockerfile") return { name: "docker" };
+  if (normalizedFileName === "makefile") return { name: "config" };
+  if (normalizedFileName.startsWith(".env")) return { name: "env" };
+  if (
+    SPECIAL_POLICY_FILENAMES.has(normalizedFileName) ||
+    normalizedFileName === "readme.md" ||
+    normalizedFileName === "readme"
+  ) {
+    return { name: "readme" };
+  }
+  if (normalizedFileName.endsWith(".lock")) return { name: "lock" };
 
-  if (SPREADSHEET_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileSpreadsheet,
-      className: "text-emerald-600 dark:text-emerald-400",
-    };
-  }
-
-  if (extension === ".pdf") {
-    return {
-      Icon: FileBadge2,
-      className: "text-rose-600 dark:text-rose-400",
-    };
-  }
+  if (SPREADSHEET_EXTENSIONS.has(extension)) return { name: "csv" };
+  if (extension === ".pdf") return { name: "pdf" };
 
   if (IMAGE_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileImage,
-      className: "text-sky-600 dark:text-sky-400",
-    };
+    return { name: extension === ".svg" ? "svg" : "image" };
   }
+  if (ARCHIVE_EXTENSIONS.has(extension)) return { name: "zip" };
+  if (AUDIO_EXTENSIONS.has(extension)) return { name: "audio" };
+  if (VIDEO_EXTENSIONS.has(extension)) return { name: "video" };
+  if (JSON_EXTENSIONS.has(extension)) return { name: "json" };
 
-  if (ARCHIVE_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileArchive,
-      className: "text-amber-600 dark:text-amber-400",
-    };
+  switch (extension) {
+    case ".ts":
+    case ".tsx":
+      return { name: "typescript" };
+    case ".js":
+    case ".jsx":
+    case ".mjs":
+    case ".cjs":
+      return { name: "javascript" };
+    case ".css":
+      return { name: "css" };
+    case ".scss":
+    case ".sass":
+      return { name: "sass" };
+    case ".html":
+    case ".htm":
+      return { name: "html" };
+    case ".xml":
+      return { name: "xml" };
+    case ".py":
+      return { name: "python" };
+    case ".sh":
+    case ".bash":
+    case ".zsh":
+      return { name: "bash" };
+    case ".sql":
+      return { name: "database" };
+    case ".go":
+      return { name: "go" };
+    case ".rs":
+      return { name: "rust" };
+    case ".java":
+      return { name: "java" };
+    case ".kt":
+      return { name: "kotlin" };
+    case ".php":
+      return { name: "php" };
+    case ".swift":
+      return { name: "swift" };
+    case ".c":
+      return { name: "c" };
+    case ".cc":
+    case ".cpp":
+    case ".h":
+    case ".hpp":
+      return { name: "cpp" };
+    case ".md":
+    case ".mdx":
+    case ".markdown":
+      return { name: "markdown" };
+    case ".yml":
+    case ".yaml":
+      return { name: "yaml" };
+    case ".toml":
+      return { name: "toml" };
+    case ".ini":
+      return { name: "config" };
+    default:
+      return { name: "text" };
   }
-
-  if (AUDIO_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileAudio2,
-      className: "text-teal-600 dark:text-teal-400",
-    };
-  }
-
-  if (VIDEO_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileVideoCamera,
-      className: "text-orange-600 dark:text-orange-400",
-    };
-  }
-
-  if (JSON_EXTENSIONS.has(extension)) {
-    return {
-      Icon: FileJson,
-      className: "text-amber-700 dark:text-amber-300",
-    };
-  }
-
-  if (
-    CODE_EXTENSIONS.has(extension) ||
-    SPECIAL_CODE_FILENAMES.has(normalizedFileName)
-  ) {
-    return {
-      Icon: FileCode2,
-      className: "text-sky-700 dark:text-sky-300",
-    };
-  }
-
-  if (
-    CONFIG_EXTENSIONS.has(extension) ||
-    normalizedFileName.startsWith(".env")
-  ) {
-    return {
-      Icon: FileCog,
-      className: "text-slate-600 dark:text-slate-400",
-    };
-  }
-
-  return {
-    Icon: FileText,
-    className: "text-muted-foreground",
-  };
 }
 
 function isMarkdownPreviewPayload(
@@ -688,7 +700,9 @@ function remapDirectoryEntriesByPath(
 ) {
   let changed = false;
   const nextEntriesByPath: Record<string, LocalFileEntry[]> = {};
-  for (const [directoryPath, entries] of Object.entries(directoryEntriesByPath)) {
+  for (const [directoryPath, entries] of Object.entries(
+    directoryEntriesByPath,
+  )) {
     const remappedDirectoryPath =
       remapPathAfterRename(sourcePath, nextPath, directoryPath) ||
       directoryPath;
@@ -913,11 +927,13 @@ function isWorkspaceRootExplorerView(
   workspaceRootPath: string | null | undefined,
 ) {
   const normalizedCurrentPath = normalizeComparablePath(currentPath ?? "");
-  const normalizedWorkspaceRoot = normalizeComparablePath(workspaceRootPath ?? "");
+  const normalizedWorkspaceRoot = normalizeComparablePath(
+    workspaceRootPath ?? "",
+  );
   return Boolean(
     normalizedCurrentPath &&
-      normalizedWorkspaceRoot &&
-      normalizedCurrentPath === normalizedWorkspaceRoot,
+    normalizedWorkspaceRoot &&
+    normalizedCurrentPath === normalizedWorkspaceRoot,
   );
 }
 
@@ -956,8 +972,30 @@ function renameSelectionEnd(targetName: string, isDirectory: boolean) {
   return lastDotIndex;
 }
 
+function getExplorerRowTooltip(entry: LocalFileEntry, isExpanded: boolean) {
+  if (entry.isDirectory) {
+    return isExpanded ? `Collapse ${entry.name}` : `Expand ${entry.name}`;
+  }
+  return `Open ${entry.name}`;
+}
+
+function getExplorerRowId(absolutePath: string) {
+  return `explorer-row-${absolutePath.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
 function createAttachmentDragPreview(entry: LocalFileEntry) {
   const preview = document.createElement("div");
+  const rootStyles = getComputedStyle(document.documentElement);
+  const popoverBg =
+    rootStyles.getPropertyValue("--popover").trim() ||
+    rootStyles.getPropertyValue("--card").trim() ||
+    "var(--background)";
+  const primary = rootStyles.getPropertyValue("--primary").trim() || "#f58419";
+  const popoverFg =
+    rootStyles.getPropertyValue("--popover-foreground").trim() ||
+    rootStyles.getPropertyValue("--foreground").trim() ||
+    "#111";
+
   preview.style.position = "fixed";
   preview.style.top = "-1000px";
   preview.style.left = "-1000px";
@@ -965,12 +1003,12 @@ function createAttachmentDragPreview(entry: LocalFileEntry) {
   preview.style.alignItems = "center";
   preview.style.maxWidth = "220px";
   preview.style.padding = "6px 10px";
-  preview.style.border = "1px solid rgba(252, 127, 120, 0.34)";
+  preview.style.border = `1px solid color-mix(in oklch, ${primary} 34%, transparent)`;
   preview.style.borderRadius = "999px";
-  preview.style.background = "rgba(255, 248, 247, 0.96)";
-  preview.style.boxShadow = "0 10px 24px rgba(45, 18, 16, 0.14)";
+  preview.style.background = `color-mix(in oklch, ${popoverBg} 92%, transparent)`;
+  preview.style.boxShadow = `0 10px 24px color-mix(in oklch, ${popoverFg} 14%, transparent)`;
   preview.style.backdropFilter = "blur(10px)";
-  preview.style.color = "rgba(49, 32, 29, 0.96)";
+  preview.style.color = popoverFg;
   preview.style.fontFamily =
     "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   preview.style.pointerEvents = "none";
@@ -1053,7 +1091,6 @@ export function FileExplorerPane({
   const [previewError, setPreviewError] = useState("");
   const [saving, setSaving] = useState(false);
   const [fileBookmarks, setFileBookmarks] = useState<FileBookmarkPayload[]>([]);
-  const [containerWidth, setContainerWidth] = useState(0);
   const [contextMenu, setContextMenu] =
     useState<FileExplorerContextMenuState | null>(null);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
@@ -1064,7 +1101,37 @@ export function FileExplorerPane({
     string | null
   >(null);
   const [paneExternalDropTarget, setPaneExternalDropTarget] = useState(false);
+  const [confirmRequest, setConfirmRequest] = useState<{
+    title: string;
+    description?: string;
+    confirmLabel?: string;
+    destructive?: boolean;
+  } | null>(null);
+  const confirmResolveRef = useRef<((value: boolean) => void) | null>(null);
   const { selectedWorkspaceId } = useWorkspaceSelection();
+
+  const requestConfirmation = useCallback(
+    (request: {
+      title: string;
+      description?: string;
+      confirmLabel?: string;
+      destructive?: boolean;
+    }) => {
+      confirmResolveRef.current?.(false);
+      return new Promise<boolean>((resolve) => {
+        confirmResolveRef.current = resolve;
+        setConfirmRequest(request);
+      });
+    },
+    [],
+  );
+
+  const handleConfirmResolution = useCallback((result: boolean) => {
+    const resolve = confirmResolveRef.current;
+    confirmResolveRef.current = null;
+    setConfirmRequest(null);
+    resolve?.(result);
+  }, []);
 
   currentPathRef.current = currentPath;
 
@@ -1373,13 +1440,23 @@ export function FileExplorerPane({
       }
     };
 
-    const timer = window.setInterval(() => {
+    const tick = () => {
+      if (document.visibilityState !== "visible") return;
       void refreshLoadedDirectories();
-    }, 1200);
+    };
+
+    const timer = window.setInterval(tick, 5000);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refreshLoadedDirectories();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       cancelled = true;
       window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [
     currentPath,
@@ -1408,24 +1485,6 @@ export function FileExplorerPane({
       unsubscribe();
     };
   }, [selectedWorkspaceId]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
-      return;
-    }
-
-    const syncWidth = () => {
-      setContainerWidth(container.getBoundingClientRect().width);
-    };
-
-    syncWidth();
-
-    const observer = new ResizeObserver(syncWidth);
-    observer.observe(container);
-
-    return () => observer.disconnect();
-  }, []);
 
   useEffect(() => {
     return () => {
@@ -1465,7 +1524,15 @@ export function FileExplorerPane({
     window.addEventListener("resize", closeMenu);
     window.addEventListener("blur", closeMenu);
 
+    const focusTimer = window.setTimeout(() => {
+      const firstItem = contextMenuRef.current?.querySelector<HTMLElement>(
+        '[role="menuitem"]:not([disabled])',
+      );
+      firstItem?.focus();
+    }, 0);
+
     return () => {
+      window.clearTimeout(focusTimer);
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleEscape);
       window.removeEventListener("resize", closeMenu);
@@ -1498,7 +1565,8 @@ export function FileExplorerPane({
       isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
     );
     const workspaceEntries = entries.filter(
-      (entry) => !isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
+      (entry) =>
+        !isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
     );
     const protectedRows = buildRows(protectedRootEntries);
     const workspaceRows = buildRows(workspaceEntries);
@@ -1547,7 +1615,7 @@ export function FileExplorerPane({
   const creationTargetDirectoryPath = selectedEntry?.isDirectory
     ? selectedEntry.absolutePath
     : selectedEntry
-      ? getParentFolderPath(selectedEntry.absolutePath) ?? currentPath
+      ? (getParentFolderPath(selectedEntry.absolutePath) ?? currentPath)
       : currentPath;
   const isDirty =
     preview?.kind === "text" && preview.isEditable
@@ -1575,13 +1643,16 @@ export function FileExplorerPane({
     resetPreviewState();
   }, [error, hasVisibleEntryRows, loading, resetPreviewState]);
 
-  const openPreviewLink = useCallback((url: string) => {
-    if (onOpenLinkInBrowser) {
-      onOpenLinkInBrowser(url);
-      return;
-    }
-    void window.electronAPI.ui.openExternalUrl(url);
-  }, [onOpenLinkInBrowser]);
+  const openPreviewLink = useCallback(
+    (url: string) => {
+      if (onOpenLinkInBrowser) {
+        onOpenLinkInBrowser(url);
+        return;
+      }
+      void window.electronAPI.ui.openExternalUrl(url);
+    },
+    [onOpenLinkInBrowser],
+  );
 
   const closeContextMenu = useCallback(() => {
     setContextMenu(null);
@@ -1679,7 +1750,11 @@ export function FileExplorerPane({
         });
       }
     },
-    [directoryEntriesByPath, selectedWorkspaceId, validateWorkspaceScopedTargetPath],
+    [
+      directoryEntriesByPath,
+      selectedWorkspaceId,
+      validateWorkspaceScopedTargetPath,
+    ],
   );
 
   const refreshDirectoryEntries = useCallback(
@@ -1795,15 +1870,19 @@ export function FileExplorerPane({
     [closeContextMenu, ensureDirectoryEntriesLoaded, expandedDirectoryPaths],
   );
 
-  const confirmDiscardIfDirty = useCallback(() => {
+  const confirmDiscardIfDirty = useCallback(async () => {
     if (!isDirty) {
       return true;
     }
 
-    return window.confirm(
-      "You have unsaved changes. Press Cancel to go back and save them, or OK to discard them.",
-    );
-  }, [isDirty]);
+    return requestConfirmation({
+      title: "Discard unsaved changes?",
+      description:
+        "You have unsaved changes in this file. Discarding will lose them — cancel to return and save first.",
+      confirmLabel: "Discard changes",
+      destructive: true,
+    });
+  }, [isDirty, requestConfirmation]);
 
   useEffect(() => {
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -2006,7 +2085,7 @@ export function FileExplorerPane({
     }
 
     const skipConfirm = options?.skipConfirm ?? false;
-    if (!skipConfirm && !confirmDiscardIfDirty()) {
+    if (!skipConfirm && !(await confirmDiscardIfDirty())) {
       return;
     }
 
@@ -2076,7 +2155,7 @@ export function FileExplorerPane({
       }
 
       const skipConfirm = options?.skipConfirm ?? false;
-      if (!skipConfirm && !confirmDiscardIfDirty()) {
+      if (!skipConfirm && !(await confirmDiscardIfDirty())) {
         return;
       }
 
@@ -2099,8 +2178,106 @@ export function FileExplorerPane({
     ],
   );
 
-  const closePreview = () => {
-    if (!confirmDiscardIfDirty()) {
+  const handleTreeKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (renamingPath) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isEditableKeyboardTarget(event.target)) return;
+
+      const entryRows = visibleRows.filter(
+        (row): row is Extract<FileExplorerVisibleRow, { type: "entry" }> =>
+          row.type === "entry",
+      );
+      if (entryRows.length === 0) return;
+
+      const currentIndex = entryRows.findIndex(
+        (row) => row.entry.absolutePath === selectedPath,
+      );
+
+      const focus = (index: number) => {
+        const clamped = Math.max(0, Math.min(index, entryRows.length - 1));
+        setSelectedPath(entryRows[clamped].entry.absolutePath);
+      };
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          focus(currentIndex < 0 ? 0 : currentIndex + 1);
+          return;
+        case "ArrowUp":
+          event.preventDefault();
+          focus(currentIndex < 0 ? 0 : currentIndex - 1);
+          return;
+        case "Home":
+          event.preventDefault();
+          focus(0);
+          return;
+        case "End":
+          event.preventDefault();
+          focus(entryRows.length - 1);
+          return;
+        case "ArrowRight": {
+          if (currentIndex < 0) return;
+          const row = entryRows[currentIndex];
+          if (row.entry.isDirectory) {
+            event.preventDefault();
+            if (!row.isExpanded) {
+              void toggleDirectoryExpansion(row.entry);
+              return;
+            }
+            const child = entryRows[currentIndex + 1];
+            if (child && child.depth > row.depth) {
+              focus(currentIndex + 1);
+            }
+          }
+          return;
+        }
+        case "ArrowLeft": {
+          if (currentIndex < 0) return;
+          const row = entryRows[currentIndex];
+          event.preventDefault();
+          if (row.entry.isDirectory && row.isExpanded) {
+            void toggleDirectoryExpansion(row.entry);
+            return;
+          }
+          for (let i = currentIndex - 1; i >= 0; i -= 1) {
+            if (entryRows[i].depth < row.depth) {
+              focus(i);
+              return;
+            }
+          }
+          return;
+        }
+        case "Enter": {
+          if (currentIndex < 0) return;
+          const row = entryRows[currentIndex];
+          event.preventDefault();
+          if (row.entry.isDirectory) {
+            void toggleDirectoryExpansion(row.entry);
+          } else if (previewInPane) {
+            void openFilePreview(row.entry.absolutePath);
+          } else {
+            void openFileTarget(row.entry.absolutePath);
+          }
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [
+      openFilePreview,
+      openFileTarget,
+      previewInPane,
+      renamingPath,
+      selectedPath,
+      toggleDirectoryExpansion,
+      visibleRows,
+    ],
+  );
+
+  const closePreview = async () => {
+    if (!(await confirmDiscardIfDirty())) {
       return;
     }
 
@@ -2187,7 +2364,6 @@ export function FileExplorerPane({
   );
   const activeBookmarkId =
     preview?.absolutePath ?? selectedFileEntry?.absolutePath ?? currentPath;
-  const isCompact = containerWidth > 0 && containerWidth < 420;
   const normalizedQuery = query.trim().toLowerCase();
 
   const toggleBookmark = async () => {
@@ -2332,8 +2508,7 @@ export function FileExplorerPane({
       );
       const nextAbsolutePath = payload.absolutePath;
       const parentPath =
-        getParentFolderPath(sourcePath) ??
-        currentPathRef.current;
+        getParentFolderPath(sourcePath) ?? currentPathRef.current;
       setDirectoryEntriesByPath((current) =>
         remapDirectoryEntriesByPath(current, sourcePath, nextAbsolutePath),
       );
@@ -2375,7 +2550,10 @@ export function FileExplorerPane({
           nextAbsolutePath,
           current.absolutePath,
         );
-        if (!remappedAbsolutePath || remappedAbsolutePath === current.absolutePath) {
+        if (
+          !remappedAbsolutePath ||
+          remappedAbsolutePath === current.absolutePath
+        ) {
           return current;
         }
         return {
@@ -2476,8 +2654,12 @@ export function FileExplorerPane({
   );
 
   const importExternalEntriesToDirectory = useCallback(
-    async (dataTransfer: DataTransfer | null, destinationDirectoryPath: string) => {
-      const normalizedDestinationDirectoryPath = destinationDirectoryPath.trim();
+    async (
+      dataTransfer: DataTransfer | null,
+      destinationDirectoryPath: string,
+    ) => {
+      const normalizedDestinationDirectoryPath =
+        destinationDirectoryPath.trim();
       if (!normalizedDestinationDirectoryPath || importInFlightRef.current) {
         return;
       }
@@ -2489,7 +2671,8 @@ export function FileExplorerPane({
       importInFlightRef.current = true;
 
       try {
-        const importedEntries = await collectDroppedExternalEntries(dataTransfer);
+        const importedEntries =
+          await collectDroppedExternalEntries(dataTransfer);
         if (importedEntries.length === 0) {
           return;
         }
@@ -2514,7 +2697,9 @@ export function FileExplorerPane({
             ) === index,
         ) as string[];
         await Promise.all(
-          refreshTargets.map((targetPath) => refreshDirectoryEntries(targetPath)),
+          refreshTargets.map((targetPath) =>
+            refreshDirectoryEntries(targetPath),
+          ),
         );
 
         const firstImportedPath = payload.absolutePaths[0] ?? "";
@@ -2564,7 +2749,10 @@ export function FileExplorerPane({
         return false;
       }
       const protectedMessage =
-        protectedWorkspacePathMessage(workspaceRootPath, normalizedSourcePath) ||
+        protectedWorkspacePathMessage(
+          workspaceRootPath,
+          normalizedSourcePath,
+        ) ||
         protectedWorkspacePathMessage(
           workspaceRootPath,
           normalizedDestinationDirectoryPath,
@@ -2608,7 +2796,9 @@ export function FileExplorerPane({
             ) === index,
         );
         await Promise.all(
-          refreshTargets.map((targetPath) => refreshDirectoryEntries(targetPath)),
+          refreshTargets.map((targetPath) =>
+            refreshDirectoryEntries(targetPath),
+          ),
         );
         await revealPathInTree(payload.absolutePath);
         if (explorerClipboardEntry) {
@@ -2675,7 +2865,8 @@ export function FileExplorerPane({
     async (destinationDirectoryPath?: string | null) => {
       const clipboardEntry = explorerClipboardEntry;
       const normalizedDestinationDirectoryPath =
-        (destinationDirectoryPath ?? "").trim() || currentPathRef.current.trim();
+        (destinationDirectoryPath ?? "").trim() ||
+        currentPathRef.current.trim();
       if (
         !clipboardEntry ||
         !normalizedDestinationDirectoryPath ||
@@ -2686,7 +2877,9 @@ export function FileExplorerPane({
 
       const normalizedWorkspaceId = selectedWorkspaceId?.trim() || "";
       if (clipboardEntry.workspaceId !== normalizedWorkspaceId) {
-        setError("Copy, cut, and paste only work within the current workspace.");
+        setError(
+          "Copy, cut, and paste only work within the current workspace.",
+        );
         return;
       }
 
@@ -2821,13 +3014,18 @@ export function FileExplorerPane({
         return false;
       }
       if (
-        isProtectedWorkspacePath(workspaceRootPath, normalizedDraggedEntryPath) ||
+        isProtectedWorkspacePath(
+          workspaceRootPath,
+          normalizedDraggedEntryPath,
+        ) ||
         isProtectedWorkspacePath(workspaceRootPath, normalizedTargetPath)
       ) {
         return false;
       }
 
-      const draggedEntryParentPath = getParentFolderPath(draggedEntryPath ?? "");
+      const draggedEntryParentPath = getParentFolderPath(
+        draggedEntryPath ?? "",
+      );
       return (
         normalizeComparablePath(draggedEntryParentPath ?? "") !==
         normalizedTargetPath
@@ -2929,11 +3127,16 @@ export function FileExplorerPane({
         setError(protectedMessage);
         return;
       }
-      const confirmed = window.confirm(
-        entry.isDirectory
-          ? `Delete folder "${entry.name}" and all of its contents? This cannot be undone.`
-          : `Delete file "${entry.name}"? This cannot be undone.`,
-      );
+      const confirmed = await requestConfirmation({
+        title: entry.isDirectory
+          ? `Delete folder "${entry.name}"?`
+          : `Delete file "${entry.name}"?`,
+        description: entry.isDirectory
+          ? "The folder and all of its contents will be permanently removed. This cannot be undone."
+          : "This file will be permanently removed. This cannot be undone.",
+        confirmLabel: "Delete",
+        destructive: true,
+      });
       if (!confirmed) {
         return;
       }
@@ -2984,6 +3187,7 @@ export function FileExplorerPane({
       onDeleteEntry,
       preview?.absolutePath,
       refreshDirectoryEntries,
+      requestConfirmation,
       resetPreviewState,
       selectedPath,
       selectedWorkspaceId,
@@ -3017,14 +3221,18 @@ export function FileExplorerPane({
   const previewFileIcon = selectedEntry
     ? getExplorerIconDescriptor(previewFileName, selectedEntry.isDirectory)
     : getExplorerIconDescriptor(previewFileName, false);
-  const PreviewFileIcon = previewFileIcon.Icon;
 
   const content = showInlinePreview ? (
     <div className="flex h-full min-h-0 flex-col bg-background">
       {/* File identity header */}
       <div className="flex shrink-0 items-center gap-3 border-b border-border/30 px-4 py-2.5">
-        <span className={`grid size-7 shrink-0 place-items-center rounded-lg border border-border/40 bg-muted/30 ${previewFileIcon.className}`}>
-          <PreviewFileIcon size={14} />
+        <span className="grid size-7 shrink-0 place-items-center rounded-lg border border-border/40 bg-muted/30">
+          <IconifyIcon
+            icon={`catppuccin:${previewFileIcon.name}`}
+            width={15}
+            height={15}
+            className="grayscale contrast-125"
+          />
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -3032,14 +3240,19 @@ export function FileExplorerPane({
               {previewFileName}
             </span>
             {isDirty ? (
-              <Badge variant="outline" className="border-warning/30 bg-warning/10 text-warning">
+              <Badge
+                variant="outline"
+                className="border-warning/30 bg-warning/10 text-warning"
+              >
                 Unsaved
               </Badge>
             ) : null}
           </div>
-          <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             {selectedPath ? (
-              <span className="truncate">{selectedPath.split("/").slice(-2, -1)[0] || ""}/</span>
+              <span className="truncate">
+                {selectedPath.split("/").slice(-2, -1)[0] || ""}/
+              </span>
             ) : null}
             {preview?.size != null ? (
               <span className="shrink-0">{formatFileSize(preview.size)}</span>
@@ -3047,7 +3260,9 @@ export function FileExplorerPane({
             {preview?.modifiedAt ? (
               <>
                 <span className="shrink-0 text-border">·</span>
-                <span className="shrink-0">{formatModified(preview.modifiedAt)}</span>
+                <span className="shrink-0">
+                  {formatModified(preview.modifiedAt)}
+                </span>
               </>
             ) : null}
           </div>
@@ -3059,24 +3274,33 @@ export function FileExplorerPane({
         {previewLoading ? (
           <div className="grid h-full place-items-center">
             <div className="text-center">
-              <Loader2 size={16} className="mx-auto animate-spin text-muted-foreground" />
-              <div className="mt-2 text-xs text-muted-foreground">Loading file...</div>
+              <Loader2
+                size={16}
+                className="mx-auto animate-spin text-muted-foreground"
+              />
+              <div className="mt-2 text-xs text-muted-foreground">
+                Loading file...
+              </div>
             </div>
           </div>
         ) : previewError ? (
           <div className="grid h-full place-items-center px-6 text-center">
             <div>
-              <div className="text-sm font-medium text-destructive">Cannot preview</div>
-              <div className="mt-1 text-xs text-muted-foreground">{previewError}</div>
+              <div className="text-sm font-medium text-destructive">
+                Cannot preview
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {previewError}
+              </div>
             </div>
           </div>
         ) : preview?.kind === "text" ? (
           isMarkdownPreview && textPreviewMode === "preview" ? (
             <div className="h-full overflow-auto">
-              <div className="mx-auto max-w-2xl px-6 py-6">
+              <div className="mx-auto max-w-3xl px-10 py-12">
                 {previewDraft.trim() ? (
                   <SimpleMarkdown
-                    className="chat-markdown text-sm leading-7 text-foreground"
+                    className="file-preview-markdown"
                     onLinkClick={openPreviewLink}
                   >
                     {previewDraft}
@@ -3108,14 +3332,13 @@ export function FileExplorerPane({
           ) : (
             <div className="h-full overflow-auto bg-muted/20">
               <textarea
+                aria-label={`Edit ${preview.name}`}
                 value={previewDraft}
                 onChange={(event) => setPreviewDraft(event.target.value)}
                 readOnly={!preview.isEditable}
                 spellCheck={false}
                 className={`h-full min-h-full w-full resize-none border-0 bg-transparent px-6 py-5 font-mono text-[13px] leading-6 text-foreground outline-none ${
-                  preview.isEditable
-                    ? ""
-                    : "cursor-default opacity-80"
+                  preview.isEditable ? "" : "cursor-default opacity-80"
                 }`}
               />
             </div>
@@ -3154,7 +3377,12 @@ export function FileExplorerPane({
           />
         ) : (
           <div className="flex h-full flex-col items-center justify-center rounded-lg border border-border bg-muted px-5 text-center">
-            <FileText size={22} className="mb-3 text-muted-foreground" />
+            <IconifyIcon
+              icon="catppuccin:text"
+              width={22}
+              height={22}
+              className="mb-3 grayscale contrast-125 opacity-60"
+            />
             <div className="text-sm font-medium text-foreground">
               Preview unavailable
             </div>
@@ -3173,7 +3401,7 @@ export function FileExplorerPane({
           <div className="chat-scrollbar-hidden flex min-h-0 flex-1 flex-col items-center gap-1 overflow-x-hidden overflow-y-auto px-1">
             {fileBookmarks.map((bookmark) => {
               const isActive = activeBookmarkId === bookmark.targetPath;
-              const { Icon, className } = getExplorerIconDescriptor(
+              const descriptor = getExplorerIconDescriptor(
                 bookmark.targetPath,
                 bookmark.isDirectory,
               );
@@ -3185,11 +3413,16 @@ export function FileExplorerPane({
                   title={bookmark.label}
                   className={`grid size-7 shrink-0 place-items-center rounded-md transition-colors ${
                     isActive
-                      ? "bg-primary/12 text-primary"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                      ? "bg-accent text-foreground ring-1 ring-inset ring-primary/30"
+                      : "text-muted-foreground hover:bg-muted"
                   }`}
                 >
-                  <Icon size={14} className={className} />
+                  <IconifyIcon
+                    icon={`catppuccin:${descriptor.name}`}
+                    width={15}
+                    height={15}
+                    className="grayscale contrast-125"
+                  />
                 </button>
               );
             })}
@@ -3198,15 +3431,16 @@ export function FileExplorerPane({
       ) : null}
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <div className="shrink-0 border-b border-border px-3 py-2">
-          <div className="flex items-center gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2 rounded-xl border border-border bg-muted/50 px-2.5 py-1.5 text-xs transition-colors focus-within:border-ring">
-              <Search size={13} className="shrink-0 text-muted-foreground" />
+        <div className="shrink-0 border-b border-border px-2 py-1.5">
+          <div className="flex items-center gap-1.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-xs transition-colors focus-within:border-ring">
+              <Search size={12} className="shrink-0 text-muted-foreground" />
               <input
+                aria-label="Search files"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                className="embedded-input min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/50"
-                placeholder="Search files"
+                className="embedded-input min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+                placeholder="Search"
               />
             </div>
             <DropdownMenu>
@@ -3222,7 +3456,7 @@ export function FileExplorerPane({
                   />
                 }
               >
-                <Plus size={13} />
+                <Plus size={14} />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" sideOffset={6} className="w-40">
                 <DropdownMenuItem
@@ -3254,7 +3488,7 @@ export function FileExplorerPane({
               }`}
             >
               <Star
-                size={13}
+                size={14}
                 className={activeBookmark ? "fill-current" : ""}
               />
             </Button>
@@ -3262,9 +3496,16 @@ export function FileExplorerPane({
         </div>
 
         <div
-          className={`chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1.5 pb-1.5 pt-1 ${
+          role="tree"
+          aria-label="Workspace files"
+          tabIndex={0}
+          aria-activedescendant={
+            selectedPath ? getExplorerRowId(selectedPath) : undefined
+          }
+          onKeyDown={handleTreeKeyDown}
+          className={`chat-scrollbar-hidden min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1 py-1 outline-none focus-visible:ring-1 focus-visible:ring-ring/50 ${
             paneExternalDropTarget
-              ? "rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/30"
+              ? "rounded-sm ring-1 ring-inset ring-primary/40"
               : ""
           }`}
           onDragOver={onPaneDragOver}
@@ -3272,18 +3513,18 @@ export function FileExplorerPane({
           onDrop={onPaneDrop}
         >
           {loading ? (
-            <div className="px-2 py-4 text-xs text-muted-foreground">
-              Loading directory...
+            <div className="px-1.5 py-2 text-xs text-muted-foreground">
+              Loading…
             </div>
           ) : null}
 
           {error ? (
-            <div className="px-2 py-3 text-xs text-destructive">{error}</div>
+            <div className="px-1.5 py-2 text-xs text-destructive">{error}</div>
           ) : null}
 
           {!loading && !error && visibleRows.length === 0 ? (
-            <div className="px-2 py-4 text-xs text-muted-foreground">
-              No files matched your search.
+            <div className="px-1.5 py-2 text-xs text-muted-foreground">
+              No matches.
             </div>
           ) : null}
 
@@ -3291,325 +3532,323 @@ export function FileExplorerPane({
             ? filteredEntries.map((section, sectionIndex) => (
                 <div
                   key={section.id}
-                  className={
-                    sectionIndex > 0 ? "mt-3 border-t border-border/40 pt-2" : ""
+                  role="group"
+                  aria-label={
+                    section.id === "protected"
+                      ? "Protected workspace files"
+                      : "Workspace files"
                   }
+                  className={sectionIndex > 0 ? "mt-1.5 pt-1.5" : ""}
                 >
                   {section.rows.map((row) => {
-                if (row.type === "feedback") {
-                  return (
-                    <div
-                      key={row.id}
-                      className={`mb-0.5 rounded-md px-2 py-1.5 text-[11px] ${
-                        row.tone === "error"
-                          ? "text-destructive"
-                          : "text-muted-foreground"
-                      }`}
-                      style={{ paddingLeft: `${8 + row.depth * 16}px` }}
-                    >
-                      {row.message}
-                    </div>
-                  );
-                }
-
-                const { entry, depth, isExpanded, isLoadingChildren } = row;
-                const { Icon, className } = getExplorerIconDescriptor(
-                  entry.name,
-                  entry.isDirectory,
-                );
-                const entryIsProtected = isProtectedWorkspacePath(
-                  workspaceRootPath,
-                  entry.absolutePath,
-                );
-                const selected = selectedPath === entry.absolutePath;
-                const isRenaming = renamingPath === entry.absolutePath;
-                const isDirectoryDropTarget =
-                  directoryDropTargetPath === entry.absolutePath;
-                const isContextMenuTarget =
-                  contextMenu?.entry.absolutePath === entry.absolutePath;
-                const rowHoverActionsClassName = `${
-                  selected || isContextMenuTarget
-                    ? "opacity-100"
-                    : "opacity-0 pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
-                }`;
-                const rowClassName = `group mb-0.5 w-full rounded-md px-2 py-1.5 text-left transition-colors ${
-                  selected
-                    ? "bg-primary/10 text-primary"
-                    : "text-foreground/80 hover:bg-accent hover:text-accent-foreground"
-                } ${
-                  isDirectoryDropTarget
-                    ? "bg-emerald-500/10 text-emerald-700 ring-1 ring-emerald-500/30 dark:text-emerald-300"
-                    : ""
-                } ${isRenaming ? "cursor-default" : "cursor-pointer"}`;
-                const nameField = isRenaming ? (
-                  <input
-                    ref={renameInputRef}
-                    value={renameDraft}
-                    onChange={(event) => setRenameDraft(event.target.value)}
-                    onBlur={() => {
-                      void submitRenameEntry();
-                    }}
-                    onClick={(event) => event.stopPropagation()}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        event.preventDefault();
-                        void submitRenameEntry();
-                        return;
-                      }
-                      if (event.key === "Escape") {
-                        event.preventDefault();
-                        cancelRenameEntry();
-                      }
-                    }}
-                    disabled={renameSaving}
-                    className="embedded-input h-6 min-w-0 flex-1 rounded-sm border border-border/70 bg-background px-1.5 text-xs font-medium text-foreground outline-none focus:border-ring disabled:opacity-60"
-                  />
-                ) : (
-                  <span className="truncate text-xs font-medium">
-                    {entry.name}
-                  </span>
-                );
-                const disclosureControl = entry.isDirectory ? (
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      void toggleDirectoryExpansion(entry);
-                    }}
-                    className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label={
-                      isExpanded ? "Collapse folder" : "Expand folder"
+                    if (row.type === "feedback") {
+                      return (
+                        <div
+                          key={row.id}
+                          className={`rounded-sm px-1.5 py-1 text-xs ${
+                            row.tone === "error"
+                              ? "text-destructive"
+                              : "text-muted-foreground"
+                          }`}
+                          style={{ paddingLeft: `${6 + row.depth * 12}px` }}
+                        >
+                          {row.message}
+                        </div>
+                      );
                     }
-                  >
-                    <ChevronRight
-                      size={12}
-                      className={`transition-transform duration-200 ${
-                        isExpanded ? "rotate-90" : ""
-                      } ${isLoadingChildren ? "opacity-60" : ""}`}
-                    />
-                  </button>
-                ) : (
-                  <span className="size-4 shrink-0" />
-                );
-                const rowContent = (
-                  <span
-                    className="flex min-w-0 flex-1 items-center gap-2"
-                    style={{ paddingLeft: `${depth * 16}px` }}
-                  >
-                    {disclosureControl}
-                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <span className="flex min-w-0 items-center gap-2">
-                        <Icon size={14} className={`shrink-0 ${className}`} />
+
+                    const { entry, depth, isExpanded, isLoadingChildren } = row;
+                    const descriptor = getExplorerIconDescriptor(
+                      entry.name,
+                      entry.isDirectory,
+                      isExpanded,
+                    );
+                    const entryIsProtected = isProtectedWorkspacePath(
+                      workspaceRootPath,
+                      entry.absolutePath,
+                    );
+                    const selected = selectedPath === entry.absolutePath;
+                    const isRenaming = renamingPath === entry.absolutePath;
+                    const isDirectoryDropTarget =
+                      directoryDropTargetPath === entry.absolutePath;
+                    const isContextMenuTarget =
+                      contextMenu?.entry.absolutePath === entry.absolutePath;
+                    const rowHoverActionsClassName = `${
+                      selected || isContextMenuTarget
+                        ? "opacity-100"
+                        : "opacity-0 pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+                    }`;
+                    const rowClassName = `group w-full rounded-sm px-1.5 py-1 text-left transition-colors ${
+                      selected
+                        ? "bg-accent text-foreground"
+                        : "text-foreground hover:bg-muted"
+                    } ${
+                      isDirectoryDropTarget
+                        ? "ring-1 ring-inset ring-primary/40"
+                        : ""
+                    } ${isRenaming ? "cursor-default" : "cursor-pointer"}`;
+                    const nameField = isRenaming ? (
+                      <input
+                        ref={renameInputRef}
+                        value={renameDraft}
+                        onChange={(event) => setRenameDraft(event.target.value)}
+                        onBlur={() => {
+                          void submitRenameEntry();
+                        }}
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void submitRenameEntry();
+                            return;
+                          }
+                          if (event.key === "Escape") {
+                            event.preventDefault();
+                            cancelRenameEntry();
+                          }
+                        }}
+                        disabled={renameSaving}
+                        className="embedded-input h-6 min-w-0 flex-1 rounded-sm border border-border bg-background px-1.5 text-sm text-foreground outline-none focus:border-ring disabled:opacity-60"
+                      />
+                    ) : (
+                      <span className="truncate text-sm">{entry.name}</span>
+                    );
+                    const disclosureControl = entry.isDirectory ? (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void toggleDirectoryExpansion(entry);
+                        }}
+                        className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+                        aria-label={
+                          isExpanded ? "Collapse folder" : "Expand folder"
+                        }
+                      >
+                        <ChevronRight
+                          size={10}
+                          className={`transition-transform duration-150 ${
+                            isExpanded ? "rotate-90" : ""
+                          } ${isLoadingChildren ? "opacity-60" : ""}`}
+                        />
+                      </button>
+                    ) : (
+                      <span className="size-3.5 shrink-0" />
+                    );
+                    const rowContent = (
+                      <span
+                        className="flex min-w-0 flex-1 items-center gap-1.5"
+                        style={{ paddingLeft: `${depth * 12}px` }}
+                      >
+                        {disclosureControl}
+                        <IconifyIcon
+                          icon={`catppuccin:${descriptor.name}`}
+                          strokeWidth={1.25}
+                          stroke="currentColor"
+                          className="shrink-0 size-4 text-foreground/80"
+                        />
                         {nameField}
                       </span>
-                      <span className="flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground">
-                        <span className="truncate">
-                          {formatModified(entry.modifiedAt)}
-                        </span>
-                        {!entry.isDirectory ? (
-                          <span className="shrink-0">
-                            {formatFileSize(entry.size)}
-                          </span>
-                        ) : null}
-                      </span>
-                    </span>
-                  </span>
-                );
-                return (
-                  <div
-                    key={entry.absolutePath}
-                    className={rowClassName}
-                    title={
-                      entry.isDirectory
-                        ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, use @ or drag to attach in chat, drop files or folders here`
-                        : previewInPane
-                          ? `${entry.name} — double-click to open file, use @ or drag to attach in chat`
-                          : `${entry.name} — click to open file, use @ or drag to attach in chat`
-                    }
-                    onDragOver={(event) => {
-                      const canMoveDraggedEntry =
-                        canDropDraggedEntryIntoDirectory(entry);
-                      const canImportExternalEntries =
-                        entry.isDirectory &&
-                        hasExternalExplorerDropData(event.dataTransfer);
-                      if (!canMoveDraggedEntry && !canImportExternalEntries) {
-                        return;
-                      }
-                      event.preventDefault();
-                      event.stopPropagation();
-                      event.dataTransfer.dropEffect = canMoveDraggedEntry
-                        ? "move"
-                        : "copy";
-                      if (paneExternalDropTarget) {
-                        setPaneExternalDropTarget(false);
-                      }
-                      if (directoryDropTargetPath !== entry.absolutePath) {
-                        setDirectoryDropTargetPath(entry.absolutePath);
-                      }
-                    }}
-                    onDragLeave={(event) => {
-                      if (directoryDropTargetPath !== entry.absolutePath) {
-                        return;
-                      }
-                      const relatedTarget = event.relatedTarget;
-                      if (
-                        typeof Node !== "undefined" &&
-                        relatedTarget instanceof Node &&
-                        event.currentTarget.contains(relatedTarget)
-                      ) {
-                        return;
-                      }
-                      setDirectoryDropTargetPath(null);
-                    }}
-                    onDrop={(event) => {
-                      const canMoveDraggedEntry =
-                        canDropDraggedEntryIntoDirectory(entry);
-                      const canImportExternalEntries =
-                        entry.isDirectory &&
-                        hasExternalExplorerDropData(event.dataTransfer);
-                      if (
-                        !canMoveDraggedEntry &&
-                        !canImportExternalEntries
-                      ) {
-                        return;
-                      }
-                      event.preventDefault();
-                      event.stopPropagation();
-                      clearActiveDropTargets();
-                      if (canMoveDraggedEntry && draggedEntryPath) {
-                        void moveEntryToDirectory(
-                          draggedEntryPath,
-                          entry.absolutePath,
-                        );
-                        return;
-                      }
-                      void importExternalEntriesToDirectory(
-                        event.dataTransfer,
-                        entry.absolutePath,
-                      );
-                    }}
-                    onContextMenu={(event) => {
-                      event.preventDefault();
-                      if (isRenaming) {
-                        return;
-                      }
-                      openEntryContextMenu(entry, {
-                        x: event.clientX,
-                        y: event.clientY,
-                      });
-                    }}
-                  >
-                    {isRenaming ? (
-                      <div className="w-full">{rowContent}</div>
-                    ) : (
-                      <div className="flex w-full min-w-0 items-center gap-1">
-                        <button
-                          type="button"
-                          draggable={!entryIsProtected}
-                          onClick={() => {
-                            setSelectedPath(entry.absolutePath);
-                            closeContextMenu();
-                            if (entry.isDirectory) {
-                              void toggleDirectoryExpansion(entry);
-                              return;
-                            }
-                            if (!previewInPane) {
-                              void openFileTarget(entry.absolutePath);
-                            }
-                          }}
-                          onDoubleClick={() => {
-                            if (!entry.isDirectory && previewInPane) {
-                              void openFilePreview(entry.absolutePath);
-                            }
-                          }}
-                          onDragStart={(event) => {
-                            if (entryIsProtected) {
-                              event.preventDefault();
-                              return;
-                            }
-
-                            setDraggedEntryPath(entry.absolutePath);
-                            clearActiveDropTargets();
-                            event.dataTransfer.effectAllowed = "copyMove";
-                            event.dataTransfer.setData(
-                              EXPLORER_INTERNAL_MOVE_DRAG_TYPE,
+                    );
+                    return (
+                      <div
+                        key={entry.absolutePath}
+                        id={getExplorerRowId(entry.absolutePath)}
+                        role="treeitem"
+                        aria-level={depth + 1}
+                        aria-selected={selected}
+                        aria-expanded={
+                          entry.isDirectory ? isExpanded : undefined
+                        }
+                        aria-label={entry.name}
+                        className={rowClassName}
+                        title={getExplorerRowTooltip(entry, isExpanded)}
+                        onDragOver={(event) => {
+                          const canMoveDraggedEntry =
+                            canDropDraggedEntryIntoDirectory(entry);
+                          const canImportExternalEntries =
+                            entry.isDirectory &&
+                            hasExternalExplorerDropData(event.dataTransfer);
+                          if (
+                            !canMoveDraggedEntry &&
+                            !canImportExternalEntries
+                          ) {
+                            return;
+                          }
+                          event.preventDefault();
+                          event.stopPropagation();
+                          event.dataTransfer.dropEffect = canMoveDraggedEntry
+                            ? "move"
+                            : "copy";
+                          if (paneExternalDropTarget) {
+                            setPaneExternalDropTarget(false);
+                          }
+                          if (directoryDropTargetPath !== entry.absolutePath) {
+                            setDirectoryDropTargetPath(entry.absolutePath);
+                          }
+                        }}
+                        onDragLeave={(event) => {
+                          if (directoryDropTargetPath !== entry.absolutePath) {
+                            return;
+                          }
+                          const relatedTarget = event.relatedTarget;
+                          if (
+                            typeof Node !== "undefined" &&
+                            relatedTarget instanceof Node &&
+                            event.currentTarget.contains(relatedTarget)
+                          ) {
+                            return;
+                          }
+                          setDirectoryDropTargetPath(null);
+                        }}
+                        onDrop={(event) => {
+                          const canMoveDraggedEntry =
+                            canDropDraggedEntryIntoDirectory(entry);
+                          const canImportExternalEntries =
+                            entry.isDirectory &&
+                            hasExternalExplorerDropData(event.dataTransfer);
+                          if (
+                            !canMoveDraggedEntry &&
+                            !canImportExternalEntries
+                          ) {
+                            return;
+                          }
+                          event.preventDefault();
+                          event.stopPropagation();
+                          clearActiveDropTargets();
+                          if (canMoveDraggedEntry && draggedEntryPath) {
+                            void moveEntryToDirectory(
+                              draggedEntryPath,
                               entry.absolutePath,
                             );
-                            event.dataTransfer.setData(
-                              EXPLORER_ATTACHMENT_DRAG_TYPE,
-                              serializeExplorerAttachmentDragPayload({
-                                absolutePath: entry.absolutePath,
-                                name: entry.name,
-                                size: Number.isFinite(entry.size)
-                                  ? Math.max(0, entry.size)
-                                  : 0,
-                                mimeType: entry.isDirectory
-                                  ? "inode/directory"
-                                  : null,
-                                kind: entry.isDirectory
-                                  ? "folder"
-                                  : inferDraggedAttachmentKind(entry.name),
-                              }),
-                            );
-                            const preview = createAttachmentDragPreview(entry);
-                            dragPreviewRef.current?.remove();
-                            dragPreviewRef.current = preview;
-                            event.dataTransfer.setDragImage(preview, 18, 18);
-                          }}
-                          onDragEnd={() => {
-                            setDraggedEntryPath(null);
-                            clearActiveDropTargets();
-                            dragPreviewRef.current?.remove();
-                            dragPreviewRef.current = null;
-                          }}
-                          className="w-full min-w-0 cursor-pointer text-left"
-                          title={
-                            entry.isDirectory
-                              ? `${entry.name} — click to ${isExpanded ? "collapse" : "expand"} folder, use @ or drag to attach in chat, drop files or folders here`
-                              : previewInPane
-                                ? `${entry.name} — double-click to open file, use @ or drag to attach in chat`
-                                : `${entry.name} — click to open file, use @ or drag to attach in chat`
+                            return;
                           }
-                        >
-                          {rowContent}
-                        </button>
-                        <div className="flex shrink-0 items-center gap-0.5">
-                          {onReferenceInChat ? (
-                            <Button
+                          void importExternalEntriesToDirectory(
+                            event.dataTransfer,
+                            entry.absolutePath,
+                          );
+                        }}
+                        onContextMenu={(event) => {
+                          event.preventDefault();
+                          if (isRenaming) {
+                            return;
+                          }
+                          openEntryContextMenu(entry, {
+                            x: event.clientX,
+                            y: event.clientY,
+                          });
+                        }}
+                      >
+                        {isRenaming ? (
+                          <div className="w-full">{rowContent}</div>
+                        ) : (
+                          <div className="flex w-full min-w-0 items-center gap-1">
+                            <button
                               type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              aria-label={`Attach ${entry.name} to chat`}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                referenceEntryInChat(entry);
+                              draggable={!entryIsProtected}
+                              onClick={() => {
+                                setSelectedPath(entry.absolutePath);
+                                closeContextMenu();
+                                if (entry.isDirectory) {
+                                  void toggleDirectoryExpansion(entry);
+                                  return;
+                                }
+                                if (!previewInPane) {
+                                  void openFileTarget(entry.absolutePath);
+                                }
                               }}
-                              className={`shrink-0 text-[11px] font-semibold text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
+                              onDoubleClick={() => {
+                                if (!entry.isDirectory && previewInPane) {
+                                  void openFilePreview(entry.absolutePath);
+                                }
+                              }}
+                              onDragStart={(event) => {
+                                if (entryIsProtected) {
+                                  event.preventDefault();
+                                  return;
+                                }
+
+                                setDraggedEntryPath(entry.absolutePath);
+                                clearActiveDropTargets();
+                                event.dataTransfer.effectAllowed = "copyMove";
+                                event.dataTransfer.setData(
+                                  EXPLORER_INTERNAL_MOVE_DRAG_TYPE,
+                                  entry.absolutePath,
+                                );
+                                event.dataTransfer.setData(
+                                  EXPLORER_ATTACHMENT_DRAG_TYPE,
+                                  serializeExplorerAttachmentDragPayload({
+                                    absolutePath: entry.absolutePath,
+                                    name: entry.name,
+                                    size: Number.isFinite(entry.size)
+                                      ? Math.max(0, entry.size)
+                                      : 0,
+                                    mimeType: entry.isDirectory
+                                      ? "inode/directory"
+                                      : null,
+                                    kind: entry.isDirectory
+                                      ? "folder"
+                                      : inferDraggedAttachmentKind(entry.name),
+                                  }),
+                                );
+                                const preview =
+                                  createAttachmentDragPreview(entry);
+                                dragPreviewRef.current?.remove();
+                                dragPreviewRef.current = preview;
+                                event.dataTransfer.setDragImage(
+                                  preview,
+                                  18,
+                                  18,
+                                );
+                              }}
+                              onDragEnd={() => {
+                                setDraggedEntryPath(null);
+                                clearActiveDropTargets();
+                                dragPreviewRef.current?.remove();
+                                dragPreviewRef.current = null;
+                              }}
+                              className="w-full min-w-0 cursor-pointer text-left"
+                              tabIndex={-1}
                             >
-                              <AtSign size={12} />
-                            </Button>
-                          ) : null}
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-xs"
-                            aria-label={`More actions for ${entry.name}`}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              openEntryContextMenu(entry, {
-                                anchorRect:
-                                  event.currentTarget.getBoundingClientRect(),
-                              });
-                            }}
-                            className={`shrink-0 text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
-                          >
-                            <MoreHorizontal size={12} />
-                          </Button>
-                        </div>
+                              {rowContent}
+                            </button>
+                            <div className="flex shrink-0 items-center gap-0.5">
+                              {onReferenceInChat ? (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  aria-label={`Attach ${entry.name} to chat`}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    referenceEntryInChat(entry);
+                                  }}
+                                  className={`shrink-0 text-xs font-semibold text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
+                                >
+                                  <AtSign size={12} />
+                                </Button>
+                              ) : null}
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                aria-label={`More actions for ${entry.name}`}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  openEntryContextMenu(entry, {
+                                    anchorRect:
+                                      event.currentTarget.getBoundingClientRect(),
+                                  });
+                                }}
+                                className={`shrink-0 text-muted-foreground transition-opacity ${rowHoverActionsClassName}`}
+                              >
+                                <MoreHorizontal size={12} />
+                              </Button>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
-                );
+                    );
                   })}
                 </div>
               ))
@@ -3654,24 +3893,22 @@ export function FileExplorerPane({
               />
             </Button>
             {supportsRenderedTextPreview ? (
-              <div className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5">
+              <div className="inline-flex items-center gap-px rounded-lg border border-border/40 bg-muted/25 p-[3px]">
                 <Button
                   type="button"
-                  variant={
-                    textPreviewMode === "preview" ? "secondary" : "ghost"
-                  }
+                  variant="ghost"
                   size="xs"
                   onClick={() => setTextPreviewMode("preview")}
-                  className={textPreviewMode === "preview" ? "shadow-sm" : ""}
+                  className={`px-3 font-normal ${textPreviewMode === "preview" ? "bg-background text-foreground shadow-sm hover:bg-background" : "text-muted-foreground"}`}
                 >
                   Preview
                 </Button>
                 <Button
                   type="button"
-                  variant={textPreviewMode === "edit" ? "secondary" : "ghost"}
+                  variant="ghost"
                   size="xs"
                   onClick={() => setTextPreviewMode("edit")}
-                  className={textPreviewMode === "edit" ? "shadow-sm" : ""}
+                  className={`px-3 font-normal ${textPreviewMode === "edit" ? "bg-background text-foreground shadow-sm hover:bg-background" : "text-muted-foreground"}`}
                 >
                   Edit
                 </Button>
@@ -3699,15 +3936,18 @@ export function FileExplorerPane({
   const contextMenuTargetDirectoryPath = contextMenu?.entry.isDirectory
     ? contextMenu.entry.absolutePath
     : contextMenu
-      ? getParentFolderPath(contextMenu.entry.absolutePath) ??
-        currentPathRef.current
+      ? (getParentFolderPath(contextMenu.entry.absolutePath) ??
+        currentPathRef.current)
       : "";
   const contextMenuEntryIsProtected = isProtectedWorkspacePath(
     workspaceRootPath,
     contextMenu?.entry.absolutePath,
   );
   const contextMenuTargetDirectoryIsProtected = Boolean(
-    protectedWorkspacePathMessage(workspaceRootPath, contextMenuTargetDirectoryPath),
+    protectedWorkspacePathMessage(
+      workspaceRootPath,
+      contextMenuTargetDirectoryPath,
+    ),
   );
   const canPasteIntoContextMenuTarget =
     Boolean(explorerClipboardEntry) &&
@@ -3717,60 +3957,100 @@ export function FileExplorerPane({
   return (
     <>
       {explorerPane}
+      <ConfirmDialog
+        open={confirmRequest !== null}
+        onOpenChange={(open) => {
+          if (!open && confirmRequest !== null) {
+            handleConfirmResolution(false);
+          }
+        }}
+        title={confirmRequest?.title ?? ""}
+        description={confirmRequest?.description}
+        confirmLabel={confirmRequest?.confirmLabel}
+        destructive={confirmRequest?.destructive}
+        onConfirm={() => handleConfirmResolution(true)}
+      />
       {contextMenu && contextMenuPosition
         ? createPortal(
             <div
               ref={contextMenuRef}
+              role="menu"
+              aria-label={`Actions for ${contextMenu.entry.name}`}
               style={contextMenuPosition}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                  event.preventDefault();
+                  const items = Array.from(
+                    contextMenuRef.current?.querySelectorAll<HTMLElement>(
+                      '[role="menuitem"]:not([disabled])',
+                    ) ?? [],
+                  );
+                  if (items.length === 0) return;
+                  const activeIndex = items.findIndex(
+                    (item) => item === document.activeElement,
+                  );
+                  const delta = event.key === "ArrowDown" ? 1 : -1;
+                  const nextIndex =
+                    activeIndex < 0
+                      ? 0
+                      : (activeIndex + delta + items.length) % items.length;
+                  items[nextIndex].focus();
+                }
+              }}
               className="fixed z-[80] rounded-xl border border-border/70 bg-popover/92 p-1.5 text-popover-foreground shadow-xl ring-1 ring-foreground/10 backdrop-blur-xl"
             >
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 onClick={() => {
                   void createEntry("file", contextMenuTargetDirectoryPath);
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 New file
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 onClick={() => {
                   void createEntry("directory", contextMenuTargetDirectoryPath);
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 New folder
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 onClick={() => {
                   copyExplorerEntryToClipboard(contextMenu.entry, "copy");
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 Copy
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 disabled={contextMenuEntryIsProtected}
                 onClick={() => {
                   copyExplorerEntryToClipboard(contextMenu.entry, "cut");
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 Cut
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 disabled={!canPasteIntoContextMenuTarget}
@@ -3779,31 +4059,33 @@ export function FileExplorerPane({
                     contextMenuTargetDirectoryPath,
                   );
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 Paste
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 disabled={contextMenuEntryIsProtected}
                 onClick={() => {
                   void renameEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="w-full justify-start"
+                className="w-full justify-start font-normal"
               >
                 Rename…
               </Button>
               <Button
                 type="button"
+                role="menuitem"
                 variant="ghost"
                 size="default"
                 disabled={contextMenuEntryIsProtected}
                 onClick={() => {
                   void deleteEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                className="w-full justify-start font-normal text-destructive hover:bg-destructive/10 hover:text-destructive"
               >
                 Delete…
               </Button>

--- a/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/desktop/src/components/panes/IntegrationsPane.tsx
@@ -315,13 +315,69 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
   }
 
   if (isLoading) {
-    return embedded ? (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 size={18} className="animate-spin text-muted-foreground" />
+    const skeletonCards = [
+      "w-24", "w-20", "w-28", "w-16", "w-24", "w-20",
+    ];
+    const skeletonGrid = (
+      <div
+        role="status"
+        aria-busy="true"
+        aria-label="Loading integrations"
+      >
+        {/* Skeleton search bar */}
+        <div className="mt-5 flex items-center gap-3">
+          <div className="h-9 flex-1 animate-pulse rounded-lg bg-muted-foreground/20" />
+          <div className="h-9 w-20 animate-pulse rounded-lg bg-muted-foreground/20" />
+        </div>
+        {/* Skeleton section label */}
+        <div className="mt-6 h-3 w-24 animate-pulse rounded bg-muted-foreground/20" />
+        {/* Skeleton cards */}
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          {skeletonCards.map((descWidth, index) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+              key={index}
+              className="flex items-center gap-3 rounded-xl border border-border px-3 py-3"
+            >
+              {/* Icon placeholder */}
+              <div className="size-9 shrink-0 animate-pulse rounded-md bg-muted-foreground/20" />
+              {/* Name + description */}
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <div className="h-3 w-16 animate-pulse rounded bg-muted-foreground/20" />
+                <div className={`h-2.5 animate-pulse rounded bg-muted-foreground/20 ${descWidth}`} />
+              </div>
+              {/* Button placeholder */}
+              <div className="size-7 shrink-0 animate-pulse rounded-md bg-muted-foreground/20" />
+            </div>
+          ))}
+        </div>
       </div>
-    ) : (
-      <section className="relative flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
-        <Loader2 size={18} className="animate-spin text-muted-foreground" />
+    );
+
+    if (embedded) {
+      return (
+        <div className="max-w-5xl">
+          <p className="text-sm text-muted-foreground">
+            Connect your accounts to use them in workspaces.
+          </p>
+          {skeletonGrid}
+        </div>
+      );
+    }
+
+    return (
+      <section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm">
+        <div className="relative min-h-0 flex-1 overflow-auto">
+          <div className="mx-auto max-w-5xl px-6 py-6">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Integrations
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Connect your accounts to use them in workspaces.
+            </p>
+            {skeletonGrid}
+          </div>
+        </div>
       </section>
     );
   }
@@ -332,14 +388,14 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
       {!authSessionState.isPending && !isSignedIn ? (
         <div className="mt-4 flex items-center justify-between gap-4 rounded-xl border border-destructive/20 bg-destructive/5 px-4 py-3">
           <div className="min-w-0">
-            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-widest text-destructive">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-destructive">
               <ShieldAlert size={13} />
               <span>Sign-In Required</span>
             </div>
             <p className="mt-1 text-sm font-medium text-foreground">
               Managed integrations are unavailable until you sign in.
             </p>
-            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
               You can browse the catalog below, but connecting requires an authenticated session.
             </p>
           </div>
@@ -382,7 +438,7 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
       {/* Connected */}
       {connectedIntegrations.length > 0 ? (
         <div className="mt-6">
-          <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          <h2 className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
             Connected
           </h2>
           <div className="mt-3 grid grid-cols-2 gap-2">
@@ -405,13 +461,13 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
       ) : null}
 
       {statusMessage ? (
-        <p className="mt-4 text-xs text-muted-foreground">{statusMessage}</p>
+        <p className="mt-4 text-sm text-muted-foreground">{statusMessage}</p>
       ) : null}
 
       {/* Available — grouped by category */}
       {groupedIntegrations.map(([category, items]) => (
         <div key={category} className="mt-6">
-          <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          <h2 className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
             {category.charAt(0).toUpperCase() + category.slice(1)}
           </h2>
           <div className="mt-3 grid grid-cols-2 gap-2">
@@ -503,7 +559,7 @@ function IntegrationRow({
   const muted = actionMode === "disabled";
   return (
     <div
-      className={`flex items-center gap-3 rounded-xl border border-border px-3 py-2.5 transition-colors ${
+      className={`flex items-center gap-3 rounded-xl border border-border px-3 py-3 transition-colors ${
         muted ? "opacity-50" : "hover:bg-muted"
       }`}
     >
@@ -521,7 +577,7 @@ function IntegrationRow({
         <div className="truncate text-sm font-medium text-foreground">
           {integration.name}
         </div>
-        <div className="truncate text-xs text-muted-foreground">
+        <div className="truncate text-sm text-muted-foreground">
           {integration.description}
         </div>
       </div>

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -461,7 +461,7 @@ export function InternalSurfacePane({
     if (isLoading) {
       return (
         <div className="flex h-full items-center justify-center">
-          <div className="inline-flex items-center gap-2 text-[12px] text-muted-foreground">
+          <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 size={14} className="animate-spin" />
             <span>Loading file preview...</span>
           </div>
@@ -490,8 +490,8 @@ export function InternalSurfacePane({
           {/* Toolbar */}
           <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/30 px-4 py-2">
             <div className="min-w-0">
-              <div className="text-[13px] font-medium text-foreground">{preview.name}</div>
-              <div className="text-[11px] text-muted-foreground">
+              <div className="text-sm font-medium text-foreground">{preview.name}</div>
+              <div className="text-xs text-muted-foreground">
                 {new Date(preview.modifiedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
                 {preview.size != null ? ` · ${formatPreviewSize(preview.size)}` : ""}
                 {isDirty ? " · Unsaved changes" : ""}
@@ -536,8 +536,8 @@ export function InternalSurfacePane({
           </div>
 
           {/* Content */}
-          <div className="min-h-0 flex-1 overflow-auto">
-            {isMarkdownPreview && textPreviewMode === "preview" ? (
+          {isMarkdownPreview && textPreviewMode === "preview" ? (
+            <div className="min-h-0 flex-1 overflow-auto">
               <div className="mx-auto max-w-2xl px-6 py-6">
                 {previewDraft.trim() ? (
                   <SimpleMarkdown
@@ -552,35 +552,35 @@ export function InternalSurfacePane({
                   </div>
                 )}
               </div>
-            ) : isHtmlPreview && textPreviewMode === "preview" ? (
-              previewDraft.trim() ? (
-                <div className="h-full overflow-hidden bg-muted/20 p-4">
-                  <iframe
-                    title={preview.name}
-                    sandbox=""
-                    srcDoc={previewDraft}
-                    className="h-full w-full rounded-lg border border-border bg-white"
-                  />
-                </div>
-              ) : (
-                <div className="grid h-full place-items-center px-6 text-center">
-                  <div className="text-xs text-muted-foreground">
-                    Empty file — switch to Edit to add markup.
-                  </div>
-                </div>
-              )
+            </div>
+          ) : isHtmlPreview && textPreviewMode === "preview" ? (
+            previewDraft.trim() ? (
+              <div className="min-h-0 flex-1 overflow-hidden bg-muted/20 p-4">
+                <iframe
+                  title={preview.name}
+                  sandbox=""
+                  srcDoc={previewDraft}
+                  className="h-full w-full rounded-lg border border-border bg-white"
+                />
+              </div>
             ) : (
-              <textarea
-                value={previewDraft}
-                onChange={(event) => setPreviewDraft(event.target.value)}
-                readOnly={!preview.isEditable}
-                spellCheck={false}
-                className={`h-full min-h-full w-full resize-none border-0 bg-transparent px-6 py-5 font-mono text-[13px] leading-6 text-foreground outline-none ${
-                  preview.isEditable ? "" : "cursor-default opacity-80"
-                }`}
-              />
-            )}
-          </div>
+              <div className="grid min-h-0 flex-1 place-items-center px-6 text-center">
+                <div className="text-xs text-muted-foreground">
+                  Empty file — switch to Edit to add markup.
+                </div>
+              </div>
+            )
+          ) : (
+            <textarea
+              value={previewDraft}
+              onChange={(event) => setPreviewDraft(event.target.value)}
+              readOnly={!preview.isEditable}
+              spellCheck={false}
+              className={`min-h-0 flex-1 w-full resize-none border-0 bg-transparent px-6 py-5 font-mono text-sm text-foreground outline-none ${
+                preview.isEditable ? "" : "cursor-default opacity-80"
+              }`}
+            />
+          )}
         </div>
       );
     }
@@ -618,21 +618,59 @@ export function InternalSurfacePane({
         ];
       if (activeSheet) {
         return (
-          <SpreadsheetEditor
-            sheets={tablePreviewDraft}
-            activeSheetIndex={activeTableSheetIndex}
-            onActiveSheetIndexChange={setActiveTableSheetIndex}
-            editable={preview.isEditable}
-            readOnlyReason={
-              activeSheet.truncated
-                ? "Trimmed previews are read-only"
-                : preview.extension === ".xls"
-                  ? "Legacy .xls files are read-only"
-                  : null
-            }
-            onChange={setTablePreviewDraft}
-            onOpenLinkInBrowser={openPreviewLink}
-          />
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/30 px-4 py-2">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-foreground">
+                  {preview.name}
+                </div>
+                <div className="truncate text-xs text-muted-foreground/85">
+                  {new Date(preview.modifiedAt).toLocaleDateString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                  {preview.size != null
+                    ? ` · ${formatPreviewSize(preview.size)}`
+                    : ""}
+                  {` · ${tablePreviewDraft.length} sheet${tablePreviewDraft.length === 1 ? "" : "s"}`}
+                  {isDirty ? " · Unsaved changes" : ""}
+                </div>
+              </div>
+              {preview.isEditable ? (
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void savePreview()}
+                    disabled={!isDirty || isSaving}
+                  >
+                    <Save size={12} />
+                    {isSaving ? "Saving" : "Save"}
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-hidden p-3">
+              <SpreadsheetEditor
+                sheets={tablePreviewDraft}
+                activeSheetIndex={activeTableSheetIndex}
+                onActiveSheetIndexChange={setActiveTableSheetIndex}
+                editable={preview.isEditable}
+                readOnlyReason={
+                  activeSheet.truncated
+                    ? "Trimmed previews are read-only"
+                    : preview.extension === ".xls"
+                      ? "Legacy .xls files are read-only"
+                      : null
+                }
+                onChange={setTablePreviewDraft}
+                onOpenLinkInBrowser={openPreviewLink}
+              />
+            </div>
+          </div>
         );
       }
     }
@@ -668,7 +706,7 @@ export function InternalSurfacePane({
 
   return (
     <section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border/40 bg-background">
-      <div className="min-h-0 flex-1 overflow-auto">{body}</div>
+      <div className="flex min-h-0 flex-1 flex-col">{body}</div>
     </section>
   );
 }
@@ -717,10 +755,10 @@ function EmptyState({
             <FileText size={18} />
           )}
         </div>
-        <div className="mt-3 text-[16px] font-medium text-foreground">
+        <div className="mt-3 text-base font-medium text-foreground">
           {title}
         </div>
-        <div className="mt-2 text-[12px] leading-6 text-muted-foreground/82">
+        <div className="mt-2 text-xs leading-6 text-muted-foreground/82">
           {detail}
         </div>
       </div>

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
@@ -1,4 +1,4 @@
-import { AppWindow, CheckCircle2, LoaderCircle, Plus, TriangleAlert } from "lucide-react";
+import { AppWindow, Plus } from "lucide-react";
 import { providerIcon } from "@/components/onboarding/constants";
 import { Button } from "@/components/ui/button";
 import type { WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
@@ -21,77 +21,114 @@ function appInitials(label: string): string {
   return `${parts[0].slice(0, 1)}${parts[1].slice(0, 1)}`.toUpperCase();
 }
 
+type AppStatusTone = "ready" | "loading" | "error";
+
+function appStatusTone(app: WorkspaceInstalledAppDefinition): AppStatusTone {
+  if (app.error?.trim()) {
+    return "error";
+  }
+  if (app.ready) {
+    return "ready";
+  }
+  return "loading";
+}
+
+function statusPipClass(tone: AppStatusTone): string {
+  if (tone === "error") {
+    return "bg-destructive";
+  }
+  if (tone === "ready") {
+    return "bg-emerald-500";
+  }
+  return "bg-sky-500 animate-pulse";
+}
+
+function statusPipLabel(tone: AppStatusTone): string {
+  if (tone === "error") {
+    return "Error";
+  }
+  if (tone === "ready") {
+    return "Ready";
+  }
+  return "Starting";
+}
+
 export function SpaceApplicationsExplorerPane({
   installedApps,
   activeAppId = null,
   onSelectApp,
   onAddApp,
 }: SpaceApplicationsExplorerPaneProps) {
+  const isEmpty = installedApps.length === 0;
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
-      <div className="flex items-center justify-between gap-3 border-b border-border/45 px-3 py-2.5">
-        <div className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
-          Applications
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={onAddApp}
-          className="h-7 gap-1.5 rounded-md px-2.5 text-[11px]"
-        >
-          <Plus size={12} />
-          Add apps
+      <div className="flex items-center justify-between gap-3 border-b border-border/40 p-2">
+        <Button type="button" variant="ghost" size="sm" onClick={onAddApp}>
+          <Plus className="size-4" />
+          <span className="text-muted-foreground/80">Add Application</span>
         </Button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
-        {installedApps.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border/40 px-3 py-3 text-xs leading-5 text-muted-foreground/70">
-            Installed workspace apps will appear here once the selected workspace has applications.
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {isEmpty ? (
+          <div className="flex flex-col items-center justify-center gap-2.5 px-4 py-10 text-center">
+            <div className="grid size-10 place-items-center rounded-[10px] bg-muted text-muted-foreground/70">
+              <AppWindow size={16} />
+            </div>
+            <div className="text-xs leading-5 text-muted-foreground">
+              No apps installed in this workspace yet.
+            </div>
           </div>
         ) : (
-          <div className="space-y-1">
+          <div className="space-y-0.5">
             {installedApps.map((app) => {
               const isActive = activeAppId === app.id;
-              const hasError = Boolean(app.error?.trim());
-              const isReady = app.ready && !hasError;
+              const tone = appStatusTone(app);
+              const statusLabel = statusPipLabel(tone);
               return (
                 <Button
                   key={app.id}
+                  type="button"
                   variant="ghost"
                   size="sm"
                   onClick={() => onSelectApp(app.id)}
-                  className={`h-auto w-full justify-start rounded-lg px-2.5 py-2 text-left ${
-                    isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                  aria-current={isActive ? "page" : undefined}
+                  aria-label={`${app.label} — ${statusLabel}`}
+                  className={`relative h-auto w-full justify-start gap-0 rounded-lg px-2.5 py-2 text-left transition-colors ${
+                    isActive
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-accent/55"
                   }`}
                 >
-                  <div className="flex min-w-0 flex-1 items-start gap-2.5">
-                    <div className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
-                      {providerIcon(app.id, 16) ?? (
-                        <span className="text-[11px] font-semibold uppercase tracking-wide">
-                          {appInitials(app.label)}
-                        </span>
-                      )}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <span className="truncate text-xs font-medium text-foreground">
-                          {app.label}
-                        </span>
-                        {hasError ? (
-                          <TriangleAlert size={12} className="shrink-0 text-destructive" />
-                        ) : isReady ? (
-                          <CheckCircle2 size={12} className="shrink-0 text-emerald-500" />
-                        ) : (
-                          <LoaderCircle size={12} className="shrink-0 animate-spin text-sky-500" />
+                  {isActive ? (
+                    <span
+                      aria-hidden="true"
+                      className="absolute left-0 top-1/2 h-5 w-[2px] -translate-y-1/2 rounded-full bg-primary"
+                    />
+                  ) : null}
+                  <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                    <div className="relative shrink-0">
+                      <div className="grid size-9 place-items-center rounded-[10px] bg-muted text-muted-foreground">
+                        {providerIcon(app.id, 16) ?? (
+                          <span className="text-xs font-semibold uppercase tracking-wide">
+                            {appInitials(app.label)}
+                          </span>
                         )}
                       </div>
-                      <div className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+                      <span
+                        aria-hidden="true"
+                        className={`absolute -bottom-0.5 -right-0.5 size-[9px] rounded-full ring-2 ring-background ${statusPipClass(tone)}`}
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {app.label}
+                      </div>
+                      <div className="mt-0.5 line-clamp-1 text-xs leading-5 text-muted-foreground">
                         {app.summary}
                       </div>
                     </div>
-                    <AppWindow size={14} className="mt-0.5 shrink-0 text-muted-foreground/70" />
                   </div>
                 </Button>
               );

--- a/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserDisplayPane.tsx
@@ -59,6 +59,7 @@ interface SpaceBrowserDisplayPaneProps {
   suspendNativeView?: boolean;
   layoutSyncKey?: string;
   embedded?: boolean;
+  jumpPulseKey?: number;
 }
 
 export function SpaceBrowserDisplayPane({
@@ -66,6 +67,7 @@ export function SpaceBrowserDisplayPane({
   suspendNativeView = false,
   layoutSyncKey = "",
   embedded = false,
+  jumpPulseKey = 0,
 }: SpaceBrowserDisplayPaneProps) {
   const [inputValue, setInputValue] = useState("");
   const [addressFocused, setAddressFocused] = useState(false);
@@ -106,6 +108,21 @@ export function SpaceBrowserDisplayPane({
 
   const showAgentActivityHighlight =
     sessionBrowserStatus?.tone === "active" || glowPreviewEnabled;
+
+  const [jumpFlashActive, setJumpFlashActive] = useState(false);
+  useEffect(() => {
+    if (jumpPulseKey <= 0) {
+      return;
+    }
+    setJumpFlashActive(true);
+    const timeoutId = window.setTimeout(() => {
+      setJumpFlashActive(false);
+    }, 720);
+    return () => {
+      window.clearTimeout(timeoutId);
+      setJumpFlashActive(false);
+    };
+  }, [jumpPulseKey]);
 
   useEffect(() => {
     setInputValue(activeTab.url || "");
@@ -339,10 +356,10 @@ export function SpaceBrowserDisplayPane({
       className={`relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden ${
         embedded
           ? "bg-transparent"
-          : "rounded-xl border border-border bg-card/80 shadow-md backdrop-blur-sm"
+          : "rounded-xl border border-border bg-card"
       }`}
     >
-      <div className="shrink-0 border-b border-border/45 px-4 py-2">
+      <div className="shrink-0 border-b border-border/30 px-4 py-2">
         <div className="flex flex-wrap items-center gap-1.5">
           <Button
             variant="ghost"
@@ -386,13 +403,13 @@ export function SpaceBrowserDisplayPane({
           <form onSubmit={onSubmit} className="min-w-0 flex-1">
             <div
               ref={addressFieldRef}
-              className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 transition-colors focus-within:border-ring"
+              className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 transition-colors focus-within:border-ring"
               onClick={selectAddressInput}
             >
               {isActiveTabBusy ? (
                 <Loader2
                   size={13}
-                  className="shrink-0 animate-spin text-primary/85"
+                  className="shrink-0 animate-spin text-primary"
                 />
               ) : (
                 <Globe size={13} className="shrink-0 text-muted-foreground" />
@@ -410,7 +427,7 @@ export function SpaceBrowserDisplayPane({
                   window.setTimeout(() => setAddressFocused(false), 120)
                 }
                 onKeyDown={onAddressKeyDown}
-                className="embedded-input w-full min-w-0 bg-transparent text-[12px] text-foreground outline-none placeholder:text-muted-foreground/55"
+                className="embedded-input w-full min-w-0 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
                 placeholder="Enter URL or search"
               />
             </div>
@@ -423,24 +440,23 @@ export function SpaceBrowserDisplayPane({
             onClick={onToggleBookmark}
             disabled={!activeTab.url}
             className={`shrink-0 rounded-full ${
-              isBookmarked ? "border-primary/50 bg-primary/10 text-primary" : ""
+              isBookmarked ? "text-primary" : ""
             }`}
             aria-label={isBookmarked ? "Remove bookmark" : "Add bookmark"}
           >
             <Star size={13} fill={isBookmarked ? "currentColor" : "none"} />
           </Button>
-
         </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden p-3">
         <div
           ref={viewportRef}
-          className={`relative h-full min-h-0 overflow-hidden rounded-xl border bg-card transition-all ${
+          className={`relative h-full min-h-0 overflow-hidden rounded-xl border bg-card transition-colors ${
             showAgentActivityHighlight
-              ? "browser-active-glow border-border/45"
+              ? "browser-active-glow border-border/30"
               : "border-border"
-          }`}
+          } ${jumpFlashActive ? "browser-jump-flash" : ""}`}
         >
           {showAgentActivityHighlight ? (
             <div
@@ -451,11 +467,14 @@ export function SpaceBrowserDisplayPane({
 
           {!activeTab.initialized ? (
             <div className="absolute inset-0 grid place-items-center bg-card p-6 text-center">
-              <div className="pointer-events-none w-full max-w-[360px] rounded-[24px] border border-border bg-card/92 px-6 py-6 shadow-lg backdrop-blur-sm">
-                <div className="mt-4 text-[15px] font-medium tracking-[-0.02em] text-foreground">
+              <div className="flex flex-col items-center gap-3">
+                <div className="grid size-11 place-items-center rounded-[12px] bg-muted text-muted-foreground">
+                  <Loader2 size={18} className="animate-spin" />
+                </div>
+                <div className="text-sm font-medium tracking-[-0.01em] text-foreground">
                   Starting {browserSpace === "agent" ? "agent" : "user"} browser
                 </div>
-                <div className="mt-1.5 text-[12px] leading-6 text-muted-foreground">
+                <div className="max-w-[320px] text-xs leading-5 text-muted-foreground">
                   Opening the embedded{" "}
                   {browserSpace === "agent" ? "agent" : "user"} browser for this
                   workspace.
@@ -465,8 +484,9 @@ export function SpaceBrowserDisplayPane({
           ) : null}
 
           {activeTab.error ? (
-            <div className="absolute inset-x-4 bottom-4 rounded-xl border border-amber-300/40 bg-black/70 px-3 py-2 text-xs text-amber-100/85">
-              {activeTab.error}
+            <div className="absolute inset-x-4 bottom-4 flex items-start gap-2 rounded-lg border-l-2 border-amber-500 bg-card px-3 py-2 text-xs leading-5 text-foreground shadow-sm">
+              <span className="mt-0.5 size-1.5 shrink-0 rounded-full bg-amber-500" />
+              <span className="min-w-0 flex-1">{activeTab.error}</span>
             </div>
           ) : null}
         </div>

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -22,12 +22,31 @@ interface SpaceBrowserExplorerPaneProps {
   browserSpace: BrowserSpaceId;
   onBrowserSpaceChange: (space: BrowserSpaceId) => void;
   onActivateDisplay: () => void;
+  hasPendingAgentJump?: boolean;
+}
+
+type SessionStatusTone = "active" | "waiting" | "paused" | "error" | "idle";
+
+function sessionStatusBadgeClasses(tone: SessionStatusTone): string {
+  switch (tone) {
+    case "active":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
+    case "waiting":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-100";
+    case "paused":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-100";
+    case "error":
+      return "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-100";
+    default:
+      return "border-border/50 bg-muted text-muted-foreground";
+  }
 }
 
 export function SpaceBrowserExplorerPane({
   browserSpace,
   onBrowserSpaceChange,
   onActivateDisplay,
+  hasPendingAgentJump = false,
 }: SpaceBrowserExplorerPaneProps) {
   const {
     selectedWorkspaceId,
@@ -100,33 +119,45 @@ export function SpaceBrowserExplorerPane({
     );
   };
 
+  const hasBookmarks = bookmarks.length > 0;
+  const hasTabs = browserState.tabs.length > 0;
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
-      <div className="border-b border-border/45 px-3 py-2.5">
+      <div className="border-b border-border/30 px-3 py-2.5">
         <Tabs
           value={browserSpace}
           onValueChange={(value) => openBrowserSpace(value as BrowserSpaceId)}
         >
           <TabsList className="w-full">
-            <TabsTrigger value="user" className="flex-1 gap-1.5">
+            <TabsTrigger value="user" className="flex-1 gap-1.5 text-xs">
               <User size={12} />
               User
               <Badge
                 variant="secondary"
-                className="ml-0.5 px-1.5 py-0 text-[10px]"
+                className="ml-0.5 h-4 min-w-4 px-1 text-xs"
               >
                 {browserState.tabCounts.user}
               </Badge>
             </TabsTrigger>
-            <TabsTrigger value="agent" className="flex-1 gap-1.5">
+            <TabsTrigger
+              value="agent"
+              className="relative flex-1 gap-1.5 text-xs"
+            >
               <Bot size={12} />
               Agent
               <Badge
                 variant="secondary"
-                className="ml-0.5 px-1.5 py-0 text-[10px]"
+                className="ml-0.5 h-4 min-w-4 px-1 text-xs"
               >
                 {browserState.tabCounts.agent}
               </Badge>
+              {hasPendingAgentJump && browserSpace !== "agent" ? (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-1.5 top-1 size-1.5 animate-pulse rounded-full bg-primary"
+                />
+              ) : null}
             </TabsTrigger>
           </TabsList>
         </Tabs>
@@ -138,7 +169,7 @@ export function SpaceBrowserExplorerPane({
               onValueChange={selectAgentSessionBrowser}
               disabled={!hasAgentSessionBrowsers}
             >
-              <SelectTrigger className="h-9 min-w-0 flex-1 basis-0 rounded-[11px] border-border/45 bg-card px-3 text-left text-xs font-medium shadow-none">
+              <SelectTrigger className="h-9 min-w-0 flex-1 basis-0 rounded-lg border-border/45 bg-card px-3 text-left text-xs shadow-none">
                 <SelectValue
                   placeholder={
                     hasAgentSessionBrowsers
@@ -163,14 +194,14 @@ export function SpaceBrowserExplorerPane({
                     <SelectItem
                       key={session.session_id}
                       value={session.session_id}
-                      className="rounded-[11px] px-3 py-2 text-xs"
+                      className="rounded-md px-3 py-2 text-xs"
                     >
                       <span className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
-                        <span className="min-w-0 truncate font-medium text-foreground">
+                        <span className="min-w-0 truncate text-foreground">
                           {browserSessionTitle(session, session.session_id)}
                         </span>
                         {!isSelectedSession ? (
-                          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/85">
+                          <span className="shrink-0 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                             {browserSessionStatusLabel(runtimeState)}
                           </span>
                         ) : null}
@@ -184,26 +215,19 @@ export function SpaceBrowserExplorerPane({
             {sessionBrowserStatus ? (
               <Badge
                 variant="secondary"
-                className={`shrink-0 gap-1 rounded-full px-1.5 py-0.5 text-[10px] ${
-                  sessionBrowserStatus.tone === "active"
-                    ? "border border-emerald-300/60 bg-emerald-500/12 text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200"
-                    : sessionBrowserStatus.tone === "waiting"
-                      ? "border border-amber-300/60 bg-amber-500/12 text-amber-700 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-100"
-                      : sessionBrowserStatus.tone === "paused"
-                        ? "border border-sky-300/60 bg-sky-500/12 text-sky-700 dark:border-sky-400/30 dark:bg-sky-500/10 dark:text-sky-100"
-                        : sessionBrowserStatus.tone === "error"
-                          ? "border border-rose-300/60 bg-rose-500/12 text-rose-700 dark:border-rose-400/35 dark:bg-rose-500/10 dark:text-rose-100"
-                          : ""
-                }`}
+                className={`shrink-0 gap-1 rounded-full border px-2 py-0.5 text-xs ${sessionStatusBadgeClasses(
+                  sessionBrowserStatus.tone as SessionStatusTone,
+                )}`}
               >
                 {sessionBrowserStatus.tone === "paused" ? (
                   <Pause size={10} />
                 ) : (
                   <span
-                    className={`inline-block size-2 rounded-full ${
+                    aria-hidden="true"
+                    className={`inline-block size-1.5 rounded-full ${
                       sessionBrowserStatus.flashing
-                        ? "animate-pulse bg-emerald-300"
-                        : "bg-current/80"
+                        ? "animate-pulse bg-emerald-500"
+                        : "bg-current opacity-70"
                     }`}
                   />
                 )}
@@ -216,18 +240,14 @@ export function SpaceBrowserExplorerPane({
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
         <div className="space-y-0.5">
-          {bookmarks.length === 0 ? (
-            <div className="px-2 py-1 text-xs text-muted-foreground/70">
-              Saved bookmarks will appear here.
-            </div>
-          ) : (
+          {hasBookmarks ? (
             bookmarks.map((bookmark) => (
               <Button
                 key={bookmark.id}
                 variant="ghost"
                 size="sm"
                 onClick={() => openBookmark(bookmark)}
-                className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-left"
+                className="h-auto w-full justify-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-accent/55"
               >
                 {bookmark.faviconUrl ? (
                   <img
@@ -236,63 +256,64 @@ export function SpaceBrowserExplorerPane({
                     className="size-4 shrink-0 rounded-sm"
                   />
                 ) : (
-                  <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-primary/12 text-primary">
+                  <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-muted text-muted-foreground">
                     <Star size={10} />
                   </div>
                 )}
-                <div className="min-w-0">
-                  <div className="truncate text-xs font-medium text-foreground">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm text-foreground">
                     {bookmark.title}
-                  </div>
-                  <div className="truncate text-[11px] text-muted-foreground">
-                    {bookmark.url}
                   </div>
                 </div>
               </Button>
             ))
+          ) : (
+            <div className="px-2.5 py-1.5 text-xs text-muted-foreground">
+              Saved bookmarks will appear here.
+            </div>
           )}
         </div>
 
-        <div className="mt-4 border-t border-border/40 pt-3">
-          <div className="mb-2 flex items-center justify-between gap-2 px-2">
-            <div className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
-              Tabs
-            </div>
+        <div className="mt-4 border-t border-border/30 pt-2">
+          <div className="mb-1.5 flex items-center justify-between gap-2">
             <Button
               type="button"
-              variant="outline"
-              size="xs"
+              variant="ghost"
+              size="sm"
               onClick={openNewTab}
               aria-label="Open new tab"
+              className="gap-1.5 text-xs text-muted-foreground"
             >
-              <Plus size={11} />
+              <Plus size={12} />
               New Tab
             </Button>
           </div>
           <div className="space-y-0.5">
-            {browserState.tabs.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/40 px-3 py-3 text-xs text-muted-foreground/70">
-                No open tabs in the {browserSpace} browser.
-              </div>
-            ) : (
+            {hasTabs ? (
               browserState.tabs.map((tab) => {
                 const isActive = tab.id === activeTab.id;
                 return (
                   <div
                     key={tab.id}
-                    className={`group flex items-center gap-2 rounded-lg px-2 py-1.5 transition-colors ${
+                    className={`group relative flex items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors ${
                       isActive
                         ? "bg-accent text-accent-foreground"
-                        : "hover:bg-accent/50"
+                        : "hover:bg-accent/55"
                     }`}
                   >
+                    {isActive ? (
+                      <span
+                        aria-hidden="true"
+                        className="absolute left-0 top-1/2 h-4 w-[2px] -translate-y-1/2 rounded-full bg-primary"
+                      />
+                    ) : null}
                     <button
                       type="button"
                       onClick={() => {
                         onActivateDisplay();
                         void window.electronAPI.browser.setActiveTab(tab.id);
                       }}
-                      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
                       title={tab.title || tab.url}
                     >
                       {tab.faviconUrl ? (
@@ -310,12 +331,9 @@ export function SpaceBrowserExplorerPane({
                           )}
                         </div>
                       )}
-                      <div className="min-w-0">
-                        <div className="truncate text-xs font-medium">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm">
                           {tab.title || "New Tab"}
-                        </div>
-                        <div className="truncate text-[11px] text-muted-foreground">
-                          {tab.url || "about:blank"}
                         </div>
                       </div>
                     </button>
@@ -327,13 +345,22 @@ export function SpaceBrowserExplorerPane({
                         void window.electronAPI.browser.closeTab(tab.id);
                       }}
                       aria-label={`Close ${tab.title || "tab"}`}
-                      className="shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100"
+                      className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
                     >
-                      <X size={11} />
+                      <X size={12} />
                     </Button>
                   </div>
                 );
               })
+            ) : (
+              <div className="flex flex-col items-center justify-center gap-2 px-4 py-8 text-center">
+                <div className="grid size-9 place-items-center rounded-[10px] bg-muted text-muted-foreground">
+                  <Globe size={14} />
+                </div>
+                <div className="text-xs leading-5 text-muted-foreground">
+                  No open tabs in the {browserSpace} browser.
+                </div>
+              </div>
             )}
           </div>
         </div>

--- a/desktop/src/components/panes/SpreadsheetEditor.tsx
+++ b/desktop/src/components/panes/SpreadsheetEditor.tsx
@@ -302,68 +302,29 @@ export function SpreadsheetEditor({
     );
   }
 
+  const metadataParts: string[] = [];
+  metadataParts.push(`${activeSheet.rows.length} rows`);
+  metadataParts.push(`${activeSheet.columns.length} columns`);
+  if (activeSheet.truncated) {
+    metadataParts.push("Preview trimmed");
+  }
+  if (!editable && readOnlyReason) {
+    metadataParts.push(readOnlyReason);
+  }
+
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-muted">
-      {sheets.length > 1 ? (
-        <div className="chat-scrollbar-hidden flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-2">
-          {sheets.map((sheet, index) => {
-            const isActive = index === activeSheetIndex;
-            return (
-              <button
-                key={`${sheet.name}-${sheet.index}`}
-                type="button"
-                onClick={() => onActiveSheetIndexChange(index)}
-                className={`rounded-md border px-2 py-1 text-[11px] transition-colors ${
-                  isActive
-                    ? "border-primary/35 bg-primary/12 text-primary"
-                    : "border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                }`}
-              >
-                {sheet.name}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/70 bg-background/70 px-3 py-2">
-        <div className="text-[11px] text-muted-foreground">
-          {activeSheet.rows.length} visible rows
-          {" · "}
-          {activeSheet.columns.length} visible columns
-          {activeSheet.truncated ? " · Preview trimmed" : ""}
-          {!editable && readOnlyReason ? ` · ${readOnlyReason}` : ""}
-        </div>
-        {editable ? (
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              onClick={addColumn}
-            >
-              <Plus size={11} />
-              Column
-            </Button>
-            <Button type="button" variant="ghost" size="xs" onClick={addRow}>
-              <Plus size={11} />
-              Row
-            </Button>
-          </div>
-        ) : null}
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto bg-background">
-        <table className="w-max min-w-full border-collapse text-xs text-foreground">
-          <thead className="sticky top-0 z-[1] bg-background/95 backdrop-blur-sm">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-border/40 bg-background">
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-max min-w-full border-separate border-spacing-0 text-sm text-foreground">
+          <thead className="sticky top-0 z-[2]">
             <tr>
-              <th className="sticky left-0 z-[2] border-b border-r border-border bg-background/95 px-2 py-1.5 text-left text-[11px] text-muted-foreground backdrop-blur-sm">
-                #
+              <th className="sticky left-0 z-[3] w-11 border-b border-r border-border/35 bg-muted/45 px-0 py-0 text-center text-xs font-normal uppercase tracking-[0.08em] text-muted-foreground/70 backdrop-blur-sm">
+                <div className="flex h-8 items-center justify-center">#</div>
               </th>
               {activeSheet.columns.map((column, columnIndex) => (
                 <th
                   key={`${column}-${columnIndex}`}
-                  className="min-w-[164px] border-b border-r border-border bg-background/95 px-0 py-0 text-left text-[11px] text-muted-foreground backdrop-blur-sm"
+                  className="min-w-[172px] border-b border-r border-border/35 bg-muted/45 px-0 py-0 text-left text-xs font-medium text-foreground/88 backdrop-blur-sm last:border-r-0"
                 >
                   {activeSheet.hasHeaderRow && editable ? (
                     <input
@@ -372,7 +333,7 @@ export function SpreadsheetEditor({
                         updateHeaderValue(columnIndex, event.target.value)
                       }
                       aria-label={`Column ${columnIndex + 1}`}
-                      className="embedded-input h-9 w-full border-0 bg-transparent px-3 text-[11px] font-medium text-foreground outline-none"
+                      className="embedded-input h-8 w-full border-0 bg-transparent px-3 text-xs font-medium text-foreground outline-none"
                     />
                   ) : (
                     <div className="px-3 py-2 font-medium text-foreground/88">
@@ -388,7 +349,7 @@ export function SpreadsheetEditor({
               <tr>
                 <td
                   colSpan={activeSheet.columns.length + 1}
-                  className="px-3 py-8 text-center text-xs text-muted-foreground"
+                  className="px-3 py-10 text-center text-xs text-muted-foreground"
                 >
                   {editable
                     ? "No rows yet. Add a row to start editing."
@@ -397,12 +358,11 @@ export function SpreadsheetEditor({
               </tr>
             ) : (
               activeSheet.rows.map((row, rowIndex) => (
-                <tr
-                  key={`row-${rowIndex}`}
-                  className="odd:bg-background even:bg-muted/10"
-                >
-                  <td className="sticky left-0 border-b border-r border-border bg-inherit px-2 py-1.5 align-top text-[11px] text-muted-foreground">
-                    {rowIndex + 1}
+                <tr key={`row-${rowIndex}`} className="group/row">
+                  <td className="sticky left-0 z-[1] w-11 border-b border-r border-border/25 bg-background px-0 py-0 text-center align-middle text-xs text-muted-foreground/70 transition-colors group-hover/row:bg-accent/25 group-hover/row:text-muted-foreground">
+                    <div className="flex min-h-8 items-center justify-center">
+                      {rowIndex + 1}
+                    </div>
                   </td>
                   {activeSheet.columns.map((_column, columnIndex) => {
                     const value = row[columnIndex] ?? "";
@@ -412,10 +372,10 @@ export function SpreadsheetEditor({
                     return (
                       <td
                         key={`cell-${rowIndex}-${columnIndex}`}
-                        className="min-w-[164px] border-b border-r border-border px-0 py-0 align-top"
+                        className="min-w-[172px] border-b border-r border-border/20 px-0 py-0 align-top transition-colors last:border-r-0 group-hover/row:bg-accent/20"
                       >
                         {editable ? (
-                          <div className="flex h-9 items-center gap-1 px-2">
+                          <div className="flex min-h-8 items-center gap-1 px-2 py-1">
                             <input
                               value={value}
                               onChange={(event) =>
@@ -432,7 +392,7 @@ export function SpreadsheetEditor({
                                 )
                               }
                               aria-label={`Row ${rowIndex + 1}, Column ${columnIndex + 1}`}
-                              className={`embedded-input h-full min-w-0 flex-1 border-0 bg-transparent px-1 text-xs outline-none ${
+                              className={`embedded-input h-6 min-w-0 flex-1 border-0 bg-transparent px-1 text-sm outline-none ${
                                 cellLink
                                   ? "text-primary underline underline-offset-2"
                                   : "text-foreground"
@@ -444,7 +404,7 @@ export function SpreadsheetEditor({
                                 onClick={() => openSpreadsheetCellLink(cellLink)}
                                 aria-label={`Open link from row ${rowIndex + 1}, column ${columnIndex + 1}`}
                                 title={cellLink}
-                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-primary transition-colors hover:bg-primary/10 hover:text-primary/85"
+                                className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
                               >
                                 <ArrowUpRight size={12} />
                               </button>
@@ -455,12 +415,12 @@ export function SpreadsheetEditor({
                             type="button"
                             onClick={() => openSpreadsheetCellLink(cellLink)}
                             title={cellLink}
-                            className="block h-full w-full cursor-pointer bg-transparent px-3 py-2 text-left text-xs break-words whitespace-pre-wrap text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
+                            className="block h-full w-full cursor-pointer bg-transparent px-3 py-2 text-left text-sm break-words whitespace-pre-wrap text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
                           >
                             {value || cellLink}
                           </button>
                         ) : (
-                          <div className="px-3 py-2 break-words whitespace-pre-wrap">
+                          <div className="px-3 py-2 text-sm break-words whitespace-pre-wrap">
                             {value || "\u00a0"}
                           </div>
                         )}
@@ -472,6 +432,51 @@ export function SpreadsheetEditor({
             )}
           </tbody>
         </table>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border/35 bg-muted/25 px-2.5 py-1.5">
+        <div className="chat-scrollbar-hidden flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          {sheets.length > 1 ? (
+            sheets.map((sheet, index) => {
+              const isActive = index === activeSheetIndex;
+              return (
+                <button
+                  key={`${sheet.name}-${sheet.index}`}
+                  type="button"
+                  onClick={() => onActiveSheetIndexChange(index)}
+                  className={`shrink-0 rounded-md px-2.5 py-1 text-xs transition-colors ${
+                    isActive
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  }`}
+                >
+                  {sheet.name}
+                </button>
+              );
+            })
+          ) : (
+            <span className="truncate px-1 text-xs text-muted-foreground/75">
+              {activeSheet.name}
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="hidden text-xs text-muted-foreground/75 sm:inline">
+            {metadataParts.join(" · ")}
+          </span>
+          {editable ? (
+            <div className="flex items-center gap-1">
+              <Button type="button" variant="ghost" size="xs" onClick={addColumn}>
+                <Plus size={11} />
+                Column
+              </Button>
+              <Button type="button" variant="ghost" size="xs" onClick={addRow}>
+                <Plus size={11} />
+                Row
+              </Button>
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/desktop/src/components/panes/browserSessionUi.ts
+++ b/desktop/src/components/panes/browserSessionUi.ts
@@ -176,14 +176,5 @@ export function browserSurfaceStatusSummary(params: {
     };
   }
 
-  if (params.controlMode === "session_owned") {
-    return {
-      label: "Ready",
-      detail: "Choose a different agent session to inspect another browser surface.",
-      tone: "idle",
-      flashing: false,
-    };
-  }
-
   return null;
 }

--- a/desktop/src/components/settings/SubmissionsPanel.tsx
+++ b/desktop/src/components/settings/SubmissionsPanel.tsx
@@ -306,9 +306,43 @@ export function SubmissionsPanel() {
   }
 
   if (loading) {
+    const skeletonWidths = [
+      { name: "w-32", sub: "w-20", badge: "w-16", size: "w-8", date: "w-16" },
+      { name: "w-44", sub: "w-28", badge: "w-14", size: "w-10", date: "w-14" },
+      { name: "w-36", sub: "w-16", badge: "w-16", size: "w-6", date: "w-20" },
+      { name: "w-28", sub: "w-24", badge: "w-14", size: "w-8", date: "w-16" },
+      { name: "w-40", sub: "w-20", badge: "w-16", size: "w-10", date: "w-14" },
+    ];
     return (
-      <div className="flex items-center justify-center py-16">
-        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      <div
+        role="status"
+        aria-busy="true"
+        aria-label="Loading submissions"
+        className="max-w-[960px]"
+      >
+        <div className="grid grid-cols-[20px_minmax(0,1fr)_100px_80px_110px_40px] items-center gap-3 border-b border-border/40 px-4 pb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          <span />
+          <span>Template</span>
+          <span>Status</span>
+          <span>Size</span>
+          <span>Date</span>
+          <span />
+        </div>
+        {skeletonWidths.map((w, i) => (
+          <div key={i} className="border-b border-border/30">
+            <div className="grid grid-cols-[20px_minmax(0,1fr)_100px_80px_110px_40px] items-center gap-3 px-4 py-3">
+              <span className="size-3.5 animate-pulse rounded-sm bg-muted-foreground/20" />
+              <div className="min-w-0 space-y-1.5">
+                <span className={`block h-3.5 animate-pulse rounded bg-muted-foreground/20 ${w.name}`} />
+                <span className={`block h-2.5 animate-pulse rounded bg-muted-foreground/20 ${w.sub}`} />
+              </div>
+              <span className={`h-5 animate-pulse rounded-full bg-muted-foreground/20 ${w.badge}`} />
+              <span className={`h-3 animate-pulse rounded bg-muted-foreground/20 ${w.size}`} />
+              <span className={`h-3 animate-pulse rounded bg-muted-foreground/20 ${w.date}`} />
+              <span className="size-5 animate-pulse rounded bg-muted-foreground/20" />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
@@ -329,14 +363,14 @@ export function SubmissionsPanel() {
       <div className="rounded-[24px] border border-border/40 bg-card/80 px-6 py-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
-            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               <ShieldAlert className="size-3.5 text-primary" />
               <span>Sign-In Required</span>
             </div>
             <p className="mt-2 text-sm font-medium text-foreground">
               Your template submissions are only available after you sign in.
             </p>
-            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
               Connect this desktop app to your account to review and
               manage marketplace submissions.
             </p>
@@ -361,7 +395,7 @@ export function SubmissionsPanel() {
         <p className="text-sm font-medium text-foreground">
           No submissions yet
         </p>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Publish a workspace template to see it listed here.
         </p>
       </div>

--- a/desktop/src/components/ui/confirm-dialog.tsx
+++ b/desktop/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,73 @@
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPrimitive.Portal>
+        <AlertDialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-background/70 backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <AlertDialogPrimitive.Popup
+          className={cn(
+            "fixed top-1/2 left-1/2 z-[91] w-[min(420px,calc(100vw-32px))]",
+            "-translate-x-1/2 -translate-y-1/2 rounded-xl border border-border",
+            "bg-popover p-5 text-popover-foreground shadow-xl ring-1 ring-foreground/10",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "outline-none",
+          )}
+        >
+          <AlertDialogPrimitive.Title className="text-sm font-semibold text-foreground">
+            {title}
+          </AlertDialogPrimitive.Title>
+          {description ? (
+            <AlertDialogPrimitive.Description className="mt-2 text-xs leading-6 text-muted-foreground">
+              {description}
+            </AlertDialogPrimitive.Description>
+          ) : null}
+          <div className="mt-5 flex items-center justify-end gap-2">
+            <AlertDialogPrimitive.Close
+              render={
+                <Button type="button" variant="ghost" size="sm">
+                  {cancelLabel}
+                </Button>
+              }
+            />
+            <Button
+              type="button"
+              variant={destructive ? "destructive" : "default"}
+              size="sm"
+              onClick={() => {
+                onConfirm();
+                onOpenChange(false);
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </AlertDialogPrimitive.Popup>
+      </AlertDialogPrimitive.Portal>
+    </AlertDialogPrimitive.Root>
+  );
+}

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -236,13 +236,13 @@ body {
   0%,
   100% {
     opacity: 0.62;
-    box-shadow:
-      inset 0 0 18px color-mix(in oklch, var(--primary) 14%, transparent);
+    box-shadow: inset 0 0 18px
+      color-mix(in oklch, var(--primary) 14%, transparent);
   }
   50% {
     opacity: 0.96;
-    box-shadow:
-      inset 0 0 38px color-mix(in oklch, var(--primary) 30%, transparent);
+    box-shadow: inset 0 0 38px
+      color-mix(in oklch, var(--primary) 30%, transparent);
   }
 }
 
@@ -256,9 +256,32 @@ body {
   animation: holaboss-browser-active-frame 2.8s ease-in-out infinite;
 }
 
+@keyframes holaboss-browser-jump-flash {
+  0% {
+    box-shadow:
+      0 0 0 0 transparent,
+      inset 0 0 0 0 transparent;
+  }
+  18% {
+    box-shadow:
+      0 0 36px color-mix(in oklch, var(--primary) 48%, transparent),
+      inset 0 0 36px color-mix(in oklch, var(--primary) 24%, transparent);
+  }
+  100% {
+    box-shadow:
+      0 0 0 0 transparent,
+      inset 0 0 0 0 transparent;
+  }
+}
+
+.browser-jump-flash {
+  animation: holaboss-browser-jump-flash 720ms ease-out;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .browser-active-glow,
-  .browser-active-glow-frame {
+  .browser-active-glow-frame,
+  .browser-jump-flash {
     animation: none;
   }
 }
@@ -282,8 +305,8 @@ body {
 /* ---- Chat bubbles ---- */
 
 .theme-chat-user-bubble {
-  background: color-mix(in oklch, var(--primary) 14%, transparent);
-  border-color: color-mix(in oklch, var(--primary) 24%, transparent);
+  background: color-mix(in oklch, var(--muted) 85%, var(--foreground) 4%);
+  border-color: transparent;
   box-shadow: none;
 }
 
@@ -415,61 +438,61 @@ webview {
   color: var(--foreground);
 }
 
-/* ---- Simple Markdown (marketplace kit README) ---- */
+
+/* ---- Simple Markdown ---- */
 
 .simple-markdown {
+  font-size: 15px;
+  line-height: 1.72;
   color: var(--foreground);
-  font-size: 13px;
-  line-height: 1.75;
 }
 
 .simple-markdown .md-h1 {
-  font-size: 22px;
-  font-weight: 600;
+  font-size: 28px;
+  font-weight: 500;
   letter-spacing: -0.03em;
-  margin-top: 28px;
-  margin-bottom: 12px;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 16px;
   color: var(--foreground);
 }
 
 .simple-markdown .md-h2 {
-  font-size: 17px;
-  font-weight: 600;
+  font-size: 22px;
+  font-weight: 500;
   letter-spacing: -0.02em;
-  margin-top: 24px;
+  line-height: 1.3;
+  margin-top: 36px;
   margin-bottom: 10px;
   color: var(--foreground);
 }
 
 .simple-markdown .md-h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin-top: 20px;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.4;
+  margin-top: 28px;
   margin-bottom: 8px;
   color: var(--foreground);
 }
 
 .simple-markdown .md-h4 {
-  font-size: 13px;
-  font-weight: 600;
-  margin-top: 18px;
-  margin-bottom: 8px;
-  color: var(--foreground);
-}
-
-.simple-markdown .md-h5 {
-  font-size: 12px;
-  font-weight: 600;
-  margin-top: 16px;
-  margin-bottom: 8px;
-  color: var(--foreground);
-}
-
-.simple-markdown .md-h6 {
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 500;
-  margin-top: 14px;
+  line-height: 1.5;
+  margin-top: 20px;
   margin-bottom: 6px;
+  color: var(--foreground);
+}
+
+.simple-markdown .md-h5,
+.simple-markdown .md-h6 {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-top: 16px;
+  margin-bottom: 4px;
   color: var(--muted-foreground);
 }
 
@@ -483,13 +506,23 @@ webview {
 }
 
 .simple-markdown .md-p {
-  margin-top: 8px;
-  margin-bottom: 8px;
+  margin-top: 12px;
+  margin-bottom: 0;
+  color: color-mix(in oklch, var(--foreground) 88%, transparent);
+}
+
+.simple-markdown .md-p:first-child,
+.simple-markdown .md-ul:first-child,
+.simple-markdown .md-ol:first-child,
+.simple-markdown .md-blockquote:first-child,
+.simple-markdown .md-code-block:first-child,
+.simple-markdown .md-table:first-child {
+  margin-top: 0;
 }
 
 .simple-markdown .md-img {
   max-width: 100%;
-  border-radius: 12px;
+  border-radius: 10px;
   margin-top: 12px;
   margin-bottom: 12px;
 }
@@ -497,161 +530,25 @@ webview {
 .simple-markdown .md-code-block {
   background: color-mix(in oklch, var(--background) 80%, black);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 10px;
   padding: 14px 16px;
   margin: 12px 0;
   overflow-x: auto;
-  font-size: 11px;
+  font-size: 12.5px;
   line-height: 1.6;
   white-space: pre;
   font-family: ui-monospace, monospace;
 }
 
 .simple-markdown .md-inline-code {
-  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
   border-radius: 5px;
-  padding: 2px 6px;
-  font-size: 11.5px;
+  padding: 1px 5px;
+  font-size: 12.5px;
   font-family: ui-monospace, monospace;
+  font-weight: 400;
 }
 
-.simple-markdown .md-blockquote {
-  border-left: 3px solid var(--border);
-  padding-left: 14px;
-  margin: 12px 0;
-  color: var(--muted-foreground);
-  font-style: italic;
-}
-
-.simple-markdown .md-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 12px;
-}
-
-.simple-markdown .md-table th,
-.simple-markdown .md-table td {
-  border: 1px solid var(--border);
-  padding: 8px 12px;
-  text-align: left;
-}
-
-.simple-markdown .md-table th {
-  font-weight: 600;
-  background: var(--muted);
-}
-
-.simple-markdown .md-ul,
-.simple-markdown .md-ol {
-  padding-left: 20px;
-  margin: 8px 0;
-}
-
-.simple-markdown .md-li,
-.simple-markdown .md-oli {
-  margin: 4px 0;
-}
-
-.simple-markdown .md-link {
-  color: var(--primary);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.simple-markdown .md-hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 20px 0;
-}
-
-/* ---- Simple Markdown (marketplace kit README) ---- */
-.simple-markdown {
-  color: rgb(var(--color-text-main) / 0.88);
-  font-size: 13px;
-  line-height: 1.75;
-}
-.simple-markdown .md-h1 {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  margin-top: 28px;
-  margin-bottom: 12px;
-  color: rgb(var(--color-text-main));
-}
-.simple-markdown .md-h2 {
-  font-size: 17px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  margin-top: 24px;
-  margin-bottom: 10px;
-  color: rgb(var(--color-text-main));
-}
-.simple-markdown .md-h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin-top: 20px;
-  margin-bottom: 8px;
-  color: rgb(var(--color-text-main));
-}
-.simple-markdown .md-h4 {
-  font-size: 13px;
-  font-weight: 600;
-  margin-top: 18px;
-  margin-bottom: 8px;
-  color: rgb(var(--color-text-main));
-}
-.simple-markdown .md-h5 {
-  font-size: 12px;
-  font-weight: 600;
-  margin-top: 16px;
-  margin-bottom: 8px;
-  color: rgb(var(--color-text-main));
-}
-.simple-markdown .md-h6 {
-  font-size: 12px;
-  font-weight: 500;
-  margin-top: 14px;
-  margin-bottom: 6px;
-  color: rgb(var(--color-text-muted));
-}
-.simple-markdown .md-h1:first-child,
-.simple-markdown .md-h2:first-child,
-.simple-markdown .md-h3:first-child,
-.simple-markdown .md-h4:first-child,
-.simple-markdown .md-h5:first-child,
-.simple-markdown .md-h6:first-child {
-  margin-top: 0;
-}
-.simple-markdown .md-p {
-  margin-top: 8px;
-  margin-bottom: 8px;
-}
-.simple-markdown .md-img {
-  max-width: 100%;
-  border-radius: 12px;
-  margin-top: 12px;
-  margin-bottom: 12px;
-}
-.simple-markdown .md-code-block {
-  background: rgba(0, 0, 0, 0.12);
-  border: 1px solid rgb(var(--color-panel-border) / 0.3);
-  border-radius: 12px;
-  padding: 14px 16px;
-  margin: 12px 0;
-  overflow-x: auto;
-  font-size: 11px;
-  line-height: 1.6;
-  white-space: pre;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-}
-.simple-markdown .md-inline-code {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 5px;
-  padding: 2px 6px;
-  font-size: 11.5px;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-}
 .simple-markdown .md-code-block > code {
   background: transparent;
   border-radius: 0;
@@ -659,54 +556,86 @@ webview {
   font-size: inherit;
   font-family: inherit;
 }
+
 .simple-markdown .md-blockquote {
-  border-left: 3px solid rgb(var(--color-panel-border) / 0.5);
-  padding-left: 14px;
-  margin: 12px 0;
-  color: rgb(var(--color-text-muted) / 0.82);
-  font-style: italic;
+  border-left: 2px solid var(--border);
+  padding-left: 16px;
+  margin: 14px 0;
+  color: var(--muted-foreground);
+  font-style: normal;
 }
+
 .simple-markdown .md-table {
   width: 100%;
   border-collapse: collapse;
-  margin: 12px 0;
-  font-size: 12px;
+  margin: 14px 0;
+  font-size: 13.5px;
 }
+
 .simple-markdown .md-table th,
 .simple-markdown .md-table td {
-  border: 1px solid rgb(var(--color-panel-border) / 0.3);
   padding: 8px 12px;
   text-align: left;
 }
+
 .simple-markdown .md-table th {
-  font-weight: 600;
-  background: rgba(0, 0, 0, 0.06);
+  font-weight: 500;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  border-bottom: 1px solid var(--border);
 }
+
+.simple-markdown .md-table td {
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
+}
+
+.simple-markdown .md-table tr:last-child td {
+  border-bottom: none;
+}
+
 .simple-markdown .md-ul,
 .simple-markdown .md-ol {
-  padding-left: 20px;
-  margin: 8px 0;
+  padding-left: 22px;
+  margin: 12px 0;
 }
+
 .simple-markdown .md-ul {
   list-style: disc;
 }
+
 .simple-markdown .md-ol {
   list-style: decimal;
 }
+
 .simple-markdown .md-li,
 .simple-markdown .md-oli {
   margin: 4px 0;
+  color: color-mix(in oklch, var(--foreground) 80%, transparent);
 }
+
 .simple-markdown .md-link {
-  color: rgb(var(--color-text-main));
+  color: var(--foreground);
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklch, var(--foreground) 30%, transparent);
 }
+
+.simple-markdown .md-link:hover {
+  text-decoration-color: var(--foreground);
+}
+
+.simple-markdown strong {
+  font-weight: 500;
+}
+
 .simple-markdown .md-hr {
   border: none;
-  border-top: 1px solid rgb(var(--color-panel-border) / 0.3);
-  margin: 20px 0;
+  border-top: 1px solid var(--border);
+  margin: 24px 0;
+  opacity: 0.4;
 }
+
+/* ---- Chat Markdown (conversation context — scales down simple-markdown) ---- */
 
 .chat-markdown {
   max-width: 100%;
@@ -714,21 +643,112 @@ webview {
   word-break: break-word;
 }
 
+/* font-size per role */
 .chat-user-markdown {
-  font-size: 13px;
-  line-height: 1.75;
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 .chat-assistant-markdown {
-  font-size: 14px;
-  line-height: 1.8;
+  font-size: 15px;
+  line-height: 1.72;
+}
+
+.chat-assistant-markdown .md-p {
+  margin-top: 14px;
+}
+
+.chat-assistant-markdown .md-ul,
+.chat-assistant-markdown .md-ol {
+  margin: 14px 0;
+}
+
+.chat-assistant-markdown .md-li,
+.chat-assistant-markdown .md-oli {
+  margin: 6px 0;
+}
+
+.chat-assistant-markdown .md-h1 {
+  font-size: 1.45em;
+  font-weight: 600;
+  line-height: 1.35;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+}
+
+.chat-assistant-markdown .md-h2 {
+  font-size: 1.25em;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.chat-assistant-markdown .md-h3 {
+  font-size: 1.1em;
+  font-weight: 600;
+  line-height: 1.45;
+  margin-top: 1.3em;
+  margin-bottom: 0.4em;
+}
+
+.chat-assistant-markdown .md-h4 {
+  font-size: 1em;
+  font-weight: 600;
+  line-height: 1.5;
+  margin-top: 1.1em;
+  margin-bottom: 0.35em;
+}
+
+.chat-assistant-markdown .md-h1:first-child,
+.chat-assistant-markdown .md-h2:first-child,
+.chat-assistant-markdown .md-h3:first-child,
+.chat-assistant-markdown .md-h4:first-child,
+.chat-assistant-markdown .md-p:first-child,
+.chat-assistant-markdown .md-ul:first-child,
+.chat-assistant-markdown .md-ol:first-child {
+  margin-top: 0;
+}
+
+.chat-assistant-markdown strong {
+  font-weight: 600;
+}
+
+.chat-assistant-markdown .md-p + .md-ul,
+.chat-assistant-markdown .md-p + .md-ol {
+  margin-top: 0;
+}
+
+.chat-assistant-markdown .md-h1 + *,
+.chat-assistant-markdown .md-h2 + *,
+.chat-assistant-markdown .md-h3 + *,
+.chat-assistant-markdown .md-h4 + * {
+  margin-top: 0;
+}
+
+.chat-assistant-markdown .md-inline-code {
+  background: color-mix(in oklch, var(--muted) 80%, transparent);
+  border-radius: 4px;
+  padding: 0.15em 0.38em;
+  font-size: 0.875em;
+  font-weight: 500;
+}
+
+.chat-assistant-markdown .md-blockquote {
+  border-left: 2px solid color-mix(in oklch, var(--foreground) 25%, transparent);
+  padding: 0.35em 0 0.35em 1em;
+  margin: 1em 0;
+  color: color-mix(in oklch, var(--foreground) 75%, transparent);
+  font-weight: 500;
 }
 
 .chat-thinking-markdown {
   font-size: 12px;
-  line-height: 1.55;
+  line-height: 1.6;
+  color: color-mix(in oklch, var(--foreground) 70%, transparent);
 }
 
+/* overflow-wrap for chat URLs and long tokens */
 .chat-markdown .md-link,
 .chat-markdown .md-p,
 .chat-markdown .md-li,
@@ -740,27 +760,56 @@ webview {
   word-break: break-word;
 }
 
+/* headings — same DNA as simple-markdown but scaled for chat bubbles */
 .chat-markdown .md-h1 {
-  font-size: 17px;
-  line-height: 1.5;
-  margin-top: 14px;
-  margin-bottom: 6px;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  margin-top: 18px;
+  margin-bottom: 8px;
 }
 
 .chat-markdown .md-h2 {
-  font-size: 15px;
-  line-height: 1.55;
-  margin-top: 12px;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  margin-top: 16px;
   margin-bottom: 6px;
 }
 
 .chat-markdown .md-h3,
-.chat-markdown .md-h4,
+.chat-markdown .md-h4 {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin-top: 12px;
+  margin-bottom: 4px;
+}
+
 .chat-markdown .md-h5,
 .chat-markdown .md-h6 {
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
   margin-top: 10px;
   margin-bottom: 4px;
+  color: var(--muted-foreground);
+}
+
+.chat-markdown .md-h1:first-child,
+.chat-markdown .md-h2:first-child,
+.chat-markdown .md-h3:first-child,
+.chat-markdown .md-h4:first-child,
+.chat-markdown .md-h5:first-child,
+.chat-markdown .md-h6:first-child {
+  margin-top: 0;
+}
+
+.chat-markdown .md-p {
+  margin-top: 10px;
+  margin-bottom: 0;
 }
 
 .chat-markdown .md-p:first-child,
@@ -781,8 +830,61 @@ webview {
   margin-bottom: 0;
 }
 
+.chat-markdown .md-ul,
+.chat-markdown .md-ol {
+  margin: 10px 0;
+}
+
+.chat-markdown .md-li,
+.chat-markdown .md-oli {
+  margin: 3px 0;
+}
+
 .chat-markdown .md-code-block {
   margin: 10px 0;
   font-size: 12px;
   line-height: 1.55;
+}
+
+
+/* ---- File Preview Markdown (document reader — spacing modifier) ---- */
+
+.simple-markdown.file-preview-markdown .md-h1 {
+  margin-bottom: 18px;
+}
+
+.simple-markdown.file-preview-markdown .md-h2 {
+  margin-top: 48px;
+  margin-bottom: 12px;
+}
+
+.simple-markdown.file-preview-markdown .md-h3 {
+  margin-top: 36px;
+  margin-bottom: 10px;
+}
+
+.simple-markdown.file-preview-markdown .md-h4 {
+  margin-top: 26px;
+}
+
+.simple-markdown.file-preview-markdown .md-p {
+  margin-top: 14px;
+}
+
+.simple-markdown.file-preview-markdown .md-ul,
+.simple-markdown.file-preview-markdown .md-ol {
+  margin: 14px 0;
+}
+
+.simple-markdown.file-preview-markdown .md-li,
+.simple-markdown.file-preview-markdown .md-oli {
+  margin: 6px 0;
+}
+
+.simple-markdown.file-preview-markdown .md-blockquote {
+  margin: 18px 0;
+}
+
+.simple-markdown.file-preview-markdown .md-hr {
+  margin: 36px 0;
 }


### PR DESCRIPTION
## Summary

Coordinated UX pass across the desktop app: new runtime status indicator, skeleton loaders in place of spinners, typography refactor across the Settings dialog, and a shadcn-primitive refresh of the Automations pane.

### Settings dialog
- Skeleton loaders replace spinners in `BillingSummaryCard`, `BillingSettingsPanel` usage list, `SubmissionsPanel`, `IntegrationsPane`, and `AutomationsPane`
- Typography pass: sidebar nav `h-8 text-[13px]` → `h-9 text-sm`, dialog header `text-base` → `text-lg`, body text bumped from `text-xs` → `text-sm` across panels
- Eyebrow tracking normalized from `0.18em`/`widest` → `0.14em`
- Workspace selector in Automations tab rebuilt with shadcn defaults (no `rounded-full`, no opacity-on-token borders); adds `FolderKanban` icon + contextual empty-state placeholder

### AutomationsPane
- Custom pill tabs replaced with shadcn `Tabs` / `TabsList` / `TabsTrigger`
- Hand-rolled toggle `<button>` with spinner overlay replaced with shadcn `Switch`
- Raw `DropdownMenuTrigger` box replaced with `Button variant="ghost" size="icon-sm"`
- Opacity-on-design-token hacks removed (`text-muted-foreground/75`, `text-destructive/85`, `hover:bg-accent/20`, etc.)
- Hardcoded `rgba(...)` notification-kind badge replaced with amber tokens
- Magic radii `rounded-[24px]`/`rounded-[20px]`/`rounded-[14px]` dropped for system values

### Runtime status indicator
- New `RuntimeStatusIndicator` component rendered at bottom-left of `AppShell`
- Removes semantically confusing green dot from the user avatar in `TopTabsBar`
- Click opens Settings → Model Providers; native `title` shows `lastError` detail

### CreditsPill
- `Loader2` spinner + `"..."` text replaced with skeleton pill (circle + bar) to avoid content jump when credits arrive

### BillingSettingsPanel
- Refresh button converted to Tooltip-wrapped icon button (`RefreshCw`) from a text button

### Other pane polish
- `ChatPane`, `FileExplorerPane`, `InternalSurfacePane`, `SpaceApplicationsExplorerPane`, `SpaceBrowserDisplayPane`, `SpaceBrowserExplorerPane`, `SpreadsheetEditor` cleanup
- New `browser-jump-flash` keyframe + `.browser-jump-flash` animation in `index.css`
- New `confirm-dialog` shadcn primitive added
- Minor `electron/main.ts` and `package.json` adjustments

### Tests
- Test assertions updated to match new class strings and new primitives (SettingsDialog, TopTabsBar, AutomationsPane, BillingSettingsPanel)
- Regex tolerance widened for formatter reflow (multi-line wrapping of `useCallback` arg and `Switch` aria-label)
- All existing behavioral assertions preserved

## Test plan

- [ ] `node --test` on all touched test files passes (21 tests green locally)
- [ ] `npx tsc --noEmit` exits 0
- [ ] Manual smoke: open Settings dialog — Billing, Submissions, Integrations, Automations all render skeletons while loading then transition cleanly
- [ ] Manual smoke: top-right user avatar no longer carries the runtime-status green dot
- [ ] Manual smoke: bottom-left runtime indicator shows Runtime running / Runtime error correctly; click opens Model Providers
- [ ] Manual smoke: Automations pane tabs toggle, Switch toggle enables/disables cronjob, kebab menu run/edit/delete all work
- [ ] Manual smoke: Billing refresh icon button spins on click and tooltip shows "Refreshing..." during refresh