### PR TITLE
docs: refine prompt boundary and walkthrough docs

### DIFF
--- a/docs/pi-only-prompt-semantics-inventory.md
+++ b/docs/pi-only-prompt-semantics-inventory.md
@@ -1,212 +1,130 @@
-# PI-Only Prompt Semantics Inventory
+# PI Harness Prompt Boundary
 
-This note inventories behavior-shaping prompt semantics that currently exist only in the PI harness path instead of the harness-agnostic runtime prompt contract.
+This document describes the prompt-facing boundary between the shared runtime contract and the `pi` harness host.
 
-Relevant runtime contract:
-- [agent-runtime-config.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/api-server/src/agent-runtime-config.ts:1527) returns `system_prompt`, `context_messages`, `prompt_sections`, and `prompt_layers`
-- Anything that should behave the same across harnesses should ideally originate there
+Use it when you need to decide whether a behavior belongs in:
 
-## What Counts As PI-Only Prompt Semantics
+- `runtime/api-server`, where the runtime defines agent behavior that should apply across harnesses
+- `runtime/harness-host/src/pi.ts` and related PI host helpers, where the `pi` path serializes that behavior into a PI-native request shape or enforces PI-local execution rules
 
-PI-only prompt semantics are instructions or behavior nudges that:
-- change what the model is encouraged to do
-- are injected in `runtime/harness-host/src/pi.ts` or PI-specific tool definitions
-- are not represented upstream in `runtime/api-server`
+## Runtime-Owned Prompt Contract
 
-Pure transport formatting does not count unless it carries behavior policy.
+The runtime owns the parts of the prompt that should stay consistent even if the harness changes.
 
-## Should Move Upstream
+That includes:
 
-### 1. Todo resume and continuation policy
+- the base workspace instructions from `AGENTS.md`
+- execution doctrine and response-delivery policy
+- todo continuity policy
+- session-memory-backed resume context
+- scratchpad metadata and scratchpad usage guidance
+- recalled durable memory
+- current-user context
+- operator-surface context
+- pending user-memory proposals
+- capability policy derived from the run's tool and MCP surface
+- runtime-backed tool semantics for `todoread`, `todowrite`, `skill`, `web_search`, `write_report`, scratchpad tools, onboarding tools, cronjob tools, and image generation
+- quoted workspace-skill preparation from leading `/skill-id` lines in the user instruction
 
-Current PI-only sources:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:1368) `resumeTodoReadInstruction(...)`
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:2288) `todoread` prompt guidelines
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:2328) `todowrite` prompt guidelines
+The shared sources of truth are:
 
-Behavior encoded there:
-- newest user message is primary
-- do not auto-resume unfinished todo on ambiguous user messages
-- ask first on conversational or ambiguous continuation messages
-- keep executing resumed work until complete or genuinely blocked
-- do not stop only for progress updates while executable todo items remain
-- preserve unfinished todo when user redirects to unrelated work
-
-Why this should move:
-- this is not PI transport behavior
-- this is core session continuation policy
-- other harnesses should follow the same continuation logic
-
-Suggested home:
 - `runtime/api-server/src/agent-runtime-prompt.ts`
-- likely a dedicated runtime section such as `todo_continuity_policy`
+- `runtime/api-server/src/agent-runtime-config.ts`
+- `runtime/api-server/src/workspace-skills.ts`
+- `runtime/api-server/src/runtime-agent-tools.ts`
+- `runtime/api-server/src/native-web-search.ts`
 
-### 2. Quoted workspace skill expansion
+If a rule changes how the agent should plan, continue work, use memory, or decide between tools independent of harness, it belongs here.
 
-Current PI-only sources:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:1271) `resolveQuotedSkillSections(...)`
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:653) prompt-body insertion of `Quoted workspace skills:`
+## What PI Owns
 
-Behavior encoded there:
-- leading slash skill references in the instruction are expanded into full skill markdown blocks
-- missing quoted skills produce explicit prompt feedback
+The PI host keeps the parts of the execution boundary that are specific to the PI request shape or to PI-managed local tool state.
 
-Why this should move:
-- this is user-visible behavior
-- if `/skill-name` works in one harness, it should work in all harnesses
-- the current implementation makes quoted skill support a PI feature instead of a runtime feature
+### Prompt payload construction
 
-Suggested home:
-- runtime-side instruction preprocessing before harness dispatch
-- or a dedicated prompt section emitted by `runtime/api-server`
+`runtime/harness-host/src/pi.ts` owns `buildPiPromptPayload(...)`.
 
-### 3. `write_report` usage policy
+That function turns the already-prepared runtime request into the PI prompt body by concatenating:
 
-Current PI-only source:
-- [pi-runtime-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-runtime-tools.ts:614) `runtimeToolPromptGuidelines("write_report")`
+1. runtime-prepared `quoted_skill_blocks`
+2. a missing-skill warning when `missing_quoted_skill_ids` is non-empty
+3. the cleaned user instruction
+4. a `Runtime context:` block that wraps each runtime `context_message`
+5. attachment-derived prompt sections returned by `attachment-prompt-content.ts`
 
-Behavior encoded there:
-- use `write_report` for long, evidence-heavy, or multi-source work
-- do not use it for short self-contained answers
-- if the user asked for research or latest information and findings were gathered, save a report before final answer
-- keep chat reply short after report creation
+This is transport and serialization logic. It is not the source of truth for prompt semantics.
 
-Why this should move:
-- `write_report` is a runtime tool, not a PI-only tool
-- the threshold for creating an artifact should be consistent across harnesses
+### Attachment projection
 
-Suggested home:
-- shared runtime tool metadata in `runtime/harnesses/src/runtime-agent-tools.ts`
-- or a runtime prompt section keyed off capability availability
+`runtime/harness-host/src/attachment-prompt-content.ts` owns how staged attachments become PI prompt content.
 
-### 4. Web-search recency wording
+It is responsible for:
 
-Current PI-only source:
-- [pi-web-search.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-web-search.ts:99)
+- extracting inline text from common document formats such as PDF, DOCX, PPTX, and spreadsheets
+- keeping image attachments separate so they can be passed as image content rather than flattened into text
+- producing the human-readable attachment sections that `buildPiPromptPayload(...)` appends to the PI request body
 
-Behavior encoded there:
-- PI appends “The current year is X; include X in recent-information queries.”
+The runtime decides which attachments belong to the run. The PI host decides how those attachments are encoded for PI.
 
-Why this should move:
-- this is a query-planning heuristic, not a PI transport detail
-- if web search exists in multiple harnesses, recency handling should be shared
+### Runtime-tool packaging
 
-Suggested home:
-- shared web-search tool definition metadata
-- or a general runtime recency policy
+`runtime/harness-host/src/pi-runtime-tools.ts` owns PI `ToolDefinition` wrappers for runtime-backed tools.
 
-## Should Probably Move Upstream Or Be Derived From Shared Metadata
+This layer is responsible for:
 
-These items are partially duplicated already. The projection can remain harness-local, but the source text should not be handwritten only in PI.
+- PI-native parameter schemas
+- PI-specific tool descriptions and usage guidance
+- HTTP proxying to the runtime capability endpoints
+- attaching workspace, session, input, and model metadata to runtime-tool calls
 
-### 5. Scratchpad tool guidance
+The underlying tool behavior still comes from the runtime. PI only packages and forwards those tool calls.
 
-Current PI-only source:
-- [pi-runtime-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-runtime-tools.ts:625)
+### Skill widening over PI-managed tools
 
-Behavior encoded there:
-- when to read scratchpad
-- how to interpret scratchpad truth status
-- when to append vs replace vs clear
+The `skill` tool itself is runtime-backed, but PI still owns local widening enforcement for PI-managed tools and commands.
 
-Why only “probably”:
-- some scratchpad guidance already exists upstream in [agent-runtime-prompt.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/api-server/src/agent-runtime-prompt.ts:375) and [agent-runtime-prompt.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/api-server/src/agent-runtime-prompt.ts:663)
-- PI still adds extra tool-specific policy that other harnesses would miss
+That logic lives in `runtime/harness-host/src/pi.ts` and is built from the runtime-provided `workspace_skills` manifests.
 
-Suggested direction:
-- keep tool-level projection in harnesses
-- move canonical scratchpad guidance into shared metadata or runtime prompt sections
+PI keeps:
 
-### 6. `download_url` and background terminal routing guidance
+- the live widening state for the run
+- wrappers that deny managed tools or commands until a skill grants them
+- application of granted tools and commands returned by the runtime-backed `skill` call
+- `skill_invocation` event mapping for the PI event stream
 
-Current PI-only source:
-- [pi-runtime-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-runtime-tools.ts:606)
-- [pi-runtime-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-runtime-tools.ts:639)
+This remains host-local because it governs PI-managed tool wrappers, not the shared meaning of a skill.
 
