### PR TITLE
fix(desktop): guard emitWindowStateChanged against disposed render frames

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -6955,11 +6955,30 @@ function emitWindowStateChanged(
   if (!resolvedWindow) {
     return;
   }
-
-  resolvedWindow.webContents.send(
-    "ui:windowState",
-    desktopWindowStatePayload(resolvedWindow),
-  );
+  // Window-state events ('maximize'/'minimize'/'ready-to-show'/...) can
+  // race with window teardown. There are two distinct disposal states to
+  // guard against:
+  //   1. WebContents fully destroyed — caught by isDestroyed().
+  //   2. WebContents alive but the underlying RenderFrame (WebFrameMain)
+  //      has been disposed mid-teardown — send() throws
+  //      `Render frame was disposed before WebFrameMain could be accessed`
+  //      and isDestroyed() still returns false.
+  // We catch (1) cheaply and try/catch (2) since it's not introspectable.
+  const wc = resolvedWindow.webContents;
+  if (wc.isDestroyed()) {
+    return;
+  }
+  try {
+    wc.send("ui:windowState", desktopWindowStatePayload(resolvedWindow));
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /render frame was disposed/i.test(error.message)
+    ) {
+      return;
+    }
+    throw error;
+  }
 }
 
 function runtimeModelProxyApiKeyFromConfig(


### PR DESCRIPTION
## Summary

Suppress the noisy `Error: Render frame was disposed before WebFrameMain could be accessed` thrown from `emitWindowStateChanged` when window-state events race with window teardown.

```
[dev:electron:run] Error sending from webFrameMain:  Error: Render frame was disposed before WebFrameMain could be accessed
[dev:electron:run]     at s.send (node:electron/js2c/browser_init:2:103960)
[dev:electron:run]     at b.send (node:electron/js2c/browser_init:2:88255)
[dev:electron:run]     at emitWindowStateChanged (.../main.cjs:5583:30)
[dev:electron:run]     at BrowserWindow.<anonymous> (.../main.cjs:18009:5)
```

Window-state events (`'maximize'` / `'unmaximize'` / `'minimize'` / `'restore'` / `'enter-full-screen'` / `'leave-full-screen'` / `'ready-to-show'`) can fire after the renderer has begun teardown — particularly during window close, app quit, or dev-mode hot reload. Two disposal states race with the listener:

1. **WebContents fully destroyed** — `webContents.isDestroyed() === true`.
2. **WebContents alive, RenderFrame disposed mid-teardown** — `isDestroyed()` still returns `false`, but `send()` throws because the underlying `WebFrameMain` is gone.

`resolveTargetWindow()` already guards the `BrowserWindow` itself but not its `WebContents`. This PR adds:

- A cheap `webContents.isDestroyed()` short-circuit for case 1.
- A `try/catch` around `send()` for case 2 (RenderFrame state is not introspectable from outside). Match `/render frame was disposed/i` and silently return; rethrow anything else so real bugs are not swallowed.

## Test plan

- [x] `npm --prefix desktop run typecheck`
- [ ] In dev: trigger several `cmd+w` close → reopen cycles and confirm the stderr line no longer appears
- [ ] In dev: trigger a hot reload mid-resize and confirm no throw
- [ ] Production: window state events on a normal launch still update the UI as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)