### PR TITLE
refactor(desktop): browser-pane tabs/navigation extraction (BP-P5b)

### DIFF
--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -139,6 +139,15 @@ export interface BrowserPaneTabStateDeps {
 
   /** Default URL to seed a new tab with when there's nothing else to land on. */
   homeUrl: string;
+
+  /** P6 callback — keep an agent-session space alive (extends suspend timer). */
+  touchAgentSessionBrowserSpace: (
+    workspaceId: string,
+    sessionId?: string | null,
+  ) => void;
+
+  /** Detect ERR_ABORTED-style load errors (utils). */
+  isAbortedBrowserLoadError: (error: unknown) => boolean;
 }
 
 export interface BrowserPaneTabState {
@@ -161,6 +170,12 @@ export interface BrowserPaneTabState {
   closeBrowserTab: (
     tabId: string,
     space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ) => Promise<BrowserTabListPayload>;
+  navigateActiveBrowserTab: (
+    workspaceId: string,
+    targetUrl: string,
+    space?: BrowserSpaceId,
     sessionId?: string | null,
   ) => Promise<BrowserTabListPayload>;
   // ensureBrowserTabSpaceInitialized + initialBrowserTabSeed deferred —
@@ -473,6 +488,46 @@ export function createBrowserPaneTabState(
     );
   }
 
+  async function navigateActiveBrowserTab(
+    workspaceId: string,
+    targetUrl: string,
+    space: BrowserSpaceId = deps.getActiveSpaceId(),
+    sessionId?: string | null,
+  ): Promise<BrowserTabListPayload> {
+    await deps.ensureBrowserWorkspace(workspaceId, space, sessionId);
+    if (space === "agent" && deps.browserSessionId(sessionId)) {
+      deps.touchAgentSessionBrowserSpace(workspaceId, sessionId);
+    }
+    const activeTab = getActiveBrowserTab(workspaceId, space, sessionId, {
+      useVisibleAgentSession: !deps.browserSessionId(sessionId),
+    });
+    if (!activeTab) {
+      throw new Error("No active browser tab is available.");
+    }
+
+    try {
+      activeTab.state = { ...activeTab.state, error: "" };
+      await activeTab.view.webContents.loadURL(targetUrl);
+    } catch (error) {
+      if (deps.isAbortedBrowserLoadError(error)) {
+        return deps.browserWorkspaceSnapshot(workspaceId, space, sessionId, {
+          useVisibleAgentSession: !deps.browserSessionId(sessionId),
+        });
+      }
+      activeTab.state = {
+        ...activeTab.state,
+        loading: false,
+        error: error instanceof Error ? error.message : "Failed to load URL.",
+      };
+      emitBrowserState(workspaceId, space);
+      throw error;
+    }
+
+    return deps.browserWorkspaceSnapshot(workspaceId, space, sessionId, {
+      useVisibleAgentSession: !deps.browserSessionId(sessionId),
+    });
+  }
+
   async function closeBrowserTab(
     tabId: string,
     space?: BrowserSpaceId | null,
@@ -643,6 +698,7 @@ export function createBrowserPaneTabState(
     focusBrowserTabInSpace,
     setActiveBrowserTab,
     closeBrowserTab,
+    navigateActiveBrowserTab,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,
     currentBrowserTabPageTitle,

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -27,6 +27,7 @@ import type {
   BrowserSpaceId,
   BrowserStatePayload,
   BrowserTabListPayload,
+  BrowserVisibleSnapshotPayload,
 } from "../../shared/browser-pane-protocol.js";
 
 /**
@@ -111,6 +112,8 @@ export interface BrowserPaneTabStateDeps {
 
 export interface BrowserPaneTabState {
   hasVisibleBounds: () => boolean;
+  setBounds: (bounds: BrowserBoundsPayload) => void;
+  captureVisibleSnapshot: () => Promise<BrowserVisibleSnapshotPayload | null>;
   closeBrowserTabRecord: (tab: BrowserTabRecord) => void;
   getActiveBrowserTab: (
     workspaceId?: string | null,
@@ -155,6 +158,48 @@ export function createBrowserPaneTabState(
   function hasVisibleBounds(): boolean {
     const b = deps.getBrowserBounds();
     return b.width > 0 && b.height > 0;
+  }
+
+  function setBounds(bounds: BrowserBoundsPayload): void {
+    deps.setBrowserBounds({
+      x: Math.max(0, Math.round(bounds.x)),
+      y: Math.max(0, Math.round(bounds.y)),
+      width: Math.max(0, Math.round(bounds.width)),
+      height: Math.max(0, Math.round(bounds.height)),
+    });
+
+    const target = activeVisibleBrowserTarget();
+    const activeTab = getActiveBrowserTab(
+      target.workspaceId,
+      target.space,
+      target.sessionId,
+      { useVisibleAgentSession: true },
+    );
+    if (!activeTab || !hasVisibleBounds()) {
+      const win = deps.getMainWindow();
+      win?.setBrowserView(null);
+      deps.setAttachedView(null);
+      return;
+    }
+    updateAttachedBrowserView();
+  }
+
+  async function captureVisibleSnapshot(): Promise<BrowserVisibleSnapshotPayload | null> {
+    const target = activeVisibleBrowserTarget();
+    const activeTab = getActiveBrowserTab(
+      target.workspaceId,
+      target.space,
+      target.sessionId,
+      { useVisibleAgentSession: true },
+    );
+    if (!activeTab || !hasVisibleBounds()) {
+      return null;
+    }
+    const image = await activeTab.view.webContents.capturePage();
+    return {
+      bounds: { ...deps.getBrowserBounds() },
+      dataUrl: `data:image/png;base64,${image.toPNG().toString("base64")}`,
+    };
   }
 
   function getActiveBrowserTab(
@@ -390,6 +435,8 @@ export function createBrowserPaneTabState(
 
   return {
     hasVisibleBounds,
+    setBounds,
+    captureVisibleSnapshot,
     closeBrowserTabRecord,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -108,6 +108,37 @@ export interface BrowserPaneTabStateDeps {
   sendHistoryToPopup: (history: BrowserHistoryEntryPayload[]) => void;
 
   reserveMainWindowClosedListenerBudget: (additionalClosedListeners?: number) => void;
+
+  /** P6 callback — provision/reuse the workspace for a given space+session. */
+  ensureBrowserWorkspace: (
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ) => Promise<BrowserWorkspaceState | null>;
+
+  /** P6 callback — promote a session to the visible agent space. */
+  setVisibleAgentBrowserSession: (
+    workspace: BrowserWorkspaceState,
+    sessionId: string,
+  ) => void;
+
+  /**
+   * P5b-4 callback — open a fresh tab in the given workspace+space. We pass
+   * it in (rather than implement here) because createBrowserTab is heavy and
+   * lives in main.ts until the next extraction.
+   */
+  createBrowserTab: (
+    workspaceId: string,
+    options: {
+      url?: string;
+      browserSpace?: BrowserSpaceId;
+      sessionId?: string | null;
+      [key: string]: unknown;
+    },
+  ) => string | null;
+
+  /** Default URL to seed a new tab with when there's nothing else to land on. */
+  homeUrl: string;
 }
 
 export interface BrowserPaneTabState {
@@ -115,6 +146,26 @@ export interface BrowserPaneTabState {
   setBounds: (bounds: BrowserBoundsPayload) => void;
   captureVisibleSnapshot: () => Promise<BrowserVisibleSnapshotPayload | null>;
   closeBrowserTabRecord: (tab: BrowserTabRecord) => void;
+  focusBrowserTabInSpace: (
+    workspaceId: string,
+    tabSpace: BrowserTabSpaceState,
+    tabId: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ) => void;
+  setActiveBrowserTab: (
+    tabId: string,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ) => Promise<BrowserTabListPayload>;
+  closeBrowserTab: (
+    tabId: string,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ) => Promise<BrowserTabListPayload>;
+  // ensureBrowserTabSpaceInitialized + initialBrowserTabSeed deferred —
+  // they pull in oppositeBrowserSpaceId / browserTabSpaceStates / NEW_TAB_TITLE
+  // which are still being threaded through. Move them in BP-P5b-4.
   getActiveBrowserTab: (
     workspaceId?: string | null,
     space?: BrowserSpaceId | null,
@@ -344,6 +395,157 @@ export function createBrowserPaneTabState(
     ).close?.();
   }
 
+  function focusBrowserTabInSpace(
+    workspaceId: string,
+    tabSpace: BrowserTabSpaceState,
+    tabId: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ): void {
+    tabSpace.activeTabId = tabId;
+    deps.browserTabSpaceTouch(tabSpace);
+    if (space === "agent" && deps.browserSessionId(sessionId)) {
+      deps.scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
+    }
+    if (
+      workspaceId === deps.getActiveWorkspaceId() &&
+      space === deps.getActiveSpaceId()
+    ) {
+      updateAttachedBrowserView();
+    }
+    emitBrowserState(workspaceId, space);
+    void deps.persistWorkspace(workspaceId);
+  }
+
+  async function setActiveBrowserTab(
+    tabId: string,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ): Promise<BrowserTabListPayload> {
+    const browserSpace = deps.browserSpaceId(space);
+    const normalizedSessionId =
+      browserSpace === "agent"
+        ? deps.browserSessionId(sessionId) ||
+          deps.browserSessionId(deps.getActiveSessionId())
+        : "";
+    const workspace = await deps.ensureBrowserWorkspace(
+      undefined,
+      browserSpace,
+      normalizedSessionId,
+    );
+    const tabSpace = deps.browserTabSpaceState(
+      workspace,
+      browserSpace,
+      normalizedSessionId,
+      { useVisibleAgentSession: !normalizedSessionId },
+    );
+    if (!workspace || !tabSpace || !tabSpace.tabs.has(tabId)) {
+      return deps.browserWorkspaceSnapshot(
+        undefined,
+        browserSpace,
+        normalizedSessionId,
+        { useVisibleAgentSession: true },
+      );
+    }
+
+    tabSpace.activeTabId = tabId;
+    deps.browserTabSpaceTouch(tabSpace);
+    if (browserSpace === "agent" && normalizedSessionId) {
+      deps.setVisibleAgentBrowserSession(workspace, normalizedSessionId);
+      deps.scheduleAgentSessionBrowserLifecycleCheck(
+        workspace.workspaceId,
+        normalizedSessionId,
+      );
+    }
+    if (
+      workspace.workspaceId === deps.getActiveWorkspaceId() &&
+      browserSpace === deps.getActiveSpaceId()
+    ) {
+      updateAttachedBrowserView();
+    }
+    emitBrowserState(workspace.workspaceId, browserSpace);
+    await deps.persistWorkspace(workspace.workspaceId);
+    return deps.browserWorkspaceSnapshot(
+      workspace.workspaceId,
+      browserSpace,
+      normalizedSessionId,
+      { useVisibleAgentSession: true },
+    );
+  }
+
+  async function closeBrowserTab(
+    tabId: string,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+  ): Promise<BrowserTabListPayload> {
+    const browserSpace = deps.browserSpaceId(space);
+    const normalizedSessionId =
+      browserSpace === "agent"
+        ? deps.browserSessionId(sessionId) ||
+          deps.browserSessionId(deps.getActiveSessionId())
+        : "";
+    const workspace = await deps.ensureBrowserWorkspace(
+      undefined,
+      browserSpace,
+      normalizedSessionId,
+    );
+    const tabSpace = deps.browserTabSpaceState(
+      workspace,
+      browserSpace,
+      normalizedSessionId,
+      { useVisibleAgentSession: !normalizedSessionId },
+    );
+    const tab = tabSpace?.tabs.get(tabId);
+    if (!workspace || !tabSpace || !tab) {
+      return deps.browserWorkspaceSnapshot(
+        undefined,
+        browserSpace,
+        normalizedSessionId,
+        { useVisibleAgentSession: true },
+      );
+    }
+
+    const tabIds = Array.from(tabSpace.tabs.keys());
+    const closedIndex = tabIds.indexOf(tabId);
+    tabSpace.tabs.delete(tabId);
+    closeBrowserTabRecord(tab);
+    deps.browserTabSpaceTouch(tabSpace);
+
+    if (tabSpace.tabs.size === 0) {
+      const replacementTabId = deps.createBrowserTab(workspace.workspaceId, {
+        url: deps.homeUrl,
+        browserSpace,
+        sessionId: normalizedSessionId,
+      });
+      tabSpace.activeTabId = replacementTabId ?? "";
+    } else if (tabSpace.activeTabId === tabId) {
+      const remainingIds = Array.from(tabSpace.tabs.keys());
+      tabSpace.activeTabId =
+        remainingIds[Math.max(0, closedIndex - 1)] ?? remainingIds[0] ?? "";
+    }
+
+    if (
+      workspace.workspaceId === deps.getActiveWorkspaceId() &&
+      browserSpace === deps.getActiveSpaceId()
+    ) {
+      updateAttachedBrowserView();
+    }
+    if (browserSpace === "agent" && normalizedSessionId) {
+      deps.scheduleAgentSessionBrowserLifecycleCheck(
+        workspace.workspaceId,
+        normalizedSessionId,
+      );
+    }
+    emitBrowserState(workspace.workspaceId, browserSpace);
+    await deps.persistWorkspace(workspace.workspaceId);
+    return deps.browserWorkspaceSnapshot(
+      workspace.workspaceId,
+      browserSpace,
+      normalizedSessionId,
+      { useVisibleAgentSession: true },
+    );
+  }
+
   function syncBrowserState(
     workspaceId: string,
     tabId: string,
@@ -438,6 +640,9 @@ export function createBrowserPaneTabState(
     setBounds,
     captureVisibleSnapshot,
     closeBrowserTabRecord,
+    focusBrowserTabInSpace,
+    setActiveBrowserTab,
+    closeBrowserTab,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,
     currentBrowserTabPageTitle,

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -1,0 +1,405 @@
+/**
+ * Browser-pane tab state — query, view-attachment, and state-emit functions
+ * (BP-P5b-1).
+ *
+ * The **read + emit** half of the tab subsystem. The write half
+ * (createBrowserTab, navigateActiveBrowserTab, setActiveBrowserTab,
+ * closeBrowserTab, showBrowserViewContextMenu, handleBrowserWindowOpenAsTab)
+ * lands in subsequent extractions. Splitting the read side first keeps
+ * each commit reviewable.
+ *
+ * Note: this module does NOT own `attachedBrowserTabView` or `browserBounds`
+ * directly. Those vars still live as module-level `let`s in main.ts because
+ * many functions that have not yet migrated read/write them. We expose
+ * getters + setters through `deps` so tab-state.ts and main.ts share a
+ * single source of truth. When the remaining write-side functions move,
+ * those vars can collapse into the factory closure.
+ */
+import type {
+  BrowserView,
+  BrowserWindow,
+  WebContents,
+} from "electron";
+
+import type {
+  BrowserBoundsPayload,
+  BrowserHistoryEntryPayload,
+  BrowserSpaceId,
+  BrowserStatePayload,
+  BrowserTabListPayload,
+} from "../../shared/browser-pane-protocol.js";
+
+/**
+ * Minimal structural views of main.ts's `BrowserTabRecord`,
+ * `BrowserTabSpaceState`, and `BrowserWorkspaceState`. We don't depend on
+ * the full types because they reference other main-only shapes (download
+ * payloads, lifecycle state, etc.) that haven't migrated yet. The actual
+ * records main passes in are structurally compatible.
+ */
+export interface BrowserTabRecord {
+  view: BrowserView;
+  state: BrowserStatePayload;
+  popupFrameName?: string;
+  popupOpenedAtMs?: number;
+}
+
+export interface BrowserTabSpaceState {
+  tabs: Map<string, BrowserTabRecord>;
+  activeTabId: string;
+}
+
+export interface BrowserWorkspaceState {
+  workspaceId: string;
+  history: BrowserHistoryEntryPayload[];
+}
+
+export interface BrowserPaneTabStateDeps {
+  getMainWindow: () => BrowserWindow | null;
+  getActiveWorkspaceId: () => string;
+  getActiveSpaceId: () => BrowserSpaceId;
+  getActiveSessionId: () => string;
+
+  /**
+   * Reading + writing main.ts's module-level `attachedBrowserTabView`. main
+   * still owns the var until the rest of the tab write-path moves.
+   */
+  getAttachedView: () => BrowserView | null;
+  setAttachedView: (view: BrowserView | null) => void;
+
+  /**
+   * Reading + writing main.ts's module-level `browserBounds`.
+   */
+  getBrowserBounds: () => BrowserBoundsPayload;
+  setBrowserBounds: (bounds: BrowserBoundsPayload) => void;
+
+  getWorkspace: (workspaceId: string) => BrowserWorkspaceState | null;
+  getWorkspaceOrEmpty: (
+    workspaceId?: string | null,
+  ) => BrowserWorkspaceState | null;
+
+  persistWorkspace: (workspaceId: string) => Promise<void> | void;
+
+  browserSpaceId: (value?: string | null) => BrowserSpaceId;
+  browserSessionId: (value?: string | null) => string;
+  browserTabSpaceState: (
+    workspace: BrowserWorkspaceState | null | undefined,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+    options?: { createIfMissing?: boolean; useVisibleAgentSession?: boolean },
+  ) => BrowserTabSpaceState | null;
+  browserTabSpaceTouch: (tabSpace: BrowserTabSpaceState) => void;
+
+  browserWorkspaceSnapshot: (
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+    options?: { useVisibleAgentSession?: boolean },
+  ) => BrowserTabListPayload;
+
+  scheduleAgentSessionBrowserLifecycleCheck: (
+    workspaceId: string,
+    sessionId?: string | null,
+  ) => void;
+
+  shouldTrackHistoryUrl: (url: string) => boolean;
+
+  hasOpenHistoryPopup: () => boolean;
+  sendHistoryToPopup: (history: BrowserHistoryEntryPayload[]) => void;
+
+  reserveMainWindowClosedListenerBudget: (additionalClosedListeners?: number) => void;
+}
+
+export interface BrowserPaneTabState {
+  hasVisibleBounds: () => boolean;
+  closeBrowserTabRecord: (tab: BrowserTabRecord) => void;
+  getActiveBrowserTab: (
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+    options?: { useVisibleAgentSession?: boolean },
+  ) => BrowserTabRecord | null;
+  activeVisibleBrowserTarget: () => {
+    workspaceId: string;
+    space: BrowserSpaceId;
+    sessionId: string | null;
+  };
+  currentBrowserTabPageTitle: (tab: BrowserTabRecord) => string;
+  currentBrowserTabUrl: (tab: BrowserTabRecord) => string;
+  applyBoundsToTab: (
+    workspaceId: string,
+    tabId: string,
+    space?: BrowserSpaceId,
+    sessionId?: string | null,
+  ) => void;
+  updateAttachedBrowserView: () => void;
+  syncBrowserState: (
+    workspaceId: string,
+    tabId: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ) => void;
+  emitBrowserState: (
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+  ) => void;
+  emitHistoryState: (workspaceId?: string | null) => void;
+  recordHistoryVisit: (
+    workspaceId: string,
+    entry: Pick<BrowserHistoryEntryPayload, "url" | "title" | "faviconUrl">,
+  ) => Promise<void>;
+}
+
+export function createBrowserPaneTabState(
+  deps: BrowserPaneTabStateDeps,
+): BrowserPaneTabState {
+  function hasVisibleBounds(): boolean {
+    const b = deps.getBrowserBounds();
+    return b.width > 0 && b.height > 0;
+  }
+
+  function getActiveBrowserTab(
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+    sessionId?: string | null,
+    options?: { useVisibleAgentSession?: boolean },
+  ): BrowserTabRecord | null {
+    const browserSpace = deps.browserSpaceId(space);
+    const workspace = deps.getWorkspaceOrEmpty(workspaceId);
+    const tabSpace = deps.browserTabSpaceState(
+      workspace,
+      browserSpace,
+      sessionId,
+      options,
+    );
+    if (!tabSpace || !tabSpace.activeTabId) {
+      return null;
+    }
+    return tabSpace.tabs.get(tabSpace.activeTabId) ?? null;
+  }
+
+  function activeVisibleBrowserTarget(): {
+    workspaceId: string;
+    space: BrowserSpaceId;
+    sessionId: string | null;
+  } {
+    const space = deps.getActiveSpaceId();
+    return {
+      workspaceId: deps.getActiveWorkspaceId(),
+      space,
+      sessionId: space === "agent" ? deps.getActiveSessionId() : null,
+    };
+  }
+
+  function currentBrowserTabPageTitle(tab: BrowserTabRecord): string {
+    return tab.view.webContents.getTitle() || tab.state.title || "";
+  }
+
+  function currentBrowserTabUrl(tab: BrowserTabRecord): string {
+    return tab.view.webContents.getURL() || tab.state.url || "";
+  }
+
+  function applyBoundsToTab(
+    workspaceId: string,
+    tabId: string,
+    space: BrowserSpaceId = deps.getActiveSpaceId(),
+    sessionId?: string | null,
+  ): void {
+    const workspace = deps.getWorkspace(workspaceId);
+    const tab = deps.browserTabSpaceState(workspace, space, sessionId, {
+      useVisibleAgentSession: !deps.browserSessionId(sessionId),
+    })?.tabs.get(tabId);
+    if (!tab) {
+      return;
+    }
+    tab.view.setBounds(deps.getBrowserBounds());
+  }
+
+  function updateAttachedBrowserView(): void {
+    const win = deps.getMainWindow();
+    if (!win || win.isDestroyed()) {
+      return;
+    }
+    const activeTab = getActiveBrowserTab(
+      deps.getActiveWorkspaceId(),
+      deps.getActiveSpaceId(),
+      null,
+      { useVisibleAgentSession: true },
+    );
+    if (!activeTab || !hasVisibleBounds()) {
+      if (deps.getAttachedView()) {
+        win.setBrowserView(null);
+        deps.setAttachedView(null);
+      }
+      return;
+    }
+    if (deps.getAttachedView() !== activeTab.view) {
+      deps.reserveMainWindowClosedListenerBudget(1);
+      win.setBrowserView(activeTab.view);
+      deps.setAttachedView(activeTab.view);
+    }
+    const space = deps.getActiveSpaceId();
+    applyBoundsToTab(
+      deps.getActiveWorkspaceId(),
+      activeTab.state.id,
+      space,
+      space === "agent" ? deps.getActiveSessionId() : null,
+    );
+  }
+
+  function emitBrowserState(
+    workspaceId?: string | null,
+    space?: BrowserSpaceId | null,
+  ): void {
+    const win = deps.getMainWindow();
+    if (!win || win.isDestroyed()) {
+      return;
+    }
+    const activeId = deps.getActiveWorkspaceId();
+    const normalized =
+      typeof workspaceId === "string" ? workspaceId.trim() : activeId;
+    const browserSpace = deps.browserSpaceId(space);
+    if (normalized !== activeId) {
+      return;
+    }
+    if (browserSpace !== deps.getActiveSpaceId()) {
+      return;
+    }
+    win.webContents.send(
+      "browser:state",
+      deps.browserWorkspaceSnapshot(normalized, browserSpace, null, {
+        useVisibleAgentSession: true,
+      }),
+    );
+  }
+
+  function emitHistoryState(workspaceId?: string | null): void {
+    const win = deps.getMainWindow();
+    const activeId = deps.getActiveWorkspaceId();
+    const normalized =
+      typeof workspaceId === "string" ? workspaceId.trim() : activeId;
+    if (!win || win.isDestroyed()) {
+      if (!deps.hasOpenHistoryPopup()) {
+        return;
+      }
+      return;
+    }
+    if (normalized !== activeId) {
+      return;
+    }
+    const workspace = deps.getWorkspaceOrEmpty(normalized);
+    const history = workspace?.history ?? [];
+    win.webContents.send("browser:history", history);
+    deps.sendHistoryToPopup(history);
+  }
+
+  function closeBrowserTabRecord(tab: BrowserTabRecord): void {
+    tab.view.webContents.removeAllListeners();
+    void (
+      tab.view.webContents as unknown as { close?: () => void }
+    ).close?.();
+  }
+
+  function syncBrowserState(
+    workspaceId: string,
+    tabId: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ): void {
+    const workspace = deps.getWorkspace(workspaceId);
+    const tabSpace = deps.browserTabSpaceState(workspace, space, sessionId);
+    const tab = tabSpace?.tabs.get(tabId);
+    if (!workspace || !tab) {
+      return;
+    }
+    if (tabSpace) {
+      deps.browserTabSpaceTouch(tabSpace);
+    }
+    if (space === "agent" && deps.browserSessionId(sessionId)) {
+      deps.scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
+    }
+
+    const viewContents: WebContents = tab.view.webContents;
+    const updatedState: BrowserStatePayload = {
+      ...tab.state,
+      url: viewContents.getURL() || tab.state.url,
+      title: viewContents.getTitle() || tab.state.title,
+      faviconUrl: tab.state.faviconUrl,
+      canGoBack: viewContents.navigationHistory.canGoBack(),
+      canGoForward: viewContents.navigationHistory.canGoForward(),
+    };
+    tab.state = updatedState;
+    emitBrowserState(workspaceId, space);
+    void deps.persistWorkspace(workspaceId);
+  }
+
+  async function recordHistoryVisit(
+    workspaceId: string,
+    entry: Pick<BrowserHistoryEntryPayload, "url" | "title" | "faviconUrl">,
+  ): Promise<void> {
+    const workspace = deps.getWorkspace(workspaceId);
+    const url = entry.url.trim();
+    if (!workspace || !deps.shouldTrackHistoryUrl(url)) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const existing = workspace.history.find((item) => item.url === url);
+
+    if (existing) {
+      workspace.history = workspace.history
+        .map((item) =>
+          item.id === existing.id
+            ? {
+                ...item,
+                title: entry.title?.trim() || item.title || url,
+                faviconUrl: entry.faviconUrl || item.faviconUrl,
+                visitCount: item.visitCount + 1,
+                lastVisitedAt: now,
+              }
+            : item,
+        )
+        .sort(
+          (a, b) =>
+            new Date(b.lastVisitedAt).getTime() -
+            new Date(a.lastVisitedAt).getTime(),
+        );
+    } else {
+      workspace.history = [
+        {
+          id: `history-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          url,
+          title: entry.title?.trim() || url,
+          faviconUrl: entry.faviconUrl,
+          visitCount: 1,
+          createdAt: now,
+          lastVisitedAt: now,
+        },
+        ...workspace.history,
+      ]
+        .sort(
+          (a, b) =>
+            new Date(b.lastVisitedAt).getTime() -
+            new Date(a.lastVisitedAt).getTime(),
+        )
+        .slice(0, 500);
+    }
+
+    emitHistoryState(workspaceId);
+    await deps.persistWorkspace(workspaceId);
+  }
+
+  return {
+    hasVisibleBounds,
+    closeBrowserTabRecord,
+    getActiveBrowserTab,
+    activeVisibleBrowserTarget,
+    currentBrowserTabPageTitle,
+    currentBrowserTabUrl,
+    applyBoundsToTab,
+    updateAttachedBrowserView,
+    syncBrowserState,
+    emitBrowserState,
+    emitHistoryState,
+    recordHistoryVisit,
+  };
+}

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -15,10 +15,14 @@
  * single source of truth. When the remaining write-side functions move,
  * those vars can collapse into the factory closure.
  */
-import type {
-  BrowserView,
-  BrowserWindow,
-  WebContents,
+import {
+  Menu,
+  clipboard,
+  type BrowserView,
+  type BrowserWindow,
+  type ContextMenuParams,
+  type MenuItemConstructorOptions,
+  type WebContents,
 } from "electron";
 
 import type {
@@ -160,6 +164,20 @@ export interface BrowserPaneTabStateDeps {
    * duplicate of an existing tab (and merged) rather than spawned anew.
    */
   duplicateBrowserPopupTabWindowMs: number;
+
+  /** Queue a save-as override for an upcoming Electron download. */
+  queueBrowserDownloadPrompt: (
+    workspaceId: string,
+    targetUrl: string,
+    options: {
+      defaultFilename: string;
+      dialogTitle: string;
+      buttonLabel: string;
+    },
+  ) => void;
+
+  /** Compute a sanitized suggested filename from the right-click context. */
+  browserContextSuggestedFilename: (context: ContextMenuParams) => string;
 }
 
 export interface BrowserPaneTabState {
@@ -198,6 +216,13 @@ export interface BrowserPaneTabState {
     space: BrowserSpaceId,
     sessionId?: string | null,
   ) => void;
+  showBrowserViewContextMenu: (params: {
+    workspaceId: string;
+    space: BrowserSpaceId;
+    sessionId?: string | null;
+    view: BrowserView;
+    context: ContextMenuParams;
+  }) => void;
   // ensureBrowserTabSpaceInitialized + initialBrowserTabSeed deferred —
   // they pull in oppositeBrowserSpaceId / browserTabSpaceStates / NEW_TAB_TITLE
   // which are still being threaded through. Move them in BP-P5b-4.
@@ -506,6 +531,150 @@ export function createBrowserPaneTabState(
       normalizedSessionId,
       { useVisibleAgentSession: true },
     );
+  }
+
+  function showBrowserViewContextMenu(params: {
+    workspaceId: string;
+    space: BrowserSpaceId;
+    sessionId?: string | null;
+    view: BrowserView;
+    context: ContextMenuParams;
+  }): void {
+    const { workspaceId, space, sessionId, view, context } = params;
+    const template: MenuItemConstructorOptions[] = [];
+    const selectionText = context.selectionText.trim();
+    const linkUrl = context.linkURL.trim();
+    const canGoBack = view.webContents.navigationHistory.canGoBack();
+    const canGoForward = view.webContents.navigationHistory.canGoForward();
+    const bounds = deps.getBrowserBounds();
+    const popupX = bounds.x + context.x;
+    const popupY = bounds.y + context.y;
+    const imageUrl = context.srcURL.trim();
+
+    if (linkUrl) {
+      template.push(
+        {
+          label: "Open Link in New Tab",
+          click: () =>
+            handleBrowserWindowOpenAsTab(
+              workspaceId,
+              linkUrl,
+              "foreground-tab",
+              "",
+              space,
+              sessionId,
+            ),
+        },
+        {
+          label: "Open Link Externally",
+          click: () => {
+            deps.openExternalUrlFromMain(linkUrl, "browser context menu");
+          },
+        },
+        {
+          label: "Copy Link Address",
+          click: () => {
+            clipboard.writeText(linkUrl);
+          },
+        },
+        { type: "separator" },
+      );
+    }
+
+    if (context.mediaType === "image" && imageUrl) {
+      template.push(
+        {
+          label: "Open Image in New Tab",
+          click: () =>
+            handleBrowserWindowOpenAsTab(
+              workspaceId,
+              imageUrl,
+              "foreground-tab",
+              "",
+              space,
+              sessionId,
+            ),
+        },
+        {
+          label: "Copy Image Address",
+          click: () => {
+            clipboard.writeText(imageUrl);
+          },
+        },
+        {
+          label: "Save Image As...",
+          click: () => {
+            deps.queueBrowserDownloadPrompt(workspaceId, imageUrl, {
+              defaultFilename: deps.browserContextSuggestedFilename(context),
+              dialogTitle: "Save Image As",
+              buttonLabel: "Save Image",
+            });
+            void view.webContents.downloadURL(imageUrl);
+          },
+        },
+        { type: "separator" },
+      );
+    }
+
+    if (context.isEditable) {
+      template.push(
+        { label: "Undo", role: "undo", enabled: context.editFlags.canUndo },
+        { label: "Redo", role: "redo", enabled: context.editFlags.canRedo },
+        { type: "separator" },
+        { label: "Cut", role: "cut", enabled: context.editFlags.canCut },
+        { label: "Copy", role: "copy", enabled: context.editFlags.canCopy },
+        { label: "Paste", role: "paste", enabled: context.editFlags.canPaste },
+        {
+          label: "Select All",
+          role: "selectAll",
+          enabled: context.editFlags.canSelectAll,
+        },
+      );
+    } else if (selectionText) {
+      template.push(
+        { label: "Copy", role: "copy", enabled: context.editFlags.canCopy },
+        {
+          label: "Select All",
+          role: "selectAll",
+          enabled: context.editFlags.canSelectAll,
+        },
+      );
+    } else {
+      template.push(
+        {
+          label: "Back",
+          enabled: canGoBack,
+          click: () => view.webContents.navigationHistory.goBack(),
+        },
+        {
+          label: "Forward",
+          enabled: canGoForward,
+          click: () => view.webContents.navigationHistory.goForward(),
+        },
+        {
+          label: "Reload",
+          click: () => view.webContents.reload(),
+        },
+        {
+          label: "Select All",
+          role: "selectAll",
+          enabled: context.editFlags.canSelectAll,
+        },
+      );
+    }
+
+    if (template.length === 0) {
+      return;
+    }
+
+    const win = deps.getMainWindow();
+    Menu.buildFromTemplate(template).popup({
+      window: win ?? undefined,
+      frame: context.frame ?? undefined,
+      x: popupX,
+      y: popupY,
+      sourceType: context.menuSourceType,
+    });
   }
 
   function handleBrowserWindowOpenAsTab(
@@ -817,6 +986,7 @@ export function createBrowserPaneTabState(
     closeBrowserTab,
     navigateActiveBrowserTab,
     handleBrowserWindowOpenAsTab,
+    showBrowserViewContextMenu,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,
     currentBrowserTabPageTitle,

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -15,10 +15,12 @@
  * single source of truth. When the remaining write-side functions move,
  * those vars can collapse into the factory closure.
  */
+import path from "node:path";
+
 import {
+  BrowserView,
   Menu,
   clipboard,
-  type BrowserView,
   type BrowserWindow,
   type ContextMenuParams,
   type MenuItemConstructorOptions,
@@ -51,11 +53,19 @@ export interface BrowserTabRecord {
 export interface BrowserTabSpaceState {
   tabs: Map<string, BrowserTabRecord>;
   activeTabId: string;
+  lifecycleState: "active" | "suspended" | null;
+}
+
+export interface BrowserSessionIdentity {
+  userAgent: string;
+  acceptLanguages: string;
 }
 
 export interface BrowserWorkspaceState {
   workspaceId: string;
   history: BrowserHistoryEntryPayload[];
+  session: import("electron").Session;
+  browserIdentity: BrowserSessionIdentity;
 }
 
 export interface BrowserPaneTabStateDeps {
@@ -126,21 +136,6 @@ export interface BrowserPaneTabStateDeps {
     sessionId: string,
   ) => void;
 
-  /**
-   * P5b-4 callback — open a fresh tab in the given workspace+space. We pass
-   * it in (rather than implement here) because createBrowserTab is heavy and
-   * lives in main.ts until the next extraction.
-   */
-  createBrowserTab: (
-    workspaceId: string,
-    options: {
-      url?: string;
-      browserSpace?: BrowserSpaceId;
-      sessionId?: string | null;
-      [key: string]: unknown;
-    },
-  ) => string | null;
-
   /** Default URL to seed a new tab with when there's nothing else to land on. */
   homeUrl: string;
 
@@ -178,6 +173,37 @@ export interface BrowserPaneTabStateDeps {
 
   /** Compute a sanitized suggested filename from the right-click context. */
   browserContextSuggestedFilename: (context: ContextMenuParams) => string;
+
+  /** Should `window.open()` for this URL spawn a real BrowserWindow popup? */
+  shouldAllowBrowserPopupWindow: (
+    url: string,
+    frameName: string,
+    features: string,
+  ) => boolean;
+
+  /** P6 callback — show user-vs-agent control prompt; returns true if input should be intercepted. */
+  maybePromptBrowserInterrupt: (
+    workspaceId: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ) => boolean;
+
+  /** Detect ERR_ABORTED-style did-fail-load events. */
+  isAbortedBrowserLoadFailure: (
+    errorCode: number,
+    errorDescription: string,
+  ) => boolean;
+
+  /** Whether a webContents is currently being driven programmatically. */
+  isProgrammaticBrowserInput: (
+    webContents: import("electron").WebContents,
+  ) => boolean;
+
+  /** Directory containing the popup preload bundles (for spawned popup windows). */
+  preloadDir: string;
+
+  /** Title used for blank/new tabs. */
+  newTabTitle: string;
 }
 
 export interface BrowserPaneTabState {
@@ -223,6 +249,20 @@ export interface BrowserPaneTabState {
     view: BrowserView;
     context: ContextMenuParams;
   }) => void;
+  createBrowserTab: (
+    workspaceId: string,
+    options?: {
+      browserSpace?: BrowserSpaceId;
+      sessionId?: string | null;
+      id?: string;
+      url?: string;
+      title?: string;
+      faviconUrl?: string;
+      popupFrameName?: string;
+      popupOpenedAtMs?: number;
+      skipInitialHistoryRecord?: boolean;
+    },
+  ) => string | null;
   // ensureBrowserTabSpaceInitialized + initialBrowserTabSeed deferred —
   // they pull in oppositeBrowserSpaceId / browserTabSpaceStates / NEW_TAB_TITLE
   // which are still being threaded through. Move them in BP-P5b-4.
@@ -754,7 +794,7 @@ export function createBrowserPaneTabState(
       return;
     }
 
-    const nextTabId = deps.createBrowserTab(workspaceId, {
+    const nextTabId = createBrowserTab(workspaceId, {
       url: normalizedUrl,
       browserSpace: space,
       sessionId,
@@ -853,7 +893,7 @@ export function createBrowserPaneTabState(
     deps.browserTabSpaceTouch(tabSpace);
 
     if (tabSpace.tabs.size === 0) {
-      const replacementTabId = deps.createBrowserTab(workspace.workspaceId, {
+      const replacementTabId = createBrowserTab(workspace.workspaceId, {
         url: deps.homeUrl,
         browserSpace,
         sessionId: normalizedSessionId,
@@ -976,6 +1016,303 @@ export function createBrowserPaneTabState(
     await deps.persistWorkspace(workspaceId);
   }
 
+  function createBrowserTab(
+    workspaceId: string,
+    options: {
+      browserSpace?: BrowserSpaceId;
+      sessionId?: string | null;
+      id?: string;
+      url?: string;
+      title?: string;
+      faviconUrl?: string;
+      popupFrameName?: string;
+      popupOpenedAtMs?: number;
+      skipInitialHistoryRecord?: boolean;
+    } = {},
+  ): string | null {
+    const workspace = deps.getWorkspace(workspaceId);
+    const browserSpace = deps.browserSpaceId(options.browserSpace);
+    const normalizedSessionId = deps.browserSessionId(options.sessionId);
+    const tabSpace = deps.browserTabSpaceState(
+      workspace,
+      browserSpace,
+      normalizedSessionId,
+      { createIfMissing: Boolean(normalizedSessionId) },
+    );
+    const win = deps.getMainWindow();
+    if (!win || !workspace || !tabSpace) {
+      return null;
+    }
+    tabSpace.lifecycleState = "active";
+    deps.browserTabSpaceTouch(tabSpace);
+
+    const tabId =
+      options.id?.trim() ||
+      `tab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const initialUrl = options.url?.trim() || "";
+    const hasInitialUrl = initialUrl.length > 0;
+    let suppressNextHistoryEntry = Boolean(options.skipInitialHistoryRecord);
+    const view = new BrowserView({
+      webPreferences: {
+        session: workspace.session,
+        sandbox: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+      },
+    });
+    view.webContents.setUserAgent(workspace.browserIdentity.userAgent);
+    const state: BrowserStatePayload = {
+      id: tabId,
+      url: initialUrl,
+      title: options.title || deps.newTabTitle,
+      faviconUrl: options.faviconUrl,
+      canGoBack: false,
+      canGoForward: false,
+      loading: false,
+      initialized: !hasInitialUrl,
+      error: "",
+    };
+    tabSpace.tabs.set(tabId, {
+      view,
+      state,
+      popupFrameName: options.popupFrameName?.trim() || undefined,
+      popupOpenedAtMs:
+        typeof options.popupOpenedAtMs === "number"
+          ? options.popupOpenedAtMs
+          : undefined,
+    });
+
+    view.setBounds(deps.getBrowserBounds());
+    view.setAutoResize({
+      width: false,
+      height: false,
+      horizontal: false,
+      vertical: false,
+    });
+    view.webContents.setWindowOpenHandler(
+      ({ url, disposition, frameName, features }) => {
+        const normalizedUrl = url.trim();
+        if (!normalizedUrl) {
+          return { action: "deny" };
+        }
+
+        if (deps.shouldAllowBrowserPopupWindow(normalizedUrl, frameName, features)) {
+          return {
+            action: "allow",
+            overrideBrowserWindowOptions: {
+              parent: deps.getMainWindow() ?? undefined,
+              autoHideMenuBar: true,
+              backgroundColor: "#050907",
+              width: 520,
+              height: 760,
+              minWidth: 420,
+              minHeight: 620,
+              webPreferences: {
+                session: workspace.session,
+                preload: path.join(deps.preloadDir, "browserPopupPreload.cjs"),
+              },
+            },
+          };
+        }
+
+        try {
+          const parsed = new URL(normalizedUrl);
+          if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            deps.openExternalUrlFromMain(normalizedUrl, "browser window open");
+            return { action: "deny" };
+          }
+        } catch {
+          return { action: "deny" };
+        }
+
+        const shouldOpenAsTab =
+          disposition === "foreground-tab" ||
+          disposition === "background-tab" ||
+          disposition === "new-window";
+        if (shouldOpenAsTab) {
+          handleBrowserWindowOpenAsTab(
+            workspaceId,
+            normalizedUrl,
+            disposition,
+            frameName,
+            browserSpace,
+            normalizedSessionId,
+          );
+        }
+        return { action: "deny" };
+      },
+    );
+    view.webContents.setZoomFactor(1);
+    view.webContents.setVisualZoomLevelLimits(1, 1).catch(() => undefined);
+
+    const currentTabRecord = () =>
+      deps.browserTabSpaceState(
+        deps.getWorkspace(workspaceId),
+        browserSpace,
+        normalizedSessionId,
+      )?.tabs.get(tabId);
+
+    view.webContents.on("before-input-event", (event, input) => {
+      if (deps.isProgrammaticBrowserInput(view.webContents)) {
+        return;
+      }
+      if (
+        (input.type === "keyDown" ||
+          input.type === "keyUp" ||
+          input.type === "char" ||
+          input.type === "rawKeyDown") &&
+        deps.maybePromptBrowserInterrupt(
+          workspaceId,
+          browserSpace,
+          normalizedSessionId,
+        )
+      ) {
+        event.preventDefault();
+      }
+    });
+
+    view.webContents.on("before-mouse-event", (event, mouse) => {
+      if (deps.isProgrammaticBrowserInput(view.webContents)) {
+        return;
+      }
+      if (
+        mouse.type !== "mouseMove" &&
+        mouse.type !== "mouseEnter" &&
+        mouse.type !== "mouseLeave" &&
+        deps.maybePromptBrowserInterrupt(
+          workspaceId,
+          browserSpace,
+          normalizedSessionId,
+        )
+      ) {
+        event.preventDefault();
+      }
+    });
+
+    view.webContents.on("dom-ready", () => {
+      const currentTab = currentTabRecord();
+      if (!currentTab) {
+        return;
+      }
+      currentTab.state = { ...currentTab.state, initialized: true, error: "" };
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+    });
+
+    view.webContents.on("did-start-loading", () => {
+      const currentTab = currentTabRecord();
+      if (!currentTab) {
+        return;
+      }
+      currentTab.state = { ...currentTab.state, loading: true, error: "" };
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+    });
+
+    view.webContents.on("did-stop-loading", () => {
+      const currentTab = currentTabRecord();
+      if (!currentTab) {
+        return;
+      }
+      currentTab.state = { ...currentTab.state, loading: false, error: "" };
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+      if (suppressNextHistoryEntry) {
+        suppressNextHistoryEntry = false;
+        return;
+      }
+      void recordHistoryVisit(workspaceId, {
+        url: currentTab.view.webContents.getURL() || currentTab.state.url,
+        title: currentTab.view.webContents.getTitle() || currentTab.state.title,
+        faviconUrl: currentTab.state.faviconUrl,
+      });
+    });
+
+    view.webContents.on("page-title-updated", () => {
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+    });
+
+    view.webContents.on("page-favicon-updated", (_event, favicons) => {
+      const currentTab = currentTabRecord();
+      if (!currentTab) {
+        return;
+      }
+      currentTab.state = {
+        ...currentTab.state,
+        faviconUrl: favicons[0] || currentTab.state.faviconUrl,
+      };
+      emitBrowserState(workspaceId, browserSpace);
+      void deps.persistWorkspace(workspaceId);
+    });
+
+    view.webContents.on("did-navigate", () => {
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+    });
+
+    view.webContents.on("did-navigate-in-page", () => {
+      syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
+    });
+
+    view.webContents.on("context-menu", (_event, params) => {
+      showBrowserViewContextMenu({
+        workspaceId,
+        space: browserSpace,
+        sessionId: normalizedSessionId,
+        view,
+        context: params,
+      });
+    });
+
+    view.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        if (
+          !isMainFrame ||
+          deps.isAbortedBrowserLoadFailure(errorCode, errorDescription)
+        ) {
+          return;
+        }
+        const currentTab = currentTabRecord();
+        if (!currentTab) {
+          return;
+        }
+        currentTab.state = {
+          ...currentTab.state,
+          loading: false,
+          error: `${errorDescription} (${errorCode})`,
+          url: validatedURL || currentTab.state.url,
+        };
+        emitBrowserState(workspaceId, browserSpace);
+        void deps.persistWorkspace(workspaceId);
+      },
+    );
+
+    if (hasInitialUrl) {
+      void view.webContents.loadURL(initialUrl).catch((error: unknown) => {
+        if (deps.isAbortedBrowserLoadError(error)) {
+          return;
+        }
+        const currentTab = currentTabRecord();
+        if (!currentTab) {
+          return;
+        }
+        currentTab.state = {
+          ...currentTab.state,
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load page.",
+        };
+        emitBrowserState(workspaceId, browserSpace);
+        void deps.persistWorkspace(workspaceId);
+      });
+    }
+
+    if (browserSpace === "agent" && normalizedSessionId) {
+      deps.scheduleAgentSessionBrowserLifecycleCheck(
+        workspaceId,
+        normalizedSessionId,
+      );
+    }
+
+    return tabId;
+  }
+
   return {
     hasVisibleBounds,
     setBounds,
@@ -987,6 +1324,7 @@ export function createBrowserPaneTabState(
     navigateActiveBrowserTab,
     handleBrowserWindowOpenAsTab,
     showBrowserViewContextMenu,
+    createBrowserTab,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,
     currentBrowserTabPageTitle,

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -148,6 +148,18 @@ export interface BrowserPaneTabStateDeps {
 
   /** Detect ERR_ABORTED-style load errors (utils). */
   isAbortedBrowserLoadError: (error: unknown) => boolean;
+
+  /** Open a non-http(s) URL in the OS default browser (main owns this). */
+  openExternalUrlFromMain: (url: string, reason: string) => void;
+
+  /** Normalize a popup window's frame name for de-dup. (utils) */
+  normalizeBrowserPopupFrameName: (frameName?: string | null) => string;
+
+  /**
+   * Window during which a window.open() with the same URL is treated as a
+   * duplicate of an existing tab (and merged) rather than spawned anew.
+   */
+  duplicateBrowserPopupTabWindowMs: number;
 }
 
 export interface BrowserPaneTabState {
@@ -178,6 +190,14 @@ export interface BrowserPaneTabState {
     space?: BrowserSpaceId,
     sessionId?: string | null,
   ) => Promise<BrowserTabListPayload>;
+  handleBrowserWindowOpenAsTab: (
+    workspaceId: string,
+    targetUrl: string,
+    disposition: string,
+    frameName: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ) => void;
   // ensureBrowserTabSpaceInitialized + initialBrowserTabSeed deferred —
   // they pull in oppositeBrowserSpaceId / browserTabSpaceStates / NEW_TAB_TITLE
   // which are still being threaded through. Move them in BP-P5b-4.
@@ -488,6 +508,103 @@ export function createBrowserPaneTabState(
     );
   }
 
+  function handleBrowserWindowOpenAsTab(
+    workspaceId: string,
+    targetUrl: string,
+    disposition: string,
+    frameName: string,
+    space: BrowserSpaceId,
+    sessionId?: string | null,
+  ): void {
+    const normalizedUrl = targetUrl.trim();
+    if (!normalizedUrl) {
+      return;
+    }
+
+    try {
+      const parsed = new URL(normalizedUrl);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        deps.openExternalUrlFromMain(normalizedUrl, "browser tab creation");
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    const workspace = deps.getWorkspace(workspaceId);
+    const tabSpace = deps.browserTabSpaceState(workspace, space, sessionId, {
+      createIfMissing: true,
+    });
+    if (!workspace || !tabSpace) {
+      return;
+    }
+
+    const normalizedFrameName = deps.normalizeBrowserPopupFrameName(frameName);
+    const now = Date.now();
+    const existingPopupTab = Array.from(tabSpace.tabs.entries()).find(
+      ([, tab]) =>
+        (normalizedFrameName && tab.popupFrameName === normalizedFrameName) ||
+        (!normalizedFrameName &&
+          tab.state.url === normalizedUrl &&
+          typeof tab.popupOpenedAtMs === "number" &&
+          now - tab.popupOpenedAtMs <= deps.duplicateBrowserPopupTabWindowMs),
+    );
+
+    if (existingPopupTab) {
+      const [existingTabId, existingTab] = existingPopupTab;
+      existingTab.popupFrameName =
+        normalizedFrameName || existingTab.popupFrameName;
+      existingTab.popupOpenedAtMs = now;
+      if (existingTab.state.url !== normalizedUrl) {
+        existingTab.state = { ...existingTab.state, error: "" };
+        void existingTab.view.webContents
+          .loadURL(normalizedUrl)
+          .catch((error: unknown) => {
+            if (deps.isAbortedBrowserLoadError(error)) {
+              return;
+            }
+            existingTab.state = {
+              ...existingTab.state,
+              loading: false,
+              error:
+                error instanceof Error ? error.message : "Failed to load URL.",
+            };
+            emitBrowserState(workspaceId, space);
+            void deps.persistWorkspace(workspaceId);
+          });
+      }
+      if (disposition !== "background-tab") {
+        focusBrowserTabInSpace(
+          workspaceId,
+          tabSpace,
+          existingTabId,
+          space,
+          sessionId,
+        );
+      }
+      return;
+    }
+
+    const nextTabId = deps.createBrowserTab(workspaceId, {
+      url: normalizedUrl,
+      browserSpace: space,
+      sessionId,
+      popupFrameName: normalizedFrameName,
+      popupOpenedAtMs: now,
+    });
+    if (!nextTabId) {
+      return;
+    }
+
+    if (disposition !== "background-tab") {
+      focusBrowserTabInSpace(workspaceId, tabSpace, nextTabId, space, sessionId);
+      return;
+    }
+
+    emitBrowserState(workspaceId, space);
+    void deps.persistWorkspace(workspaceId);
+  }
+
   async function navigateActiveBrowserTab(
     workspaceId: string,
     targetUrl: string,
@@ -699,6 +816,7 @@ export function createBrowserPaneTabState(
     setActiveBrowserTab,
     closeBrowserTab,
     navigateActiveBrowserTab,
+    handleBrowserWindowOpenAsTab,
     getActiveBrowserTab,
     activeVisibleBrowserTarget,
     currentBrowserTabPageTitle,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -126,6 +126,10 @@ import {
   createBrowserPaneDownloads,
   type BrowserPaneDownloads,
 } from "./browser-pane/downloads.js";
+import {
+  createBrowserPaneTabState,
+  type BrowserPaneTabState,
+} from "./browser-pane/tab-state.js";
 import type {
   BrowserCopyWorkspaceProfilePayload,
   BrowserImportProfilePayload,
@@ -898,6 +902,72 @@ const agentSessionCache = new Map<
 >();
 const userBrowserInterruptPrompts = new Set<string>();
 const programmaticBrowserInputDepth = new WeakMap<WebContents, number>();
+// Tab state — query, view-attachment, state-emit, history (BP-P5b-1).
+// Reads/writes main's `attachedBrowserTabView` + `browserBounds` through
+// deps getters/setters so functions still owned by main share one source
+// of truth. Heavier write-side functions (createBrowserTab, navigation,
+// context-menu, popup-as-tab handling) move in subsequent extractions.
+const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
+  getMainWindow: () => mainWindow,
+  getActiveWorkspaceId: () => activeBrowserWorkspaceId,
+  getActiveSpaceId: () => activeBrowserSpaceId,
+  getActiveSessionId: () => activeBrowserSessionId,
+  getAttachedView: () => attachedBrowserTabView,
+  setAttachedView: (view) => {
+    attachedBrowserTabView = view;
+  },
+  getBrowserBounds: () => browserBounds,
+  setBrowserBounds: (bounds) => {
+    browserBounds = bounds;
+  },
+  getWorkspace: (id) =>
+    browserWorkspaceFromMap(id) as unknown as Parameters<
+      Parameters<typeof createBrowserPaneTabState>[0]["getWorkspace"]
+    >[0] extends string
+      ? ReturnType<
+          Parameters<typeof createBrowserPaneTabState>[0]["getWorkspace"]
+        >
+      : never,
+  getWorkspaceOrEmpty: (id) =>
+    browserWorkspaceOrEmpty(id) as unknown as ReturnType<
+      Parameters<typeof createBrowserPaneTabState>[0]["getWorkspaceOrEmpty"]
+    >,
+  persistWorkspace: (id) => persistBrowserWorkspace(id),
+  browserSpaceId: (value) => browserSpaceId(value),
+  browserSessionId: (value) => browserSessionId(value),
+  browserTabSpaceState: (workspace, space, sessionId, options) =>
+    browserTabSpaceState(
+      workspace as unknown as BrowserWorkspaceState | null | undefined,
+      space,
+      sessionId,
+      options,
+    ) as unknown as ReturnType<
+      Parameters<typeof createBrowserPaneTabState>[0]["browserTabSpaceState"]
+    >,
+  browserTabSpaceTouch: (tabSpace) =>
+    browserTabSpaceTouch(tabSpace as unknown as BrowserTabSpaceState),
+  browserWorkspaceSnapshot: (workspaceId, space, sessionId, options) =>
+    browserWorkspaceSnapshot(workspaceId, space, sessionId, options),
+  scheduleAgentSessionBrowserLifecycleCheck: (workspaceId, sessionId) =>
+    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId),
+  shouldTrackHistoryUrl: (url) => shouldTrackHistoryUrl(url),
+  hasOpenHistoryPopup: () => browserPanePopups.hasOpenHistoryPopup(),
+  sendHistoryToPopup: (history) => browserPanePopups.sendHistoryToPopup(history),
+  reserveMainWindowClosedListenerBudget: (count) =>
+    reserveMainWindowClosedListenerBudget(count),
+});
+const getActiveBrowserTab = browserPaneTabState.getActiveBrowserTab;
+const activeVisibleBrowserTarget = browserPaneTabState.activeVisibleBrowserTarget;
+const currentBrowserTabPageTitle = browserPaneTabState.currentBrowserTabPageTitle;
+const currentBrowserTabUrl = browserPaneTabState.currentBrowserTabUrl;
+const applyBoundsToTab = browserPaneTabState.applyBoundsToTab;
+const hasVisibleBrowserBounds = browserPaneTabState.hasVisibleBounds;
+const updateAttachedBrowserView = browserPaneTabState.updateAttachedBrowserView;
+const emitBrowserState = browserPaneTabState.emitBrowserState;
+const emitHistoryState = browserPaneTabState.emitHistoryState;
+const closeBrowserTabRecord = browserPaneTabState.closeBrowserTabRecord;
+const syncBrowserState = browserPaneTabState.syncBrowserState;
+const recordHistoryVisit = browserPaneTabState.recordHistoryVisit;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -18728,61 +18798,7 @@ function shouldTrackHistoryUrl(rawUrl: string) {
   return shouldTrackHistoryUrlUtil(rawUrl);
 }
 
-async function recordHistoryVisit(
-  workspaceId: string,
-  entry: Pick<BrowserHistoryEntryPayload, "url" | "title" | "faviconUrl">,
-) {
-  const workspace = browserWorkspaceFromMap(workspaceId);
-  const url = entry.url.trim();
-  if (!workspace || !shouldTrackHistoryUrl(url)) {
-    return;
-  }
-
-  const now = new Date().toISOString();
-  const existing = workspace.history.find((item) => item.url === url);
-
-  if (existing) {
-    workspace.history = workspace.history
-      .map((item) =>
-        item.id === existing.id
-          ? {
-              ...item,
-              title: entry.title?.trim() || item.title || url,
-              faviconUrl: entry.faviconUrl || item.faviconUrl,
-              visitCount: item.visitCount + 1,
-              lastVisitedAt: now,
-            }
-          : item,
-      )
-      .sort(
-        (a, b) =>
-          new Date(b.lastVisitedAt).getTime() -
-          new Date(a.lastVisitedAt).getTime(),
-      );
-  } else {
-    workspace.history = [
-      {
-        id: `history-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        url,
-        title: entry.title?.trim() || url,
-        faviconUrl: entry.faviconUrl,
-        visitCount: 1,
-        createdAt: now,
-        lastVisitedAt: now,
-      },
-      ...workspace.history,
-    ]
-      .sort(
-        (a, b) =>
-          new Date(b.lastVisitedAt).getTime() -
-          new Date(a.lastVisitedAt).getTime(),
-      )
-      .slice(0, 500);
-  }
-
-  emitHistoryState(workspaceId);
-  await persistBrowserWorkspace(workspaceId);
-}
+// recordHistoryVisit moved to browser-pane/tab-state.ts (BP-P5b-1).
 
 function browserWorkspaceSnapshot(
   workspaceId?: string | null,
@@ -18842,47 +18858,8 @@ function browserWorkspaceSnapshot(
   };
 }
 
-function getActiveBrowserTab(
-  workspaceId?: string | null,
-  space?: BrowserSpaceId | null,
-  sessionId?: string | null,
-  options?: {
-    useVisibleAgentSession?: boolean;
-  },
-): BrowserTabRecord | null {
-  const browserSpace = browserSpaceId(space);
-  const workspace = browserWorkspaceOrEmpty(workspaceId);
-  const tabSpace = browserTabSpaceState(
-    workspace,
-    browserSpace,
-    sessionId,
-    options,
-  );
-  if (!tabSpace || !tabSpace.activeTabId) {
-    return null;
-  }
-  return tabSpace.tabs.get(tabSpace.activeTabId) ?? null;
-}
-
-function activeVisibleBrowserTarget(): {
-  workspaceId: string;
-  space: BrowserSpaceId;
-  sessionId: string | null;
-} {
-  return {
-    workspaceId: activeBrowserWorkspaceId,
-    space: activeBrowserSpaceId,
-    sessionId: activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
-  };
-}
-
-function currentBrowserTabPageTitle(tab: BrowserTabRecord): string {
-  return tab.view.webContents.getTitle() || tab.state.title || "";
-}
-
-function currentBrowserTabUrl(tab: BrowserTabRecord): string {
-  return tab.view.webContents.getURL() || tab.state.url || "";
-}
+// getActiveBrowserTab, activeVisibleBrowserTarget, currentBrowserTabPageTitle,
+// currentBrowserTabUrl moved to browser-pane/tab-state.ts (BP-P5b-1).
 
 function reserveMainWindowClosedListenerBudget(additionalClosedListeners = 0) {
   if (!mainWindow || mainWindow.isDestroyed()) {
@@ -18903,76 +18880,9 @@ function reserveMainWindowClosedListenerBudget(additionalClosedListeners = 0) {
   }
 }
 
-function applyBoundsToTab(
-  workspaceId: string,
-  tabId: string,
-  space: BrowserSpaceId = activeBrowserSpaceId,
-  sessionId?: string | null,
-) {
-  const workspace = browserWorkspaceFromMap(workspaceId);
-  const tab = browserTabSpaceState(workspace, space, sessionId, {
-    useVisibleAgentSession: !browserSessionId(sessionId),
-  })?.tabs.get(tabId);
-  if (!tab) {
-    return;
-  }
-  tab.view.setBounds(browserBounds);
-}
-
-function hasVisibleBrowserBounds() {
-  return browserBounds.width > 0 && browserBounds.height > 0;
-}
-
-function emitBrowserState(
-  workspaceId?: string | null,
-  space?: BrowserSpaceId | null,
-) {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    return;
-  }
-  const normalizedWorkspaceId =
-    typeof workspaceId === "string"
-      ? workspaceId.trim()
-      : activeBrowserWorkspaceId;
-  const browserSpace = browserSpaceId(space);
-  if (normalizedWorkspaceId !== activeBrowserWorkspaceId) {
-    return;
-  }
-  if (browserSpace !== activeBrowserSpaceId) {
-    return;
-  }
-  mainWindow.webContents.send(
-    "browser:state",
-    browserWorkspaceSnapshot(normalizedWorkspaceId, browserSpace, null, {
-      useVisibleAgentSession: true,
-    }),
-  );
-}
-
-function emitHistoryState(workspaceId?: string | null) {
-  const normalizedWorkspaceId =
-    typeof workspaceId === "string"
-      ? workspaceId.trim()
-      : activeBrowserWorkspaceId;
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    if (!browserPanePopups.hasOpenHistoryPopup()) {
-      return;
-    }
-    return;
-  }
-  if (normalizedWorkspaceId !== activeBrowserWorkspaceId) {
-    return;
-  }
-  const workspace = browserWorkspaceOrEmpty(normalizedWorkspaceId);
-  const history = workspace?.history ?? [];
-  mainWindow.webContents.send("browser:history", history);
-  browserPanePopups.sendHistoryToPopup(history);
-}
-
-function closeBrowserTabRecord(tab: BrowserTabRecord) {
-  tab.view.webContents.removeAllListeners();
-  void tab.view.webContents.close();
-}
+// applyBoundsToTab, hasVisibleBrowserBounds, emitBrowserState,
+// emitHistoryState, closeBrowserTabRecord moved to
+// browser-pane/tab-state.ts (BP-P5b-1).
 
 function destroyBrowserWorkspace(workspaceId: string) {
   const workspace = browserWorkspaceFromMap(workspaceId);
@@ -19000,67 +18910,8 @@ function destroyBrowserWorkspace(workspaceId: string) {
   browserWorkspaces.delete(workspaceId);
 }
 
-function updateAttachedBrowserView() {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    return;
-  }
-  const activeTab = getActiveBrowserTab(
-    activeBrowserWorkspaceId,
-    activeBrowserSpaceId,
-    null,
-    { useVisibleAgentSession: true },
-  );
-  if (!activeTab || !hasVisibleBrowserBounds()) {
-    if (attachedBrowserTabView) {
-      mainWindow.setBrowserView(null);
-      attachedBrowserTabView = null;
-    }
-    return;
-  }
-  if (attachedBrowserTabView !== activeTab.view) {
-    reserveMainWindowClosedListenerBudget(1);
-    mainWindow.setBrowserView(activeTab.view);
-    attachedBrowserTabView = activeTab.view;
-  }
-  applyBoundsToTab(
-    activeBrowserWorkspaceId,
-    activeTab.state.id,
-    activeBrowserSpaceId,
-    activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
-  );
-}
-
-function syncBrowserState(
-  workspaceId: string,
-  tabId: string,
-  space: BrowserSpaceId,
-  sessionId?: string | null,
-) {
-  const workspace = browserWorkspaceFromMap(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, space, sessionId);
-  const tab = tabSpace?.tabs.get(tabId);
-  if (!workspace || !tab) {
-    return;
-  }
-  if (tabSpace) {
-    browserTabSpaceTouch(tabSpace);
-  }
-  if (space === "agent" && browserSessionId(sessionId)) {
-    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
-  }
-
-  const viewContents = tab.view.webContents;
-  tab.state = {
-    ...tab.state,
-    url: viewContents.getURL() || tab.state.url,
-    title: viewContents.getTitle() || tab.state.title,
-    faviconUrl: tab.state.faviconUrl,
-    canGoBack: viewContents.navigationHistory.canGoBack(),
-    canGoForward: viewContents.navigationHistory.canGoForward(),
-  };
-  emitBrowserState(workspaceId, space);
-  void persistBrowserWorkspace(workspaceId);
-}
+// updateAttachedBrowserView, syncBrowserState moved to
+// browser-pane/tab-state.ts (BP-P5b-1).
 
 function normalizeBrowserPopupFrameName(frameName?: string | null): string {
   return normalizeBrowserPopupFrameNameUtil(frameName);

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -964,9 +964,17 @@ const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
       workspace as unknown as BrowserWorkspaceState,
       sessionId,
     ),
-  createBrowserTab: (workspaceId, options) =>
-    createBrowserTab(workspaceId, options),
   homeUrl: HOME_URL,
+  shouldAllowBrowserPopupWindow: (url, frameName, features) =>
+    shouldAllowBrowserPopupWindow(url, frameName, features),
+  maybePromptBrowserInterrupt: (workspaceId, space, sessionId) =>
+    maybePromptBrowserInterrupt(workspaceId, space, sessionId),
+  isAbortedBrowserLoadFailure: (errorCode, errorDescription) =>
+    isAbortedBrowserLoadFailure(errorCode, errorDescription),
+  isProgrammaticBrowserInput: (webContents) =>
+    isProgrammaticBrowserInput(webContents),
+  preloadDir: __dirname,
+  newTabTitle: NEW_TAB_TITLE,
   touchAgentSessionBrowserSpace: (workspaceId, sessionId) =>
     touchAgentSessionBrowserSpace(workspaceId, sessionId),
   isAbortedBrowserLoadError: (error) => isAbortedBrowserLoadError(error),
@@ -1014,6 +1022,7 @@ const closeBrowserTab = browserPaneTabState.closeBrowserTab;
 const navigateActiveBrowserTab = browserPaneTabState.navigateActiveBrowserTab;
 const handleBrowserWindowOpenAsTab = browserPaneTabState.handleBrowserWindowOpenAsTab;
 const showBrowserViewContextMenu = browserPaneTabState.showBrowserViewContextMenu;
+const createBrowserTab = browserPaneTabState.createBrowserTab;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -18982,295 +18991,6 @@ function consumeBrowserDownloadOverride(
   return override ?? null;
 }
 
-
-function createBrowserTab(
-  workspaceId: string,
-  options: {
-    browserSpace?: BrowserSpaceId;
-    sessionId?: string | null;
-    id?: string;
-    url?: string;
-    title?: string;
-    faviconUrl?: string;
-    popupFrameName?: string;
-    popupOpenedAtMs?: number;
-    skipInitialHistoryRecord?: boolean;
-  } = {},
-) {
-  const workspace = browserWorkspaceFromMap(workspaceId);
-  const browserSpace = browserSpaceId(options.browserSpace);
-  const normalizedSessionId = browserSessionId(options.sessionId);
-  const tabSpace = browserTabSpaceState(
-    workspace,
-    browserSpace,
-    normalizedSessionId,
-    {
-      createIfMissing: Boolean(normalizedSessionId),
-    },
-  );
-  if (!mainWindow || !workspace || !tabSpace) {
-    return null;
-  }
-  tabSpace.lifecycleState = "active";
-  browserTabSpaceTouch(tabSpace);
-
-  const tabId =
-    options.id?.trim() ||
-    `tab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const initialUrl = options.url?.trim() || "";
-  const hasInitialUrl = initialUrl.length > 0;
-  let suppressNextHistoryEntry = Boolean(options.skipInitialHistoryRecord);
-  const view = new BrowserView({
-    webPreferences: {
-      session: workspace.session,
-      sandbox: false,
-      nodeIntegration: false,
-      contextIsolation: true,
-    },
-  });
-  view.webContents.setUserAgent(workspace.browserIdentity.userAgent);
-  const state = createBrowserState({
-    id: tabId,
-    url: initialUrl,
-    title: options.title || NEW_TAB_TITLE,
-    faviconUrl: options.faviconUrl,
-    initialized: !hasInitialUrl,
-  });
-  tabSpace.tabs.set(tabId, {
-    view,
-    state,
-    popupFrameName: options.popupFrameName?.trim() || undefined,
-    popupOpenedAtMs:
-      typeof options.popupOpenedAtMs === "number" ? options.popupOpenedAtMs : undefined,
-  });
-
-  view.setBounds(browserBounds);
-  view.setAutoResize({
-    width: false,
-    height: false,
-    horizontal: false,
-    vertical: false,
-  });
-  view.webContents.setWindowOpenHandler(
-    ({ url, disposition, frameName, features }) => {
-      const normalizedUrl = url.trim();
-      if (!normalizedUrl) {
-        return { action: "deny" };
-      }
-
-      if (shouldAllowBrowserPopupWindow(normalizedUrl, frameName, features)) {
-        return {
-          action: "allow",
-          overrideBrowserWindowOptions: {
-            parent: mainWindow ?? undefined,
-            autoHideMenuBar: true,
-            backgroundColor: "#050907",
-            width: 520,
-            height: 760,
-            minWidth: 420,
-            minHeight: 620,
-            webPreferences: {
-              session: workspace.session,
-              preload: path.join(__dirname, "browserPopupPreload.cjs"),
-            },
-          },
-        };
-      }
-
-      try {
-        const parsed = new URL(normalizedUrl);
-        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-          openExternalUrlFromMain(normalizedUrl, "browser window open");
-          return { action: "deny" };
-        }
-      } catch {
-        return { action: "deny" };
-      }
-
-      const shouldOpenAsTab =
-        disposition === "foreground-tab" ||
-        disposition === "background-tab" ||
-        disposition === "new-window";
-      if (shouldOpenAsTab) {
-        handleBrowserWindowOpenAsTab(
-          workspaceId,
-          normalizedUrl,
-          disposition,
-          frameName,
-          browserSpace,
-          normalizedSessionId,
-        );
-      }
-      return { action: "deny" };
-    },
-  );
-  view.webContents.setZoomFactor(1);
-  view.webContents.setVisualZoomLevelLimits(1, 1).catch(() => undefined);
-
-  const currentTabRecord = () =>
-    browserTabSpaceState(
-      browserWorkspaceFromMap(workspaceId),
-      browserSpace,
-      normalizedSessionId,
-    )?.tabs.get(tabId);
-
-  view.webContents.on("before-input-event", (event, input) => {
-    if (isProgrammaticBrowserInput(view.webContents)) {
-      return;
-    }
-    if (
-      (input.type === "keyDown" ||
-        input.type === "keyUp" ||
-        input.type === "char" ||
-        input.type === "rawKeyDown") &&
-      maybePromptBrowserInterrupt(
-        workspaceId,
-        browserSpace,
-        normalizedSessionId,
-      )
-    ) {
-      event.preventDefault();
-    }
-  });
-
-  view.webContents.on("before-mouse-event", (event, mouse) => {
-    if (isProgrammaticBrowserInput(view.webContents)) {
-      return;
-    }
-    if (
-      mouse.type !== "mouseMove" &&
-      mouse.type !== "mouseEnter" &&
-      mouse.type !== "mouseLeave" &&
-      maybePromptBrowserInterrupt(
-        workspaceId,
-        browserSpace,
-        normalizedSessionId,
-      )
-    ) {
-      event.preventDefault();
-    }
-  });
-
-  view.webContents.on("dom-ready", () => {
-    const currentTab = currentTabRecord();
-    if (!currentTab) {
-      return;
-    }
-    currentTab.state = { ...currentTab.state, initialized: true, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-  });
-
-  view.webContents.on("did-start-loading", () => {
-    const currentTab = currentTabRecord();
-    if (!currentTab) {
-      return;
-    }
-    currentTab.state = { ...currentTab.state, loading: true, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-  });
-
-  view.webContents.on("did-stop-loading", () => {
-    const currentTab = currentTabRecord();
-    if (!currentTab) {
-      return;
-    }
-    currentTab.state = { ...currentTab.state, loading: false, error: "" };
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-    if (suppressNextHistoryEntry) {
-      suppressNextHistoryEntry = false;
-      return;
-    }
-    void recordHistoryVisit(workspaceId, {
-      url: currentTab.view.webContents.getURL() || currentTab.state.url,
-      title: currentTab.view.webContents.getTitle() || currentTab.state.title,
-      faviconUrl: currentTab.state.faviconUrl,
-    });
-  });
-
-  view.webContents.on("page-title-updated", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-  });
-
-  view.webContents.on("page-favicon-updated", (_event, favicons) => {
-    const currentTab = currentTabRecord();
-    if (!currentTab) {
-      return;
-    }
-    currentTab.state = {
-      ...currentTab.state,
-      faviconUrl: favicons[0] || currentTab.state.faviconUrl,
-    };
-    emitBrowserState(workspaceId, browserSpace);
-    void persistBrowserWorkspace(workspaceId);
-  });
-
-  view.webContents.on("did-navigate", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-  });
-
-  view.webContents.on("did-navigate-in-page", () => {
-    syncBrowserState(workspaceId, tabId, browserSpace, normalizedSessionId);
-  });
-
-  view.webContents.on("context-menu", (_event, params) => {
-    showBrowserViewContextMenu({
-      workspaceId,
-      space: browserSpace,
-      sessionId: normalizedSessionId,
-      view,
-      context: params,
-    });
-  });
-
-  view.webContents.on(
-    "did-fail-load",
-    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
-      if (
-        !isMainFrame ||
-        isAbortedBrowserLoadFailure(errorCode, errorDescription)
-      ) {
-        return;
-      }
-      const currentTab = currentTabRecord();
-      if (!currentTab) {
-        return;
-      }
-      currentTab.state = {
-        ...currentTab.state,
-        loading: false,
-        error: `${errorDescription} (${errorCode})`,
-        url: validatedURL || currentTab.state.url,
-      };
-      emitBrowserState(workspaceId, browserSpace);
-      void persistBrowserWorkspace(workspaceId);
-    },
-  );
-
-  if (hasInitialUrl) {
-    void view.webContents.loadURL(initialUrl).catch((error) => {
-      if (isAbortedBrowserLoadError(error)) {
-        return;
-      }
-      const currentTab = currentTabRecord();
-      if (!currentTab) {
-        return;
-      }
-      currentTab.state = {
-        ...currentTab.state,
-        loading: false,
-        error: error instanceof Error ? error.message : "Failed to load page.",
-      };
-      emitBrowserState(workspaceId, browserSpace);
-      void persistBrowserWorkspace(workspaceId);
-    });
-  }
-
-  if (browserSpace === "agent" && normalizedSessionId) {
-    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, normalizedSessionId);
-  }
-
-  return tabId;
-}
 
 function initialBrowserTabSeed(
   workspaceId: string,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -974,6 +974,10 @@ const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
   normalizeBrowserPopupFrameName: (frameName) =>
     normalizeBrowserPopupFrameName(frameName),
   duplicateBrowserPopupTabWindowMs: DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS,
+  queueBrowserDownloadPrompt: (workspaceId, targetUrl, options) =>
+    queueBrowserDownloadPrompt(workspaceId, targetUrl, options),
+  browserContextSuggestedFilename: (context) =>
+    browserContextSuggestedFilename(context),
 });
 const getActiveBrowserTab = browserPaneTabState.getActiveBrowserTab;
 const activeVisibleBrowserTarget = browserPaneTabState.activeVisibleBrowserTarget;
@@ -1009,6 +1013,7 @@ const setActiveBrowserTab = browserPaneTabState.setActiveBrowserTab;
 const closeBrowserTab = browserPaneTabState.closeBrowserTab;
 const navigateActiveBrowserTab = browserPaneTabState.navigateActiveBrowserTab;
 const handleBrowserWindowOpenAsTab = browserPaneTabState.handleBrowserWindowOpenAsTab;
+const showBrowserViewContextMenu = browserPaneTabState.showBrowserViewContextMenu;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -18977,147 +18982,6 @@ function consumeBrowserDownloadOverride(
   return override ?? null;
 }
 
-function showBrowserViewContextMenu(params: {
-  workspaceId: string;
-  space: BrowserSpaceId;
-  sessionId?: string | null;
-  view: BrowserView;
-  context: ContextMenuParams;
-}) {
-  const { workspaceId, space, sessionId, view, context } = params;
-  const template: MenuItemConstructorOptions[] = [];
-  const selectionText = context.selectionText.trim();
-  const linkUrl = context.linkURL.trim();
-  const canGoBack = view.webContents.navigationHistory.canGoBack();
-  const canGoForward = view.webContents.navigationHistory.canGoForward();
-  const popupX = browserBounds.x + context.x;
-  const popupY = browserBounds.y + context.y;
-  const imageUrl = context.srcURL.trim();
-
-  if (linkUrl) {
-    template.push(
-      {
-        label: "Open Link in New Tab",
-        click: () =>
-          handleBrowserWindowOpenAsTab(
-            workspaceId,
-            linkUrl,
-            "foreground-tab",
-            "",
-            space,
-            sessionId,
-          ),
-      },
-      {
-        label: "Open Link Externally",
-        click: () => {
-          openExternalUrlFromMain(linkUrl, "browser context menu");
-        },
-      },
-      {
-        label: "Copy Link Address",
-        click: () => {
-          clipboard.writeText(linkUrl);
-        },
-      },
-      { type: "separator" },
-    );
-  }
-
-  if (context.mediaType === "image" && imageUrl) {
-    template.push(
-      {
-        label: "Open Image in New Tab",
-        click: () =>
-          handleBrowserWindowOpenAsTab(
-            workspaceId,
-            imageUrl,
-            "foreground-tab",
-            "",
-            space,
-            sessionId,
-          ),
-      },
-      {
-        label: "Copy Image Address",
-        click: () => {
-          clipboard.writeText(imageUrl);
-        },
-      },
-      {
-        label: "Save Image As...",
-        click: () => {
-          queueBrowserDownloadPrompt(workspaceId, imageUrl, {
-            defaultFilename: browserContextSuggestedFilename(context),
-            dialogTitle: "Save Image As",
-            buttonLabel: "Save Image",
-          });
-          void view.webContents.downloadURL(imageUrl);
-        },
-      },
-      { type: "separator" },
-    );
-  }
-
-  if (context.isEditable) {
-    template.push(
-      { label: "Undo", role: "undo", enabled: context.editFlags.canUndo },
-      { label: "Redo", role: "redo", enabled: context.editFlags.canRedo },
-      { type: "separator" },
-      { label: "Cut", role: "cut", enabled: context.editFlags.canCut },
-      { label: "Copy", role: "copy", enabled: context.editFlags.canCopy },
-      { label: "Paste", role: "paste", enabled: context.editFlags.canPaste },
-      {
-        label: "Select All",
-        role: "selectAll",
-        enabled: context.editFlags.canSelectAll,
-      },
-    );
-  } else if (selectionText) {
-    template.push(
-      { label: "Copy", role: "copy", enabled: context.editFlags.canCopy },
-      {
-        label: "Select All",
-        role: "selectAll",
-        enabled: context.editFlags.canSelectAll,
-      },
-    );
-  } else {
-    template.push(
-      {
-        label: "Back",
-        enabled: canGoBack,
-        click: () => view.webContents.navigationHistory.goBack(),
-      },
-      {
-        label: "Forward",
-        enabled: canGoForward,
-        click: () => view.webContents.navigationHistory.goForward(),
-      },
-      {
-        label: "Reload",
-        click: () => view.webContents.reload(),
-      },
-      {
-        label: "Select All",
-        role: "selectAll",
-        enabled: context.editFlags.canSelectAll,
-      },
-    );
-  }
-
-  if (template.length === 0) {
-    return;
-  }
-
-  Menu.buildFromTemplate(template).popup({
-    window: mainWindow ?? undefined,
-    frame: context.frame ?? undefined,
-    x: popupX,
-    y: popupY,
-    sourceType: context.menuSourceType,
-  });
-}
 
 function createBrowserTab(
   workspaceId: string,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -967,6 +967,9 @@ const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
   createBrowserTab: (workspaceId, options) =>
     createBrowserTab(workspaceId, options),
   homeUrl: HOME_URL,
+  touchAgentSessionBrowserSpace: (workspaceId, sessionId) =>
+    touchAgentSessionBrowserSpace(workspaceId, sessionId),
+  isAbortedBrowserLoadError: (error) => isAbortedBrowserLoadError(error),
 });
 const getActiveBrowserTab = browserPaneTabState.getActiveBrowserTab;
 const activeVisibleBrowserTarget = browserPaneTabState.activeVisibleBrowserTarget;
@@ -1000,6 +1003,7 @@ const focusBrowserTabInSpace = (
   );
 const setActiveBrowserTab = browserPaneTabState.setActiveBrowserTab;
 const closeBrowserTab = browserPaneTabState.closeBrowserTab;
+const navigateActiveBrowserTab = browserPaneTabState.navigateActiveBrowserTab;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -5412,45 +5416,7 @@ function isAbortedBrowserLoadFailure(
   return isAbortedBrowserLoadFailureUtil(errorCode, errorDescription);
 }
 
-async function navigateActiveBrowserTab(
-  workspaceId: string,
-  targetUrl: string,
-  space: BrowserSpaceId = activeBrowserSpaceId,
-  sessionId?: string | null,
-): Promise<BrowserTabListPayload> {
-  await ensureBrowserWorkspace(workspaceId, space, sessionId);
-  if (space === "agent" && browserSessionId(sessionId)) {
-    touchAgentSessionBrowserSpace(workspaceId, sessionId);
-  }
-  const activeTab = getActiveBrowserTab(workspaceId, space, sessionId, {
-    useVisibleAgentSession: !browserSessionId(sessionId),
-  });
-  if (!activeTab) {
-    throw new Error("No active browser tab is available.");
-  }
-
-  try {
-    activeTab.state = { ...activeTab.state, error: "" };
-    await activeTab.view.webContents.loadURL(targetUrl);
-  } catch (error) {
-    if (isAbortedBrowserLoadError(error)) {
-      return browserWorkspaceSnapshot(workspaceId, space, sessionId, {
-        useVisibleAgentSession: !browserSessionId(sessionId),
-      });
-    }
-    activeTab.state = {
-      ...activeTab.state,
-      loading: false,
-      error: error instanceof Error ? error.message : "Failed to load URL.",
-    };
-    emitBrowserState(workspaceId, space);
-    throw error;
-  }
-
-  return browserWorkspaceSnapshot(workspaceId, space, sessionId, {
-    useVisibleAgentSession: !browserSessionId(sessionId),
-  });
-}
+// navigateActiveBrowserTab moved to browser-pane/tab-state.ts (BP-P5b-4).
 
 async function handleDesktopBrowserServiceRequest(
   request: IncomingMessage,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -955,6 +955,18 @@ const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
   sendHistoryToPopup: (history) => browserPanePopups.sendHistoryToPopup(history),
   reserveMainWindowClosedListenerBudget: (count) =>
     reserveMainWindowClosedListenerBudget(count),
+  ensureBrowserWorkspace: (workspaceId, space, sessionId) =>
+    ensureBrowserWorkspace(workspaceId, space, sessionId) as unknown as ReturnType<
+      Parameters<typeof createBrowserPaneTabState>[0]["ensureBrowserWorkspace"]
+    >,
+  setVisibleAgentBrowserSession: (workspace, sessionId) =>
+    setVisibleAgentBrowserSession(
+      workspace as unknown as BrowserWorkspaceState,
+      sessionId,
+    ),
+  createBrowserTab: (workspaceId, options) =>
+    createBrowserTab(workspaceId, options),
+  homeUrl: HOME_URL,
 });
 const getActiveBrowserTab = browserPaneTabState.getActiveBrowserTab;
 const activeVisibleBrowserTarget = browserPaneTabState.activeVisibleBrowserTarget;
@@ -970,6 +982,24 @@ const syncBrowserState = browserPaneTabState.syncBrowserState;
 const recordHistoryVisit = browserPaneTabState.recordHistoryVisit;
 const setBrowserBounds = browserPaneTabState.setBounds;
 const captureVisibleBrowserSnapshot = browserPaneTabState.captureVisibleSnapshot;
+const focusBrowserTabInSpace = (
+  workspaceId: string,
+  tabSpace: BrowserTabSpaceState,
+  tabId: string,
+  space: BrowserSpaceId,
+  sessionId?: string | null,
+) =>
+  browserPaneTabState.focusBrowserTabInSpace(
+    workspaceId,
+    tabSpace as unknown as Parameters<
+      typeof browserPaneTabState.focusBrowserTabInSpace
+    >[1],
+    tabId,
+    space,
+    sessionId,
+  );
+const setActiveBrowserTab = browserPaneTabState.setActiveBrowserTab;
+const closeBrowserTab = browserPaneTabState.closeBrowserTab;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -18926,24 +18956,7 @@ function isBrowserPopupWindowRequest(
   return isBrowserPopupWindowRequestUtil(frameName, features);
 }
 
-function focusBrowserTabInSpace(
-  workspaceId: string,
-  tabSpace: BrowserTabSpaceState,
-  tabId: string,
-  space: BrowserSpaceId,
-  sessionId?: string | null,
-) {
-  tabSpace.activeTabId = tabId;
-  browserTabSpaceTouch(tabSpace);
-  if (space === "agent" && browserSessionId(sessionId)) {
-    scheduleAgentSessionBrowserLifecycleCheck(workspaceId, sessionId);
-  }
-  if (workspaceId === activeBrowserWorkspaceId && space === activeBrowserSpaceId) {
-    updateAttachedBrowserView();
-  }
-  emitBrowserState(workspaceId, space);
-  void persistBrowserWorkspace(workspaceId);
-}
+// focusBrowserTabInSpace moved to browser-pane/tab-state.ts (BP-P5b-3).
 
 function handleBrowserWindowOpenAsTab(
   workspaceId: string,
@@ -19843,115 +19856,9 @@ async function setActiveBrowserWorkspace(
   );
 }
 
-async function setActiveBrowserTab(
-  tabId: string,
-  space?: BrowserSpaceId | null,
-  sessionId?: string | null,
-) {
-  const browserSpace = browserSpaceId(space);
-  const normalizedSessionId =
-    browserSpace === "agent"
-      ? browserSessionId(sessionId) || browserSessionId(activeBrowserSessionId)
-      : "";
-  const workspace = await ensureBrowserWorkspace(
-    undefined,
-    browserSpace,
-    normalizedSessionId,
-  );
-  const tabSpace = browserTabSpaceState(workspace, browserSpace, normalizedSessionId, {
-    useVisibleAgentSession: !normalizedSessionId,
-  });
-  if (!workspace || !tabSpace || !tabSpace.tabs.has(tabId)) {
-    return browserWorkspaceSnapshot(undefined, browserSpace, normalizedSessionId, {
-      useVisibleAgentSession: true,
-    });
-  }
+// setActiveBrowserTab moved to browser-pane/tab-state.ts (BP-P5b-3).
 
-  tabSpace.activeTabId = tabId;
-  browserTabSpaceTouch(tabSpace);
-  if (browserSpace === "agent" && normalizedSessionId) {
-    setVisibleAgentBrowserSession(workspace, normalizedSessionId);
-    scheduleAgentSessionBrowserLifecycleCheck(workspace.workspaceId, normalizedSessionId);
-  }
-  if (
-    workspace.workspaceId === activeBrowserWorkspaceId &&
-    browserSpace === activeBrowserSpaceId
-  ) {
-    updateAttachedBrowserView();
-  }
-  emitBrowserState(workspace.workspaceId, browserSpace);
-  await persistBrowserWorkspace(workspace.workspaceId);
-  return browserWorkspaceSnapshot(
-    workspace.workspaceId,
-    browserSpace,
-    normalizedSessionId,
-    { useVisibleAgentSession: true },
-  );
-}
-
-async function closeBrowserTab(
-  tabId: string,
-  space?: BrowserSpaceId | null,
-  sessionId?: string | null,
-) {
-  const browserSpace = browserSpaceId(space);
-  const normalizedSessionId =
-    browserSpace === "agent"
-      ? browserSessionId(sessionId) || browserSessionId(activeBrowserSessionId)
-      : "";
-  const workspace = await ensureBrowserWorkspace(
-    undefined,
-    browserSpace,
-    normalizedSessionId,
-  );
-  const tabSpace = browserTabSpaceState(workspace, browserSpace, normalizedSessionId, {
-    useVisibleAgentSession: !normalizedSessionId,
-  });
-  const tab = tabSpace?.tabs.get(tabId);
-  if (!workspace || !tabSpace || !tab) {
-    return browserWorkspaceSnapshot(undefined, browserSpace, normalizedSessionId, {
-      useVisibleAgentSession: true,
-    });
-  }
-
-  const tabIds = Array.from(tabSpace.tabs.keys());
-  const closedIndex = tabIds.indexOf(tabId);
-  tabSpace.tabs.delete(tabId);
-  closeBrowserTabRecord(tab);
-  browserTabSpaceTouch(tabSpace);
-
-  if (tabSpace.tabs.size === 0) {
-    const replacementTabId = createBrowserTab(workspace.workspaceId, {
-      url: HOME_URL,
-      browserSpace,
-      sessionId: normalizedSessionId,
-    });
-    tabSpace.activeTabId = replacementTabId ?? "";
-  } else if (tabSpace.activeTabId === tabId) {
-    const remainingIds = Array.from(tabSpace.tabs.keys());
-    tabSpace.activeTabId =
-      remainingIds[Math.max(0, closedIndex - 1)] ?? remainingIds[0] ?? "";
-  }
-
-  if (
-    workspace.workspaceId === activeBrowserWorkspaceId &&
-    browserSpace === activeBrowserSpaceId
-  ) {
-    updateAttachedBrowserView();
-  }
-  if (browserSpace === "agent" && normalizedSessionId) {
-    scheduleAgentSessionBrowserLifecycleCheck(workspace.workspaceId, normalizedSessionId);
-  }
-  emitBrowserState(workspace.workspaceId, browserSpace);
-  await persistBrowserWorkspace(workspace.workspaceId);
-  return browserWorkspaceSnapshot(
-    workspace.workspaceId,
-    browserSpace,
-    normalizedSessionId,
-    { useVisibleAgentSession: true },
-  );
-}
-
+// closeBrowserTab moved to browser-pane/tab-state.ts (BP-P5b-3).
 // setBrowserBounds, captureVisibleBrowserSnapshot moved to
 // browser-pane/tab-state.ts (BP-P5b-2).
 

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -970,6 +970,10 @@ const browserPaneTabState: BrowserPaneTabState = createBrowserPaneTabState({
   touchAgentSessionBrowserSpace: (workspaceId, sessionId) =>
     touchAgentSessionBrowserSpace(workspaceId, sessionId),
   isAbortedBrowserLoadError: (error) => isAbortedBrowserLoadError(error),
+  openExternalUrlFromMain: (url, reason) => openExternalUrlFromMain(url, reason),
+  normalizeBrowserPopupFrameName: (frameName) =>
+    normalizeBrowserPopupFrameName(frameName),
+  duplicateBrowserPopupTabWindowMs: DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS,
 });
 const getActiveBrowserTab = browserPaneTabState.getActiveBrowserTab;
 const activeVisibleBrowserTarget = browserPaneTabState.activeVisibleBrowserTarget;
@@ -1004,6 +1008,7 @@ const focusBrowserTabInSpace = (
 const setActiveBrowserTab = browserPaneTabState.setActiveBrowserTab;
 const closeBrowserTab = browserPaneTabState.closeBrowserTab;
 const navigateActiveBrowserTab = browserPaneTabState.navigateActiveBrowserTab;
+const handleBrowserWindowOpenAsTab = browserPaneTabState.handleBrowserWindowOpenAsTab;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -18924,93 +18929,6 @@ function isBrowserPopupWindowRequest(
 
 // focusBrowserTabInSpace moved to browser-pane/tab-state.ts (BP-P5b-3).
 
-function handleBrowserWindowOpenAsTab(
-  workspaceId: string,
-  targetUrl: string,
-  disposition: string,
-  frameName: string,
-  space: BrowserSpaceId,
-  sessionId?: string | null,
-) {
-  const normalizedUrl = targetUrl.trim();
-  if (!normalizedUrl) {
-    return;
-  }
-
-  try {
-    const parsed = new URL(normalizedUrl);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      openExternalUrlFromMain(normalizedUrl, "browser tab creation");
-      return;
-    }
-  } catch {
-    return;
-  }
-
-  const workspace = browserWorkspaceFromMap(workspaceId);
-  const tabSpace = browserTabSpaceState(workspace, space, sessionId, {
-    createIfMissing: true,
-  });
-  if (!workspace || !tabSpace) {
-    return;
-  }
-
-  const normalizedFrameName = normalizeBrowserPopupFrameName(frameName);
-  const now = Date.now();
-  const existingPopupTab = Array.from(tabSpace.tabs.entries()).find(
-    ([, tab]) =>
-      (normalizedFrameName && tab.popupFrameName === normalizedFrameName) ||
-      (!normalizedFrameName &&
-        tab.state.url === normalizedUrl &&
-        typeof tab.popupOpenedAtMs === "number" &&
-        now - tab.popupOpenedAtMs <= DUPLICATE_BROWSER_POPUP_TAB_WINDOW_MS),
-  );
-
-  if (existingPopupTab) {
-    const [existingTabId, existingTab] = existingPopupTab;
-    existingTab.popupFrameName =
-      normalizedFrameName || existingTab.popupFrameName;
-    existingTab.popupOpenedAtMs = now;
-    if (existingTab.state.url !== normalizedUrl) {
-      existingTab.state = { ...existingTab.state, error: "" };
-      void existingTab.view.webContents.loadURL(normalizedUrl).catch((error) => {
-        if (isAbortedBrowserLoadError(error)) {
-          return;
-        }
-        existingTab.state = {
-          ...existingTab.state,
-          loading: false,
-          error: error instanceof Error ? error.message : "Failed to load URL.",
-        };
-        emitBrowserState(workspaceId, space);
-        void persistBrowserWorkspace(workspaceId);
-      });
-    }
-    if (disposition !== "background-tab") {
-      focusBrowserTabInSpace(workspaceId, tabSpace, existingTabId, space, sessionId);
-    }
-    return;
-  }
-
-  const nextTabId = createBrowserTab(workspaceId, {
-    url: normalizedUrl,
-    browserSpace: space,
-    sessionId,
-    popupFrameName: normalizedFrameName,
-    popupOpenedAtMs: now,
-  });
-  if (!nextTabId) {
-    return;
-  }
-
-  if (disposition !== "background-tab") {
-    focusBrowserTabInSpace(workspaceId, tabSpace, nextTabId, space, sessionId);
-    return;
-  }
-
-  emitBrowserState(workspaceId, space);
-  void persistBrowserWorkspace(workspaceId);
-}
 
 function browserContextSuggestedFilename(context: ContextMenuParams): string {
   return browserContextSuggestedFilenameUtil(context, sanitizeAttachmentName);

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -968,6 +968,8 @@ const emitHistoryState = browserPaneTabState.emitHistoryState;
 const closeBrowserTabRecord = browserPaneTabState.closeBrowserTabRecord;
 const syncBrowserState = browserPaneTabState.syncBrowserState;
 const recordHistoryVisit = browserPaneTabState.recordHistoryVisit;
+const setBrowserBounds = browserPaneTabState.setBounds;
+const captureVisibleBrowserSnapshot = browserPaneTabState.captureVisibleSnapshot;
 const reportedOperatorSurfaceContexts = new Map<
   string,
   ReportedOperatorSurfaceContextPayload
@@ -19950,45 +19952,8 @@ async function closeBrowserTab(
   );
 }
 
-function setBrowserBounds(bounds: BrowserBoundsPayload) {
-  browserBounds = {
-    x: Math.max(0, Math.round(bounds.x)),
-    y: Math.max(0, Math.round(bounds.y)),
-    width: Math.max(0, Math.round(bounds.width)),
-    height: Math.max(0, Math.round(bounds.height)),
-  };
-
-  const activeTab = getActiveBrowserTab(
-    activeBrowserWorkspaceId,
-    activeBrowserSpaceId,
-    activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
-    { useVisibleAgentSession: true },
-  );
-  if (!activeTab || !hasVisibleBrowserBounds()) {
-    mainWindow?.setBrowserView(null);
-    attachedBrowserTabView = null;
-    return;
-  }
-  updateAttachedBrowserView();
-}
-
-async function captureVisibleBrowserSnapshot(): Promise<BrowserVisibleSnapshotPayload | null> {
-  const activeTab = getActiveBrowserTab(
-    activeBrowserWorkspaceId,
-    activeBrowserSpaceId,
-    activeBrowserSpaceId === "agent" ? activeBrowserSessionId : null,
-    { useVisibleAgentSession: true },
-  );
-  if (!activeTab || !hasVisibleBrowserBounds()) {
-    return null;
-  }
-
-  const image = await activeTab.view.webContents.capturePage();
-  return {
-    bounds: { ...browserBounds },
-    dataUrl: `data:image/png;base64,${image.toPNG().toString("base64")}`,
-  };
-}
+// setBrowserBounds, captureVisibleBrowserSnapshot moved to
+// browser-pane/tab-state.ts (BP-P5b-2).
 
 function ensureAuthPopupWindow() {
   if (authPopupWindow && !authPopupWindow.isDestroyed()) {

--- a/desktop/shared/browser-pane-protocol.ts
+++ b/desktop/shared/browser-pane-protocol.ts
@@ -35,7 +35,9 @@ export interface BrowserStatePayload {
   canGoForward: boolean;
   loading: boolean;
   initialized: boolean;
-  error?: string | null;
+  // main's ambient global declares this as `error: string`. Keep
+  // structurally compatible.
+  error: string;
 }
 
 export interface BrowserTabCountsPayload {
@@ -43,20 +45,18 @@ export interface BrowserTabCountsPayload {
   agent: number;
 }
 
-export type BrowserTabLifecycleState =
-  | "active"
-  | "suspended"
-  | "evicted"
-  | "released";
+// Match main.ts's ambient declaration which uses a narrower set + null variant.
+export type BrowserTabLifecycleState = "active" | "suspended" | null;
 
-export type BrowserControlMode = "user" | "agent" | "shared";
+export type BrowserControlMode = "none" | "user_locked" | "session_owned";
 
 export interface BrowserTabListPayload {
   space: BrowserSpaceId;
   activeTabId: string;
   tabs: BrowserStatePayload[];
   tabCounts: BrowserTabCountsPayload;
-  sessionId: string;
+  // main's ambient global allows null when no session is bound.
+  sessionId: string | null;
   lifecycleState: BrowserTabLifecycleState;
   controlMode: BrowserControlMode;
   controlSessionId: string | null;


### PR DESCRIPTION
Continues browser-pane extraction. Moves the tab subsystem out of desktop/electron/main.ts into browser-pane/tab-state.ts across 7 incremental commits (P5b-1 → P5b-7). main.ts: 22,723 → 21,836 (−887 lines). See commit messages for sub-phase scopes.