-Upstream duplication already exists:
-- [agent-capability-registry.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/api-server/src/agent-capability-registry.ts:1280)
-- [agent-capability-registry.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/api-server/src/agent-capability-registry.ts:1285)
+### MCP materialization for PI
 
-Assessment:
-- the decision policy is already becoming runtime-owned
-- PI still contains a second, more detailed version
-- this should be deduplicated so harnesses derive from one shared source
+The runtime prepares `mcp_servers` and any explicit `mcp_tool_refs`.
 
-### 7. Todo tool schema usage advice
+The PI host still owns:
 
-Current PI-only source:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:2334)
+- building PI MCP server bindings from that prepared payload
+- discovering tools from those configured servers
+- constraining servers that have explicit `mcp_tool_refs`
+- exposing the discovered tool set to the PI session
 
-Behavior encoded there:
-- valid todo ops
-- use `name` instead of `title`
-- use `content` instead of `title` for tasks
-- read current ids before mutating an existing plan
-- keep one task `in_progress`
+This is part of host-side tool materialization, not prompt policy.
 
-Assessment:
-- some of this belongs in tool parameter schemas and runtime-side validation
-- some of it is true cross-harness usage guidance
-- the projection should remain harness-local, but the canonical rules should be shared
+## What Stays Outside Prompt Semantics But Remains PI-Local
 
-## Can Stay Harness-Local
+The `pi` path also owns several execution details that are not really prompt semantics at all:
 
-These are projection concerns. They affect prompt shape, but not the underlying policy contract.
+- PI session creation and persisted harness session reuse
+- PI-native post-run compaction
+- provider-specific reasoning normalization
+- local coding tools from the PI SDK
+- workspace-boundary enforcement wrappers around PI-managed local tools
+- native event normalization back into the runtime event contract
 
-### 8. Runtime context block wrappers
+Those are part of the harness host, but they are separate from the shared runtime prompt contract.
 
-Current PI-only source:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:638)
+## Boundary Rule
 
-Behavior:
-- wraps runtime context messages as:
-  - `Runtime context:`
-  - `[Runtime Context N]`
+Use this rule when deciding where a change belongs:
 
-Assessment:
-- this is serialization, not policy
-- another harness may project the same `context_messages` differently
+- If the change affects what the agent should know, prioritize, remember, or do across harnesses, implement it in the runtime.
+- If the change affects how the PI host serializes prompt content, wraps PI-local tools, or maps PI-native events, keep it in the PI host.
 
-### 9. Attachment, folder, and image prompt serialization
-
-Current PI-only source:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:687)
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:703)
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:712)
-
-Behavior:
-- inlines extracted document text
-- lists image attachments
-- lists folder attachment paths
-- says folder contents are not inlined automatically
-
-Assessment:
-- this is mostly harness projection
-- the runtime may later define a richer attachment contract, but this is not the highest-priority prompt-policy leak
-
-### 10. Tool `promptSnippet` packaging itself
-
-Current PI-only sources:
-- [pi.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi.ts:2293)
-- [pi-runtime-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-runtime-tools.ts:820)
-- [pi-browser-tools.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-browser-tools.ts:331)
-- [pi-web-search.ts](/Users/jeffrey/Desktop/holaboss/holaOS-runtime-work-checkpoints/runtime/harness-host/src/pi-web-search.ts:261)
-
-Assessment:
-- each harness may need to package tool metadata differently
-- that projection can stay local
-- but the meaning carried inside descriptions and guidelines should come from shared definitions where possible
-
-## Priority Order
-
-1. Move todo continuation policy upstream.
-2. Move quoted skill expansion upstream.
-3. Move `write_report` policy into shared runtime tool metadata.
-4. Move web-search recency guidance into shared metadata.
-5. Deduplicate scratchpad, terminal, and download guidance so PI only projects shared text.
-
-## Practical Rule
-
-Use this boundary:
-- if it changes agent behavior across sessions or tools, define it in `runtime/api-server` or shared tool metadata
-- if it only changes how one harness serializes already-defined content, keep it in the harness adapter
+That boundary keeps the runtime as the owner of agent behavior and keeps the harness host as the owner of transport, projection, and PI-local enforcement.

--- a/docs/runtime-prompt-construction-walkthrough.md
+++ b/docs/runtime-prompt-construction-walkthrough.md
@@ -1,72 +1,38 @@
 # Runtime Prompt Construction Walkthrough
 
-Last verified against the local code in this worktree on `2026-04-22`.
+This document shows how a single runtime turn becomes the prompt seen by the `pi` harness host.
 
-This document explains how one runtime turn becomes the prompt seen by the PI harness host after the resume-context and compaction-boundary removal.
-
-It is based on current implementation, not intended architecture.
-
-## Scope
-
-This walkthrough covers the current prompt path for a local runtime turn:
-
-1. `TsRunnerRequest` enters `executeTsRunnerRequest(...)`
-2. runtime bootstrap loads dynamic per-run context
-3. runtime builds `AgentRuntimeConfigCliRequest`
-4. runtime projects that request into prompt sections
-5. sections become:
-   - `system_prompt`
-   - `context_messages`
-   - `prompt_layers`
-   - `prompt_cache_profile`
-6. the PI runtime adapter forwards that into the harness-host request
-7. the PI host combines:
-   - `system_prompt`
-   - user `instruction`
-   - runtime context messages
-   - quoted skills
-   - attachments
-   - persisted PI session history
-
-Relevant implementation files:
+It follows the current implementation in:
 
 - `runtime/api-server/src/ts-runner.ts`
 - `runtime/api-server/src/agent-runtime-config.ts`
 - `runtime/api-server/src/agent-runtime-prompt.ts`
 - `runtime/api-server/src/agent-prompt-sections.ts`
-- `runtime/api-server/src/agent-capability-registry.ts`
+- `runtime/api-server/src/workspace-skills.ts`
 - `runtime/harnesses/src/pi.ts`
 - `runtime/harness-host/src/pi.ts`
+- `runtime/harness-host/src/attachment-prompt-content.ts`
+- `runtime/harness-host/src/pi-runtime-tools.ts`
 
-## High-Level Shape
+## End-To-End Shape
 
-The runtime does not build one monolithic prompt string directly.
+One run moves through these layers:
 
-It first builds structured prompt sections with:
+1. the runtime compiles the workspace plan and loads dynamic run context
+2. the runtime resolves workspace skills and prepares any quoted skill blocks
+3. the runtime projects structured prompt sections into `system_prompt` and `context_messages`
+4. the PI runtime adapter builds a reduced host request
+5. the PI host turns that request into a PI-native prompt body
+6. the PI host executes the run using:
+   - the PI system prompt override
+   - the PI prompt body
+   - PI session history from the persisted harness session
 
-- `id`
-- `channel`
-- `apply_at`
-- `precedence`
-- `priority`
-- `volatility`
-- `content`
-
-Those sections are then rendered into:
-
-- `system_prompt`
-  - only sections whose `channel === "system_prompt"`
-- `context_messages`
-  - flattened compatibility list of sections whose channel is one of:
-    - `context_message`
-    - `resume_context`
-    - `attachment`
-
-That split matters because PI host treats them differently.
+The runtime owns the prompt contract. The PI host owns the final request shape.
 
 ## Worked Example
 
-Assume this turn enters the runtime:
+Assume the runtime receives this queued input:
 
 ```json
 {
@@ -74,57 +40,101 @@ Assume this turn enters the runtime:
   "session_id": "session-main",
   "input_id": "input-42",
   "session_kind": "workspace_session",
-  "instruction": "Continue the cloud cost investigation. Use the notes from earlier, update the findings, and give me the answer in chat.",
+  "instruction": "/cloud_costs\n\nContinue the cloud cost investigation. Update the findings and answer in chat.",
   "model": "openai/gpt-5.4",
-  "attachments": [],
-  "thinking_value": null,
-  "debug": false
+  "thinking_value": "medium",
+  "attachments": [
+    {
+      "id": "attachment-1",
+      "kind": "file",
+      "name": "ec2-cost-breakdown.pdf",
+      "mime_type": "application/pdf",
+      "size_bytes": 238144,
+      "workspace_path": "inputs/input-42/ec2-cost-breakdown.pdf"
+    }
+  ]
 }
 ```
 
-Also assume:
+Assume the workspace also has:
 
-- root `AGENTS.md` exists and contains workspace instructions
-- browser tools are available for this run
-- runtime tools are staged, including scratchpad tools and todo tools
-- one or more MCP servers are available
-- the session already has:
-  - a session memory excerpt
-  - a session scratchpad file
-  - persisted PI session history
+- root `AGENTS.md`
+- a workspace skill `cloud_costs`
+- a session-memory file for `session-main`
+- a session scratchpad file for `session-main`
+- recalled durable memory for cloud-cost investigations
+- a persisted PI harness session file for `session-main`
 
