### PR TITLE
fix: disable embedded proactive bridge worker

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -16359,7 +16359,9 @@ async function startEmbeddedRuntime() {
           HOLABOSS_DESKTOP_BROWSER_URL: desktopBrowserServiceUrl,
           HOLABOSS_DESKTOP_BROWSER_AUTH_TOKEN:
             desktopBrowserServiceAuthToken,
-          PROACTIVE_ENABLE_REMOTE_BRIDGE: "1",
+          // Proactive is temporarily disabled product-wide, so keep the
+          // embedded runtime bridge worker off until the backend is re-enabled.
+          PROACTIVE_ENABLE_REMOTE_BRIDGE: "0",
           PROACTIVE_BRIDGE_BASE_URL: runtimeProactiveBridgeBaseUrl(),
           PYTHONDONTWRITEBYTECODE: "1",
           HOLABOSS_AUTH_BASE_URL: AUTH_BASE_URL,

--- a/desktop/electron/runtime-auth-env.test.mjs
+++ b/desktop/electron/runtime-auth-env.test.mjs
@@ -29,6 +29,10 @@ test("embedded runtime bridge uses the same proactive base URL resolution as int
   );
   assert.match(
     source,
+    /PROACTIVE_ENABLE_REMOTE_BRIDGE:\s*"0"/,
+  );
+  assert.match(
+    source,
     /PROACTIVE_BRIDGE_BASE_URL:\s*runtimeProactiveBridgeBaseUrl\(\)/,
   );
 });


### PR DESCRIPTION
## Context
- proactive is currently disabled product-wide
- the desktop embedded runtime was still enabling the remote proactive bridge worker at launch
- this keeps the runtime from polling the bridge until the feature is re-enabled

## Changes
- set `PROACTIVE_ENABLE_REMOTE_BRIDGE` to `"0"` in the embedded runtime env wiring
- add a regression test that asserts the embedded runtime source keeps the bridge worker disabled

## Validation
- `node --test desktop/electron/runtime-auth-env.test.mjs`