### PR TITLE
fix: preserve PI session continuity after failed runs

### DIFF
--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -2883,7 +2883,7 @@ test("claimed input passes persisted child session kind into the runner payload"
   store.close();
 });
 
-test("claimed input resets harness session binding to the local session after run_failed", async () => {
+test("claimed input persists terminal harness session binding after run_failed", async () => {
   const store = makeStore("hb-claimed-input-harness-session-reset-");
   const workspace = store.createWorkspace({
     workspaceId: "workspace-1",
@@ -2927,6 +2927,54 @@ test("claimed input resets harness session binding to the local session after ru
   });
 
   assert.ok(binding);
-  assert.equal(binding.harnessSessionId, "session-main");
+  assert.equal(binding.harnessSessionId, "failed-session");
+  store.close();
+});
+
+test("claimed input keeps existing harness session binding when run_failed omits one", async () => {
+  const store = makeStore("hb-claimed-input-harness-session-failed-keep-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: "stale-pi-session",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" },
+  });
+  setNodeRunnerCommand([
+    "const request = process.argv.at(-1) ?? '';",
+    "void request;",
+    `process.stdout.write(JSON.stringify({ session_id: 'session-main', input_id: '${queued.inputId}', sequence: 1, event_type: 'run_started', payload: { status: 'started' } }) + '\\n');`,
+    `process.stdout.write(JSON.stringify({ session_id: 'session-main', input_id: '${queued.inputId}', sequence: 2, event_type: 'run_failed', payload: { type: 'OpenCodeSessionError', message: 'boom' } }) + '\\n');`,
+  ]);
+
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+  });
+
+  const binding = store.getBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+  });
+
+  assert.ok(binding);
+  assert.equal(binding.harnessSessionId, "stale-pi-session");
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -1387,24 +1387,15 @@ function maybePersistHarnessSessionId(params: {
   if (!["run_completed", "run_failed"].includes(params.eventType)) {
     return;
   }
-  if (params.eventType === "run_failed") {
-    params.store.upsertBinding({
-      workspaceId: params.workspaceId,
-      sessionId: params.sessionId,
-      harness: params.harness,
-      harnessSessionId: params.sessionId,
-    });
-    return;
-  }
-  const harnessSessionId = params.payload.harness_session_id;
-  if (typeof harnessSessionId !== "string" || !harnessSessionId.trim()) {
+  const harnessSessionId = nonEmptyString(params.payload.harness_session_id);
+  if (!harnessSessionId) {
     return;
   }
   params.store.upsertBinding({
     workspaceId: params.workspaceId,
     sessionId: params.sessionId,
     harness: params.harness,
-    harnessSessionId: harnessSessionId.trim(),
+    harnessSessionId,
   });
 }
 

--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -3017,6 +3017,51 @@ test("buildPiPromptPayload frames persisted todo state as advisory continuity wh
   }
 });
 
+test("buildPiPromptPayload falls back to persisted session file when requested id is stale", async () => {
+  const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "hb-pi-stale-requested-session-"));
+  const stateDir = path.join(workspaceDir, ".holaboss", "pi-agent");
+  fs.mkdirSync(path.join(workspaceDir, ".holaboss", "pi-sessions"), { recursive: true });
+  const persistedSessionPath = path.join(workspaceDir, ".holaboss", "pi-sessions", "session-1.jsonl");
+  fs.writeFileSync(persistedSessionPath, "", "utf8");
+
+  const [, todoWrite] = createPiTodoToolDefinitions({
+    stateDir,
+    sessionId: "session-1",
+  });
+  await todoWrite.execute(
+    "call-seed",
+    {
+      ops: [
+        {
+          op: "replace",
+          phases: [
+            {
+              name: "Implementation",
+              tasks: [{ content: "Resume the existing work" }],
+            },
+          ],
+        },
+      ],
+    },
+    undefined,
+    undefined,
+    {} as never
+  );
+
+  try {
+    const prompt = await buildPiPromptPayload({
+      ...baseRequest(),
+      workspace_dir: workspaceDir,
+      harness_session_id: "session-1",
+      persisted_harness_session_id: persistedSessionPath,
+    });
+
+    assert.match(prompt.text, /Resumed session note:/);
+  } finally {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
 test("buildPiPromptPayload expands leading slash skill references into quoted skill blocks", async () => {
   const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "hb-pi-slash-skills-"));
   const skillsDir = path.join(workspaceDir, "skills");

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -1076,12 +1076,22 @@ function wrapToolWithWorkspaceBoundary<TTool extends { name: string; execute: (.
 }
 
 function resolveRequestedSessionFile(request: HarnessHostPiRequest): string | null {
-  const candidate = firstNonEmptyString(request.harness_session_id, request.persisted_harness_session_id);
-  if (!candidate) {
-    return null;
+  const candidates = [
+    firstNonEmptyString(request.harness_session_id),
+    firstNonEmptyString(request.persisted_harness_session_id),
+  ];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
   }
-  const resolved = path.resolve(candidate);
-  return fs.existsSync(resolved) ? resolved : null;
+  return null;
 }
 
 export function buildPiMcpToolName(serverId: string, toolName: string): string {


### PR DESCRIPTION
## Context

Investigated the diagnostics bundle at `~/Desktop/holaboss-diagnostics-2026-04-24T11-53-08Z` for context loss in workspace `twitter koc`.

The workspace/session transcript was still persisted in SQLite, but failed PI turns were resetting `agent_runtime_sessions.harness_session_id` to the logical session id. The next turn then attempted to resume from that UUID instead of the real PI JSONL session file, so the harness restarted without prior session state.

## Changes

- preserve terminal `harness_session_id` values from both successful and failed terminal events
- keep the existing harness session binding when a failed terminal event omits a harness session id
- make PI session resolution fall back from a stale requested id to a valid persisted session file
- add regression tests for failed-run binding preservation and stale requested-session fallback

## Validation

- `npm exec -- node --import tsx --test src/claimed-input-executor.test.ts --test-name-pattern "harness session"`
- `npm exec -- node --import tsx --test src/pi.test.ts --test-name-pattern "persisted session file|persisted todo"`
- `npm run typecheck` in `runtime/api-server`
- `npm run typecheck` in `runtime/harness-host`