-## Step 1: Workspace Prompt Source
+## Step 1: Load the Static Workspace Prompt
 
-The base workspace prompt comes from root `AGENTS.md`.
+`workspace-runtime-plan.ts` compiles the workspace plan and loads root `AGENTS.md` into `general_config.agent.prompt`.
 
-That is loaded into `general_config.agent.prompt` when the workspace runtime plan is compiled in:
+That prompt becomes the workspace-specific instruction block later rendered into the `workspace_policy` system-prompt section.
 
-- `runtime/api-server/src/workspace-runtime-plan.ts`
+At this point the runtime has:
 
-So before runtime adds anything dynamic, there is already a static workspace prompt sourced from `AGENTS.md`.
+- authored workspace config from `workspace.yaml`
+- authored workspace instructions from `AGENTS.md`
+- resolved MCP configuration
+- resolved application configuration
 
-## Step 2: Runtime Bootstrap Loads Dynamic Context
+## Step 2: Resolve Workspace Skills and Prepare the Instruction
 
-Inside `executeTsRunnerRequest(...)` in `runtime/api-server/src/ts-runner.ts`, runtime loads the dynamic prompt inputs before prompt projection.
+Before prompt projection, `ts-runner.ts` resolves the available skills with `resolveWorkspaceSkills(...)`.
 
-### 2.1 `sessionResumeContext`
+For this example, assume it finds:
+
+```json
+[
+  {
+    "skill_id": "cloud_costs",
+    "skill_name": "cloud_costs",
+    "source_dir": "/workspace/skills/cloud_costs",
+    "file_path": "/workspace/skills/cloud_costs/SKILL.md",
+    "origin": "workspace",
+    "granted_tools": ["bash"],
+    "granted_commands": ["aws-cost-query"]
+  }
+]
+```
+
+Then `prepareInstructionWithQuotedWorkspaceSkills(...)` parses the leading `/cloud_costs` line and produces:
+
+```json
+{
+  "body": "Continue the cloud cost investigation. Update the findings and answer in chat.",
+  "quoted_skill_blocks": [
+    "<skill name=\"cloud_costs\" location=\"/workspace/skills/cloud_costs/SKILL.md\">\nReferences are relative to /workspace/skills/cloud_costs.\n\nReview billing evidence before proposing savings actions.\n</skill>"
+  ],
+  "missing_quoted_skill_ids": []
+}
+```
+
+Important detail:
+
+- the runtime prepares the quoted skill block once
+- the PI host does not parse slash-prefixed skill references from raw instruction text
+
+## Step 3: Load Dynamic Run Context
+
+`executeTsRunnerRequest(...)` then loads the runtime-owned context that is specific to this run.
+
+### Session resume context
+
+This comes from the session-memory file, not from synthesized recent-turn mini-history.
 
 Example:
 
 ```json
 {
   "session_memory_path": "workspace/workspace-1/runtime/session-memory/session-main.md",
-  "session_memory_excerpt": "Investigation focused on AWS spend growth, vendor overlap, and whether idle GPU instances explain the spike."
+  "session_memory_excerpt": "Investigation focused on EC2 spend growth, idle GPU workers, and duplicate vendor subscriptions."
 }
 ```
 
-Current behavior:
+### Session scratchpad context
 
-- this comes from the runtime-managed session-memory file only
-- there is no fallback that synthesizes `recent_runtime_context`, `recent_turns`, or `recent_user_messages`
-- runtime does not emit a synthetic resume event before the harness run
-
-### 2.2 `sessionScratchpadContext`
+The scratchpad metadata is loaded, but the full scratchpad body is not inlined into the prompt.
 
 Example:
 
@@ -134,16 +144,11 @@ Example:
   "file_path": ".holaboss/scratchpads/session-main.md",
   "updated_at": "2026-04-22T10:15:00.000Z",
   "size_bytes": 1420,
-  "preview": "AWS spend spike mostly correlates with idle GPU workers and duplicate vendor monitoring subscriptions."
+  "preview": "Idle GPU workers and duplicate monitoring subscriptions explain most of the spike."
 }
 ```
 
-Source:
-
-- `runtime/api-server/src/session-scratchpad.ts`
-- loaded by `loadSessionScratchpadContext(...)`
-
-### 2.3 `recalledMemoryContext`
+### Recalled durable memory
 
 Example:
 
@@ -153,8 +158,8 @@ Example:
     {
       "scope": "workspace",
       "memory_type": "procedure",
-      "title": "Cloud spend investigations should verify idle compute first",
-      "summary": "When investigating infra spend spikes, check idle compute, duplicate subscriptions, and recent deployment changes before suggesting optimization work.",
+      "title": "Check idle compute before proposing optimizations",
+      "summary": "For cloud-cost investigations, verify idle compute, duplicate subscriptions, and recent deployment changes before proposing savings work.",
       "path": "workspace/workspace-1/knowledge/cloud-cost-procedure.md",
       "verification_policy": "check_before_use",
       "freshness_state": "fresh"
@@ -163,95 +168,57 @@ Example:
 }
 ```
 
-### 2.4 `currentUserContext`
+### Other runtime context
 
-Example:
+The runtime may also load:
 
-```json
-{
-  "profile_id": "default",
-  "name": "Jeffrey",
-  "name_source": "runtime_profile"
-}
-```
+- `current_user_context`
+- `operator_surface_context`
+- `pending_user_memory_context`
+- `evolve_candidate_context`
 
-### 2.5 `operatorSurfaceContext`
-
-Example:
+For this example, assume:
 
 ```json
 {
-  "active_surface_id": "browser:user",
-  "surfaces": [
-    {
-      "surface_id": "browser:user",
-      "surface_type": "browser",
-      "owner": "user",
-      "active": true,
-      "mutability": "inspect_only",
-      "summary": "AWS billing dashboard is open to EC2 spend breakdown."
-    }
-  ]
+  "current_user_context": {
+    "profile_id": "default",
+    "name": "Jeffrey",
+    "name_source": "runtime_profile"
+  },
+  "operator_surface_context": {
+    "active_surface_id": "browser:user",
+    "surfaces": [
+      {
+        "surface_id": "browser:user",
+        "surface_type": "browser",
+        "owner": "user",
+        "active": true,
+        "mutability": "inspect_only",
+        "summary": "AWS billing dashboard is open to EC2 spend breakdown."
+      }
+    ]
+  },
+  "pending_user_memory_context": null,
+  "evolve_candidate_context": null
 }
 ```
 
-### 2.6 `pendingUserMemoryContext`
+## Step 4: Build the Runtime Config Request
 
-Example:
+`buildAgentRuntimeConfigRequest(...)` packages the workspace prompt, dynamic context, selected model, and visible capability surface into one `AgentRuntimeConfigCliRequest`.
 
-```json
-{
-  "entries": [
-    {
-      "proposal_id": "proposal-1",
-      "proposal_kind": "response_style",
-      "target_key": "response_style",
-      "title": "Prefers concise answers",
-      "summary": "The user asked for concise output.",
-      "evidence": "give me the answer in chat"
-    }
-  ]
-}
-```
-
-### 2.7 `evolveCandidateContext`
-
-Only present for accepted evolve/task-proposal flows.
-
-For a normal workspace session, this is often `null`.
-
-## Step 3: Runtime Builds the Request for Prompt Projection
-
-All of the above is packed into one `AgentRuntimeConfigCliRequest` by:
-
-- `buildAgentRuntimeConfigRequest(...)`
-- file: `runtime/api-server/src/ts-runner.ts`
-
-Conceptually, the request looks like this:
+A representative request looks like this:
 
 ```json
 {
   "session_id": "session-main",
   "workspace_id": "workspace-1",
   "input_id": "input-42",
+  "session_mode": "code",
   "session_kind": "workspace_session",
-  "harness_id": "pi",
-  "browser_tools_available": true,
-  "browser_tool_ids": ["browser_open", "browser_eval"],
-  "runtime_tool_ids": [
-    "write_report",
-    "holaboss_scratchpad_read",
-    "holaboss_scratchpad_write"
-  ],
-  "workspace_command_ids": [],
-  "session_resume_context": { "...": "..." },
-  "recalled_memory_context": { "...": "..." },
-  "current_user_context": { "...": "..." },
-  "operator_surface_context": { "...": "..." },
-  "pending_user_memory_context": { "...": "..." },
-  "session_scratchpad_context": { "...": "..." },
   "selected_model": "openai/gpt-5.4",
-  "workspace_skill_ids": [],
+  "workspace_skill_ids": ["cloud_costs"],
   "default_tools": [
     "read",
     "edit",
@@ -260,618 +227,70 @@ Conceptually, the request looks like this:
     "glob",
     "list",
     "question",
-    "todowrite",
     "todoread",
+    "todowrite",
     "skill"
   ],
   "extra_tools": [
-    "browser_open",
-    "browser_eval",
+    "web_search",
+    "write_report",
     "holaboss_scratchpad_read",
-    "holaboss_scratchpad_write"
+    "holaboss_scratchpad_write",
+    "browser_open",
+    "browser_eval"
   ],
-  "resolved_mcp_tool_refs": [
-    {
-      "tool_id": "notion_search",
-      "server_id": "mcp-notion",
-      "tool_name": "search"
-    }
-  ],
+  "resolved_mcp_tool_refs": [],
+  "resolved_mcp_server_ids": ["context7"],
   "agent": {
     "id": "workspace.general",
     "model": "gpt-5.2",
-    "prompt": "<contents of AGENTS.md>",
-    "role": null
+    "prompt": "<contents of AGENTS.md>"
+  },
+  "session_resume_context": {
+    "session_memory_path": "workspace/workspace-1/runtime/session-memory/session-main.md",
+    "session_memory_excerpt": "Investigation focused on EC2 spend growth, idle GPU workers, and duplicate vendor subscriptions."
+  },
+  "session_scratchpad_context": {
+    "exists": true,
+    "file_path": ".holaboss/scratchpads/session-main.md",
+    "updated_at": "2026-04-22T10:15:00.000Z",
+    "size_bytes": 1420,
+    "preview": "Idle GPU workers and duplicate monitoring subscriptions explain most of the spike."
   }
 }
 ```
 
