### PR TITLE
Dashboard v2 polish: bugs, style, refresh, persistence

### DIFF
--- a/desktop/src/components/dashboard/BoardView.tsx
+++ b/desktop/src/components/dashboard/BoardView.tsx
@@ -12,12 +12,14 @@ import type { BoardViewSpec, ColorToken } from "@/lib/dashboardSchema";
 import { EmptyState } from "./EmptyState";
 import { colorClasses, formatSmartDate, hashToColor, looksLikeDateColumn } from "./format";
 import { isStatusColumn, StatusBadge } from "./StatusBadge";
+import { usePersistedState } from "./usePersistedState";
 
 interface BoardViewProps {
   view: BoardViewSpec;
   columns: string[];
   rows: unknown[][];
   emptyState?: string;
+  storageKeyBase?: string;
 }
 
 // Read-only Kanban: rows are bucketed by distinct values of the
@@ -26,8 +28,17 @@ interface BoardViewProps {
 // header (Notion-style). Selection is component-local; we don't
 // persist back to YAML in v2 because the dashboard is a pure
 // function of its file.
-export function BoardView({ view, columns, rows, emptyState }: BoardViewProps) {
-  const [activeGroupBy, setActiveGroupBy] = useState<string>(view.group_by);
+export function BoardView({
+  view,
+  columns,
+  rows,
+  emptyState,
+  storageKeyBase,
+}: BoardViewProps) {
+  const [activeGroupBy, setActiveGroupBy] = usePersistedState<string>(
+    storageKeyBase ? `${storageKeyBase}:board:groupBy` : undefined,
+    view.group_by,
+  );
   const initialGroupBy = view.group_by;
 
   // Reset when the YAML changes the initial group_by underneath us

--- a/desktop/src/components/dashboard/BoardView.tsx
+++ b/desktop/src/components/dashboard/BoardView.tsx
@@ -1,5 +1,5 @@
-import { Check, ChevronDown } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Check, ChevronDown, Columns3 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   DropdownMenu,
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { BoardViewSpec, ColorToken } from "@/lib/dashboardSchema";
 
+import { EmptyState } from "./EmptyState";
 import { colorClasses, formatSmartDate, hashToColor, looksLikeDateColumn } from "./format";
 import { isStatusColumn, StatusBadge } from "./StatusBadge";
 
@@ -27,16 +28,16 @@ interface BoardViewProps {
 // function of its file.
 export function BoardView({ view, columns, rows, emptyState }: BoardViewProps) {
   const [activeGroupBy, setActiveGroupBy] = useState<string>(view.group_by);
+  const initialGroupBy = view.group_by;
 
   // Reset when the YAML changes the initial group_by underneath us
-  // (e.g. agent re-emits the dashboard).
-  const initialGroupBy = view.group_by;
-  if (
-    activeGroupBy !== view.group_by &&
-    !columns.includes(activeGroupBy)
-  ) {
-    setActiveGroupBy(initialGroupBy);
-  }
+  // (e.g. agent re-emits the dashboard) and the previously-selected
+  // column has gone away. Effect rather than render-phase setState.
+  useEffect(() => {
+    if (activeGroupBy !== view.group_by && !columns.includes(activeGroupBy)) {
+      setActiveGroupBy(view.group_by);
+    }
+  }, [view.group_by, columns, activeGroupBy]);
 
   const titleIdx = columns.indexOf(view.card_title);
   const subtitleIdx = view.card_subtitle ? columns.indexOf(view.card_subtitle) : -1;
@@ -113,9 +114,7 @@ export function BoardView({ view, columns, rows, emptyState }: BoardViewProps) {
     return (
       <div className="pt-2">
         <div className="mb-2">{picker}</div>
-        <div className="py-8 text-center text-xs text-muted-foreground">
-          {emptyState ?? "No rows."}
-        </div>
+        <EmptyState icon={Columns3} message={emptyState ?? "Nothing here yet."} />
       </div>
     );
   }

--- a/desktop/src/components/dashboard/BoardView.tsx
+++ b/desktop/src/components/dashboard/BoardView.tsx
@@ -166,8 +166,7 @@ export function BoardView({
                 // biome-ignore lint/suspicious/noArrayIndexKey: SQL row order is the natural key
                 <article
                   key={rIdx}
-                  tabIndex={0}
-                  className="cursor-default rounded-md border border-transparent bg-fg-4 px-3 py-2.5 text-xs transition-all hover:border-border hover:bg-card hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  className="rounded-md border border-transparent bg-fg-4 px-3 py-2.5 text-xs transition-colors hover:border-border hover:bg-card"
                 >
                   <div className="line-clamp-3 leading-snug text-foreground">
                     {formatCell(row[titleIdx])}

--- a/desktop/src/components/dashboard/ChartPanel.tsx
+++ b/desktop/src/components/dashboard/ChartPanel.tsx
@@ -5,7 +5,7 @@ import {
   type LucideIcon,
   PieChart as PieChartIcon,
 } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -31,6 +31,7 @@ import type {
 
 import type { DataViewState } from "./DataViewPanel";
 import { EmptyState } from "./EmptyState";
+import { ErrorMessage } from "./ErrorMessage";
 import { formatValue } from "./format";
 
 const CHART_ICON: Record<ChartSpec["kind"], LucideIcon> = {
@@ -74,14 +75,30 @@ const SERIES_DARK = [
   "oklch(70.4% 0.04 256.788)",  // slate-400
 ];
 
-function pickSeriesPalette(): string[] {
-  if (typeof document !== "undefined") {
-    const isDark =
-      document.documentElement.classList.contains("dark") ||
-      document.documentElement.dataset.theme === "dark";
-    return isDark ? SERIES_DARK : SERIES_LIGHT;
-  }
-  return SERIES_LIGHT;
+function readIsDark(): boolean {
+  if (typeof document === "undefined") return false;
+  const root = document.documentElement;
+  return root.classList.contains("dark") || root.dataset.theme === "dark";
+}
+
+// Subscribes to live theme changes on <html>. Recharts paints into SVG
+// and can't pick up CSS vars at render time, so the palette is plain
+// OKLch literals — meaning charts won't repaint on theme toggle unless
+// the component re-renders. This hook does that via MutationObserver.
+function useSeriesPalette(): string[] {
+  const [isDark, setIsDark] = useState<boolean>(readIsDark);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    const update = () => setIsDark(readIsDark());
+    const mo = new MutationObserver(update);
+    mo.observe(root, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme"],
+    });
+    return () => mo.disconnect();
+  }, []);
+  return isDark ? SERIES_DARK : SERIES_LIGHT;
 }
 
 export function ChartPanel({ panel, state }: ChartPanelProps) {
@@ -101,9 +118,7 @@ export function ChartPanel({ panel, state }: ChartPanelProps) {
         {state.kind === "loading" ? (
           <ChartSkeleton />
         ) : state.kind === "error" ? (
-          <div className="my-3 rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            {state.message}
-          </div>
+          <ErrorMessage message={state.message} />
         ) : state.rows.length === 0 ? (
           <EmptyState
             icon={CHART_ICON[panel.chart.kind] ?? BarChart3}
@@ -148,7 +163,7 @@ function CartesianChartBody({
   chart: Extract<ChartSpec, { kind: "line" | "bar" | "area" }>;
   state: Extract<DataViewState, { kind: "data" }>;
 }) {
-  const palette = pickSeriesPalette();
+  const palette = useSeriesPalette();
   const xIdx = state.columns.indexOf(chart.x);
   const seriesIdx = chart.y
     .map((s) => ({ name: s, idx: state.columns.indexOf(s) }))
@@ -391,7 +406,7 @@ function PieChartBody({
   chart: Extract<ChartSpec, { kind: "pie" | "donut" }>;
   state: Extract<DataViewState, { kind: "data" }>;
 }) {
-  const palette = pickSeriesPalette();
+  const palette = useSeriesPalette();
   const labelIdx = state.columns.indexOf(chart.label);
   const valueIdx = state.columns.indexOf(chart.value);
 

--- a/desktop/src/components/dashboard/ChartPanel.tsx
+++ b/desktop/src/components/dashboard/ChartPanel.tsx
@@ -295,16 +295,36 @@ function CartesianChartBody({
                 wrapperStyle={{ fontSize: 11, paddingTop: 8 }}
               />
             ) : null}
-            {seriesIdx.map((s, i) => (
-              <Bar
-                key={s.name}
-                dataKey={s.name}
-                fill={palette[i % palette.length]}
-                radius={[3, 3, 0, 0]}
-                stackId={chart.stacked ? "stack" : undefined}
-                isAnimationActive
-              />
-            ))}
+            {seriesIdx.map((s, i) => {
+              // color_by_sign only applies to single-series bars: per-row
+              // Cell color picked by sign. Stacked bars get radius=0
+              // because per-segment rounded corners look like dents.
+              const colorBySign =
+                chart.color_by_sign === true && seriesIdx.length === 1;
+              return (
+                <Bar
+                  key={s.name}
+                  dataKey={s.name}
+                  fill={palette[i % palette.length]}
+                  radius={chart.stacked ? 0 : [3, 3, 0, 0]}
+                  stackId={chart.stacked ? "stack" : undefined}
+                  isAnimationActive
+                >
+                  {colorBySign
+                    ? data.map((entry, idx) => {
+                        const v = entry[s.name];
+                        const n = typeof v === "number" ? v : null;
+                        const fill =
+                          n !== null && n < 0 ? palette[1] : palette[0];
+                        return (
+                          // biome-ignore lint/suspicious/noArrayIndexKey: row order is the natural key
+                          <Cell key={idx} fill={fill} />
+                        );
+                      })
+                    : null}
+                </Bar>
+              );
+            })}
           </BarChart>
         ) : (
           <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>

--- a/desktop/src/components/dashboard/ChartPanel.tsx
+++ b/desktop/src/components/dashboard/ChartPanel.tsx
@@ -109,7 +109,7 @@ export function ChartPanel({ panel, state }: ChartPanelProps) {
           {panel.title}
         </h3>
         {panel.description ? (
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          <p className="mt-1 truncate text-xs text-muted-foreground">
             {panel.description}
           </p>
         ) : null}

--- a/desktop/src/components/dashboard/ChartPanel.tsx
+++ b/desktop/src/components/dashboard/ChartPanel.tsx
@@ -1,3 +1,10 @@
+import {
+  AreaChart as AreaChartIcon,
+  BarChart3,
+  LineChart as LineChartIcon,
+  type LucideIcon,
+  PieChart as PieChartIcon,
+} from "lucide-react";
 import { useMemo } from "react";
 import {
   Area,
@@ -22,8 +29,17 @@ import type {
   ChartSpec,
 } from "@/lib/dashboardSchema";
 
-import { formatValue } from "./format";
 import type { DataViewState } from "./DataViewPanel";
+import { EmptyState } from "./EmptyState";
+import { formatValue } from "./format";
+
+const CHART_ICON: Record<ChartSpec["kind"], LucideIcon> = {
+  line: LineChartIcon,
+  bar: BarChart3,
+  area: AreaChartIcon,
+  pie: PieChartIcon,
+  donut: PieChartIcon,
+};
 
 interface ChartPanelProps {
   panel: ChartPanelSpec;
@@ -71,19 +87,17 @@ function pickSeriesPalette(): string[] {
 export function ChartPanel({ panel, state }: ChartPanelProps) {
   return (
     <section className="overflow-hidden rounded-xl bg-card shadow-md smooth-corners">
-      <header className="flex items-center justify-between gap-3 border-b border-border/70 bg-fg-2 px-4 py-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
-            {panel.title}
-          </h3>
-          {panel.description ? (
-            <span className="hidden truncate text-xs text-muted-foreground md:inline">
-              · {panel.description}
-            </span>
-          ) : null}
-        </div>
+      <header className="border-b border-border/70 bg-fg-2 px-4 py-3">
+        <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
+          {panel.title}
+        </h3>
+        {panel.description ? (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {panel.description}
+          </p>
+        ) : null}
       </header>
-      <div className="px-4 py-4">
+      <div className="px-4 py-3">
         {state.kind === "loading" ? (
           <ChartSkeleton />
         ) : state.kind === "error" ? (
@@ -91,9 +105,11 @@ export function ChartPanel({ panel, state }: ChartPanelProps) {
             {state.message}
           </div>
         ) : state.rows.length === 0 ? (
-          <div className="grid h-[260px] place-items-center text-xs text-muted-foreground">
-            {panel.empty_state ?? "No data."}
-          </div>
+          <EmptyState
+            icon={CHART_ICON[panel.chart.kind] ?? BarChart3}
+            message={panel.empty_state ?? "Nothing here yet."}
+            minHeight={260}
+          />
         ) : (
           <ChartBody chart={panel.chart} state={state} />
         )}
@@ -138,21 +154,6 @@ function CartesianChartBody({
     .map((s) => ({ name: s, idx: state.columns.indexOf(s) }))
     .filter((s) => s.idx >= 0);
 
-  if (xIdx < 0) {
-    return (
-      <ChartConfigError
-        msg={`x column "${chart.x}" not in projection.`}
-      />
-    );
-  }
-  if (seriesIdx.length === 0) {
-    return (
-      <ChartConfigError
-        msg={`y column(s) ${chart.y.map((s) => `"${s}"`).join(", ")} not in projection.`}
-      />
-    );
-  }
-
   // Project the row set into Recharts shape: array of objects keyed by
   // column name. Coerce numeric columns from string (sqlite REAL/
   // INTEGER come through as JS numbers but defensive about strings).
@@ -173,6 +174,21 @@ function CartesianChartBody({
       return o;
     });
   }, [state.rows, xIdx, seriesIdx, chart.x]);
+
+  if (xIdx < 0) {
+    return (
+      <ChartConfigError
+        msg={`x column "${chart.x}" not in projection.`}
+      />
+    );
+  }
+  if (seriesIdx.length === 0) {
+    return (
+      <ChartConfigError
+        msg={`y column(s) ${chart.y.map((s) => `"${s}"`).join(", ")} not in projection.`}
+      />
+    );
+  }
 
   const xTickFormatter = (raw: unknown): string => {
     if (chart.x_format === "date") return formatValue(raw, "date");
@@ -359,13 +375,6 @@ function PieChartBody({
   const labelIdx = state.columns.indexOf(chart.label);
   const valueIdx = state.columns.indexOf(chart.value);
 
-  if (labelIdx < 0) {
-    return <ChartConfigError msg={`label column "${chart.label}" not in projection.`} />;
-  }
-  if (valueIdx < 0) {
-    return <ChartConfigError msg={`value column "${chart.value}" not in projection.`} />;
-  }
-
   const data = useMemo(() => {
     type Slice = { name: string; value: number };
     let arr: Slice[] = state.rows.map((row) => {
@@ -388,6 +397,13 @@ function PieChartBody({
     }
     return arr;
   }, [state.rows, labelIdx, valueIdx, chart.sort_desc, chart.max_slices]);
+
+  if (labelIdx < 0) {
+    return <ChartConfigError msg={`label column "${chart.label}" not in projection.`} />;
+  }
+  if (valueIdx < 0) {
+    return <ChartConfigError msg={`value column "${chart.value}" not in projection.`} />;
+  }
 
   const isDonut = chart.kind === "donut";
 

--- a/desktop/src/components/dashboard/DashboardRenderer.tsx
+++ b/desktop/src/components/dashboard/DashboardRenderer.tsx
@@ -48,7 +48,11 @@ export function DashboardRenderer({
   fullWidth = false,
   refreshKey = 0,
 }: DashboardRendererProps) {
-  const parsed = useMemo(() => parseDashboard(content), [content]);
+  // Debounce parsing so live-edit keystrokes don't reparse + refire
+  // every panel's SQL query on every character. 250ms is enough that a
+  // user pausing to read sees the result, while typing isn't laggy.
+  const debouncedContent = useDebouncedValue(content, 250);
+  const parsed = useMemo(() => parseDashboard(debouncedContent), [debouncedContent]);
 
   if (!parsed.ok || !parsed.dashboard) {
     return (
@@ -394,6 +398,17 @@ function PanelDispatch({ panel, state }: { panel: DashboardPanel; state: PanelSt
       Unsupported panel state.
     </div>
   );
+}
+
+// ----- Hooks --------------------------------------------------------
+
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
 }
 
 // ----- Result merging ----------------------------------------------

--- a/desktop/src/components/dashboard/DashboardRenderer.tsx
+++ b/desktop/src/components/dashboard/DashboardRenderer.tsx
@@ -8,6 +8,7 @@ import {
   type Width,
   parseDashboard,
 } from "@/lib/dashboardSchema";
+import { bumpDashboardRefreshKey } from "@/lib/dashboardToolbarStore";
 
 import { ChartPanel } from "./ChartPanel";
 import { type DataViewState, DataViewPanel } from "./DataViewPanel";
@@ -18,6 +19,7 @@ import { TextPanel } from "./TextPanel";
 interface DashboardRendererProps {
   workspaceId: string;
   content: string;
+  dashboardPath?: string;
   /** Toggled by the host pane (InternalSurfacePane). When true, the
    *  centered max-width is dropped and the renderer fills its container. */
   fullWidth?: boolean;
@@ -45,6 +47,7 @@ type PanelState =
 export function DashboardRenderer({
   workspaceId,
   content,
+  dashboardPath,
   fullWidth = false,
   refreshKey = 0,
 }: DashboardRendererProps) {
@@ -69,6 +72,7 @@ export function DashboardRenderer({
     <DashboardBody
       workspaceId={workspaceId}
       dashboard={parsed.dashboard}
+      dashboardPath={dashboardPath}
       fullWidth={fullWidth}
       refreshKey={refreshKey}
     />
@@ -78,11 +82,13 @@ export function DashboardRenderer({
 function DashboardBody({
   workspaceId,
   dashboard,
+  dashboardPath,
   fullWidth,
   refreshKey,
 }: {
   workspaceId: string;
   dashboard: Dashboard;
+  dashboardPath: string | undefined;
   fullWidth: boolean;
   refreshKey: number;
 }) {
@@ -208,6 +214,25 @@ function DashboardBody({
     };
   }, [dashboard, workspaceId, refreshKey]);
 
+  const isRefreshing = useMemo(
+    () => panelStates.some(isPanelLoading),
+    [panelStates],
+  );
+  const [lastRefreshAt, setLastRefreshAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isRefreshing) setLastRefreshAt(Date.now());
+  }, [isRefreshing]);
+
+  // Auto-refresh — schema clamps interval ≥ 10s on parse.
+  useEffect(() => {
+    const interval = dashboard.refresh_interval;
+    if (!interval) return;
+    const id = window.setInterval(() => {
+      bumpDashboardRefreshKey();
+    }, interval * 1000);
+    return () => window.clearInterval(id);
+  }, [dashboard.refresh_interval]);
+
   // Width hints arrange panels into rows. `max-w-none` would animate
   // over a literal-billion-px change so we use a pixel value for full.
   const widthClass = fullWidth ? "max-w-[1600px]" : "max-w-4xl";
@@ -219,15 +244,21 @@ function DashboardBody({
       <div
         className={`mx-auto px-10 pt-10 pb-16 transition-[max-width] duration-200 ease-out ${widthClass}`}
       >
-        <header className="min-w-0">
-          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-            {dashboard.title}
-          </h1>
-          {dashboard.description ? (
-            <p className="mt-1 text-sm text-muted-foreground">
-              {dashboard.description}
-            </p>
-          ) : null}
+        <header className="flex min-w-0 items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+              {dashboard.title}
+            </h1>
+            {dashboard.description ? (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {dashboard.description}
+              </p>
+            ) : null}
+          </div>
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastRefreshAt={lastRefreshAt}
+          />
         </header>
 
         <div className="mt-8 flex flex-col gap-8">
@@ -238,6 +269,7 @@ function DashboardBody({
               group={group}
               panels={dashboard.panels}
               states={panelStates}
+              dashboardPath={dashboardPath}
             />
           ))}
         </div>
@@ -342,10 +374,12 @@ function RowGroup({
   group,
   panels,
   states,
+  dashboardPath,
 }: {
   group: RowGroup;
   panels: DashboardPanel[];
   states: PanelState[];
+  dashboardPath: string | undefined;
 }) {
   const cols = group.columns;
   return (
@@ -358,15 +392,31 @@ function RowGroup({
       {group.indices.map((panelIdx) => {
         const panel = panels[panelIdx];
         const state = states[panelIdx];
+        const storageKeyBase = dashboardPath
+          ? `dash:${dashboardPath}:p${panelIdx}`
+          : undefined;
         return (
-          <PanelDispatch key={panelIdx} panel={panel} state={state} />
+          <PanelDispatch
+            key={panelIdx}
+            panel={panel}
+            state={state}
+            storageKeyBase={storageKeyBase}
+          />
         );
       })}
     </div>
   );
 }
 
-function PanelDispatch({ panel, state }: { panel: DashboardPanel; state: PanelState }) {
+function PanelDispatch({
+  panel,
+  state,
+  storageKeyBase,
+}: {
+  panel: DashboardPanel;
+  state: PanelState;
+  storageKeyBase: string | undefined;
+}) {
   if (panel.type === "kpi" && state.kind === "kpi") {
     const kpi = panel as KpiPanelSpec;
     return (
@@ -385,7 +435,13 @@ function PanelDispatch({ panel, state }: { panel: DashboardPanel; state: PanelSt
     return <StatGridPanel panel={panel as StatGridPanelSpec} state={state.state} />;
   }
   if (panel.type === "data_view" && state.kind === "data_view") {
-    return <DataViewPanel panel={panel} state={state.state} />;
+    return (
+      <DataViewPanel
+        panel={panel}
+        state={state.state}
+        storageKeyBase={storageKeyBase}
+      />
+    );
   }
   if (panel.type === "text" && state.kind === "text") {
     return <TextPanel panel={panel} />;
@@ -409,6 +465,73 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
     return () => window.clearTimeout(id);
   }, [value, delayMs]);
   return debounced;
+}
+
+// ----- Refresh indicator --------------------------------------------
+
+function isPanelLoading(s: PanelState): boolean {
+  if (s.kind === "kpi") {
+    return s.main.kind === "loading" || s.delta.kind === "loading";
+  }
+  if (s.kind === "stat_grid") {
+    if (s.state.kind === "loading") return true;
+    if (s.state.kind === "stats") {
+      return (
+        s.state.values.some((v) => v.kind === "loading") ||
+        s.state.deltas.some((d) => d.kind === "loading")
+      );
+    }
+    return false;
+  }
+  if (s.kind === "data_view" || s.kind === "chart") {
+    return s.state.kind === "loading";
+  }
+  return false;
+}
+
+function RefreshIndicator({
+  isRefreshing,
+  lastRefreshAt,
+}: {
+  isRefreshing: boolean;
+  lastRefreshAt: number | null;
+}) {
+  // Tick every 30s so the relative time stays roughly accurate without
+  // re-rendering the whole dashboard on a faster cadence.
+  const [, force] = useState(0);
+  useEffect(() => {
+    if (lastRefreshAt === null || isRefreshing) return;
+    const id = window.setInterval(() => force((n) => n + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, [lastRefreshAt, isRefreshing]);
+
+  if (isRefreshing) {
+    return (
+      <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+        Refreshing…
+      </span>
+    );
+  }
+  if (lastRefreshAt === null) return null;
+  return (
+    <span
+      className="shrink-0 text-[11px] tabular-nums text-muted-foreground"
+      title={new Date(lastRefreshAt).toLocaleString()}
+    >
+      Updated {formatRelativeShort(lastRefreshAt)}
+    </span>
+  );
+}
+
+function formatRelativeShort(ts: number): string {
+  const s = Math.round((Date.now() - ts) / 1000);
+  if (s < 5) return "just now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
 }
 
 // ----- Result merging ----------------------------------------------

--- a/desktop/src/components/dashboard/DashboardRenderer.tsx
+++ b/desktop/src/components/dashboard/DashboardRenderer.tsx
@@ -270,6 +270,7 @@ function DashboardBody({
               panels={dashboard.panels}
               states={panelStates}
               dashboardPath={dashboardPath}
+              fullWidth={fullWidth}
             />
           ))}
         </div>
@@ -375,11 +376,13 @@ function RowGroup({
   panels,
   states,
   dashboardPath,
+  fullWidth,
 }: {
   group: RowGroup;
   panels: DashboardPanel[];
   states: PanelState[];
   dashboardPath: string | undefined;
+  fullWidth: boolean;
 }) {
   const cols = group.columns;
   return (
@@ -401,6 +404,7 @@ function RowGroup({
             panel={panel}
             state={state}
             storageKeyBase={storageKeyBase}
+            fullWidth={fullWidth}
           />
         );
       })}
@@ -412,10 +416,12 @@ function PanelDispatch({
   panel,
   state,
   storageKeyBase,
+  fullWidth,
 }: {
   panel: DashboardPanel;
   state: PanelState;
   storageKeyBase: string | undefined;
+  fullWidth: boolean;
 }) {
   if (panel.type === "kpi" && state.kind === "kpi") {
     const kpi = panel as KpiPanelSpec;
@@ -440,6 +446,7 @@ function PanelDispatch({
         panel={panel}
         state={state.state}
         storageKeyBase={storageKeyBase}
+        fullWidth={fullWidth}
       />
     );
   }

--- a/desktop/src/components/dashboard/DataViewPanel.tsx
+++ b/desktop/src/components/dashboard/DataViewPanel.tsx
@@ -16,12 +16,14 @@ import {
 } from "@/lib/dashboardSchema";
 
 import { BoardView } from "./BoardView";
+import { ErrorMessage } from "./ErrorMessage";
 import { ListView } from "./ListView";
 import { TableView } from "./TableView";
 
 interface DataViewPanelProps {
   panel: DataViewPanelSpec;
   state: DataViewState;
+  storageKeyBase?: string;
 }
 
 export type DataViewState =
@@ -42,7 +44,7 @@ const VIEW_META: Record<DataViewSpec["type"], { label: string; icon: LucideIcon 
 // solid card surface, header with title + connected segmented view
 // switcher with an animated indicator pill, body with the active
 // view's content. Selected view state is component-local.
-export function DataViewPanel({ panel, state }: DataViewPanelProps) {
+export function DataViewPanel({ panel, state, storageKeyBase }: DataViewPanelProps) {
   const [activeViewType, setActiveViewType] = useState<DataViewSpec["type"]>(
     () => resolveInitialView(panel).type,
   );
@@ -83,11 +85,14 @@ export function DataViewPanel({ panel, state }: DataViewPanelProps) {
         {state.kind === "loading" ? (
           <SkeletonRows />
         ) : state.kind === "error" ? (
-          <div className="my-3 rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            {state.message}
-          </div>
+          <ErrorMessage message={state.message} />
         ) : (
-          <ViewBody view={activeView} state={state} emptyState={panel.empty_state} />
+          <ViewBody
+            view={activeView}
+            state={state}
+            emptyState={panel.empty_state}
+            storageKeyBase={storageKeyBase}
+          />
         )}
       </div>
     </section>
@@ -98,10 +103,12 @@ function ViewBody({
   view,
   state,
   emptyState,
+  storageKeyBase,
 }: {
   view: DataViewSpec;
   state: Extract<DataViewState, { kind: "data" }>;
   emptyState?: string;
+  storageKeyBase: string | undefined;
 }) {
   if (view.type === "table") {
     return (
@@ -110,6 +117,7 @@ function ViewBody({
         columns={state.columns}
         rows={state.rows}
         emptyState={emptyState}
+        storageKeyBase={storageKeyBase}
       />
     );
   }
@@ -120,6 +128,7 @@ function ViewBody({
         columns={state.columns}
         rows={state.rows}
         emptyState={emptyState}
+        storageKeyBase={storageKeyBase}
       />
     );
   }

--- a/desktop/src/components/dashboard/DataViewPanel.tsx
+++ b/desktop/src/components/dashboard/DataViewPanel.tsx
@@ -53,31 +53,33 @@ export function DataViewPanel({ panel, state }: DataViewPanelProps) {
 
   return (
     <section className="group overflow-hidden rounded-xl bg-card shadow-md smooth-corners">
-      <header className="flex items-center justify-between gap-3 border-b border-border/70 bg-fg-2 px-4 py-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
-            {panel.title}
-          </h3>
-          {rowCount !== null ? (
-            <span className="shrink-0 rounded-md bg-fg-6 px-1.5 py-0.5 text-[10.5px] font-medium tabular-nums text-muted-foreground">
-              {rowCount}
-            </span>
-          ) : null}
-          {panel.description ? (
-            <span className="hidden truncate text-xs text-muted-foreground md:inline">
-              · {panel.description}
-            </span>
+      <header className="border-b border-border/70 bg-fg-2 px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
+              {panel.title}
+            </h3>
+            {rowCount !== null ? (
+              <span className="shrink-0 rounded-md bg-fg-6 px-1.5 py-0.5 text-[10.5px] font-medium tabular-nums text-muted-foreground">
+                {rowCount}
+              </span>
+            ) : null}
+          </div>
+          {panel.views.length > 1 ? (
+            <ViewTabs
+              views={panel.views}
+              active={activeViewType}
+              onChange={setActiveViewType}
+            />
           ) : null}
         </div>
-        {panel.views.length > 1 ? (
-          <ViewTabs
-            views={panel.views}
-            active={activeViewType}
-            onChange={setActiveViewType}
-          />
+        {panel.description ? (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {panel.description}
+          </p>
         ) : null}
       </header>
-      <div className="scrollbar-ghost max-h-[560px] overflow-auto px-4 pb-3">
+      <div className="scrollbar-ghost max-h-[560px] overflow-auto px-4 py-3">
         {state.kind === "loading" ? (
           <SkeletonRows />
         ) : state.kind === "error" ? (

--- a/desktop/src/components/dashboard/DataViewPanel.tsx
+++ b/desktop/src/components/dashboard/DataViewPanel.tsx
@@ -24,6 +24,7 @@ interface DataViewPanelProps {
   panel: DataViewPanelSpec;
   state: DataViewState;
   storageKeyBase?: string;
+  fullWidth?: boolean;
 }
 
 export type DataViewState =
@@ -44,7 +45,12 @@ const VIEW_META: Record<DataViewSpec["type"], { label: string; icon: LucideIcon 
 // solid card surface, header with title + connected segmented view
 // switcher with an animated indicator pill, body with the active
 // view's content. Selected view state is component-local.
-export function DataViewPanel({ panel, state, storageKeyBase }: DataViewPanelProps) {
+export function DataViewPanel({
+  panel,
+  state,
+  storageKeyBase,
+  fullWidth = false,
+}: DataViewPanelProps) {
   const [activeViewType, setActiveViewType] = useState<DataViewSpec["type"]>(
     () => resolveInitialView(panel).type,
   );
@@ -76,12 +82,16 @@ export function DataViewPanel({ panel, state, storageKeyBase }: DataViewPanelPro
           ) : null}
         </div>
         {panel.description ? (
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          <p className="mt-1 truncate text-xs text-muted-foreground">
             {panel.description}
           </p>
         ) : null}
       </header>
-      <div className="scrollbar-ghost max-h-[560px] overflow-auto px-4 py-3">
+      <div
+        className={`scrollbar-ghost overflow-auto px-4 py-3 ${
+          fullWidth ? "max-h-[800px]" : "max-h-[560px]"
+        }`}
+      >
         {state.kind === "loading" ? (
           <SkeletonRows />
         ) : state.kind === "error" ? (

--- a/desktop/src/components/dashboard/EmptyState.tsx
+++ b/desktop/src/components/dashboard/EmptyState.tsx
@@ -1,0 +1,24 @@
+import type { LucideIcon } from "lucide-react";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  message: string;
+  /** Optional sub-line. Renders below the message in lighter weight. */
+  hint?: string;
+  /** Forces a min-height so chart panels don't collapse when empty.
+   *  When omitted, the empty state sits at its natural py-10 height. */
+  minHeight?: number;
+}
+
+export function EmptyState({ icon: Icon, message, hint, minHeight }: EmptyStateProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground"
+      style={minHeight ? { minHeight } : undefined}
+    >
+      <Icon size={22} strokeWidth={1.5} className="opacity-45" />
+      <p className="text-xs">{message}</p>
+      {hint ? <p className="text-[11px] opacity-70">{hint}</p> : null}
+    </div>
+  );
+}

--- a/desktop/src/components/dashboard/ErrorMessage.tsx
+++ b/desktop/src/components/dashboard/ErrorMessage.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+
+interface ErrorMessageProps {
+  message: string;
+  /** Single-line truncate variant for tight spots (KpiCard value row).
+   *  Default is a 3-line box with the destructive frame. */
+  compact?: boolean;
+}
+
+export function ErrorMessage({ message, compact = false }: ErrorMessageProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        title={expanded ? "Click to collapse" : message}
+        className={`text-left text-xs text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+          expanded ? "whitespace-pre-wrap" : "truncate"
+        }`}
+      >
+        {message}
+      </button>
+    );
+  }
+
+  return (
+    <div className="my-3 rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        title={expanded ? "Click to collapse" : "Click to show full error"}
+        className={`block w-full text-left font-mono leading-snug focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/50 ${
+          expanded ? "whitespace-pre-wrap" : "line-clamp-3"
+        }`}
+      >
+        {message}
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/components/dashboard/KpiCard.tsx
+++ b/desktop/src/components/dashboard/KpiCard.tsx
@@ -1,3 +1,5 @@
+import { AlertTriangle } from "lucide-react";
+
 import type { ColumnFormat } from "@/lib/dashboardSchema";
 
 import { ErrorMessage } from "./ErrorMessage";
@@ -93,6 +95,13 @@ export function KpiCard({
               >
                 <span aria-hidden>{deltaInfo.arrow}</span>
                 {deltaInfo.text}
+              </span>
+            ) : delta?.kind === "error" ? (
+              <span
+                className="inline-flex items-center rounded-md bg-muted px-1 py-0.5 text-muted-foreground"
+                title="Delta query failed"
+              >
+                <AlertTriangle size={10} strokeWidth={2.25} />
               </span>
             ) : null}
           </>

--- a/desktop/src/components/dashboard/KpiCard.tsx
+++ b/desktop/src/components/dashboard/KpiCard.tsx
@@ -59,7 +59,7 @@ export function KpiCard({
   const progress = computeProgress(state, target);
 
   return (
-    <div className={compact ? "px-3 py-3" : "px-1 py-1"}>
+    <div className={compact ? "px-4 py-2" : "px-1 py-1"}>
       <div className="flex items-baseline gap-2">
         <span className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
           {title}
@@ -67,16 +67,13 @@ export function KpiCard({
       </div>
       <div className="mt-2 flex min-h-[2rem] items-baseline gap-2.5">
         {state.kind === "loading" ? (
-          <span
-            className="hb-spinner text-muted-foreground"
-            style={{ fontSize: compact ? "1.25rem" : "1.5rem" }}
+          <div
+            className={`animate-shimmer rounded-md bg-fg-6 ${
+              compact ? "h-7 w-20" : "h-8 w-28"
+            }`}
             aria-busy
             aria-label="Loading"
-          >
-            <span /><span /><span />
-            <span /><span /><span />
-            <span /><span /><span />
-          </span>
+          />
         ) : state.kind === "error" ? (
           <div className="truncate text-xs text-destructive" title={state.message}>
             {state.message}
@@ -85,7 +82,7 @@ export function KpiCard({
           <>
             <span
               className={`font-mono tabular-nums tracking-tight text-foreground ${
-                compact ? "text-2xl font-medium" : "text-[28px] font-medium leading-none"
+                compact ? "text-2xl font-semibold" : "text-3xl font-semibold leading-none"
               }`}
             >
               {valueText}
@@ -111,7 +108,7 @@ export function KpiCard({
         <div className="mt-2.5">
           <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
             <div
-              className="h-full bg-foreground/85 transition-[width] duration-500 ease-out"
+              className="h-full bg-foreground transition-[width] duration-500 ease-out"
               style={{ width: `${Math.max(0, Math.min(100, progress.pct))}%` }}
             />
           </div>

--- a/desktop/src/components/dashboard/KpiCard.tsx
+++ b/desktop/src/components/dashboard/KpiCard.tsx
@@ -1,5 +1,6 @@
 import type { ColumnFormat } from "@/lib/dashboardSchema";
 
+import { ErrorMessage } from "./ErrorMessage";
 import { formatValue } from "./format";
 
 export type KpiCardState =
@@ -75,9 +76,7 @@ export function KpiCard({
             aria-label="Loading"
           />
         ) : state.kind === "error" ? (
-          <div className="truncate text-xs text-destructive" title={state.message}>
-            {state.message}
-          </div>
+          <ErrorMessage message={state.message} compact />
         ) : (
           <>
             <span

--- a/desktop/src/components/dashboard/ListView.tsx
+++ b/desktop/src/components/dashboard/ListView.tsx
@@ -1,4 +1,5 @@
 import { Rows3 } from "lucide-react";
+import { useState } from "react";
 
 import type { ListViewSpec } from "@/lib/dashboardSchema";
 
@@ -19,6 +20,7 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
   const secondaryIdx = view.secondary ? columns.indexOf(view.secondary) : -1;
   const metaIdx = view.meta ? columns.indexOf(view.meta) : -1;
   const metaIsDate = looksLikeDateColumn(view.meta);
+  const [shownLimit, setShownLimit] = useState(500);
 
   if (primaryIdx < 0) {
     return (
@@ -31,7 +33,7 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
     return <EmptyState icon={Rows3} message={emptyState ?? "Nothing here yet."} />;
   }
 
-  const display = rows.slice(0, 500);
+  const display = rows.slice(0, shownLimit);
 
   return (
     <ul className="divide-y divide-border/40 pt-1">
@@ -72,8 +74,17 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
         );
       })}
       {rows.length > display.length ? (
-        <li className="pt-3 text-xs text-muted-foreground">
-          Showing {display.length} of {rows.length}.
+        <li className="flex items-center gap-3 pt-3 text-xs text-muted-foreground">
+          <span>
+            Showing {display.length} of {rows.length}.
+          </span>
+          <button
+            type="button"
+            onClick={() => setShownLimit((n) => n + 500)}
+            className="rounded-md border border-border px-2 py-0.5 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            Show {Math.min(500, rows.length - display.length)} more
+          </button>
         </li>
       ) : null}
     </ul>

--- a/desktop/src/components/dashboard/ListView.tsx
+++ b/desktop/src/components/dashboard/ListView.tsx
@@ -1,5 +1,8 @@
+import { Rows3 } from "lucide-react";
+
 import type { ListViewSpec } from "@/lib/dashboardSchema";
 
+import { EmptyState } from "./EmptyState";
 import { formatSmartDate, looksLikeDateColumn } from "./format";
 
 interface ListViewProps {
@@ -25,11 +28,7 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
     );
   }
   if (rows.length === 0) {
-    return (
-      <div className="py-10 text-center text-xs text-muted-foreground">
-        {emptyState ?? "Nothing here yet."}
-      </div>
-    );
+    return <EmptyState icon={Rows3} message={emptyState ?? "Nothing here yet."} />;
   }
 
   const display = rows.slice(0, 500);

--- a/desktop/src/components/dashboard/StatGridPanel.tsx
+++ b/desktop/src/components/dashboard/StatGridPanel.tsx
@@ -37,13 +37,13 @@ export function StatGridPanel({ panel, state }: StatGridPanelProps) {
           {panel.title}
         </h2>
         {panel.description ? (
-          <p className="mt-0.5 text-xs text-muted-foreground">
+          <p className="mt-1 text-xs text-muted-foreground">
             {panel.description}
           </p>
         ) : null}
       </div>
       <div
-        className={`grid divide-x divide-border/50 [&>*:first-child]:pl-0 ${gridClass}`}
+        className={`grid divide-x divide-border [&>*:first-child]:pl-0 ${gridClass}`}
       >
         {panel.stats.map((stat, i) => {
           const cardState =

--- a/desktop/src/components/dashboard/StatGridPanel.tsx
+++ b/desktop/src/components/dashboard/StatGridPanel.tsx
@@ -32,18 +32,18 @@ export function StatGridPanel({ panel, state }: StatGridPanelProps) {
 
   return (
     <section className="min-w-0">
-      <div className="mb-2.5 flex items-baseline justify-between gap-3">
-        <h2 className="text-base font-semibold tracking-tight text-foreground">
+      <div className="mb-3">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
           {panel.title}
         </h2>
         {panel.description ? (
-          <p className="hidden text-xs text-muted-foreground sm:block">
+          <p className="mt-0.5 text-xs text-muted-foreground">
             {panel.description}
           </p>
         ) : null}
       </div>
       <div
-        className={`grid gap-x-6 gap-y-4 rounded-xl bg-card p-5 shadow-md smooth-corners ${gridClass}`}
+        className={`grid divide-x divide-border/50 [&>*:first-child]:pl-0 ${gridClass}`}
       >
         {panel.stats.map((stat, i) => {
           const cardState =

--- a/desktop/src/components/dashboard/StatusBadge.tsx
+++ b/desktop/src/components/dashboard/StatusBadge.tsx
@@ -11,7 +11,7 @@ export function StatusBadge({ value }: StatusBadgeProps) {
   const className = badgeClassFor(value);
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-4 ${className}`}
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium leading-4 ${className}`}
     >
       {value || "—"}
     </span>

--- a/desktop/src/components/dashboard/TableView.tsx
+++ b/desktop/src/components/dashboard/TableView.tsx
@@ -1,8 +1,9 @@
-import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronsUpDown, ChevronUp, Table2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ColorToken, TableColumnSpec, TableViewSpec } from "@/lib/dashboardSchema";
 
+import { EmptyState } from "./EmptyState";
 import { isStatusColumn, StatusBadge } from "./StatusBadge";
 import {
   colorClasses,
@@ -83,31 +84,9 @@ export function TableView({ view, columns, rows, emptyState }: TableViewProps) {
     });
   };
 
-  if (visible.length === 0) {
-    return (
-      <div className="py-10 text-center text-xs text-muted-foreground">
-        No columns to display.
-      </div>
-    );
-  }
-  if (rows.length === 0) {
-    return (
-      <div className="py-10 text-center text-xs text-muted-foreground">
-        {emptyState ?? "No rows."}
-      </div>
-    );
-  }
-
   const beginResize = useCallback(
     (name: string, startX: number) => {
       const startWidth = effectiveWidths[name] ?? 160;
-      // Pointer events with capture — works for mouse + touch + pen
-      // and isn't lost when the cursor leaves the small handle area
-      // mid-drag.
-      const handle = document.createElement("div");
-      // Add a body-level cursor so the col-resize cursor stays even
-      // when the pointer moves off the handle (otherwise the cursor
-      // flickers on every frame). Restored on pointerup.
       const prevCursor = document.body.style.cursor;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
@@ -122,7 +101,6 @@ export function TableView({ view, columns, rows, emptyState }: TableViewProps) {
         window.removeEventListener("pointerup", onUp);
         document.body.style.cursor = prevCursor;
         document.body.style.userSelect = "";
-        handle.remove();
       };
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
@@ -130,19 +108,11 @@ export function TableView({ view, columns, rows, emptyState }: TableViewProps) {
     [effectiveWidths],
   );
 
-  // Total pixel width across all columns. The wrapper's overflow-x:
-  // auto kicks in when this exceeds the container, so very wide
-  // tables scroll horizontally with mask-edges-x fading the cut.
   const totalWidth = visible.reduce(
     (sum, c) => sum + (effectiveWidths[c.name] ?? 160),
     0,
   );
 
-  // Edge-fade only on the side that has hidden content. Notion's
-  // pattern: leftmost column shouldn't be ghosted just because the
-  // table is wider than its frame; the fade is a hint that "more
-  // exists in this direction", and there's nothing to the left of
-  // scroll position 0.
   const scrollWrapRef = useRef<HTMLDivElement | null>(null);
   const [edgeFade, setEdgeFade] = useState({ left: 0, right: 0 });
   const updateEdgeFade = useCallback(() => {
@@ -164,6 +134,13 @@ export function TableView({ view, columns, rows, emptyState }: TableViewProps) {
     ro.observe(el);
     return () => ro.disconnect();
   }, [updateEdgeFade, totalWidth]);
+
+  if (visible.length === 0) {
+    return <EmptyState icon={Table2} message="No columns to display." />;
+  }
+  if (rows.length === 0) {
+    return <EmptyState icon={Table2} message={emptyState ?? "Nothing here yet."} />;
+  }
 
   return (
     <div className="group pt-1">

--- a/desktop/src/components/dashboard/TableView.tsx
+++ b/desktop/src/components/dashboard/TableView.tsx
@@ -88,13 +88,13 @@ export function TableView({
     });
   }, [rows, sort, columns]);
 
-  const displayRows = sortedRows.slice(0, 500);
+  const [shownLimit, setShownLimit] = useState(500);
+  const displayRows = sortedRows.slice(0, shownLimit);
 
   const cycleSort = (column: string) => {
     setSort((prev) => {
       if (!prev || prev.column !== column) return { column, dir: "asc" };
-      if (prev.dir === "asc") return { column, dir: "desc" };
-      return null;
+      return { column, dir: prev.dir === "asc" ? "desc" : "asc" };
     });
   };
 
@@ -197,7 +197,7 @@ export function TableView({
                         dir === "asc"
                           ? "Sorted ascending — click for descending"
                           : dir === "desc"
-                            ? "Sorted descending — click to clear"
+                            ? "Sorted descending — click for ascending"
                             : "Click to sort"
                       }
                       className={`-mx-1 inline-flex items-center gap-1 rounded px-1 py-0.5 transition-colors hover:bg-fg-6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
@@ -246,8 +246,17 @@ export function TableView({
         </table>
       </div>
       {rows.length > displayRows.length ? (
-        <div className="pt-3 text-xs text-muted-foreground">
-          Showing {displayRows.length} of {rows.length} rows.
+        <div className="flex items-center gap-3 pt-3 text-xs text-muted-foreground">
+          <span>
+            Showing {displayRows.length} of {rows.length} rows.
+          </span>
+          <button
+            type="button"
+            onClick={() => setShownLimit((n) => n + 500)}
+            className="rounded-md border border-border px-2 py-0.5 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            Show {Math.min(500, rows.length - displayRows.length)} more
+          </button>
         </div>
       ) : null}
     </div>

--- a/desktop/src/components/dashboard/TableView.tsx
+++ b/desktop/src/components/dashboard/TableView.tsx
@@ -11,12 +11,14 @@ import {
   formatValue,
   resolveLinkTemplate,
 } from "./format";
+import { usePersistedState } from "./usePersistedState";
 
 interface TableViewProps {
   view: TableViewSpec;
   columns: string[];
   rows: unknown[][];
   emptyState?: string;
+  storageKeyBase?: string;
 }
 
 type SortDir = "asc" | "desc" | null;
@@ -40,10 +42,22 @@ interface ResolvedColumn {
 // padding, larger row text, hairline borders, soft hover. The view's
 // `columns` field, when set, drives column order, format, alignment,
 // width, color chips, and clickable links.
-export function TableView({ view, columns, rows, emptyState }: TableViewProps) {
+export function TableView({
+  view,
+  columns,
+  rows,
+  emptyState,
+  storageKeyBase,
+}: TableViewProps) {
   const visible = pickColumns(view, columns);
-  const [sort, setSort] = useState<SortState | null>(null);
-  const [resizedWidths, setResizedWidths] = useState<Record<string, number>>({});
+  const [sort, setSort] = usePersistedState<SortState | null>(
+    storageKeyBase ? `${storageKeyBase}:table:sort` : undefined,
+    null,
+  );
+  const [resizedWidths, setResizedWidths] = usePersistedState<Record<string, number>>(
+    storageKeyBase ? `${storageKeyBase}:table:widths` : undefined,
+    {},
+  );
 
   // Effective width per column: spec.width > user resize > default.
   const effectiveWidths = useMemo(() => {
@@ -292,11 +306,11 @@ function defaultColumnWidthPx(c: ResolvedColumn): number {
   if (fmt === "datetime" || fmt === "date") return 170;
   if (fmt === "url") return 140;
   if (fmt === "image_url") return 64;
+  if (fmt === "currency") return 130;
   if (
     fmt === "integer" ||
     fmt === "number" ||
     fmt === "percent" ||
-    fmt === "currency" ||
     fmt === "duration"
   ) {
     return 110;

--- a/desktop/src/components/dashboard/TextPanel.tsx
+++ b/desktop/src/components/dashboard/TextPanel.tsx
@@ -18,7 +18,7 @@ export function TextPanel({ panel }: TextPanelProps) {
   const body = useMemo(() => panel.body, [panel.body]);
   return (
     <section className="min-w-0">
-      <div className="prose prose-sm max-w-none text-foreground prose-headings:font-semibold prose-headings:tracking-tight prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-p:leading-relaxed prose-p:text-foreground/85 prose-a:text-primary prose-a:underline-offset-4 prose-strong:font-semibold prose-strong:text-foreground prose-code:rounded prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:text-[12px]">
+      <div className="prose prose-sm max-w-none text-foreground prose-headings:font-semibold prose-headings:tracking-tight prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-p:leading-relaxed prose-p:text-foreground prose-a:text-primary prose-a:underline-offset-4 prose-strong:font-semibold prose-strong:text-foreground prose-code:rounded prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:text-[12px]">
         <SimpleMarkdown>{body}</SimpleMarkdown>
       </div>
     </section>

--- a/desktop/src/components/dashboard/usePersistedState.ts
+++ b/desktop/src/components/dashboard/usePersistedState.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+// Pass `key: undefined` to opt out of persistence (e.g. ephemeral previews).
+export function usePersistedState<T>(
+  key: string | undefined,
+  initial: T,
+): [T, (next: T | ((prev: T) => T)) => void] {
+  const [state, setState] = useState<T>(() => {
+    if (!key || typeof localStorage === "undefined") return initial;
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return initial;
+      return JSON.parse(raw) as T;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    if (!key || typeof localStorage === "undefined") return;
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // ignore
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}

--- a/desktop/src/components/dashboard/usePersistedState.ts
+++ b/desktop/src/components/dashboard/usePersistedState.ts
@@ -18,11 +18,14 @@ export function usePersistedState<T>(
 
   useEffect(() => {
     if (!key || typeof localStorage === "undefined") return;
-    try {
-      localStorage.setItem(key, JSON.stringify(state));
-    } catch {
-      // ignore
-    }
+    const id = window.setTimeout(() => {
+      try {
+        localStorage.setItem(key, JSON.stringify(state));
+      } catch {
+        // ignore
+      }
+    }, 200);
+    return () => window.clearTimeout(id);
   }, [key, state]);
 
   return [state, setState];

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -639,6 +639,7 @@ export function InternalSurfacePane({
             <DashboardRenderer
               workspaceId={selectedWorkspaceId}
               content={previewDraft}
+              dashboardPath={preview.absolutePath}
               fullWidth={dashboardFullWidth}
               refreshKey={dashboardRefreshKey}
             />

--- a/desktop/src/lib/dashboardSchema.ts
+++ b/desktop/src/lib/dashboardSchema.ts
@@ -94,6 +94,10 @@ export type ChartSpec =
       x: string;
       y: string[];
       stacked?: boolean;
+      /** Single-series bar charts only: color each bar by the sign of
+       *  its value — positive uses palette[0] (sky), negative uses
+       *  palette[1] (orange). Ignored on multi-series, line, area. */
+      color_by_sign?: boolean;
       x_format?: "date" | "datetime" | "text";
       y_format?: "integer" | "number" | "percent" | "currency" | "duration";
       legend?: boolean;
@@ -591,6 +595,7 @@ function parseChartSpec(raw: unknown): ChartSpec | null {
       x,
       y,
       ...(raw.stacked === true ? { stacked: true } : {}),
+      ...(raw.color_by_sign === true ? { color_by_sign: true } : {}),
       ...(xFormat ? { x_format: xFormat } : {}),
       ...(yFormat &&
       (yFormat === "integer" ||

--- a/desktop/src/lib/dashboardSchema.ts
+++ b/desktop/src/lib/dashboardSchema.ts
@@ -203,6 +203,8 @@ export type DashboardPanel =
 export interface Dashboard {
   title: string;
   description?: string;
+  /** Auto-refresh interval in seconds. Minimum 10. */
+  refresh_interval?: number;
   panels: DashboardPanel[];
 }
 
@@ -230,6 +232,11 @@ export function parseDashboard(content: string): DashboardParseResult {
   const title = stringField(parsed, "title");
   if (!title) return { ok: false, error: "Missing required field: `title`." };
   const description = optionalStringField(parsed, "description");
+  const refreshIntervalRaw = parseNumberField(parsed.refresh_interval);
+  const refreshInterval =
+    refreshIntervalRaw !== null && refreshIntervalRaw >= 10
+      ? Math.floor(refreshIntervalRaw)
+      : null;
   const rawPanels = parsed.panels;
   if (!Array.isArray(rawPanels) || rawPanels.length === 0) {
     return { ok: false, error: "Missing or empty `panels` list." };
@@ -245,6 +252,7 @@ export function parseDashboard(content: string): DashboardParseResult {
     dashboard: {
       title,
       ...(description ? { description } : {}),
+      ...(refreshInterval !== null ? { refresh_interval: refreshInterval } : {}),
       panels,
     },
   };


### PR DESCRIPTION
## Summary

Five rounds of polish on the in-app dashboard renderer. Five commits, ~10 files touched, all behind the existing `.dashboard` surface — no API or schema breaks for existing dashboards.

## Bug fixes
- **Rules of Hooks**: TableView / ChartPanel had `useCallback` / `useEffect` / `useMemo` after early returns — fixed by hoisting hooks above guards
- **BoardView**: render-phase `setActiveGroupBy` → `useEffect`
- **DashboardRenderer**: debounce content reparse (250ms) — editor keystrokes were re-firing every panel's SQL on each char
- **ChartPanel**: stacked-bar `radius={[3,3,0,0]}` → 0 when stacked (per-segment rounded tops looked like dents)
- **KpiCard**: `delta_query` failure now shows an `AlertTriangle` badge (was silently hidden — looked like no delta_query was configured)
- **BoardView card**: drop `tabIndex={0}` + `transition-all` + `hover:shadow-sm` (empty affordance + violates design rules)

## Style / UX
- **StatGridPanel**: drop card chrome → hairline-divided KPI row, small-uppercase section title
- **KpiCard**: `text-3xl/2xl font-semibold` values; loading shimmer rect (was 9-cell spinner); progress bar drops `bg-foreground/85` opacity hack
- **ChartPanel / DataViewPanel**: header description moves to second line under title; body padding unified to `px-4 py-3`
- **StatusBadge**: `rounded-full` → `rounded-md` (matches colors-map chips)
- **Empty state**: shared `EmptyState` component with per-panel-type lucide icon (Table2 / Columns3 / Rows3 / chart-kind)
- **TextPanel**: `prose-p:text-foreground/85` → `text-foreground` (no opacity on tokens)
- `divide-border/50` → `divide-border` (dark mode was nearly invisible)
- Currency column default width 110 → 130
- Description spacing unified `mt-0.5` → `mt-1`
- Empty-state copy unified to `"Nothing here yet."`

## New schema / features
- **ChartSpec.color_by_sign**: single-series bar charts color each row by value sign (sky for ≥0, orange for <0). Cleaner than the gain/loss two-series workaround
- **Dashboard.refresh_interval**: top-level seconds field (≥10) → `setInterval(bumpDashboardRefreshKey, ...)`
- **Refresh indicator**: `"Refreshing…"` while panels are in flight, `"Updated 5s ago"` after, with a 30s tick
- **ErrorMessage**: SQL errors click-to-expand (was single-line truncate-with-title)
- **TableView / ListView**: progressive row loading — `"Show 500 more"` button extends in chunks
- **TableView sort**: two-state asc ↔ desc (was three-state with confusing null)
- **DataViewPanel**: `max-h-[800px]` in fullWidth mode (was 560px hard-cap regardless of pane size)
- **usePersistedState**: localStorage-backed table sort + column widths + board group-by, keyed by dashboard absolutePath, 200ms debounced writes
- **useSeriesPalette**: chart palette subscribes to `html.classList` via MutationObserver — chart repaints on dark/light toggle

## Test plan
- [ ] Open `trading-weekly-review.dashboard` → P&L by ticker uses sky/orange split (single series with `color_by_sign: true`)
- [ ] Resize a table column / change sort / switch board group-by → reload, state persists
- [ ] Edit a `.dashboard` file's YAML in the editor → queries debounce, no per-keystroke SQL storm
- [ ] Toggle dark/light theme → chart palette repaints without manual refresh
- [ ] Set `refresh_interval: 30` at the top of a dashboard → periodic refresh + "Updated Xs ago" pill ticks
- [ ] Trigger a SQL error in a panel → click message to expand full text

🤖 Generated with [Claude Code](https://claude.com/claude-code)