### PR TITLE
fix: add runtime Sentry diagnostics for connection drops

### DIFF
--- a/runtime/api-server/src/bridge-worker.test.ts
+++ b/runtime/api-server/src/bridge-worker.test.ts
@@ -17,6 +17,7 @@ import {
   proactiveBridgeHeaders,
   tsBridgeWorkerEnabled
 } from "./bridge-worker.js";
+import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
 
 test("ts bridge worker is enabled by default when remote bridge is enabled and only disables on explicit opt-out", () => {
   const previousBridge = process.env.PROACTIVE_ENABLE_REMOTE_BRIDGE;
@@ -173,6 +174,141 @@ test("runtime remote bridge worker polls jobs and reports results", async () => 
   assert.equal(fetchCalls[0].method, "GET");
   assert.equal(fetchCalls[1].method, "POST");
   assert.match(fetchCalls[1].body ?? "", /"job_id":"job-1"/);
+
+  if (previousBaseUrl === undefined) {
+    delete process.env.PROACTIVE_BRIDGE_BASE_URL;
+  } else {
+    process.env.PROACTIVE_BRIDGE_BASE_URL = previousBaseUrl;
+  }
+  if (previousAuth === undefined) {
+    delete process.env.HOLABOSS_SANDBOX_AUTH_TOKEN;
+  } else {
+    process.env.HOLABOSS_SANDBOX_AUTH_TOKEN = previousAuth;
+  }
+});
+
+test("runtime remote bridge worker reports poll failures to Sentry", async () => {
+  const previousBaseUrl = process.env.PROACTIVE_BRIDGE_BASE_URL;
+  const previousAuth = process.env.HOLABOSS_SANDBOX_AUTH_TOKEN;
+  process.env.PROACTIVE_BRIDGE_BASE_URL = "http://127.0.0.1:3069";
+  process.env.HOLABOSS_SANDBOX_AUTH_TOKEN = "token-1";
+
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+  const worker = new RuntimeRemoteBridgeWorker({
+    captureRuntimeException: (capture) => {
+      sentryCaptures.push(capture);
+    },
+    fetchImpl: (async () =>
+      new Response("Invalid or missing API key", {
+        status: 401,
+        headers: { "Content-Type": "text/plain" }
+      })) as typeof fetch,
+  });
+
+  await assert.rejects(worker.pollOnce(), /receive_jobs with status 401/);
+
+  assert.equal(sentryCaptures.length, 1);
+  assert.equal(sentryCaptures[0]?.tags?.surface, "proactive_bridge");
+  assert.equal(sentryCaptures[0]?.tags?.failure_kind, "poll_failure");
+  assert.equal(sentryCaptures[0]?.tags?.bridge_phase, "receive_jobs");
+  assert.equal(sentryCaptures[0]?.tags?.http_status, 401);
+  assert.equal(
+    sentryCaptures[0]?.contexts?.proactive_bridge?.endpoint,
+    "http://127.0.0.1:3069/api/v1/proactive/bridge/jobs?limit=10"
+  );
+  assert.equal(
+    sentryCaptures[0]?.extras?.response_body,
+    "Invalid or missing API key"
+  );
+  assert.equal(
+    sentryCaptures[0]?.extras?.response_content_type,
+    "text/plain"
+  );
+
+  if (previousBaseUrl === undefined) {
+    delete process.env.PROACTIVE_BRIDGE_BASE_URL;
+  } else {
+    process.env.PROACTIVE_BRIDGE_BASE_URL = previousBaseUrl;
+  }
+  if (previousAuth === undefined) {
+    delete process.env.HOLABOSS_SANDBOX_AUTH_TOKEN;
+  } else {
+    process.env.HOLABOSS_SANDBOX_AUTH_TOKEN = previousAuth;
+  }
+});
+
+test("runtime remote bridge worker reports result delivery failures to Sentry", async () => {
+  const previousBaseUrl = process.env.PROACTIVE_BRIDGE_BASE_URL;
+  const previousAuth = process.env.HOLABOSS_SANDBOX_AUTH_TOKEN;
+  process.env.PROACTIVE_BRIDGE_BASE_URL = "http://127.0.0.1:3069";
+  process.env.HOLABOSS_SANDBOX_AUTH_TOKEN = "token-1";
+
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+  const worker = new RuntimeRemoteBridgeWorker({
+    captureRuntimeException: (capture) => {
+      sentryCaptures.push(capture);
+    },
+    fetchImpl: (async (input, init) => {
+      const url = String(input);
+      if ((init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({
+            jobs: [
+              {
+                job_id: "job-1",
+                job_type: "task_proposal.create",
+                workspace_id: "workspace-1",
+                payload: {
+                  workspace_id: "workspace-1",
+                  task_name: "Review workspace",
+                  task_prompt: "Review the current workspace.",
+                  task_generation_rationale: "Bridge test"
+                }
+              }
+            ]
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      assert.equal(url, "http://127.0.0.1:3069/api/v1/proactive/bridge/results");
+      return new Response("gateway unavailable", {
+        status: 503,
+        headers: { "Content-Type": "text/plain" }
+      });
+    }) as typeof fetch,
+    executeJob: async (job) => ({
+      job_id: job.job_id,
+      status: "succeeded",
+      workspace_id: job.workspace_id,
+      job_type: job.job_type,
+      output: { ok: true }
+    })
+  });
+
+  const processed = await worker.pollOnce();
+
+  assert.equal(processed, 1);
+  assert.equal(sentryCaptures.length, 1);
+  assert.equal(sentryCaptures[0]?.tags?.surface, "proactive_bridge");
+  assert.equal(sentryCaptures[0]?.tags?.failure_kind, "job_failure");
+  assert.equal(sentryCaptures[0]?.tags?.bridge_phase, "report_result");
+  assert.equal(sentryCaptures[0]?.tags?.job_type, "task_proposal.create");
+  assert.equal(sentryCaptures[0]?.tags?.http_status, 503);
+  assert.equal(
+    sentryCaptures[0]?.contexts?.proactive_bridge_job?.job_id,
+    "job-1"
+  );
+  assert.equal(
+    sentryCaptures[0]?.extras?.response_body,
+    "gateway unavailable"
+  );
+  assert.deepEqual(sentryCaptures[0]?.extras?.reported_result, {
+    status: "succeeded",
+    error_code: null,
+    error_message: null,
+    completed_at: null,
+    has_output: true
+  });
 
   if (previousBaseUrl === undefined) {
     delete process.env.PROACTIVE_BRIDGE_BASE_URL;

--- a/runtime/api-server/src/bridge-worker.ts
+++ b/runtime/api-server/src/bridge-worker.ts
@@ -5,6 +5,12 @@ import type { RuntimeStateStore } from "@holaboss/runtime-state-store";
 import { MemoryServiceError, type MemoryServiceLike } from "./memory.js";
 import { captureWorkspaceContext } from "./proactive-context.js";
 import { runtimeConfigHeaders } from "./runtime-config.js";
+import {
+  captureRuntimeException,
+  extractRuntimeFetchErrorDiagnostics,
+  redactRuntimeSentryText,
+  redactRuntimeSentryValue,
+} from "./runtime-sentry.js";
 
 const TS_BRIDGE_WORKER_FLAG_ENV = "HOLABOSS_RUNTIME_USE_TS_BRIDGE_WORKER";
 const PROACTIVE_ENABLE_REMOTE_BRIDGE_ENV = "PROACTIVE_ENABLE_REMOTE_BRIDGE";
@@ -12,6 +18,7 @@ const PROACTIVE_BRIDGE_BASE_URL_ENV = "PROACTIVE_BRIDGE_BASE_URL";
 const HOLABOSS_BACKEND_BASE_URL_ENV = "HOLABOSS_BACKEND_BASE_URL";
 const PROACTIVE_BRIDGE_POLL_INTERVAL_SECONDS_ENV = "PROACTIVE_BRIDGE_POLL_INTERVAL_SECONDS";
 const PROACTIVE_BRIDGE_MAX_ITEMS_ENV = "PROACTIVE_BRIDGE_MAX_ITEMS";
+const PROACTIVE_BRIDGE_SENTRY_TEXT_LIMIT = 400;
 
 type LoggerLike = {
   info: (message: string, ...args: unknown[]) => void;
@@ -368,15 +375,92 @@ export interface RuntimeRemoteBridgeWorkerOptions {
   executeJob?: (job: ProactiveBridgeJob) => Promise<ProactiveBridgeJobResult>;
   store?: RuntimeStateStore;
   memoryService?: MemoryServiceLike;
+  captureRuntimeException?: typeof captureRuntimeException;
   fetchImpl?: typeof fetch;
   baseUrl?: string;
   pollIntervalMs?: number;
   maxItems?: number;
 }
 
+type ProactiveBridgeRequestPhase = "receive_jobs" | "report_result";
+
+class ProactiveBridgeRequestError extends Error {
+  readonly phase: ProactiveBridgeRequestPhase;
+  readonly endpoint: string;
+  readonly method: "GET" | "POST";
+  readonly status: number | null;
+  readonly responseBody: string | null;
+  readonly responseContentType: string | null;
+
+  constructor(params: {
+    phase: ProactiveBridgeRequestPhase;
+    endpoint: string;
+    method: "GET" | "POST";
+    status?: number | null;
+    responseBody?: string | null;
+    responseContentType?: string | null;
+    cause?: unknown;
+  }) {
+    const statusLabel =
+      typeof params.status === "number" ? ` with status ${params.status}` : "";
+    super(`Proactive bridge request failed during ${params.phase}${statusLabel}`, {
+      cause: params.cause,
+    });
+    this.name = "ProactiveBridgeRequestError";
+    this.phase = params.phase;
+    this.endpoint = params.endpoint;
+    this.method = params.method;
+    this.status = typeof params.status === "number" ? params.status : null;
+    this.responseBody = params.responseBody ?? null;
+    this.responseContentType = params.responseContentType ?? null;
+  }
+}
+
+function bridgeErrorPhase(
+  error: unknown,
+): ProactiveBridgeRequestPhase | "execute_job" {
+  return error instanceof ProactiveBridgeRequestError
+    ? error.phase
+    : "execute_job";
+}
+
+function bridgeResponsePreview(text: string): {
+  text: string;
+  truncated: boolean;
+} {
+  const redacted = redactRuntimeSentryText(text);
+  if (redacted.length <= PROACTIVE_BRIDGE_SENTRY_TEXT_LIMIT) {
+    return { text: redacted, truncated: false };
+  }
+  return {
+    text: `${redacted.slice(0, PROACTIVE_BRIDGE_SENTRY_TEXT_LIMIT)}…`,
+    truncated: true,
+  };
+}
+
+function bridgeTransportErrorCode(error: unknown): string | null {
+  const diagnostics = extractRuntimeFetchErrorDiagnostics(error);
+  const causeCode = diagnostics?.cause;
+  if (causeCode && typeof causeCode === "object" && !Array.isArray(causeCode)) {
+    const code = (causeCode as Record<string, unknown>).code;
+    if (typeof code === "string" && code.trim()) {
+      return code.trim();
+    }
+  }
+  const errorCode = diagnostics?.error;
+  if (errorCode && typeof errorCode === "object" && !Array.isArray(errorCode)) {
+    const code = (errorCode as Record<string, unknown>).code;
+    if (typeof code === "string" && code.trim()) {
+      return code.trim();
+    }
+  }
+  return null;
+}
+
 export class RuntimeRemoteBridgeWorker implements BridgeWorkerLike {
   readonly #logger: LoggerLike | undefined;
   readonly #executeJob: (job: ProactiveBridgeJob) => Promise<ProactiveBridgeJobResult>;
+  readonly #captureRuntimeException: typeof captureRuntimeException;
   readonly #fetch: typeof fetch;
   readonly #baseUrl: string;
   readonly #pollIntervalMs: number;
@@ -395,6 +479,8 @@ export class RuntimeRemoteBridgeWorker implements BridgeWorkerLike {
         : (() => {
             throw new Error("bridge worker requires executeJob or store+memoryService");
           }));
+    this.#captureRuntimeException =
+      options.captureRuntimeException ?? captureRuntimeException;
     this.#fetch = options.fetchImpl ?? fetch;
     this.#baseUrl = options.baseUrl ?? proactiveBridgeBaseUrl();
     this.#pollIntervalMs = options.pollIntervalMs ?? bridgePollIntervalMs();
@@ -421,12 +507,20 @@ export class RuntimeRemoteBridgeWorker implements BridgeWorkerLike {
   }
 
   async pollOnce(): Promise<number> {
-    const jobs = await this.#receiveJobs();
+    let jobs: ProactiveBridgeJob[];
+    try {
+      jobs = await this.#receiveJobs();
+    } catch (error) {
+      this.#capturePollFailure(error);
+      throw error;
+    }
     for (const job of jobs) {
+      let result: ProactiveBridgeJobResult | null = null;
       try {
-        const result = await this.#executeJob(job);
+        result = await this.#executeJob(job);
         await this.#reportResult(result);
       } catch (error) {
+        this.#captureJobFailure(error, job, result);
         this.#logger?.error?.("Remote proactive bridge job failed", {
           event: "runtime.proactive_bridge.job",
           outcome: "error",
@@ -441,12 +535,30 @@ export class RuntimeRemoteBridgeWorker implements BridgeWorkerLike {
   }
 
   async #receiveJobs(): Promise<ProactiveBridgeJob[]> {
-    const response = await this.#fetch(`${this.#baseUrl}/api/v1/proactive/bridge/jobs?limit=${this.#maxItems}`, {
-      method: "GET",
-      headers: this.#headers
-    });
+    const endpoint = `${this.#baseUrl}/api/v1/proactive/bridge/jobs?limit=${this.#maxItems}`;
+    let response: Response;
+    try {
+      response = await this.#fetch(endpoint, {
+        method: "GET",
+        headers: this.#headers
+      });
+    } catch (error) {
+      throw new ProactiveBridgeRequestError({
+        phase: "receive_jobs",
+        endpoint,
+        method: "GET",
+        cause: error,
+      });
+    }
     if (!response.ok) {
-      throw new Error(`Proactive bridge request failed: ${await response.text()}`);
+      throw new ProactiveBridgeRequestError({
+        phase: "receive_jobs",
+        endpoint,
+        method: "GET",
+        status: response.status,
+        responseBody: await response.text().catch(() => ""),
+        responseContentType: response.headers.get("content-type"),
+      });
     }
     const payload = await response.json();
     const jobs = isRecord(payload) && Array.isArray(payload.jobs) ? payload.jobs : [];
@@ -454,17 +566,170 @@ export class RuntimeRemoteBridgeWorker implements BridgeWorkerLike {
   }
 
   async #reportResult(result: ProactiveBridgeJobResult): Promise<void> {
-    const response = await this.#fetch(`${this.#baseUrl}/api/v1/proactive/bridge/results`, {
-      method: "POST",
-      headers: {
-        ...this.#headers,
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify(result)
-    });
-    if (!response.ok) {
-      throw new Error(`Proactive bridge request failed: ${await response.text()}`);
+    const endpoint = `${this.#baseUrl}/api/v1/proactive/bridge/results`;
+    let response: Response;
+    try {
+      response = await this.#fetch(endpoint, {
+        method: "POST",
+        headers: {
+          ...this.#headers,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(result)
+      });
+    } catch (error) {
+      throw new ProactiveBridgeRequestError({
+        phase: "report_result",
+        endpoint,
+        method: "POST",
+        cause: error,
+      });
     }
+    if (!response.ok) {
+      throw new ProactiveBridgeRequestError({
+        phase: "report_result",
+        endpoint,
+        method: "POST",
+        status: response.status,
+        responseBody: await response.text().catch(() => ""),
+        responseContentType: response.headers.get("content-type"),
+      });
+    }
+  }
+
+  #capturePollFailure(error: unknown): void {
+    const phase = bridgeErrorPhase(error);
+    const bridgeError =
+      error instanceof ProactiveBridgeRequestError ? error : null;
+    const fetchError = extractRuntimeFetchErrorDiagnostics(error);
+    const responsePreview =
+      bridgeError?.responseBody && bridgeError.responseBody.length > 0
+        ? bridgeResponsePreview(bridgeError.responseBody)
+        : null;
+    const transportErrorCode = bridgeTransportErrorCode(error);
+    this.#captureRuntimeException({
+      error,
+      level: "error",
+      fingerprint: [
+        "runtime",
+        "proactive_bridge",
+        "poll_failure",
+        phase,
+        bridgeError?.status !== null && bridgeError?.status !== undefined
+          ? String(bridgeError.status)
+          : transportErrorCode ?? "error",
+      ],
+      tags: {
+        surface: "proactive_bridge",
+        failure_kind: "poll_failure",
+        bridge_phase: phase,
+        ...(typeof bridgeError?.status === "number"
+          ? { http_status: bridgeError.status }
+          : {}),
+        ...(transportErrorCode ? { transport_error_code: transportErrorCode } : {}),
+      },
+      contexts: {
+        proactive_bridge: {
+          base_url: this.#baseUrl,
+          endpoint:
+            bridgeError?.endpoint ??
+            `${this.#baseUrl}/api/v1/proactive/bridge/jobs?limit=${this.#maxItems}`,
+          method: bridgeError?.method ?? "GET",
+          poll_interval_ms: this.#pollIntervalMs,
+          max_items: this.#maxItems,
+        },
+      },
+      extras: {
+        ...(responsePreview
+          ? {
+              response_body: responsePreview.text,
+              response_body_truncated: responsePreview.truncated,
+              response_content_type: bridgeError?.responseContentType ?? null,
+            }
+          : {}),
+        ...(fetchError ? { fetch_error: redactRuntimeSentryValue(fetchError) } : {}),
+      },
+    });
+  }
+
+  #captureJobFailure(
+    error: unknown,
+    job: ProactiveBridgeJob,
+    result: ProactiveBridgeJobResult | null,
+  ): void {
+    const phase = bridgeErrorPhase(error);
+    const bridgeError =
+      error instanceof ProactiveBridgeRequestError ? error : null;
+    const fetchError = extractRuntimeFetchErrorDiagnostics(error);
+    const responsePreview =
+      bridgeError?.responseBody && bridgeError.responseBody.length > 0
+        ? bridgeResponsePreview(bridgeError.responseBody)
+        : null;
+    const transportErrorCode = bridgeTransportErrorCode(error);
+    this.#captureRuntimeException({
+      error,
+      level: "error",
+      fingerprint: [
+        "runtime",
+        "proactive_bridge",
+        "job_failure",
+        phase,
+        job.job_type,
+        bridgeError?.status !== null && bridgeError?.status !== undefined
+          ? String(bridgeError.status)
+          : transportErrorCode ??
+              (phase === "execute_job" ? "execution_error" : "error"),
+      ],
+      tags: {
+        surface: "proactive_bridge",
+        failure_kind: "job_failure",
+        bridge_phase: phase,
+        job_type: job.job_type,
+        ...(typeof bridgeError?.status === "number"
+          ? { http_status: bridgeError.status }
+          : {}),
+        ...(transportErrorCode ? { transport_error_code: transportErrorCode } : {}),
+      },
+      contexts: {
+        proactive_bridge: {
+          base_url: this.#baseUrl,
+          endpoint: bridgeError?.endpoint ?? null,
+          method: bridgeError?.method ?? null,
+          poll_interval_ms: this.#pollIntervalMs,
+          max_items: this.#maxItems,
+        },
+        proactive_bridge_job: {
+          job_id: job.job_id,
+          job_type: job.job_type,
+          workspace_id: job.workspace_id,
+          sandbox_id: job.sandbox_id ?? null,
+          result_status: result?.status ?? null,
+          result_error_code: result?.error_code ?? null,
+          result_has_output: Boolean(result?.output),
+        },
+      },
+      extras: {
+        ...(responsePreview
+          ? {
+              response_body: responsePreview.text,
+              response_body_truncated: responsePreview.truncated,
+              response_content_type: bridgeError?.responseContentType ?? null,
+            }
+          : {}),
+        ...(fetchError ? { fetch_error: redactRuntimeSentryValue(fetchError) } : {}),
+        ...(result
+          ? {
+              reported_result: redactRuntimeSentryValue({
+                status: result.status,
+                error_code: result.error_code ?? null,
+                error_message: result.error_message ?? null,
+                completed_at: result.completed_at ?? null,
+                has_output: Boolean(result.output),
+              }),
+            }
+          : {}),
+      },
+    });
   }
 
   async #runLoop(): Promise<void> {

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -2154,27 +2154,33 @@ test("run-start registration strips the model-proxy path before calling the back
 
 test("run-start registration reports backend failures to Sentry", async () => {
   const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+  const originalWarn = console.warn;
+  console.warn = () => {};
 
-  await registerWorkspaceAgentRunStarted({
-    workspaceId: "workspace-1",
-    sessionId: "session-main",
-    inputId: "input-1",
-    runId: "workspace-1:session-main:input-1",
-    selectedModel: "elephant-alpha",
-    runtimeBinding: {
-      authToken: "token-1",
-      userId: "user-1",
-      sandboxId: "sandbox-1",
-      modelProxyBaseUrl: "http://127.0.0.1:3060/api/v1/model-proxy",
-    },
-    captureRuntimeExceptionFn: (capture) => {
-      sentryCaptures.push(capture);
-    },
-    fetchImpl: async () =>
-      new Response("binding lookup failed: api_key=secret-token", {
-        status: 401,
-      }),
-  });
+  try {
+    await registerWorkspaceAgentRunStarted({
+      workspaceId: "workspace-1",
+      sessionId: "session-main",
+      inputId: "input-1",
+      runId: "workspace-1:session-main:input-1",
+      selectedModel: "elephant-alpha",
+      runtimeBinding: {
+        authToken: "token-1",
+        userId: "user-1",
+        sandboxId: "sandbox-1",
+        modelProxyBaseUrl: "http://127.0.0.1:3060/api/v1/model-proxy",
+      },
+      captureRuntimeExceptionFn: (capture) => {
+        sentryCaptures.push(capture);
+      },
+      fetchImpl: async () =>
+        new Response("binding lookup failed: api_key=secret-token", {
+          status: 401,
+        }),
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
 
   assert.equal(sentryCaptures.length, 1);
   assert.equal(
@@ -2197,6 +2203,76 @@ test("run-start registration reports backend failures to Sentry", async () => {
     run_id: "workspace-1:session-main:input-1",
     model: "elephant-alpha",
   });
+});
+
+test("run-start registration reports fetch socket diagnostics to Sentry", async () => {
+  const sentryCaptures: RuntimeSentryCaptureOptions[] = [];
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  const fetchError = new TypeError("fetch failed");
+  Object.assign(fetchError, {
+    cause: {
+      name: "SocketError",
+      message: "other side closed",
+      code: "UND_ERR_SOCKET",
+      socket: {
+        localAddress: "198.18.0.1",
+        localPort: 51240,
+        remoteAddress: "35.160.37.189",
+        remotePort: 3060,
+        remoteFamily: "IPv4",
+        bytesWritten: 749,
+        bytesRead: 0,
+      },
+    },
+  });
+
+  try {
+    await registerWorkspaceAgentRunStarted({
+      workspaceId: "workspace-1",
+      sessionId: "session-main",
+      inputId: "input-1",
+      runId: "workspace-1:session-main:input-1",
+      selectedModel: "elephant-alpha",
+      runtimeBinding: {
+        authToken: "token-1",
+        userId: "user-1",
+        sandboxId: "sandbox-1",
+        modelProxyBaseUrl: "http://127.0.0.1:3060/api/v1/model-proxy",
+      },
+      captureRuntimeExceptionFn: (capture) => {
+        sentryCaptures.push(capture);
+      },
+      fetchImpl: async () => {
+        throw fetchError;
+      },
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(sentryCaptures.length, 1);
+  assert.deepEqual(sentryCaptures[0]?.extras?.fetch_error, {
+    error: {
+      name: "TypeError",
+      message: "fetch failed",
+    },
+    cause: {
+      name: "SocketError",
+      message: "other side closed",
+      code: "UND_ERR_SOCKET",
+    },
+    socket: {
+      localAddress: "198.18.0.1",
+      localPort: 51240,
+      remoteAddress: "35.160.37.189",
+      remotePort: 3060,
+      remoteFamily: "IPv4",
+      bytesWritten: 749,
+      bytesRead: 0,
+    },
+  });
+  assert.equal(sentryCaptures[0]?.extras?.timeout_ms, 2000);
 });
 
 test("run-event registration strips the model-proxy path before calling the backend route", async () => {

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -27,6 +27,7 @@ import {
 } from "./harness-registry.js";
 import {
   captureRuntimeException,
+  extractRuntimeFetchErrorDiagnostics,
   redactRuntimeSentryText,
   redactRuntimeSentryValue,
 } from "./runtime-sentry.js";
@@ -371,6 +372,7 @@ async function postWorkspaceAgentRunRequest(params: {
       );
     }
   } catch (error) {
+    const fetchError = extractRuntimeFetchErrorDiagnostics(error);
     (params.captureRuntimeExceptionFn ?? captureRuntimeException)({
       error,
       level: "error",
@@ -399,6 +401,7 @@ async function postWorkspaceAgentRunRequest(params: {
       extras: {
         request_body: sanitizeRuntimeSentryValue(params.body),
         timeout_ms: 2000,
+        ...(fetchError ? { fetch_error: sanitizeRuntimeSentryValue(fetchError) } : {}),
       },
     });
     console.warn(

--- a/runtime/api-server/src/runtime-sentry.ts
+++ b/runtime/api-server/src/runtime-sentry.ts
@@ -129,6 +129,116 @@ function normalizeError(value: unknown): Error {
   return new Error(message);
 }
 
+function stringDiagnostic(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = redactRuntimeSentryText(value).trim();
+  return normalized || null;
+}
+
+function numberDiagnostic(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function errorDiagnostic(value: unknown): Record<string, unknown> | null {
+  if (!(value instanceof Error) && !isRecord(value)) {
+    return null;
+  }
+  const source: Record<string, unknown> = value instanceof Error
+    ? ((value as unknown as Record<string, unknown>) ?? {})
+    : value;
+  const diagnostic: Record<string, unknown> = {};
+  const name = stringDiagnostic(
+    value instanceof Error ? value.name : source.name,
+  );
+  const message = stringDiagnostic(
+    value instanceof Error ? value.message : source.message,
+  );
+  const code = stringDiagnostic(source.code);
+  if (name) {
+    diagnostic.name = name;
+  }
+  if (message) {
+    diagnostic.message = message;
+  }
+  if (code) {
+    diagnostic.code = code;
+  }
+  return Object.keys(diagnostic).length > 0 ? diagnostic : null;
+}
+
+function socketDiagnostic(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const diagnostic: Record<string, unknown> = {};
+  const localAddress = stringDiagnostic(value.localAddress);
+  const remoteAddress = stringDiagnostic(value.remoteAddress);
+  const remoteFamily = stringDiagnostic(value.remoteFamily);
+  const localPort = numberDiagnostic(value.localPort);
+  const remotePort = numberDiagnostic(value.remotePort);
+  const timeout = numberDiagnostic(value.timeout);
+  const bytesWritten = numberDiagnostic(value.bytesWritten);
+  const bytesRead = numberDiagnostic(value.bytesRead);
+  if (localAddress) {
+    diagnostic.localAddress = localAddress;
+  }
+  if (localPort !== null) {
+    diagnostic.localPort = localPort;
+  }
+  if (remoteAddress) {
+    diagnostic.remoteAddress = remoteAddress;
+  }
+  if (remotePort !== null) {
+    diagnostic.remotePort = remotePort;
+  }
+  if (remoteFamily) {
+    diagnostic.remoteFamily = remoteFamily;
+  }
+  if (timeout !== null) {
+    diagnostic.timeout = timeout;
+  }
+  if (bytesWritten !== null) {
+    diagnostic.bytesWritten = bytesWritten;
+  }
+  if (bytesRead !== null) {
+    diagnostic.bytesRead = bytesRead;
+  }
+  return Object.keys(diagnostic).length > 0 ? diagnostic : null;
+}
+
+export function extractRuntimeFetchErrorDiagnostics(
+  error: unknown,
+): Record<string, unknown> | null {
+  const diagnostic: Record<string, unknown> = {};
+  const errorDetails = errorDiagnostic(error);
+  if (errorDetails) {
+    diagnostic.error = errorDetails;
+  }
+  const causeValue =
+    error instanceof Error
+      ? error.cause
+      : isRecord(error)
+        ? error.cause
+        : undefined;
+  const causeDetails = errorDiagnostic(causeValue);
+  if (causeDetails) {
+    diagnostic.cause = causeDetails;
+  }
+  const socketDetails = socketDiagnostic(
+    isRecord(causeValue)
+      ? causeValue.socket
+      : isRecord(error)
+        ? error.socket
+        : undefined,
+  );
+  if (socketDetails) {
+    diagnostic.socket = socketDetails;
+  }
+  return Object.keys(diagnostic).length > 0 ? diagnostic : null;
+}
+
 function envPath(name: string): string {
   return process.env[name]?.trim() || "";
 }


### PR DESCRIPTION
## Summary
- capture sanitized fetch socket metadata for runtime agent-run registration failures so transport closes are visible in Sentry
- report proactive bridge poll and result-delivery failures to Sentry with phase, endpoint, status, and redacted response previews
- add regression coverage for claimed-input fetch socket diagnostics and proactive bridge Sentry captures

## Context
The diagnostics bundle showed repeated runtime "connection error" symptoms that were actually outbound transport failures to the prod runtime on `:3060` (`UND_ERR_SOCKET`, `other side closed`, `bytesRead: 0`). We also had background proactive bridge failures that only logged a generic poll error. This PR makes both paths debuggable in Sentry.

## Validation
- `cd runtime/api-server && npm run typecheck`
- `cd runtime/api-server && node --import tsx --test src/claimed-input-executor.test.ts src/bridge-worker.test.ts --test-name-pattern='run-start registration reports backend failures to Sentry|run-start registration reports fetch socket diagnostics to Sentry|runtime remote bridge worker reports poll failures to Sentry|runtime remote bridge worker reports result delivery failures to Sentry'`
- `cd runtime/api-server && npm test`

## Notes
- no migrations
- no Supabase branch changes
- no env changes required beyond existing runtime Sentry configuration