-Important detail:
+This request still is not the final prompt. It is the runtime input to prompt projection.
 
-- `agent.prompt` is the workspace prompt from `AGENTS.md`
-- dynamic runtime context is still separate at this stage
-- there is no `recent_runtime_context` field anymore
+## Step 5: Project Structured Prompt Sections
 
-## Step 4: Capability Manifest Is Built
+`projectAgentRuntimeConfig(...)` calls `composeBaseAgentPrompt(...)`, which uses `buildBaseAgentPromptSections(...)`.
 
-Before prompt rendering, `projectAgentRuntimeConfig(...)` builds a capability manifest with:
+The runtime builds prompt sections with ids, channels, priorities, and volatility. In the current path those sections are:
 
-- `buildAgentCapabilityManifest(...)`
-- file: `runtime/api-server/src/agent-capability-registry.ts`
+- `runtime_core`
+- `execution_policy`
+- `response_delivery_policy`
+- `todo_continuity_policy` when todo tools are available
+- `session_policy`
+- `capability_policy`
+- `current_user_context`
+- `operator_surface_context`
+- `pending_user_memory`
+- `scratchpad_context`
+- `evolve_candidate_context`
+- `resume_context`
+- `memory_recall`
+- `workspace_policy`
 
-This manifest classifies the run surface:
+The key split is:
 
-- inspect tools
-- mutate tools
-- coordination tools
-- browser tools
-- runtime tools
-- workspace commands
-- workspace skills
-- MCP connectivity
+- `system_prompt` sections become one rendered system prompt
+- `context_message` and `resume_context` sections become the `context_messages` array forwarded to the harness adapter
 
-That manifest is later rendered into the `capability_policy` system-prompt section.
+### Representative rendered `system_prompt`
 
