### PR TITLE
refactor(desktop): move automations from settings into the chat pane

### DIFF
--- a/desktop/electron/authPopupPreload.ts
+++ b/desktop/electron/authPopupPreload.ts
@@ -79,7 +79,7 @@ interface WorkspaceListResponsePayload {
   offset: number;
 }
 
-type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
+type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "about";
 
 const INTERNAL_DEV_BACKEND_OVERRIDES_ENABLED =
   Boolean(process.env.VITE_DEV_SERVER_URL) || process.env.HOLABOSS_INTERNAL_DEV?.trim() === "1";

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -688,7 +688,6 @@ type UiSettingsPaneSection =
   | "integrations"
   | "submissions"
   | "settings"
-  | "automations"
   | "about";
 
 interface AddressSuggestionPayload {

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -91,7 +91,7 @@ interface BrowserAnchorBoundsPayload {
   height: number;
 }
 
-type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
+type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "about";
 
 interface DesktopWindowStatePayload {
   isFullScreen: boolean;

--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -435,19 +435,19 @@ test("app shell uses the top toolbar for shell navigation and removes the left r
 
   assert.match(source, /type ShellView = "space";/);
   assert.match(source, /const \[activeShellView, setActiveShellView\] = useState<ShellView>\("space"\);/);
-  assert.match(source, /<SettingsDialog[\s\S]*onOpenAutomationRunSession=\{\(workspaceId, sessionId\) => \{/);
-  assert.match(source, /<SettingsDialog[\s\S]*onCreateAutomationSchedule=\{\(workspaceId\) => \{/);
-  assert.match(source, /<SettingsDialog[\s\S]*onEditAutomationSchedule=\{\(workspaceId, job\) => \{/);
-  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleOpenAutomationRunSession\(sessionId, workspaceId\);/);
-  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleCreateScheduleInChat\(workspaceId\);/);
-  assert.match(source, /setSettingsDialogOpen\(false\);[\s\S]*handleEditScheduleInChat\(job, workspaceId\);/);
+  assert.match(source, /handleOpenAutomationsPane = useCallback/);
+  assert.match(source, /setAgentView\(\{ type: "automations" \}\)/);
+  assert.match(source, /onOpenAutomations=\{handleOpenAutomationsPane\}/);
+  assert.match(source, /<AutomationsPane[\s\S]*onCreateSchedule=\{\(\) =>\s*handleCreateScheduleInChat\(selectedWorkspaceId\)/);
+  assert.doesNotMatch(source, /<SettingsDialog[\s\S]*onCreateAutomationSchedule/);
+  assert.doesNotMatch(source, /<SettingsDialog[\s\S]*onEditAutomationSchedule/);
+  assert.doesNotMatch(source, /<SettingsDialog[\s\S]*onOpenAutomationRunSession/);
   assert.doesNotMatch(source, /handleOpenMarketplace/);
   assert.doesNotMatch(source, /MarketplacePane/);
   assert.doesNotMatch(source, /activeShellView === "marketplace"/);
   assert.doesNotMatch(source, /handleOpenSpace = useCallback/);
   assert.doesNotMatch(source, /onOpenSpace=\{handleOpenSpace\}/);
   assert.doesNotMatch(source, /isSpaceActive=\{spaceMode\}/);
-  assert.doesNotMatch(source, /handleOpenAutomations/);
   assert.doesNotMatch(source, /activeShellView === "automations"/);
   assert.doesNotMatch(source, /LeftNavigationRail/);
 });
@@ -684,7 +684,7 @@ test("app shell can route new schedule creation into a prefilled workspace chat"
   assert.match(source, /const chatComposerPrefillRequestKeyRef = useRef\(0\);/);
   assert.match(source, /const nextChatSessionOpenRequestKey = useCallback\(\(\) => \{\s*chatSessionOpenRequestKeyRef\.current \+= 1;\s*return chatSessionOpenRequestKeyRef\.current;\s*\}, \[\]\);/);
   assert.match(source, /const nextChatComposerPrefillRequestKey = useCallback\(\(\) => \{\s*chatComposerPrefillRequestKeyRef\.current \+= 1;\s*return chatComposerPrefillRequestKeyRef\.current;\s*\}, \[\]\);/);
-  assert.match(source, /const handleCreateScheduleInChat = useCallback\(\(\s*workspaceId\?: string \| null\) => \{/);
+  assert.match(source, /const handleCreateScheduleInChat = useCallback\(\s*\(workspaceId\?: string \| null\) => \{/);
   assert.match(source, /const normalizedWorkspaceId =\s*workspaceId\?\.trim\(\) \|\| selectedWorkspaceId\?\.trim\(\) \|\| "";/);
   assert.match(source, /if \(normalizedWorkspaceId !== \(selectedWorkspaceId\?\.trim\(\) \|\| ""\)\) \{\s*setSelectedWorkspaceId\(normalizedWorkspaceId\);\s*\}/);
   assert.match(source, /setActiveShellView\("space"\);/);
@@ -695,21 +695,19 @@ test("app shell can route new schedule creation into a prefilled workspace chat"
   assert.match(source, /setChatComposerPrefillRequest\(\{\s*text: "Create a cronjob for ",\s*requestKey: nextChatComposerPrefillRequestKey\(\),\s*mode: "replace",\s*\}\);/);
   assert.match(source, /composerPrefillRequest=\{chatComposerPrefillRequest\}/);
   assert.match(source, /onComposerPrefillConsumed=\{handleChatComposerPrefillConsumed\}/);
-  assert.match(source, /onCreateAutomationSchedule=\{\(workspaceId\) => \{/);
-  assert.match(source, /handleCreateScheduleInChat\(workspaceId\);/);
+  assert.match(source, /<AutomationsPane[\s\S]*onCreateSchedule=\{\(\) =>\s*handleCreateScheduleInChat\(selectedWorkspaceId\)/);
 });
 
 test("app shell can route schedule edits into a prefilled workspace chat", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
-  assert.match(source, /const handleEditScheduleInChat = useCallback\(\(\s*job: CronjobRecordPayload,\s*workspaceId\?: string \| null,\s*\) => \{/);
+  assert.match(source, /const handleEditScheduleInChat = useCallback\(\s*\(\s*job: CronjobRecordPayload,\s*workspaceId\?: string \| null,?\s*\) => \{/);
   assert.match(source, /const jobName =\s*job\.name\?\.trim\(\) \|\| job\.description\?\.trim\(\) \|\| "Untitled schedule";/);
-  assert.match(source, /const instruction = job\.instruction\?\.trim\(\) \|\| job\.description\?\.trim\(\) \|\| "";/);
+  assert.match(source, /const instruction =\s*job\.instruction\?\.trim\(\) \|\| job\.description\?\.trim\(\) \|\| "";/);
   assert.match(source, /Edit cronjob "\$\{jobName\}" \(id: \$\{job\.id\}\)\. Current cron: \$\{job\.cron\}\./);
   assert.match(source, /Current instruction: \$\{instruction\}\\n\\nUpdate it to:/);
   assert.match(source, /mode: "replace"/);
-  assert.match(source, /onEditAutomationSchedule=\{\(workspaceId, job\) => \{/);
-  assert.match(source, /handleEditScheduleInChat\(job, workspaceId\);/);
+  assert.match(source, /<AutomationsPane[\s\S]*onEditSchedule=\{\(job\) =>\s*handleEditScheduleInChat\(job, selectedWorkspaceId\)/);
 });
 
 test("app shell can route explorer references into chat attachments or text prefills", async () => {

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeft,
   CircleCheck,
+  Clock3,
   Folder,
   Globe,
   Inbox,
@@ -29,6 +30,7 @@ import { WorkspaceAppsDialog } from "@/components/layout/WorkspaceAppsDialog";
 import { FirstWorkspacePane } from "@/components/onboarding";
 import { AppSurfacePane } from "@/components/panes/AppSurfacePane";
 import { BrowserPane } from "@/components/panes/BrowserPane";
+import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { ChatPane } from "@/components/panes/ChatPane";
 import {
   type FileExplorerFocusRequest,
@@ -191,7 +193,6 @@ function isSettingsPaneSection(value: string): value is UiSettingsPaneSection {
     value === "integrations" ||
     value === "submissions" ||
     value === "settings" ||
-    value === "automations" ||
     value === "about"
   );
 }
@@ -199,6 +200,7 @@ function isSettingsPaneSection(value: string): value is UiSettingsPaneSection {
 type AgentView =
   | { type: "chat" }
   | { type: "inbox" }
+  | { type: "automations" }
   | {
       type: "app";
       appId: string;
@@ -3141,6 +3143,15 @@ function AppShellContent() {
     openTaskProposalInbox(selectedWorkspaceId);
   }, [openTaskProposalInbox, selectedWorkspaceId]);
 
+  const handleOpenAutomationsPane = useCallback(() => {
+    setActiveShellView("space");
+    setSpaceVisibility((previous) => ({
+      ...previous,
+      agent: true,
+    }));
+    setAgentView({ type: "automations" });
+  }, []);
+
   const handleReturnToChatPane = useCallback(() => {
     setAgentView({ type: "chat" });
     setChatFocusRequestKey((current) => current + 1);
@@ -3788,6 +3799,44 @@ function AppShellContent() {
       return <EmptyWorkspacePane />;
     }
 
+    if (agentView.type === "automations") {
+      return (
+        <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-subtle-xs backdrop-blur-sm">
+          <div className="shrink-0 border-b border-border px-4 py-2.5 sm:px-5">
+            <div className="flex items-center justify-between gap-3">
+              <div className="inline-flex min-w-0 items-center gap-2 text-base font-semibold text-foreground">
+                <Clock3 size={14} className="shrink-0 text-muted-foreground" />
+                <span className="truncate">Automations</span>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleReturnToChatPane}
+                aria-label="Return to chat"
+              >
+                <ArrowLeft size={15} />
+              </Button>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <AutomationsPane
+              workspaceId={selectedWorkspaceId}
+              emptyWorkspaceMessage="Choose a workspace from the top bar to view and manage automations."
+              onOpenRunSession={(sessionId) =>
+                handleOpenAutomationRunSession(sessionId, selectedWorkspaceId)
+              }
+              onCreateSchedule={() =>
+                handleCreateScheduleInChat(selectedWorkspaceId)
+              }
+              onEditSchedule={(job) =>
+                handleEditScheduleInChat(job, selectedWorkspaceId)
+              }
+            />
+          </div>
+        </section>
+      );
+    }
+
     if (agentView.type === "inbox") {
       return (
         <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-subtle-xs backdrop-blur-sm">
@@ -3901,6 +3950,7 @@ function AppShellContent() {
           onJumpToSessionBrowser={handleJumpToSessionBrowser}
           onOpenInbox={handleOpenInboxPane}
           inboxUnreadCount={unreadTaskProposalCount}
+          onOpenAutomations={handleOpenAutomationsPane}
           onRequestCreateSession={(request) =>
             void handleCreateSession(request)
           }
@@ -3955,6 +4005,10 @@ function AppShellContent() {
     handleJumpToSessionBrowser,
     handleMissingInternalResource,
     handleOpenInboxPane,
+    handleOpenAutomationsPane,
+    handleOpenAutomationRunSession,
+    handleCreateScheduleInChat,
+    handleEditScheduleInChat,
     handleReturnToChatPane,
     handleCreateSession,
     handleOpenLinkInNewAppBrowserTab,
@@ -4715,18 +4769,6 @@ function AppShellContent() {
         themeVariants={THEME_VARIANTS}
         onThemeVariantChange={handleThemeVariantChange}
         onOpenExternalUrl={handleOpenExternalUrl}
-        onOpenAutomationRunSession={(workspaceId, sessionId) => {
-          setSettingsDialogOpen(false);
-          handleOpenAutomationRunSession(sessionId, workspaceId);
-        }}
-        onCreateAutomationSchedule={(workspaceId) => {
-          setSettingsDialogOpen(false);
-          handleCreateScheduleInChat(workspaceId);
-        }}
-        onEditAutomationSchedule={(workspaceId, job) => {
-          setSettingsDialogOpen(false);
-          handleEditScheduleInChat(job, workspaceId);
-        }}
       />
       {selectedWorkspaceId && (
         <PublishDialog

--- a/desktop/src/components/layout/SettingsDialog.test.mjs
+++ b/desktop/src/components/layout/SettingsDialog.test.mjs
@@ -4,29 +4,19 @@ import test from "node:test";
 
 const SETTINGS_DIALOG_PATH = new URL("./SettingsDialog.tsx", import.meta.url);
 
-test("settings dialog includes an automations section with a workspace selector", async () => {
+test("settings dialog no longer surfaces automations; that surface lives in the chat pane", async () => {
   const source = await readFile(SETTINGS_DIALOG_PATH, "utf8");
 
   assert.match(source, /appVersion: string;/);
-  assert.match(source, /import \{ AutomationsPane \} from "@\/components\/panes\/AutomationsPane";/);
-  assert.match(source, /import \{ useWorkspaceDesktop \} from "@\/lib\/workspaceDesktop";/);
-  assert.match(source, /import \{\s*Select,\s*SelectContent,\s*SelectItem,\s*SelectTrigger,\s*SelectValue,\s*\} from "@\/components\/ui\/select";/);
-  assert.match(source, /import \{ Switch \} from "@\/components\/ui\/switch";/);
-  assert.match(source, /\{ id: "automations", label: "Automations", icon: Workflow \}/);
-  assert.match(source, /case "automations":\s*return "Automations";/);
-  assert.match(source, /const \{ workspaces, selectedWorkspace \} = useWorkspaceDesktop\(\);/);
-  assert.match(source, /const \[automationsWorkspaceId, setAutomationsWorkspaceId\] = useState\(""\);/);
-  assert.match(source, /activeSection === "automations" \? \(/);
-  assert.match(source, /toolbarLeading=\{/);
-  assert.match(source, /<Select\s+value=\{automationsWorkspaceId \|\| undefined\}/);
-  assert.match(source, /onValueChange=\{\(value\) =>\s*setAutomationsWorkspaceId\(value \?\? ""\)\s*\}/);
-  assert.match(source, /<SelectTrigger className="w-56">/);
-  assert.match(source, /<FolderKanban\s+size=\{14\}/);
-  assert.match(source, /placeholder=\{\s*workspaces\.length === 0\s*\? "No workspaces available"\s*: "Select workspace"\s*\}/);
-  assert.doesNotMatch(source, /<SelectTrigger className="min-w-\[220px\] rounded-full/);
-  assert.match(source, /<AutomationsPane[\s\S]*workspaceId=\{automationsWorkspaceId \|\| null\}[\s\S]*showHeader=\{false\}[\s\S]*toolbarLeading=\{/);
-  assert.match(source, /onEditSchedule=\{\(job\) => \{/);
-  assert.match(source, /onEditAutomationSchedule\(automationsWorkspaceId, job\);/);
+  assert.doesNotMatch(source, /AutomationsPane/);
+  assert.doesNotMatch(source, /\bautomations\b/);
+  assert.doesNotMatch(source, /\bAutomations\b/);
+  assert.doesNotMatch(source, /\bWorkflow\b/);
+  assert.doesNotMatch(source, /automationsWorkspaceId/);
+  assert.doesNotMatch(source, /onCreateAutomationSchedule/);
+  assert.doesNotMatch(source, /onEditAutomationSchedule/);
+  assert.doesNotMatch(source, /onOpenAutomationRunSession/);
+  assert.doesNotMatch(source, /useWorkspaceDesktop/);
 });
 
 test("settings dialog settings section shows the app controls above appearance", async () => {
@@ -79,13 +69,13 @@ test("settings dialog settings section shows the app controls above appearance",
   assert.match(source, /aria-label="Enable beta updates"/);
 });
 
-test("settings nav lists automations below model providers", async () => {
+test("settings nav drops the automations section now that it lives in the chat pane", async () => {
   const source = await readFile(SETTINGS_DIALOG_PATH, "utf8");
 
-  const providersIndex = source.indexOf('{ id: "providers", label: "Model Providers", icon: Waypoints }');
-  const automationsIndex = source.indexOf('{ id: "automations", label: "Automations", icon: Workflow }');
-
-  assert.notEqual(providersIndex, -1);
-  assert.notEqual(automationsIndex, -1);
-  assert.ok(providersIndex < automationsIndex);
+  assert.notEqual(
+    source.indexOf('{ id: "providers", label: "Model Providers", icon: Waypoints }'),
+    -1,
+  );
+  assert.equal(source.indexOf('label: "Automations"'), -1);
+  assert.equal(source.indexOf('id: "automations"'), -1);
 });

--- a/desktop/src/components/layout/SettingsDialog.tsx
+++ b/desktop/src/components/layout/SettingsDialog.tsx
@@ -5,7 +5,6 @@ import {
   Copy,
   CreditCard,
   ExternalLink,
-  FolderKanban,
   FolderOpen,
   Globe,
   Info,
@@ -18,13 +17,11 @@ import {
   Settings2,
   User2,
   Waypoints,
-  Workflow,
   X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AuthPanel } from "@/components/auth/AuthPanel";
 import { BillingSettingsPanel } from "@/components/billing/BillingSettingsPanel";
-import { AutomationsPane } from "@/components/panes/AutomationsPane";
 import { IntegrationsPane } from "@/components/panes/IntegrationsPane";
 import { SubmissionsPanel } from "@/components/settings/SubmissionsPanel";
 import { Badge } from "@/components/ui/badge";
@@ -37,7 +34,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 const THEME_SWATCHES: Record<string, [string, string, string]> = {
   "amber-minimal-dark": ["#1a1814", "#e8853a", "#2e2920"],
@@ -70,12 +66,6 @@ interface SettingsDialogProps {
   themeVariants: readonly ThemeVariant[];
   onThemeVariantChange: (variant: ThemeVariant) => void;
   onOpenExternalUrl: (url: string) => void;
-  onOpenAutomationRunSession: (workspaceId: string, sessionId: string) => void;
-  onCreateAutomationSchedule: (workspaceId: string) => void;
-  onEditAutomationSchedule: (
-    workspaceId: string,
-    job: CronjobRecordPayload,
-  ) => void;
 }
 
 const THEME_VARIANT_LABELS: Record<ThemeVariant, string> = {
@@ -103,7 +93,6 @@ const SETTINGS_SECTIONS: Array<{
   { id: "settings", label: "Settings", icon: Settings2 },
   { id: "billing", label: "Billing", icon: CreditCard },
   { id: "providers", label: "Model Providers", icon: Waypoints },
-  { id: "automations", label: "Automations", icon: Workflow },
   { id: "integrations", label: "Integrations", icon: Plug },
   { id: "submissions", label: "Submissions", icon: Send },
   { id: "about", label: "About", icon: Info },
@@ -151,8 +140,6 @@ function titleForSection(section: UiSettingsPaneSection): string {
       return "Account";
     case "billing":
       return "Billing";
-    case "automations":
-      return "Automations";
     case "providers":
       return "Model Providers";
     case "integrations":
@@ -263,13 +250,8 @@ export function SettingsDialog({
   themeVariants,
   onThemeVariantChange,
   onOpenExternalUrl,
-  onOpenAutomationRunSession,
-  onCreateAutomationSchedule,
-  onEditAutomationSchedule,
 }: SettingsDialogProps) {
-  const { workspaces, selectedWorkspace } = useWorkspaceDesktop();
   const displayAppVersion = appVersion.trim() || "Unavailable";
-  const [automationsWorkspaceId, setAutomationsWorkspaceId] = useState("");
   const [diagnosticsExportState, setDiagnosticsExportState] = useState<{
     status: "idle" | "exporting" | "success" | "error";
     message: string;
@@ -330,14 +312,6 @@ export function SettingsDialog({
       unsubscribe();
     };
   }, [open]);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    setAutomationsWorkspaceId(selectedWorkspace?.id ?? workspaces[0]?.id ?? "");
-  }, [open, selectedWorkspace?.id, workspaces]);
 
   useEffect(() => {
     if (!appUpdateStatus?.downloaded) {
@@ -749,67 +723,6 @@ export function SettingsDialog({
                     </div>
                   </div>
                 </section>
-              </div>
-            ) : null}
-
-            {activeSection === "automations" ? (
-              <div>
-                <AutomationsPane
-                  workspaceId={automationsWorkspaceId || null}
-                  showHeader={false}
-                  emptyWorkspaceMessage="Choose a workspace to view and manage automations."
-                  toolbarLeading={
-                    <Select
-                      value={automationsWorkspaceId || undefined}
-                      onValueChange={(value) =>
-                        setAutomationsWorkspaceId(value ?? "")
-                      }
-                      disabled={workspaces.length === 0}
-                    >
-                      <SelectTrigger className="w-56">
-                        <FolderKanban
-                          size={14}
-                          className="text-muted-foreground"
-                        />
-                        <SelectValue
-                          placeholder={
-                            workspaces.length === 0
-                              ? "No workspaces available"
-                              : "Select workspace"
-                          }
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {workspaces.map((workspace) => (
-                          <SelectItem key={workspace.id} value={workspace.id}>
-                            {workspace.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  }
-                  onOpenRunSession={(sessionId) => {
-                    if (!automationsWorkspaceId) {
-                      return;
-                    }
-                    onOpenAutomationRunSession(
-                      automationsWorkspaceId,
-                      sessionId,
-                    );
-                  }}
-                  onCreateSchedule={() => {
-                    if (!automationsWorkspaceId) {
-                      return;
-                    }
-                    onCreateAutomationSchedule(automationsWorkspaceId);
-                  }}
-                  onEditSchedule={(job) => {
-                    if (!automationsWorkspaceId) {
-                      return;
-                    }
-                    onEditAutomationSchedule(automationsWorkspaceId, job);
-                  }}
-                />
               </div>
             ) : null}
 

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -1,21 +1,17 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
-import {
+  AlertTriangle,
+  ChevronRight,
   Clock3,
   MoreHorizontal,
   Pencil,
   Play,
   Plus,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { PaneCard } from "@/components/ui/PaneCard";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -36,9 +32,7 @@ interface CompletedAutomationRun {
 
 interface AutomationsPaneProps {
   workspaceId?: string | null;
-  showHeader?: boolean;
   emptyWorkspaceMessage?: string;
-  toolbarLeading?: ReactNode;
   onOpenRunSession?: (sessionId: string) => void;
   onCreateSchedule?: () => void;
   onEditSchedule?: (job: CronjobRecordPayload) => void;
@@ -53,26 +47,37 @@ function normalizeErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Request failed.";
 }
 
-function formatAbsoluteTimestamp(value: string | null): string {
+function formatRelativeTimestamp(value: string | null): string {
   if (!value) {
-    return "Not available";
+    return "—";
   }
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
     return value;
   }
+  const diffMs = Date.now() - parsed;
+  const diffMin = Math.round(diffMs / 60_000);
+  if (Math.abs(diffMin) < 1) {
+    return "just now";
+  }
+  if (Math.abs(diffMin) < 60) {
+    return `${diffMin > 0 ? `${diffMin}m ago` : `in ${-diffMin}m`}`;
+  }
+  const diffHr = Math.round(diffMin / 60);
+  if (Math.abs(diffHr) < 24) {
+    return `${diffHr > 0 ? `${diffHr}h ago` : `in ${-diffHr}h`}`;
+  }
   const date = new Date(parsed);
   const datePart = date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
-    year: "numeric",
   });
   const timePart = date.toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
   });
-  return `${datePart} at ${timePart}`;
+  return `${datePart}, ${timePart}`;
 }
 
 function formatDailyCron(cron: string): string | null {
@@ -100,7 +105,7 @@ function formatDailyCron(cron: string): string | null {
 }
 
 function scheduleAtLabel(job: CronjobRecordPayload): string {
-  return formatDailyCron(job.cron) ?? formatAbsoluteTimestamp(job.next_run_at);
+  return formatDailyCron(job.cron) ?? formatRelativeTimestamp(job.next_run_at);
 }
 
 function jobTitle(job: CronjobRecordPayload): string {
@@ -120,17 +125,6 @@ function jobKindLabel(job: CronjobRecordPayload): string {
     return "Task run";
   }
   return "Automation";
-}
-
-function jobKindClassName(job: CronjobRecordPayload): string {
-  const channel = jobDeliveryChannel(job);
-  if (channel === "system_notification") {
-    return "border-warning/40 bg-warning/10 text-warning";
-  }
-  if (channel === "session_run") {
-    return "border-primary bg-primary/10 text-primary";
-  }
-  return "border-border bg-muted text-muted-foreground";
 }
 
 function runtimeStateErrorMessage(
@@ -165,27 +159,14 @@ function isTerminalRunStatus(status: string): boolean {
   );
 }
 
-function completedStatusLabel(status: string): string {
+function isFailedStatus(status: string): boolean {
   const normalized = status.trim().toUpperCase();
-  if (normalized === "ERROR" || normalized === "FAILED") {
-    return "Failed";
-  }
-  return "Completed";
-}
-
-function completedStatusClassName(status: string): string {
-  const normalized = status.trim().toUpperCase();
-  if (normalized === "ERROR" || normalized === "FAILED") {
-    return "border-destructive/30 bg-destructive/10 text-destructive";
-  }
-  return "border-primary bg-primary/10 text-primary";
+  return normalized === "ERROR" || normalized === "FAILED";
 }
 
 export function AutomationsPane({
   workspaceId,
-  showHeader = true,
   emptyWorkspaceMessage = "Choose a workspace from the top bar to view and manage automations.",
-  toolbarLeading,
   onOpenRunSession,
   onCreateSchedule,
   onEditSchedule,
@@ -218,12 +199,12 @@ export function AutomationsPane({
     [cronjobs],
   );
 
-  const statusClassName =
+  const statusBarClassName =
     statusTone === "success"
-      ? "border-primary bg-primary/5 text-foreground"
+      ? "border-b border-primary/20 bg-primary/5 text-foreground"
       : statusTone === "error"
-        ? "border-destructive/25 bg-destructive/5 text-destructive"
-        : "border-border bg-muted text-muted-foreground";
+        ? "border-b border-destructive/20 bg-destructive/5 text-destructive"
+        : "border-b border-border bg-muted/40 text-muted-foreground";
 
   const setInfoMessage = (message: string) => {
     setStatusTone("info");
@@ -313,7 +294,7 @@ export function AutomationsPane({
       await window.electronAPI.workspace.deleteCronjob(job.id);
       setCronjobs((previous) => previous.filter((item) => item.id !== job.id));
       setStatusTone("success");
-      setStatusMessage(`Deleted schedule "${jobTitle(job)}".`);
+      setStatusMessage(`Deleted "${jobTitle(job)}".`);
       void refreshData({
         preserveStatusMessage: true,
         suppressErrors: true,
@@ -338,7 +319,7 @@ export function AutomationsPane({
       );
       setStatusTone("success");
       setStatusMessage(
-        `${updated.enabled ? "Enabled" : "Disabled"} "${jobTitle(updated)}".`,
+        `${updated.enabled ? "Enabled" : "Paused"} "${jobTitle(updated)}".`,
       );
       void refreshData({
         preserveStatusMessage: true,
@@ -363,7 +344,7 @@ export function AutomationsPane({
         ),
       );
       setStatusTone("success");
-      setStatusMessage(`Ran "${jobTitle(response.cronjob)}" now.`);
+      setStatusMessage(`Running "${jobTitle(response.cronjob)}" now.`);
       void refreshData({
         preserveStatusMessage: true,
         suppressErrors: true,
@@ -382,7 +363,7 @@ export function AutomationsPane({
       return;
     }
     setInfoMessage(
-      "Schedule creation is not wired in this pane yet. Use the cronjob API/runtime route for creation.",
+      "Schedule creation is wired through the agent — try asking in chat.",
     );
   };
 
@@ -391,327 +372,107 @@ export function AutomationsPane({
       onEditSchedule(job);
       return;
     }
-    setInfoMessage(
-      "Editing isn't wired in this pane yet. Open the schedule in chat to update it.",
-    );
+    setInfoMessage("Open the schedule in chat to edit it.");
   };
 
-  const content = (
-    <>
-      <div className="relative min-h-0 flex-1 overflow-auto">
-        <div className="mx-auto flex min-h-full max-w-5xl flex-col px-6 py-6">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="min-w-0">
-              {showHeader ? (
-                <div>
-                  <h1 className="text-xl font-semibold tracking-tight text-foreground">
-                    Automations
-                  </h1>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Manage recurring schedules and review completed automation
-                    runs.
-                  </p>
-                </div>
-              ) : toolbarLeading ? (
-                toolbarLeading
-              ) : null}
-            </div>
-
-            <Button
-              type="button"
-              size="default"
-              onClick={handleNewSchedule}
-              className="rounded-full px-4"
-            >
-              <Plus size={14} />
-              New schedule
-            </Button>
-          </div>
-
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 border-b border-border px-4 py-2 sm:px-5">
+        <div className="flex items-center justify-between gap-2">
           <Tabs
             value={activeTab}
             onValueChange={(v) => setActiveTab(v as "scheduled" | "completed")}
-            className="mt-5"
           >
             <TabsList>
               <TabsTrigger value="scheduled">Scheduled</TabsTrigger>
               <TabsTrigger value="completed">Completed</TabsTrigger>
             </TabsList>
           </Tabs>
-
-          {statusMessage ? (
-            <div className="mt-4">
-              <div
-                className={`rounded-xl border px-3 py-2 text-sm ${statusClassName}`}
-              >
-                {statusMessage}
-              </div>
-            </div>
-          ) : null}
-
-          <div className="mt-5 min-h-0 flex-1 overflow-hidden rounded-2xl border border-border bg-background/70">
-            {!activeWorkspaceId ? (
-              <EmptyState message={emptyWorkspaceMessage} />
-            ) : isLoading &&
-              scheduledJobs.length === 0 &&
-              completedRuns.length === 0 ? (
-              <div
-                role="status"
-                aria-busy="true"
-                aria-label="Loading automations"
-                className="flex h-full min-h-0 flex-col"
-              >
-                <div className="shrink-0 border-b border-border px-4 py-4 sm:px-5">
-                  <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    <span>Title</span>
-                    <span>Schedule at</span>
-                    <span>Status</span>
-                    <span />
-                  </div>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  {[
-                    { titleW: "w-36", scheduleW: "w-28" },
-                    { titleW: "w-48", scheduleW: "w-32" },
-                    { titleW: "w-40", scheduleW: "w-24" },
-                    { titleW: "w-44", scheduleW: "w-36" },
-                  ].map((row, index) => (
-                    <div
-                      key={index}
-                      className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border px-4 py-4 sm:px-5"
-                    >
-                      <div className="flex flex-col gap-1.5 pr-2">
-                        <span
-                          className={`h-4 ${row.titleW} animate-pulse rounded bg-muted-foreground/20`}
-                        />
-                        <span className="h-2.5 w-16 animate-pulse rounded bg-muted" />
-                      </div>
-                      <span
-                        className={`h-4 ${row.scheduleW} animate-pulse rounded bg-muted-foreground/20`}
-                      />
-                      <span className="h-5 w-9 animate-pulse rounded-full bg-muted-foreground/20" />
-                      <div className="flex justify-end">
-                        <span className="size-7 animate-pulse rounded-md bg-muted-foreground/20" />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : activeTab === "scheduled" ? (
-              scheduledJobs.length === 0 ? (
-                <EmptyState message="No scheduled tasks in this workspace." />
-              ) : (
-                <div className="flex h-full min-h-0 flex-col">
-                  <div className="shrink-0 border-b border-border px-4 py-4 sm:px-5">
-                    <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      <span>Title</span>
-                      <span>Schedule at</span>
-                      <span>Status</span>
-                      <span />
-                    </div>
-                  </div>
-
-                  <div className="min-h-0 flex-1 overflow-y-auto">
-                    {scheduledJobs.map((job) => {
-                      const isBusy = busyJobId === job.id;
-                      return (
-                        <div
-                          key={job.id}
-                          className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1.15fr)_120px_64px] items-center gap-4 border-b border-border px-4 py-4 transition-colors hover:bg-accent sm:px-5"
-                        >
-                          <div className="min-w-0 pr-2">
-                            <div className="truncate text-sm font-medium text-foreground">
-                              {jobTitle(job)}
-                            </div>
-                            {jobKindLabel(job) !== "Automation" ? (
-                              <div className="mt-1">
-                                <Badge
-                                  variant="outline"
-                                  className={`uppercase tracking-[0.12em] ${jobKindClassName(job)}`}
-                                >
-                                  {jobKindLabel(job)}
-                                </Badge>
-                              </div>
-                            ) : null}
-                            {job.last_error ? (
-                              <div className="mt-1 truncate text-xs text-destructive">
-                                {job.last_error}
-                              </div>
-                            ) : null}
-                          </div>
-
-                          <div className="truncate text-sm text-muted-foreground">
-                            {scheduleAtLabel(job)}
-                          </div>
-
-                          <div>
-                            <Switch
-                              checked={job.enabled}
-                              onCheckedChange={() =>
-                                void handleToggleEnabled(job)
-                              }
-                              disabled={isBusy}
-                              aria-label={
-                                job.enabled
-                                  ? "Disable schedule"
-                                  : "Enable schedule"
-                              }
-                            />
-                          </div>
-
-                          <div className="flex justify-end">
-                            <DropdownMenu>
-                              <DropdownMenuTrigger
-                                render={
-                                  <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    aria-label={`Actions for ${jobTitle(job)}`}
-                                  />
-                                }
-                              >
-                                <MoreHorizontal size={16} />
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent
-                                align="end"
-                                sideOffset={8}
-                                className="w-48"
-                              >
-                                <DropdownMenuItem
-                                  onClick={() => void handleRunNow(job)}
-                                  disabled={isBusy}
-                                >
-                                  <Play size={16} />
-                                  Run now
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  onClick={() => handleEdit(job)}
-                                  disabled={isBusy}
-                                >
-                                  <Pencil size={16} />
-                                  Edit
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  onClick={() => void handleDelete(job)}
-                                  disabled={isBusy}
-                                  variant="destructive"
-                                >
-                                  <Trash2 size={16} />
-                                  Delete
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )
-            ) : completedRuns.length === 0 ? (
-              <EmptyState message="No completed automation runs yet." />
-            ) : (
-              <div className="flex h-full min-h-0 flex-col">
-                <div className="shrink-0 border-b border-border px-4 py-4 sm:px-5">
-                  <div className="grid grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    <span>Title</span>
-                    <span>Completed at</span>
-                    <span>Status</span>
-                  </div>
-                </div>
-
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  {completedRuns.map((run) => (
-                    <button
-                      key={run.sessionId}
-                      type="button"
-                      disabled={!onOpenRunSession}
-                      onClick={() => onOpenRunSession?.(run.sessionId)}
-                      className="grid w-full grid-cols-[minmax(0,1.05fr)_minmax(0,1.25fr)_120px] items-center gap-4 border-b border-border px-4 py-4 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent sm:px-5"
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-foreground">
-                          {run.title}
-                        </div>
-                        {run.errorDetail ? (
-                          <div className="mt-0.5 truncate text-xs text-destructive">
-                            {run.errorDetail}
-                          </div>
-                        ) : null}
-                      </div>
-
-                      <div className="truncate text-sm text-muted-foreground">
-                        {formatAbsoluteTimestamp(run.completedAt)}
-                      </div>
-
-                      <div>
-                        <Badge
-                          variant="outline"
-                          className={completedStatusClassName(run.status)}
-                        >
-                          {completedStatusLabel(run.status)}
-                        </Badge>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleNewSchedule}
+            aria-label="New schedule"
+            className="rounded-lg text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="size-4" />
+          </Button>
         </div>
       </div>
-    </>
-  );
 
-  if (!showHeader) {
-    const embeddedBody = !activeWorkspaceId ? (
-      <EmbeddedEmptyState message={emptyWorkspaceMessage} />
-    ) : isLoading &&
-      scheduledJobs.length === 0 &&
-      completedRuns.length === 0 ? (
-      <EmbeddedSkeleton />
-    ) : activeTab === "scheduled" ? (
-      scheduledJobs.length === 0 ? (
-        <EmbeddedEmptyState message="No scheduled tasks in this workspace." />
-      ) : (
-        <div className="overflow-hidden rounded-xl bg-card ring-1 ring-border">
-          {scheduledJobs.map((job, index) => {
-            const isBusy = busyJobId === job.id;
-            return (
-              <div key={job.id}>
-                {index > 0 ? <div className="h-px bg-border" /> : null}
-                <div className="flex items-center justify-between gap-4 px-4 py-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {jobTitle(job)}
+      {statusMessage ? (
+        <div
+          className={`shrink-0 px-4 py-1.5 text-xs sm:px-5 ${statusBarClassName}`}
+        >
+          {statusMessage}
+        </div>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {!activeWorkspaceId ? (
+          <EmptyState
+            icon={<Clock3 className="size-5 text-muted-foreground" />}
+            title="No workspace selected"
+            description={emptyWorkspaceMessage}
+          />
+        ) : isLoading &&
+          scheduledJobs.length === 0 &&
+          completedRuns.length === 0 ? (
+          <SkeletonList />
+        ) : activeTab === "scheduled" ? (
+          scheduledJobs.length === 0 ? (
+            <EmptyScheduled onCreate={handleNewSchedule} />
+          ) : (
+            <ul>
+              {scheduledJobs.map((job, index) => {
+                const isBusy = busyJobId === job.id;
+                const kindLabel = jobKindLabel(job);
+                return (
+                  <li
+                    key={job.id}
+                    className={`group relative flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent sm:px-5 ${
+                      index > 0 ? "border-t border-border" : ""
+                    } ${isBusy ? "opacity-60" : ""}`}
+                  >
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                      <Clock3 className="size-3.5" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {jobTitle(job)}
+                        </span>
+                        {kindLabel !== "Automation" ? (
+                          <Badge
+                            variant="outline"
+                            className="border-border bg-background/60 px-1.5 py-0 text-[10px] font-medium leading-4 text-muted-foreground"
+                          >
+                            {kindLabel}
+                          </Badge>
+                        ) : null}
                       </div>
-                      {jobKindLabel(job) !== "Automation" ? (
-                        <Badge
-                          variant="outline"
-                          className="border-border bg-background/60 text-[11px] text-muted-foreground"
-                        >
-                          {jobKindLabel(job)}
-                        </Badge>
+                      <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {scheduleAtLabel(job)}
+                        {!job.enabled ? (
+                          <span className="ml-1.5 text-muted-foreground/70">
+                            · paused
+                          </span>
+                        ) : null}
+                      </div>
+                      {job.last_error ? (
+                        <div className="mt-1 flex items-start gap-1 text-xs text-destructive">
+                          <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+                          <span className="truncate">{job.last_error}</span>
+                        </div>
                       ) : null}
                     </div>
-                    <div className="mt-0.5 truncate text-xs leading-5 text-muted-foreground">
-                      {scheduleAtLabel(job)}
-                    </div>
-                    {job.last_error ? (
-                      <div className="mt-0.5 truncate text-xs leading-5 text-destructive">
-                        {job.last_error}
-                      </div>
-                    ) : null}
-                  </div>
-
-                  <div className="flex shrink-0 items-center gap-2">
                     <Switch
                       checked={job.enabled}
                       onCheckedChange={() => void handleToggleEnabled(job)}
                       disabled={isBusy}
                       aria-label={
-                        job.enabled ? "Disable schedule" : "Enable schedule"
+                        job.enabled ? "Pause schedule" : "Enable schedule"
                       }
                     />
                     <DropdownMenu>
@@ -721,188 +482,182 @@ export function AutomationsPane({
                             variant="ghost"
                             size="icon-sm"
                             aria-label={`Actions for ${jobTitle(job)}`}
+                            className="rounded-lg text-muted-foreground hover:text-foreground"
                           />
                         }
                       >
-                        <MoreHorizontal size={16} />
+                        <MoreHorizontal size={14} />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent
                         align="end"
-                        sideOffset={8}
-                        className="w-48"
+                        sideOffset={6}
+                        className="w-44"
                       >
                         <DropdownMenuItem
                           onClick={() => void handleRunNow(job)}
                           disabled={isBusy}
                         >
-                          <Play size={16} />
+                          <Play size={14} />
                           Run now
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => handleEdit(job)}
                           disabled={isBusy}
                         >
-                          <Pencil size={16} />
-                          Edit
+                          <Pencil size={14} />
+                          Edit in chat
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => void handleDelete(job)}
                           disabled={isBusy}
                           variant="destructive"
                         >
-                          <Trash2 size={16} />
+                          <Trash2 size={14} />
                           Delete
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )
-    ) : completedRuns.length === 0 ? (
-      <EmbeddedEmptyState message="No completed automation runs yet." />
-    ) : (
-      <div className="overflow-hidden rounded-xl bg-card ring-1 ring-border">
-        {completedRuns.map((run, index) => (
-          <div key={run.sessionId}>
-            {index > 0 ? <div className="h-px bg-border" /> : null}
-            <button
-              type="button"
-              disabled={!onOpenRunSession}
-              onClick={() => onOpenRunSession?.(run.sessionId)}
-              className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium text-foreground">
-                  {run.title}
-                </div>
-                <div className="mt-0.5 truncate text-xs leading-5 text-muted-foreground">
-                  {formatAbsoluteTimestamp(run.completedAt)}
-                </div>
-                {run.errorDetail ? (
-                  <div className="mt-0.5 truncate text-xs leading-5 text-destructive">
-                    {run.errorDetail}
-                  </div>
-                ) : null}
-              </div>
-              <Badge
-                variant="outline"
-                className={`border-border bg-background/60 text-[11px] ${
-                  run.status.trim().toUpperCase() === "ERROR" ||
-                  run.status.trim().toUpperCase() === "FAILED"
-                    ? "text-destructive"
-                    : "text-muted-foreground"
-                }`}
-              >
-                {completedStatusLabel(run.status)}
-              </Badge>
-            </button>
-          </div>
-        ))}
-      </div>
-    );
-
-    return (
-      <div className="grid gap-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="min-w-0">{toolbarLeading}</div>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleNewSchedule}
-            className="rounded-full px-4"
-          >
-            <Plus size={14} />
-            New schedule
-          </Button>
-        </div>
-
-        <Tabs
-          value={activeTab}
-          onValueChange={(v) => setActiveTab(v as "scheduled" | "completed")}
-        >
-          <TabsList>
-            <TabsTrigger value="scheduled">Scheduled</TabsTrigger>
-            <TabsTrigger value="completed">Completed</TabsTrigger>
-          </TabsList>
-        </Tabs>
-
-        {statusMessage ? (
-          <div
-            className={`rounded-xl border px-3 py-2 text-sm ${statusClassName}`}
-          >
-            {statusMessage}
-          </div>
-        ) : null}
-
-        {embeddedBody}
-      </div>
-    );
-  }
-
-  return <PaneCard className="shadow-subtle-xs">{content}</PaneCard>;
-}
-
-function EmbeddedEmptyState({ message }: { message: string }) {
-  return (
-    <div className="overflow-hidden rounded-xl bg-card ring-1 ring-border">
-      <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
-        <Clock3 size={18} className="text-muted-foreground" />
-        <div className="text-sm font-medium text-foreground">
-          No tasks to show
-        </div>
-        <div className="max-w-lg text-xs leading-5 text-muted-foreground">
-          {message}
-        </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )
+        ) : completedRuns.length === 0 ? (
+          <EmptyState
+            icon={<Clock3 className="size-5 text-muted-foreground" />}
+            title="No runs yet"
+            description="Once a scheduled task fires, its history will show up here."
+          />
+        ) : (
+          <ul>
+            {completedRuns.map((run, index) => {
+              const failed = isFailedStatus(run.status);
+              return (
+                <li key={run.sessionId}>
+                  <button
+                    type="button"
+                    disabled={!onOpenRunSession}
+                    onClick={() => onOpenRunSession?.(run.sessionId)}
+                    className={`group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent sm:px-5 ${
+                      index > 0 ? "border-t border-border" : ""
+                    }`}
+                  >
+                    <div
+                      className={`flex size-8 shrink-0 items-center justify-center rounded-md ${
+                        failed
+                          ? "bg-destructive/10 text-destructive"
+                          : "bg-muted text-muted-foreground"
+                      }`}
+                    >
+                      {failed ? (
+                        <AlertTriangle className="size-3.5" />
+                      ) : (
+                        <Clock3 className="size-3.5" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {run.title}
+                      </div>
+                      <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {failed ? "Failed" : "Completed"}
+                        <span className="mx-1.5">·</span>
+                        {formatRelativeTimestamp(run.completedAt)}
+                      </div>
+                      {run.errorDetail ? (
+                        <div className="mt-1 truncate text-xs text-destructive">
+                          {run.errorDetail}
+                        </div>
+                      ) : null}
+                    </div>
+                    {onOpenRunSession ? (
+                      <ChevronRight className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );
 }
 
-function EmbeddedSkeleton() {
-  const rows = ["w-36", "w-48", "w-40", "w-44"];
+function EmptyState({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
   return (
-    <div
-      role="status"
-      aria-busy="true"
-      aria-label="Loading automations"
-      className="overflow-hidden rounded-xl bg-card ring-1 ring-border"
-    >
+    <div className="flex h-full flex-col items-center justify-center px-6 py-10 text-center">
+      <div className="grid size-10 place-items-center rounded-xl bg-muted">
+        {icon}
+      </div>
+      <div className="mt-3 text-sm font-medium text-foreground">{title}</div>
+      <p className="mt-1 max-w-xs text-xs leading-5 text-muted-foreground">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function EmptyScheduled({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center px-6 py-10 text-center">
+      <div className="grid size-10 place-items-center rounded-xl bg-muted text-muted-foreground">
+        <Clock3 className="size-5" />
+      </div>
+      <div className="mt-3 text-sm font-medium text-foreground">
+        No schedules yet
+      </div>
+      <p className="mt-1 max-w-[260px] text-xs leading-5 text-muted-foreground">
+        Ask the agent to set one up — try{" "}
+        <span className="text-foreground/80">
+          &ldquo;post a LinkedIn update every Monday at 9am&rdquo;
+        </span>
+        .
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onCreate}
+        className="mt-4 gap-1.5"
+      >
+        <Sparkles className="size-3.5" />
+        Ask the agent
+      </Button>
+    </div>
+  );
+}
+
+function SkeletonList() {
+  const rows = ["w-32", "w-44", "w-36", "w-40"];
+  return (
+    <ul role="status" aria-busy="true" aria-label="Loading automations">
       {rows.map((titleW, index) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-        <div key={index}>
-          {index > 0 ? <div className="h-px bg-border" /> : null}
-          <div className="flex items-center justify-between gap-4 px-4 py-3">
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div
-                className={`h-3.5 ${titleW} animate-pulse rounded bg-muted-foreground/20`}
-              />
-              <div className="h-2.5 w-28 animate-pulse rounded bg-muted-foreground/20" />
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <div className="h-5 w-9 animate-pulse rounded-full bg-muted-foreground/20" />
-              <div className="size-7 animate-pulse rounded-md bg-muted-foreground/20" />
-            </div>
+        <li
+          key={index}
+          className={`flex items-center gap-3 px-4 py-3 sm:px-5 ${
+            index > 0 ? "border-t border-border" : ""
+          }`}
+        >
+          <div className="size-8 shrink-0 animate-pulse rounded-md bg-muted-foreground/15" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div
+              className={`h-3.5 ${titleW} animate-pulse rounded bg-muted-foreground/20`}
+            />
+            <div className="h-2.5 w-24 animate-pulse rounded bg-muted-foreground/15" />
           </div>
-        </div>
+          <div className="h-5 w-9 shrink-0 animate-pulse rounded-full bg-muted-foreground/15" />
+        </li>
       ))}
-    </div>
-  );
-}
-
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div className="flex h-full w-full items-center justify-center p-6 text-center">
-      <div className="max-w-lg">
-        <Clock3 size={20} className="mx-auto text-muted-foreground" />
-        <div className="mt-3 text-sm font-medium text-foreground">
-          No tasks to show
-        </div>
-        <div className="mt-1 text-sm text-muted-foreground">{message}</div>
-      </div>
-    </div>
+    </ul>
   );
 }

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -58,6 +58,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import {
   EXPLORER_ATTACHMENT_DRAG_TYPE,
@@ -3121,6 +3126,7 @@ interface ChatPaneProps {
   onJumpToSessionBrowser?: (sessionId: string, requestKey: number) => void;
   onOpenInbox?: () => void;
   inboxUnreadCount?: number;
+  onOpenAutomations?: () => void;
   onRequestCreateSession?: (request: ChatPaneSessionOpenRequest) => void;
   composerDraftText?: string;
   onComposerDraftTextChange?: (text: string) => void;
@@ -3146,6 +3152,7 @@ export function ChatPane({
   onJumpToSessionBrowser,
   onOpenInbox,
   inboxUnreadCount = 0,
+  onOpenAutomations,
   onRequestCreateSession,
   composerDraftText = "",
   onComposerDraftTextChange,
@@ -7219,6 +7226,7 @@ export function ChatPane({
               onSelectSession={openSessionFromPicker}
               onOpenInbox={onOpenInbox}
               inboxUnreadCount={inboxUnreadCount}
+              onOpenAutomations={onOpenAutomations}
               onCreateSession={requestDraftSessionFromPicker}
             />
           </div>
@@ -7721,6 +7729,7 @@ interface SessionSelectorProps {
   onSelectSession: (sessionId: string) => void;
   onOpenInbox?: () => void;
   inboxUnreadCount: number;
+  onOpenAutomations?: () => void;
   onCreateSession: () => void;
 }
 
@@ -7734,6 +7743,7 @@ function SessionSelector({
   onSelectSession,
   onOpenInbox,
   inboxUnreadCount,
+  onOpenAutomations,
   onCreateSession,
 }: SessionSelectorProps) {
   const [open, setOpen] = useState(false);
@@ -7862,39 +7872,83 @@ function SessionSelector({
 
       <div className="flex shrink-0 items-center gap-1">
         {onOpenInbox ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => {
-              setOpen(false);
-              setQuery("");
-              onOpenInbox();
-            }}
-            aria-label="Show inbox"
-            className="relative rounded-lg text-muted-foreground hover:text-foreground"
-          >
-            <Inbox className="size-4" />
-            {inboxUnreadCount > 0 ? (
-              <span className="absolute right-1.5 top-1.5 size-2 rounded-full border border-card bg-destructive" />
-            ) : null}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => {
+                    setOpen(false);
+                    setQuery("");
+                    onOpenInbox();
+                  }}
+                  aria-label="Show inbox"
+                  className="relative rounded-lg text-muted-foreground hover:text-foreground"
+                />
+              }
+            >
+              <Inbox className="size-4" />
+              {inboxUnreadCount > 0 ? (
+                <span className="absolute right-1.5 top-1.5 size-2 rounded-full border border-card bg-destructive" />
+              ) : null}
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="py-1">
+              Inbox
+            </TooltipContent>
+          </Tooltip>
         ) : null}
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => {
-            setOpen(false);
-            setQuery("");
-            onCreateSession();
-          }}
-          aria-label="Create new session"
-          className="rounded-lg text-muted-foreground hover:text-foreground"
-        >
-          <Plus className="size-4" />
-        </Button>
+        {onOpenAutomations ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => {
+                    setOpen(false);
+                    setQuery("");
+                    onOpenAutomations();
+                  }}
+                  aria-label="Show automations"
+                  className="rounded-lg text-muted-foreground hover:text-foreground"
+                />
+              }
+            >
+              <Clock3 className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="py-1">
+              Automations
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => {
+                  setOpen(false);
+                  setQuery("");
+                  onCreateSession();
+                }}
+                aria-label="Create new session"
+                className="rounded-lg text-muted-foreground hover:text-foreground"
+              />
+            }
+          >
+            <Plus className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="py-1">
+            New session
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -103,7 +103,7 @@ declare global {
     height: number;
   }
 
-  type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "automations" | "about";
+  type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "about";
 
   interface BrowserStatePayload {
     id: string;


### PR DESCRIPTION
## Summary

Automations now lives in the chat pane as a peer to Inbox, instead of as a Settings sub-tab. Creating a schedule no longer dismisses a modal mid-flow — it just swaps the pane back to chat with the composer prefilled.

**Why this change:** clicking *New schedule* in the old Settings → Automations panel closed the dialog and dropped the user into chat with a half-finished prompt. The root cause was placing an active workspace surface inside Settings — settings is for configuration, not running work.

## What changed

**New IA**
- `ChatPane.tsx`: `Clock3` icon button next to Inbox in the session selector; all three icon buttons (Inbox / Automations / New session) wrapped in shadcn `Tooltip`
- `AppShell.tsx`: `AgentView` gains `"automations"`; new `handleOpenAutomationsPane` swaps the chat pane content (mirrors the Inbox pattern with a header + back button)
- Schedule create / edit handlers now stay inside the chat pane — no `setSettingsDialogOpen(false)` anywhere

**Settings cleanup**
- `SettingsDialog.tsx`: drops the Automations section, three automation callback props, workspace-picker state, and dead imports (`Workflow`, `AutomationsPane`, `FolderKanban`, `useWorkspaceDesktop`)
- `UiSettingsPaneSection`: drops `"automations"` in all four declaration sites (renderer types + electron preload + authPopup preload + main)

**Pane redesign**
- `AutomationsPane.tsx`: redesigned for the narrow chat-pane (~420px)
  - Single render path; `showHeader` / `toolbarLeading` props removed as dead code
  - Compact toolbar (Tabs + ghost `+` button)
  - Divider-separated rows with icon chip + title + meta + Switch + kebab
  - AI-aware empty state suggesting a natural-language prompt
  - Relative timestamps in the Completed list (\"5m ago\", \"2h ago\")
  - Failed runs flagged with `AlertTriangle` chip

**Tests**
- Updated `AppShell.test.mjs` + `SettingsDialog.test.mjs` to verify the new IA
- Loosened two pre-existing brittle regexes in the schedule-routing tests so Biome's multiline formatting no longer trips them

## Cross-workspace view

Intentionally NOT building cross-workspace Automations in this PR. Cronjobs are workspace-scoped (sandbox boundary, credit attribution, edit ownership). Switching workspaces is the existing fallback. If real demand emerges later, the right place is a separate top-bar \"Activity\" surface, not this chat-pane view.

## Test plan
- [ ] Open chat pane → click clock icon next to Inbox → Automations renders inside the chat pane
- [ ] In Automations: click `+` (New schedule) → pane swaps to chat with composer prefilled \"Create a cronjob for \"
- [ ] In Automations: kebab → Edit in chat → pane swaps to chat with edit prefill
- [ ] In Automations: toggle Switch → row updates in place, status strip shows \"Enabled/Paused…\"
- [ ] Empty workspace shows the AI-aware empty state
- [ ] Settings dialog has no Automations section anymore (Account, Settings, Billing, Model Providers, Integrations, Submissions, About only)
- [ ] Hover the three icon buttons in the chat pane toolbar — tooltips show \"Inbox\" / \"Automations\" / \"New session\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)