-## Step 5: Prompt Sections Are Constructed
-
-`composeBaseAgentPrompt(...)` calls `buildBaseAgentPromptSections(...)`.
-
-This is the actual assembly step.
-
-### 5.1 System-prompt sections
-
-These are rendered into the final `system_prompt`, in sorted order.
-
-Current sections:
-
-1. `runtime_core`
-2. `execution_policy`
-3. `response_delivery_policy`
-4. `session_policy`
-5. `todo_continuity_policy`
-6. `capability_policy`
-7. `workspace_policy`
-
-Notes:
-
-- `todo_continuity_policy` is conditional and only appears when todo coordination tools are available
-- `workspace_policy` is the loaded `AGENTS.md` content wrapped with runtime guidance
-
-### 5.2 Context-message sections
-
-These are not part of `system_prompt`. They are carried as context messages.
-
-Current sections:
-
-1. `current_user_context`
-2. `operator_surface_context`
-3. `pending_user_memory`
-4. `scratchpad_context`
-5. `evolve_candidate_context`
-6. `memory_recall`
-
-### 5.3 Resume-context section
-
-There is one special resume channel:
-
-1. `resume_context`
-
-This is rendered separately from `system_prompt` but still included in compatibility `context_messages`.
-
-There is no `recent_runtime_context` section anymore.
-
-## Step 6: Example Rendered Sections
-
-For the example run, some concrete section outputs would look like this.
-
-### 6.1 Example `todo_continuity_policy`
-
-```text
-Todo continuity policy:
-Treat todo state as explicit coordination state, not hidden memory.
-Treat the user's newest message as the primary instruction for the current turn even when unfinished todo state may already exist.
-Do not resume unfinished todo work unless the newest message clearly asks to continue it or clearly advances the same work.
-If the newest message is conversational, brief, acknowledges prior progress, or is otherwise ambiguous about continuation, respond to that message directly first and ask whether the user wants to continue the unfinished work.
-When you need the current phase ids, task ids, or recorded state from an existing todo before continuing or updating it, use `todoread` first instead of guessing.
-```
-
-### 6.2 Example `scratchpad_context`
-
-```text
-Session scratchpad:
-A session-scoped scratchpad file already exists for this session.
-The scratchpad is not loaded into prompt context automatically. Read it explicitly when those notes are needed for this turn.
-The scratchpad metadata and preview below are already loaded into prompt context. Do not read the scratchpad just to confirm its existence, path, timestamp, or preview; read it only when you need additional note contents for this turn.
-Use the scratchpad for working notes and interim state, not as durable memory or a user-facing deliverable.
-Path: `.holaboss/scratchpads/session-main.md`.
-Last updated: 2026-04-22T10:15:00.000Z.
-Size: 1420 bytes.
-Preview: AWS spend spike mostly correlates with idle GPU workers and duplicate vendor monitoring subscriptions.
-```
-
-### 6.3 Example `resume_context`
-
-```text
-Session resume context:
-Use this as continuity context derived from runtime-managed session memory excerpts. Verify current workspace state before acting on details that may have changed.
-Treat the user's newest message as authoritative for this turn. Do not resume unfinished prior work unless that newest message clearly asks to continue it or clearly advances the same task.
-If the newest message is conversational, brief, or ambiguous about continuation, respond to it directly first and ask whether the user wants to continue the unfinished prior work.
-This runtime-managed resume summary is already loaded into prompt context. Do not reopen runtime-managed continuity files just to restate this context; inspect a referenced file only when you need details not included here or need to verify that it changed during this run.
-
-Session memory:
-- Path: `workspace/workspace-1/runtime/session-memory/session-main.md`
-- Excerpt: Investigation focused on AWS spend growth, vendor overlap, and whether idle GPU instances explain the spike.
-```
-
-## Step 7: Sections Become Prompt Outputs
-
-The helpers in `runtime/api-server/src/agent-prompt-sections.ts` do four important things:
-
-1. normalize section content
-2. sort by:
-   - precedence
-   - priority
-   - apply_at
-   - channel
-   - id
-3. render system-prompt sections into one string
-4. collect compatibility context sections into a flat ordered list
-
-For the example run:
-
-### 7.1 Final `system_prompt`
-
-This is the concatenation of all `system_prompt` sections only:
-
-```text
-Base runtime instructions:
-...
-
-Execution policy:
-...
-
-Response delivery policy:
-...
-
-Session policy:
-...
-
-Todo continuity policy:
-...
-
-Capability policy for this run:
-...
-
-Workspace instructions from AGENTS.md:
-Treat these workspace instructions as additional requirements. Follow them unless they conflict with the base runtime instructions above.
-Root AGENTS.md is already loaded into this prompt. Do not read it again unless the user explicitly asks or you need to verify that the on-disk file changed during this run.
-<contents of AGENTS.md>
-```
-
-### 7.2 Final `context_messages`
-
-This is the ordered list of compatibility context sections:
-
-```json
-[
-  "<current_user_context text>",
-  "<operator_surface_context text>",
-  "<pending_user_memory text>",
-  "<scratchpad_context text>",
-  "<resume_context text>",
-  "<memory_recall text>"
-]
-```
-
-If `evolve_candidate_context` exists for the turn, it appears before `resume_context`.
-
-Important detail:
-
-- `resume_context` is not merged into `system_prompt`
-- it still becomes part of `context_messages`
-
-### 7.3 Final `prompt_layers`
-
-Only `system_prompt` sections become `prompt_layers`.
-
-Example:
-
-```json
-[
-  { "id": "runtime_core", "apply_at": "runtime_config", "content": "..." },
-  { "id": "execution_policy", "apply_at": "runtime_config", "content": "..." },
-  { "id": "response_delivery_policy", "apply_at": "runtime_config", "content": "..." },
-  { "id": "todo_continuity_policy", "apply_at": "runtime_config", "content": "..." },
-  { "id": "session_policy", "apply_at": "runtime_config", "content": "..." },
-  { "id": "capability_policy", "apply_at": "runtime_config", "content": "..." },
-  { "id": "workspace_policy", "apply_at": "runtime_config", "content": "..." }
-]
-```
-
-If todo tools are unavailable, `todo_continuity_policy` is omitted.
-
-### 7.4 Final `prompt_cache_profile`
-
-The cache profile fingerprints:
-
-- cacheable system-prompt sections
-- volatile run-level system-prompt sections
-- compatibility context section ids
-- resume-context section ids
-
-This is used for prompt observability and caching boundaries, not direct model input.
-
-## Step 8: Runtime Config Returned by the API Layer
-
-`projectAgentRuntimeConfig(...)` returns:
-
-```json
-{
-  "provider_id": "openai",
-  "model_id": "gpt-5.4",
-  "mode": "code",
-  "system_prompt": "<rendered system prompt>",
-  "context_messages": [
-    "<current_user_context>",
-    "<operator_surface_context>",
-    "<pending_user_memory>",
-    "<scratchpad_context>",
-    "<resume_context>",
-    "<memory_recall>"
-  ],
-  "prompt_sections": [...],
-  "prompt_layers": [...],
-  "prompt_cache_profile": {...},
-  "tools": {...},
-  "capability_manifest": {...}
-}
-```
-
-That object is the runtime-side prompt projection output.
-
-## Step 9: PI Runtime Adapter Forwards It
-
-The PI adapter in `runtime/harnesses/src/pi.ts` forwards the important fields into the harness-host request:
-
-- `instruction`
-- `context_messages`
-- `system_prompt`
-- `attachments`
-- model selection
-- MCP server payloads
-- workspace skill dirs
-
-Conceptually:
-
-```json
-{
-  "instruction": "Continue the cloud cost investigation. Use the notes from earlier, update the findings, and give me the answer in chat.",
-  "context_messages": [
-    "...",
-    "...",
-    "..."
-  ],
-  "system_prompt": "<rendered system prompt>",
-  "workspace_skill_dirs": [],
-  "mcp_servers": [...],
-  "mcp_tool_refs": [...],
-  "attachments": []
-}
-```
-
-## Step 10: PI Host Builds the Actual Prompt Payload
-
-Inside `runtime/harness-host/src/pi.ts`, the PI host treats `system_prompt` and `context_messages` differently.
-
-### 10.1 System prompt path
-
-`effectiveSystemPromptForRequest(...)` starts from:
-
-- `request.system_prompt`
-
-It may append one additional PI-local note:
-
-- if a resumed PI session already has persisted todo state, PI adds a short note telling the model that a persisted phased todo plan exists and that it should use `todoread` when it needs the current ids/state from that plan
-
-So the system prompt the model receives is:
-
-```text
-<rendered runtime system prompt>
-
-<optional resumed-session todo note>
-```
-
-### 10.2 User content path
-
-`buildPiPromptPayload(...)` builds the non-system content in this order:
-
-1. quoted skill blocks if the instruction references workspace skills
-2. the user `instruction`
-3. the `"Runtime context:"` block built from `context_messages`
-4. inline attachment content and attachment summaries
-
-For the example run, the textual prompt body would look roughly like:
-
-```text
-Continue the cloud cost investigation. Use the notes from earlier, update the findings, and give me the answer in chat.
-
-Runtime context:
-
-[Runtime Context 1]
-Current user context:
-...
-[/Runtime Context 1]
-
-[Runtime Context 2]
-Operator surface context:
-...
-[/Runtime Context 2]
-
-[Runtime Context 3]
-Current-turn inferred user memory:
-...
-[/Runtime Context 3]
-
-[Runtime Context 4]
-Session scratchpad:
-...
-[/Runtime Context 4]
-
-[Runtime Context 5]
-Session resume context:
-...
-[/Runtime Context 5]
-
-[Runtime Context 6]
-Recalled durable memory:
-...
-[/Runtime Context 6]
-
-Attachments: none.
-Image inputs: none.
-```
-
-Important detail:
-
-- PI no longer inserts the todo-resume advisory into the prompt body
-- runtime context is carried only through the `Runtime context:` block
-
-## Step 11: Persisted PI Session History Is Also Opened
-
-This is the most important non-obvious part of the full flow.
-
-The PI host also opens the persisted PI session file with `SessionManager.open(...)`.
-
-That means continuity does not come only from:
-
-- `system_prompt`
-- `instruction`
-- `context_messages`
-
-It also comes from:
-
-- prior persisted PI conversation and tool state
-
-So the full effective prompt state for a resumed PI run is:
-
-1. system prompt override from runtime
-2. freshly built instruction + runtime context block + attachments
-3. persisted PI session continuity
-
-This is why runtime-injected replay summaries were redundant for PI and were removed from the runtime prompt contract.
-
-## Full Concrete Trace
-
-This section shows one exact example from start to finish.
-
-Assumptions for this trace:
-
-- no quoted workspace skills in the instruction
-- no file or image attachments
-- no PI-specific resumed-session todo note
-- the persisted PI session file exists, but its prior conversation contents are not reproduced here
-
-### Trace 1: Incoming Turn Request
-
-This is the incoming `TsRunnerRequest` shape we are tracing:
-
-```json
-{
-  "workspace_id": "workspace-1",
-  "session_id": "session-main",
-  "input_id": "input-42",
-  "session_kind": "workspace_session",
-  "instruction": "Continue the cloud cost investigation. Use the notes from earlier, update the findings, and give me the answer in chat.",
-  "model": "openai/gpt-5.4",
-  "attachments": [],
-  "thinking_value": null,
-  "debug": false
-}
-```
-
-### Trace 2: Workspace Prompt Already Loaded From `AGENTS.md`
-
-For this concrete example, assume the loaded workspace prompt is exactly:
-
-```text
-- Keep answers concise.
-- Prefer markdown reports under outputs/reports for deep research.
-- Do not use browser tools unless the task is UI-specific.
-```
-
-This text becomes `agent.prompt` before any dynamic runtime context is added.
-
-### Trace 3: Runtime Bootstrap Loads Dynamic Context
-
-For this example, bootstrap resolves these dynamic context objects:
-
-`session_resume_context`
-
-```json
-{
-  "session_memory_path": "workspace/workspace-1/runtime/session-memory/session-main.md",
-  "session_memory_excerpt": "Investigation focused on AWS spend growth, vendor overlap, and whether idle GPU instances explain the spike."
-}
-```
-
-`session_scratchpad_context`
-
-```json
-{
-  "exists": true,
-  "file_path": ".holaboss/scratchpads/session-main.md",
-  "updated_at": "2026-04-22T10:15:00.000Z",
-  "size_bytes": 1420,
-  "preview": "AWS spend spike mostly correlates with idle GPU workers and duplicate vendor monitoring subscriptions."
-}
-```
-
-`current_user_context`
-
-```json
-{
-  "profile_id": "default",
-  "name": "Jeffrey",
-  "name_source": "runtime_profile"
-}
-```
-
-`operator_surface_context`
-
-```json
-{
-  "active_surface_id": "browser:user",
-  "surfaces": [
-    {
-      "surface_id": "browser:user",
-      "surface_type": "browser",
-      "owner": "user",
-      "active": true,
-      "mutability": "inspect_only",
-      "summary": "AWS billing dashboard is open to EC2 spend breakdown."
-    }
-  ]
-}
-```
-
-`pending_user_memory_context`
-
-```json
-{
-  "entries": [
-    {
-      "proposal_id": "proposal-1",
-      "proposal_kind": "response_style",
-      "target_key": "response_style",
-      "title": "Prefers concise answers",
-      "summary": "The user asked for concise output.",
-      "evidence": "give me the answer in chat"
-    }
-  ]
-}
-```
-
-`recalled_memory_context`
-
-```json
-{
-  "entries": [
-    {
-      "scope": "workspace",
-      "memory_type": "procedure",
-      "title": "Cloud spend investigations should verify idle compute first",
-      "summary": "When investigating infra spend spikes, check idle compute, duplicate subscriptions, and recent deployment changes before suggesting optimization work.",
-      "path": "workspace/workspace-1/knowledge/cloud-cost-procedure.md",
-      "verification_policy": "check_before_use",
-      "staleness_policy": "stable",
-      "freshness_state": "fresh"
-    }
-  ]
-}
-```
-
-The run also stages:
-
-- browser tools: `browser_open_tab`, `browser_get_state`
-- runtime tools: `write_report`, `holaboss_scratchpad_read`, `holaboss_scratchpad_write`
-- MCP tool refs: `notion_search`
-
-### Trace 4: Runtime Builds `AgentRuntimeConfigCliRequest`
-
-Conceptually, the runtime passes this to `projectAgentRuntimeConfig(...)`:
-
-```json
-{
-  "session_id": "session-main",
-  "workspace_id": "workspace-1",
-  "input_id": "input-42",
-  "session_kind": "workspace_session",
-  "harness_id": "pi",
-  "browser_tools_available": true,
-  "browser_tool_ids": ["browser_open_tab", "browser_get_state"],
-  "runtime_tool_ids": [
-    "write_report",
-    "holaboss_scratchpad_read",
-    "holaboss_scratchpad_write"
-  ],
-  "workspace_command_ids": [],
-  "session_resume_context": { "...see above..." },
-  "recalled_memory_context": { "...see above..." },
-  "current_user_context": { "...see above..." },
-  "operator_surface_context": { "...see above..." },
-  "pending_user_memory_context": { "...see above..." },
-  "session_scratchpad_context": { "...see above..." },
-  "selected_model": "openai/gpt-5.4",
-  "workspace_skill_ids": [],
-  "default_tools": ["read", "edit", "todoread", "todowrite", "skill"],
-  "extra_tools": [
-    "browser_open_tab",
-    "browser_get_state",
-    "holaboss_scratchpad_read",
-    "holaboss_scratchpad_write"
-  ],
-  "resolved_mcp_tool_refs": [
-    {
-      "tool_id": "notion_search",
-      "server_id": "mcp-notion",
-      "tool_name": "search"
-    }
-  ],
-  "agent": {
-    "id": "workspace.general",
-    "prompt": "- Keep answers concise.\n- Prefer markdown reports under outputs/reports for deep research.\n- Do not use browser tools unless the task is UI-specific."
-  }
-}
-```
-
-### Trace 5: Runtime Projects Prompt Layers
-
-For this run, `composeBaseAgentPrompt(...)` emits these system-prompt layers in order:
-
-```json
-[
-  "runtime_core",
-  "execution_policy",
-  "response_delivery_policy",
-  "session_policy",
-  "todo_continuity_policy",
-  "capability_policy",
-  "workspace_policy"
-]
-```
-
-It also emits these compatibility context messages, in order:
-
-1. `current_user_context`
-2. `operator_surface_context`
-3. `pending_user_memory`
-4. `scratchpad_context`
-5. `resume_context`
-6. `memory_recall`
-
-### Trace 6: Final Rendered `system_prompt`
-
-This is the exact rendered `system_prompt` for the sample above:
+The actual `system_prompt` is one long string. For this example, its structure looks like:
 
 ```text
 Base runtime instructions:
@@ -881,112 +300,139 @@ Execution doctrine:
 Inspect before mutating workspace, app, browser, runtime state, or external systems when possible.
 After edits, commands, browser actions, or state-changing tool calls, verify the result with the most direct inspection path available.
 Use available tools, skills, and MCP integrations when they are more reliable than reasoning alone.
-Treat explicit user requirements and verification targets as completion criteria, not optional detail.
-If evidence is incomplete, keep retrieving or say exactly what remains unverified.
-Treat local git as an internal recovery tool. Do not surface git chatter unless the user asks, and do not use destructive history operations unless explicitly requested.
 Treat the active workspace root as the default boundary. Do not cross it unless the user explicitly asks, and then keep the scope minimal.
 Use coordination tools instead of hidden state. The newest user message is primary.
 Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.
-Ask for missing identity details instead of guessing.
-Create or update a workspace-local skill when the user describes a reusable workflow; do not create skills for one-off state.
-When browser tools are available, use them for UI-specific verification and prefer DOM-grounded actions and extraction; use screenshots only when visual confirmation matters.
-Use relevant MCP tools directly instead of only describing them.
 When a task is long-running or multi-step, prefer using the session scratchpad for interim notes, partial findings, open questions, and compacted current state instead of keeping that material only in live context.
-Use the scratchpad for session-scoped working notes, not for durable memory or final user-facing deliverables.
 
 Response delivery policy:
 Default to concise answers.
 Keep short lookups and straightforward explanations inline.
-Do not create a report just because tools were used.
-Use `write_report` for long, structured, evidence-heavy, or referenceable outputs; if it is unavailable, write the artifact under `outputs/reports/`.
-For research, investigation, comparison, timeline, or latest-news tasks across multiple sources, prefer a report artifact and keep the chat reply to a brief summary unless the user asks for inline detail.
-When you create a report, mention the report path or title and only the most important takeaways in chat.
-
-Session policy:
-Session mode is `code`. Default to implementation-oriented work, direct inspection, concrete edits, and explicit verification when the user asks you to do work.
-This is a workspace session. You can operate broadly across the workspace, and browser tooling may be available in this session when the capability manifest exposes it.
+Use `write_report` for long, structured, evidence-heavy, or referenceable outputs.
 
 Todo continuity policy:
 Treat todo state as explicit coordination state, not hidden memory.
 Treat the user's newest message as the primary instruction for the current turn even when unfinished todo state may already exist.
-Do not resume unfinished todo work unless the newest message clearly asks to continue it or clearly advances the same work.
-If the newest message is conversational, brief, acknowledges prior progress, or is otherwise ambiguous about continuation, respond to that message directly first and ask whether the user wants to continue the unfinished work.
 When you need the current phase ids, task ids, or recorded state from an existing todo before continuing or updating it, use `todoread` first instead of guessing.
-When the user has clearly asked to continue unfinished todo work and executable todo items remain, continue until the recorded work is complete or genuinely blocked.
-Do not stop only to give progress updates or ask whether to continue while executable todo items remain after the user already asked you to continue.
-If the user's newest message clearly redirects to unrelated work, handle that new request first without marking the unfinished todo complete, then propose continuing it afterward.
 
-Capability policy for this run:
-Harness: pi.
-Session kind: workspace_session.
-Use inspection capabilities to gather context before mutating workspace, app, browser, or runtime state whenever possible.
-After edits, shell commands, browser actions, MCP mutations, or runtime mutations, run a follow-up inspection or verification step before claiming success.
-Use coordination capabilities to track progress, consult available skills, or ask for clarification instead of keeping hidden state.
-If a capability is not listed below, do not assume it is available in this run.
-Inspect tools: available (4 enabled).
-Mutating tools: available (3 enabled).
-Coordination tools: available (3 enabled).
-Browser tools: available (2 enabled).
-Runtime tools: available (2 enabled).
-Workspace commands: none.
-Workspace skills: none.
-Connected MCP access: available.
-Use surfaced MCP tools when relevant; tool names may be resolved dynamically by the runtime.
+Session policy:
+Session mode is `code`.
+This is a workspace session. You can operate broadly across the workspace, and browser tooling may be available in this session when the capability manifest exposes it.
+
+Capability policy:
+...
 
 Workspace instructions from AGENTS.md:
 Treat these workspace instructions as additional requirements. Follow them unless they conflict with the base runtime instructions above.
 Root AGENTS.md is already loaded into this prompt. Do not read it again unless the user explicitly asks or you need to verify that the on-disk file changed during this run.
-- Keep answers concise.
-- Prefer markdown reports under outputs/reports for deep research.
-- Do not use browser tools unless the task is UI-specific.
+...
 ```
 
-### Trace 7: Final `context_messages`
+### Representative `context_messages`
 
-This is the exact ordered `context_messages` array:
+The runtime also renders a compatibility list of context messages:
 
 ```json
 [
   "Current user context:\nRuntime profile id: `default`.\nThe current operator name is `Jeffrey`.\nName source: `runtime_profile`.",
-  "Operator surface context:\nUse these operator-controlled surfaces as continuity anchors when the user refers to `here`, `this page`, `my current tab`, `the file I'm in`, `this terminal`, or similar language.\nTreat the active user-owned surface as the default referent for deictic questions such as `what am I looking at right now`, `what is this`, `what page/file/screen is this`, or `what about now`, unless the user explicitly narrows to browser, tab, site, URL, terminal, editor, or another surface.\nPrefer the active user-owned surface when the user clearly wants you to continue from what they already opened, navigated, selected, or prepared.\nPrefer agent-owned surfaces for exploratory, multi-step, parallel, or potentially disruptive work.\nIf the active user-owned surface is not a browser surface, do not answer from browser state just because browser tools are available.\nDo not mutate a user-owned surface unless runtime context or capabilities explicitly allow takeover or direct control.\nCurrent active surface id: `browser:user`.\nKnown operator surfaces:\n- [user/browser] `browser:user` (active, mutability=`inspect_only`): AWS billing dashboard is open to EC2 spend breakdown.",
-  "Current-turn inferred user memory:\nThese items were inferred from the latest user input and are not durably saved yet.\nUse them for this run when directly relevant, but do not claim they are saved as long-term memory unless the user later confirms them.\n- Prefers concise answers: The user asked for concise output.\n  Evidence: give me the answer in chat",
-  "Session scratchpad:\nA session-scoped scratchpad file already exists for this session.\nThe scratchpad is not loaded into prompt context automatically. Read it explicitly when those notes are needed for this turn.\nThe scratchpad metadata and preview below are already loaded into prompt context. Do not read the scratchpad just to confirm its existence, path, timestamp, or preview; read it only when you need additional note contents for this turn.\nUse the scratchpad for working notes and interim state, not as durable memory or a user-facing deliverable.\nPath: `.holaboss/scratchpads/session-main.md`.\nLast updated: 2026-04-22T10:15:00.000Z.\nSize: 1420 bytes.\nPreview: AWS spend spike mostly correlates with idle GPU workers and duplicate vendor monitoring subscriptions.",
-  "Session resume context:\nUse this as continuity context derived from runtime-managed session memory excerpts. Verify current workspace state before acting on details that may have changed.\nTreat the user's newest message as authoritative for this turn. Do not resume unfinished prior work unless that newest message clearly asks to continue it or clearly advances the same task.\nIf the newest message is conversational, brief, or ambiguous about continuation, respond to it directly first and ask whether the user wants to continue the unfinished prior work.\nThis runtime-managed resume summary is already loaded into prompt context. Do not reopen runtime-managed continuity files just to restate this context; inspect a referenced file only when you need details not included here or need to verify that it changed during this run.\nSession memory:\n- Path: `workspace/workspace-1/runtime/session-memory/session-main.md`\n- Excerpt: Investigation focused on AWS spend growth, vendor overlap, and whether idle GPU instances explain the spike.",
-  "Recalled durable memory:\nUse these as durable memories, not as guaranteed current truth. Verify entries marked `check_before_use` or `must_reconfirm` before acting on them, and treat stale entries as hints until reconfirmed.\n- [workspace/procedure] Cloud spend investigations should verify idle compute first (`workspace/workspace-1/knowledge/cloud-cost-procedure.md`): When investigating infra spend spikes, check idle compute, duplicate subscriptions, and recent deployment changes before suggesting optimization work. Verification: `check_before_use`. Freshness: `fresh` (`stable`)."
+  "Active operator surfaces:\nTreat the active user-owned surface as the default referent for deictic questions such as `what am I looking at right now`.\n- [user/browser] `browser:user` (active, inspect_only): AWS billing dashboard is open to EC2 spend breakdown.",
+  "Session scratchpad:\nA session-scoped scratchpad file already exists for this session.\nThe scratchpad is not loaded into prompt context automatically. Read it explicitly when those notes are needed for this turn.\nPath: `.holaboss/scratchpads/session-main.md`.\nPreview: Idle GPU workers and duplicate monitoring subscriptions explain most of the spike.",
+  "Session resume context:\nUse this as continuity context derived from runtime-managed session memory excerpts.\nSession memory:\n- Path: `workspace/workspace-1/runtime/session-memory/session-main.md`\n- Excerpt: Investigation focused on EC2 spend growth, idle GPU workers, and duplicate vendor subscriptions.",
+  "Recalled durable memory:\n- [workspace/procedure] Check idle compute before proposing optimizations (`workspace/workspace-1/knowledge/cloud-cost-procedure.md`): For cloud-cost investigations, verify idle compute, duplicate subscriptions, and recent deployment changes before proposing savings work. Verification: `check_before_use`."
 ]
 ```
 
-### Trace 8: PI Adapter Forwards Runtime Prompt Fields
+## Step 6: Build the PI Host Request
 
-The PI adapter forwards:
+The runtime adapter in `runtime/harnesses/src/pi.ts` converts the runtime config into a reduced `HarnessHostPiRequest`.
 
-- `instruction`
-- `system_prompt`
-- `context_messages`
-- empty `attachments`
-- model/provider selection
-- MCP server metadata
-- workspace skill directories
+A representative request looks like:
 
-At this stage, prompt semantics are still split between:
+```json
+{
+  "workspace_id": "workspace-1",
+  "workspace_dir": "/workspace",
+  "session_id": "session-main",
+  "input_id": "input-42",
+  "browser_tools_enabled": true,
+  "browser_space": "agent",
+  "instruction": "Continue the cloud cost investigation. Update the findings and answer in chat.",
+  "quoted_skill_blocks": [
+    "<skill name=\"cloud_costs\" location=\"/workspace/skills/cloud_costs/SKILL.md\">\nReferences are relative to /workspace/skills/cloud_costs.\n\nReview billing evidence before proposing savings actions.\n</skill>"
+  ],
+  "missing_quoted_skill_ids": [],
+  "context_messages": [
+    "Current user context: ...",
+    "Active operator surfaces: ...",
+    "Session scratchpad: ...",
+    "Session resume context: ...",
+    "Recalled durable memory: ..."
+  ],
+  "attachments": [
+    {
+      "id": "attachment-1",
+      "kind": "file",
+      "name": "ec2-cost-breakdown.pdf",
+      "mime_type": "application/pdf",
+      "size_bytes": 238144,
+      "workspace_path": "inputs/input-42/ec2-cost-breakdown.pdf"
+    }
+  ],
+  "thinking_value": "medium",
+  "provider_id": "openai_direct",
+  "model_id": "gpt-5.4",
+  "runtime_api_base_url": "http://127.0.0.1:5160",
+  "system_prompt": "<rendered runtime system prompt>",
+  "workspace_skills": [
+    {
+      "skill_id": "cloud_costs",
+      "skill_name": "cloud_costs",
+      "source_dir": "/workspace/skills/cloud_costs",
+      "file_path": "/workspace/skills/cloud_costs/SKILL.md",
+      "origin": "workspace",
+      "granted_tools": ["bash"],
+      "granted_commands": ["aws-cost-query"]
+    }
+  ],
+  "mcp_servers": [
+    {
+      "name": "context7",
+      "config": {
+        "type": "remote",
+        "url": "https://mcp.context7.com/mcp"
+      }
+    }
+  ],
+  "mcp_tool_refs": []
+}
+```
 
-- `system_prompt`
-- `context_messages`
-- the raw user `instruction`
+This request is the boundary between runtime code and harness-host code.
 
-### Trace 9: PI Host Builds the Final Prompt Body
+## Step 7: Build the PI Prompt Body
 
-Because this example has:
+The PI host uses `buildPiPromptPayload(...)` to build the PI-native user-side prompt body.
 
-- no quoted skills
-- no attachments
-- no images
-- no PI-specific resumed-session todo note
+The function appends sections in this order:
 
-the final PI prompt body becomes exactly:
+1. `Quoted workspace skills:`
+2. any missing quoted-skill warning
+3. the cleaned instruction
+4. `Runtime context:` with numbered context-message blocks
+5. attachment sections returned by `buildAttachmentPromptContent(...)`
+
+For the worked example, the final prompt text looks like:
 
 ```text
-Continue the cloud cost investigation. Use the notes from earlier, update the findings, and give me the answer in chat.
+Quoted workspace skills:
+
+<skill name="cloud_costs" location="/workspace/skills/cloud_costs/SKILL.md">
+References are relative to /workspace/skills/cloud_costs.
+
+Review billing evidence before proposing savings actions.
+</skill>
+
+Continue the cloud cost investigation. Update the findings and answer in chat.
 
 Runtime context:
 
@@ -998,104 +444,105 @@ Name source: `runtime_profile`.
 [/Runtime Context 1]
 
 [Runtime Context 2]
-Operator surface context:
-Use these operator-controlled surfaces as continuity anchors when the user refers to `here`, `this page`, `my current tab`, `the file I'm in`, `this terminal`, or similar language.
-Treat the active user-owned surface as the default referent for deictic questions such as `what am I looking at right now`, `what is this`, `what page/file/screen is this`, or `what about now`, unless the user explicitly narrows to browser, tab, site, URL, terminal, editor, or another surface.
-Prefer the active user-owned surface when the user clearly wants you to continue from what they already opened, navigated, selected, or prepared.
-Prefer agent-owned surfaces for exploratory, multi-step, parallel, or potentially disruptive work.
-If the active user-owned surface is not a browser surface, do not answer from browser state just because browser tools are available.
-Do not mutate a user-owned surface unless runtime context or capabilities explicitly allow takeover or direct control.
-Current active surface id: `browser:user`.
-Known operator surfaces:
-- [user/browser] `browser:user` (active, mutability=`inspect_only`): AWS billing dashboard is open to EC2 spend breakdown.
+Active operator surfaces:
+Treat the active user-owned surface as the default referent for deictic questions such as `what am I looking at right now`.
+- [user/browser] `browser:user` (active, inspect_only): AWS billing dashboard is open to EC2 spend breakdown.
 [/Runtime Context 2]
 
 [Runtime Context 3]
-Current-turn inferred user memory:
-These items were inferred from the latest user input and are not durably saved yet.
-Use them for this run when directly relevant, but do not claim they are saved as long-term memory unless the user later confirms them.
-- Prefers concise answers: The user asked for concise output.
-  Evidence: give me the answer in chat
-[/Runtime Context 3]
-
-[Runtime Context 4]
 Session scratchpad:
 A session-scoped scratchpad file already exists for this session.
 The scratchpad is not loaded into prompt context automatically. Read it explicitly when those notes are needed for this turn.
-The scratchpad metadata and preview below are already loaded into prompt context. Do not read the scratchpad just to confirm its existence, path, timestamp, or preview; read it only when you need additional note contents for this turn.
-Use the scratchpad for working notes and interim state, not as durable memory or a user-facing deliverable.
 Path: `.holaboss/scratchpads/session-main.md`.
-Last updated: 2026-04-22T10:15:00.000Z.
-Size: 1420 bytes.
-Preview: AWS spend spike mostly correlates with idle GPU workers and duplicate vendor monitoring subscriptions.
+Preview: Idle GPU workers and duplicate monitoring subscriptions explain most of the spike.
+[/Runtime Context 3]
+
+[Runtime Context 4]
+Session resume context:
+Use this as continuity context derived from runtime-managed session memory excerpts.
+Session memory:
+- Path: `workspace/workspace-1/runtime/session-memory/session-main.md`
+- Excerpt: Investigation focused on EC2 spend growth, idle GPU workers, and duplicate vendor subscriptions.
 [/Runtime Context 4]
 
 [Runtime Context 5]
-Session resume context:
-Use this as continuity context derived from runtime-managed session memory excerpts. Verify current workspace state before acting on details that may have changed.
-Treat the user's newest message as authoritative for this turn. Do not resume unfinished prior work unless that newest message clearly asks to continue it or clearly advances the same task.
-If the newest message is conversational, brief, or ambiguous about continuation, respond to it directly first and ask whether the user wants to continue the unfinished prior work.
-This runtime-managed resume summary is already loaded into prompt context. Do not reopen runtime-managed continuity files just to restate this context; inspect a referenced file only when you need details not included here or need to verify that it changed during this run.
-Session memory:
-- Path: `workspace/workspace-1/runtime/session-memory/session-main.md`
-- Excerpt: Investigation focused on AWS spend growth, vendor overlap, and whether idle GPU instances explain the spike.
+Recalled durable memory:
+- [workspace/procedure] Check idle compute before proposing optimizations (`workspace/workspace-1/knowledge/cloud-cost-procedure.md`): For cloud-cost investigations, verify idle compute, duplicate subscriptions, and recent deployment changes before proposing savings work. Verification: `check_before_use`.
 [/Runtime Context 5]
 
-[Runtime Context 6]
-Recalled durable memory:
-Use these as durable memories, not as guaranteed current truth. Verify entries marked `check_before_use` or `must_reconfirm` before acting on them, and treat stale entries as hints until reconfirmed.
-- [workspace/procedure] Cloud spend investigations should verify idle compute first (`workspace/workspace-1/knowledge/cloud-cost-procedure.md`): When investigating infra spend spikes, check idle compute, duplicate subscriptions, and recent deployment changes before suggesting optimization work. Verification: `check_before_use`. Freshness: `fresh` (`stable`).
-[/Runtime Context 6]
-
-Attachments: none.
-Image inputs: none.
+Attached file: ec2-cost-breakdown.pdf
+Path: inputs/input-42/ec2-cost-breakdown.pdf
+MIME type: application/pdf
+Extracted text:
+...
 ```
 
-### Trace 10: Effective Final Model Input State
+If the attachment helper extracts images, those images are passed separately as PI image content rather than being flattened into the prompt text.
 
-For this run, the model effectively sees three continuity layers at once:
+## Step 8: What PI Actually Sends
 
-1. `system_prompt`
-   - the full runtime-rendered policy stack shown in Trace 6
-2. user/body prompt
-   - the exact PI prompt body shown in Trace 9
-3. persisted PI session state
-   - prior PI-native conversation and tool continuity already loaded by `SessionManager.open(...)`
+At execution time the PI path uses:
 
-That is the full end-to-end path from incoming turn request to final PI-visible prompt state.
+- `system_prompt` from the runtime as the PI system prompt override
+- the prompt body produced by `buildPiPromptPayload(...)`
+- any extracted image content from attachments
+- the persisted PI session history for the harness session
 
-## Summary Table
+The persisted PI session history is a separate continuity source. It is not serialized inside the runtime prompt.
 
-| Layer | Built Where | Example Contents | Sent To Model As |
-| --- | --- | --- | --- |
-| Workspace prompt | `workspace-runtime-plan.ts` | `AGENTS.md` | system prompt section |
-| Runtime core policy | `agent-runtime-prompt.ts` | mandatory base runtime rules | system prompt |
-| Execution policy | `agent-runtime-prompt.ts` | inspect/verify/use tools/scratchpad guidance | system prompt |
-| Response delivery policy | `agent-runtime-prompt.ts` | concise vs `write_report` guidance | system prompt |
-| Todo continuity policy | `agent-runtime-prompt.ts` | continuation rules for todo-backed work | system prompt |
-| Session policy | `agent-runtime-prompt.ts` | workspace/onboarding/task-proposal mode guidance | system prompt |
-| Capability policy | `agent-capability-registry.ts` | available tools and capability routing | system prompt |
-| Current user context | `ts-runner.ts` | profile/name | runtime context block |
-| Operator surface context | desktop/browser bridge | active browser/editor/terminal surface | runtime context block |
-| Pending user memory | `user-memory-proposals.ts` | current-turn inferred preferences | runtime context block |
-| Scratchpad context | `session-scratchpad.ts` + `ts-runner.ts` | scratchpad metadata and preview | runtime context block |
-| Session resume context | `ts-runner.ts` | session-memory excerpt | runtime context block |
-| Recalled durable memory | recall pipeline | recalled memory entries | runtime context block |
-| Attachments | PI host | inline docs, image refs, attachment summaries | user message content |
-| Persisted PI session | PI host | prior PI session state | session continuity |
+That means the model sees continuity from two places:
 
-## Practical Takeaway
+- runtime-provided prompt context
+- PI-native session history
 
-When debugging prompt behavior in this runtime, do not ask only:
+## Step 9: Tool Execution Happens After Prompt Construction
 
-- "What is in `system_prompt`?"
+Prompt construction ends before tool execution begins, but the ownership boundary matters once tools are invoked.
 
-Also ask:
+### Runtime-backed tools
 
-1. What dynamic context objects were loaded in `ts-runner.ts`?
-2. Which prompt sections were emitted?
-3. Which sections went to `system_prompt` versus `context_messages`?
-4. What did PI host append into the runtime context block?
-5. What was already present in the persisted PI session file?
+The following tools execute through the shared runtime capability API and are only proxied by the PI host:
 
-That full stack is the real prompt.
+- `todoread`
+- `todowrite`
+- `skill`
+- `web_search`
+- `write_report`
+- scratchpad tools
+- onboarding tools
+- cronjob tools
+- image generation
+
+### PI-local enforcement that still matters during the run
+
+The PI host still keeps:
+
+- skill widening over PI-managed tools and commands
+- MCP tool materialization from the prepared MCP server payload
+- workspace-boundary enforcement for PI-managed local tools
+- PI-native event normalization
+
+Those are execution-time responsibilities, not prompt-construction responsibilities.
+
+## Ownership Summary
+
+The runtime owns:
+
+- workspace instructions
+- prompt policy
+- dynamic context loading
+- session-memory-backed resume context
+- scratchpad metadata
+- recalled durable memory
+- quoted skill preparation
+- runtime-backed tool semantics
+
+The PI host owns:
+
+- prompt-body serialization
+- attachment encoding for PI
+- runtime-tool proxy packaging
+- PI session lifecycle
+- PI-local tool enforcement and event mapping
+
+That is the current prompt path: the runtime defines what the model should receive, and the PI host defines how that prepared payload is encoded for PI.


### PR DESCRIPTION
## Summary
- rewrite the PI prompt-boundary note as current-state documentation of runtime-owned semantics versus PI host projection
- rewrite the runtime prompt walkthrough as an end-to-end example from queued input to final PI prompt payload
- keep the prompt-doc review isolated from the broader runtime branch

## Validation
- not run (doc-only changes)