### PR TITLE
ChatPane interactions: per-turn actions menu + trace summary polish + streaming fade-in

### DIFF
--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -42,6 +42,8 @@ import {
   Lightbulb,
   Link2,
   Loader2,
+  ListTree,
+  MoreHorizontal,
   Paperclip,
   PencilLine,
   Plus,
@@ -54,6 +56,13 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { PaneCard } from "@/components/ui/PaneCard";
 import { BackgroundTasksPane } from "@/components/panes/BackgroundTasksPane";
@@ -8773,6 +8782,136 @@ function QueuedSessionInputRail({
   );
 }
 
+/**
+ * True when the agent invoked any filesystem-mutating tool inside this
+ * turn's execution items. Drives whether the per-turn actions menu offers
+ * "View file changes" — if no Edit / Write / patch happened, the menu
+ * entry is hidden so users aren't taught a useless affordance.
+ */
+function executionItemsHaveFileEdits(
+  items: ChatExecutionTimelineItem[],
+): boolean {
+  if (items.length === 0) {
+    return false;
+  }
+  return items.some((item) => {
+    if (item.kind !== "trace_step" || item.step.kind !== "tool") {
+      return false;
+    }
+    const title = item.step.title.toLowerCase();
+    // Tool names exposed to the user surface as "Edit"/"Write"/"Patch"/
+    // "Replace"/"MultiEdit". Match by lowercase substring rather than
+    // exact equality because titles often include the file path
+    // ("Write README.md", "Edit src/foo.ts").
+    return (
+      title.startsWith("edit") ||
+      title.startsWith("write") ||
+      title.startsWith("patch") ||
+      title.startsWith("replace") ||
+      title.startsWith("multiedit") ||
+      title.startsWith("apply") ||
+      title.startsWith("create file")
+    );
+  });
+}
+
+interface AssistantTurnActionsMenuProps {
+  /** Plain-text content the user gets when clicking Copy. */
+  copyText: string;
+  /**
+   * Triggered when the user picks "View turn details". Optional — when
+   * not provided the entry is hidden. Implementation typically expands
+   * the trace group + scrolls it into view.
+   */
+  onViewTurnDetails?: () => void;
+  /**
+   * Triggered when the user picks "View file changes". Optional + only
+   * meaningful when the turn invoked file-mutating tools.
+   */
+  onViewFileChanges?: () => void;
+  /** When true, render the file-changes entry even without a callback. */
+  hasFileEdits?: boolean;
+}
+
+/**
+ * Per-assistant-turn 3-dot menu shown on hover. Mirrors the user-side
+ * copy affordance so both speakers get parity. The menu is intentionally
+ * narrow (Copy + maybe one or two domain actions) — adding more makes
+ * the chat surface noisy on every turn.
+ */
+function AssistantTurnActionsMenu({
+  copyText,
+  onViewTurnDetails,
+  onViewFileChanges,
+  hasFileEdits,
+}: AssistantTurnActionsMenuProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    if (!copyText) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Some embedded WebContents block clipboard from non-user-gesture
+      // contexts. Silent — the menu item exists for the gesture path.
+    }
+  }
+
+  const showFileChanges = Boolean(onViewFileChanges) && Boolean(hasFileEdits);
+  const canCopy = copyText.trim().length > 0;
+
+  // Nothing to show — don't render an empty trigger that just confuses
+  // users when they hover and the menu is empty.
+  if (!canCopy && !onViewTurnDetails && !showFileChanges) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            aria-label="Turn actions"
+            className="size-6 rounded-lg text-muted-foreground hover:bg-foreground/6 hover:text-foreground"
+            size="icon-xs"
+            type="button"
+            variant="ghost"
+          >
+            <MoreHorizontal className="size-3.5" strokeWidth={1.9} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" className="w-44" sideOffset={4}>
+        {canCopy ? (
+          <DropdownMenuItem onClick={() => void handleCopy()}>
+            {copied ? <Check /> : <Copy />}
+            {copied ? "Copied" : "Copy message"}
+          </DropdownMenuItem>
+        ) : null}
+        {onViewTurnDetails ? (
+          <DropdownMenuItem onClick={onViewTurnDetails}>
+            <ListTree />
+            View turn details
+          </DropdownMenuItem>
+        ) : null}
+        {showFileChanges ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onViewFileChanges}>
+              <FileCode2 />
+              View file changes
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function AssistantTurn({
   label,
   mode,
@@ -8875,6 +9014,30 @@ function AssistantTurn({
     live && Boolean(normalizedStatus) && renderedSegments.length === 0;
   const showWorkingStatusLine =
     live && showExecutionInternals && renderedSegments.length > 0;
+
+  // Bumped by the per-turn actions menu's "View turn details" item; threads
+  // through every TraceStepGroup in this turn to force-expand them.
+  const [forceExpandToken, setForceExpandToken] = useState(0);
+  const hasFileEdits = useMemo(
+    () => executionItemsHaveFileEdits(executionItems),
+    [executionItems],
+  );
+  // Plain-text we feed to the Copy menu item — concatenate output segments;
+  // execution segments are noise for paste targets like a doc or message.
+  const copyText = useMemo(
+    () =>
+      renderedSegments
+        .filter(
+          (segment): segment is Extract<ChatAssistantSegment, { kind: "output" }> =>
+            segment.kind === "output",
+        )
+        .map((segment) => segment.text)
+        .join("\n\n")
+        .trim() || text.trim(),
+    [renderedSegments, text],
+  );
+  const hasAnyContent = renderedSegments.length > 0;
+  const showActionsMenu = hasAnyContent && !live;
   const renderStatusLine = (nextLabel: string, className = "") => {
     if (!showExecutionInternals) {
       return (
@@ -8899,7 +9062,7 @@ function AssistantTurn({
 
   return (
     <div
-      className={`flex min-w-0 justify-start ${showSeparator ? "mt-2" : ""}`.trim()}
+      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-2" : ""}`.trim()}
     >
       <article
         className={`min-w-0 w-full max-w-4xl ${
@@ -8924,6 +9087,7 @@ function AssistantTurn({
               }
               onLinkClick={onLinkClick}
               onLocalLinkClick={onLocalLinkClick}
+              forceExpandToken={forceExpandToken}
             />
           ) : segment.tone === "error" ? (
             <div
@@ -8987,6 +9151,25 @@ function AssistantTurn({
           />
         ) : null}
       </article>
+
+      {showActionsMenu ? (
+        <div className="pointer-events-none absolute top-1.5 right-1.5 opacity-0 transition-opacity duration-150 group-hover/assistant-turn:pointer-events-auto group-hover/assistant-turn:opacity-100 group-focus-within/assistant-turn:pointer-events-auto group-focus-within/assistant-turn:opacity-100">
+          <AssistantTurnActionsMenu
+            copyText={copyText}
+            hasFileEdits={hasFileEdits}
+            onViewFileChanges={
+              hasFileEdits
+                ? () => setForceExpandToken((token) => token + 1)
+                : undefined
+            }
+            onViewTurnDetails={
+              executionItems.length > 0
+                ? () => setForceExpandToken((token) => token + 1)
+                : undefined
+            }
+          />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -9628,7 +9811,11 @@ function LiveStatusLine({
   return (
     <div
       aria-live="polite"
-      className={`inline-flex items-baseline gap-0.5 text-xs leading-6 text-muted-foreground ${className}`.trim()}
+      // Keyed on the label so a status change ("Thinking" → "Editing
+      // README.md") triggers a fresh fade-in instead of an abrupt swap —
+      // makes long agent runs feel responsive instead of glitchy.
+      key={normalizedLabel}
+      className={`inline-flex items-baseline gap-0.5 text-xs leading-6 text-muted-foreground animate-in fade-in-0 slide-in-from-bottom-0.5 duration-200 ease-out ${className}`.trim()}
     >
       <span>{normalizedLabel}</span>
       <LiveStatusEllipsis />
@@ -9647,7 +9834,7 @@ function TypingStatusLine({
     <div
       aria-live="polite"
       aria-label="Assistant is typing"
-      className={`inline-flex items-center text-[18px] leading-none tracking-[0.18em] text-muted-foreground/78 ${className}`.trim()}
+      className={`inline-flex items-center text-[18px] leading-none tracking-[0.18em] text-muted-foreground/78 animate-in fade-in-0 duration-200 ease-out ${className}`.trim()}
     >
       <LiveStatusEllipsis />
     </div>
@@ -9764,6 +9951,7 @@ function TraceStepGroup({
   liveOutputStarted = false,
   onLinkClick,
   onLocalLinkClick,
+  forceExpandToken = 0,
 }: {
   items: ChatExecutionTimelineItem[];
   collapsedByStepId: Record<string, boolean>;
@@ -9772,6 +9960,12 @@ function TraceStepGroup({
   liveOutputStarted?: boolean;
   onLinkClick?: (url: string) => void;
   onLocalLinkClick?: (href: string) => void;
+  /**
+   * Counter the parent bumps to force the group open — used by the per-turn
+   * "View turn details" action so the user lands on a fully expanded trace
+   * even if they had previously collapsed it.
+   */
+  forceExpandToken?: number;
 }) {
   const steps = traceStepsFromExecutionItems(items);
   const [groupExpanded, setGroupExpanded] = useState(
@@ -9779,6 +9973,19 @@ function TraceStepGroup({
   );
   const previousLiveRef = useRef(live);
   const previousLiveOutputStartedRef = useRef(liveOutputStarted);
+  const previousForceExpandTokenRef = useRef(forceExpandToken);
+
+  // External force-expand: bump from the per-turn actions menu opens the
+  // group regardless of its previous state. Mounting at token 0 is a no-op
+  // so first paint stays governed by the live/output flow above.
+  useEffect(() => {
+    if (forceExpandToken !== previousForceExpandTokenRef.current) {
+      previousForceExpandTokenRef.current = forceExpandToken;
+      if (forceExpandToken > 0) {
+        setGroupExpanded(true);
+      }
+    }
+  }, [forceExpandToken]);
 
   useEffect(() => {
     if (live && !previousLiveRef.current) {
@@ -9835,8 +10042,12 @@ function TraceStepGroup({
         ? `Running ${stepLabel}...`
         : latestThinkingItem
           ? summarizeThinking(latestThinkingItem.text)
-          : stepCount > 0
-            ? `Used ${stepLabel}`
+          : stepCount > 0 && latestStep
+            ? // Done state: surface the last action's title so a user
+              // skimming the chat sees "Edited README.md" / "Searched
+              // marketplace" instead of "Used 5 steps". Step count
+              // moves into a trailing badge.
+              latestStep.title
             : "Execution trace";
 
   return (
@@ -9855,10 +10066,18 @@ function TraceStepGroup({
         ) : (
           <Check className="size-3.5 shrink-0 text-success" />
         )}
-        <span className="min-w-0 flex-1 leading-5">
+        <span className="min-w-0 flex-1 truncate leading-5">
           {summaryLabel}
           {summarySuffix}
         </span>
+        {stepCount > 0 && !groupIsLive && !groupHasTerminalError ? (
+          <span
+            aria-hidden
+            className="shrink-0 rounded-full bg-muted px-1.5 py-px text-[10px] tabular-nums text-muted-foreground"
+          >
+            {stepCount}
+          </span>
+        ) : null}
         <ChevronDown
           className={`size-3 shrink-0 transition-transform ${groupExpanded ? "rotate-180" : ""}`}
         />

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -8497,7 +8497,7 @@ function UserTurn({
 
   return (
     <div className="group/user-turn flex min-w-0 justify-end">
-      <div className="flex min-w-0 max-w-[420px] flex-col items-end gap-1 sm:max-w-[560px] lg:max-w-[680px]">
+      <div className="flex min-w-0 max-w-[80%] flex-col items-end gap-2">
         {parsedQuotedSkills.skillIds.length > 0 ? (
           <div className="flex max-w-full flex-wrap justify-end gap-2">
             {parsedQuotedSkills.skillIds.map((skillId) => (
@@ -8512,7 +8512,7 @@ function UserTurn({
           </div>
         ) : null}
         {userBubbleText ? (
-          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-2xl px-[18px] py-2.5 text-foreground">
+          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-2xl px-5 py-3.5 text-foreground">
             <div
               ref={bubbleContentRef}
               className="relative overflow-hidden transition-[max-height] duration-300 ease-out"
@@ -8782,12 +8782,6 @@ function QueuedSessionInputRail({
   );
 }
 
-/**
- * True when the agent invoked any filesystem-mutating tool inside this
- * turn's execution items. Drives whether the per-turn actions menu offers
- * "View file changes" — if no Edit / Write / patch happened, the menu
- * entry is hidden so users aren't taught a useless affordance.
- */
 function executionItemsHaveFileEdits(
   items: ChatExecutionTimelineItem[],
 ): boolean {
@@ -8799,10 +8793,6 @@ function executionItemsHaveFileEdits(
       return false;
     }
     const title = item.step.title.toLowerCase();
-    // Tool names exposed to the user surface as "Edit"/"Write"/"Patch"/
-    // "Replace"/"MultiEdit". Match by lowercase substring rather than
-    // exact equality because titles often include the file path
-    // ("Write README.md", "Edit src/foo.ts").
     return (
       title.startsWith("edit") ||
       title.startsWith("write") ||
@@ -8816,29 +8806,12 @@ function executionItemsHaveFileEdits(
 }
 
 interface AssistantTurnActionsMenuProps {
-  /** Plain-text content the user gets when clicking Copy. */
   copyText: string;
-  /**
-   * Triggered when the user picks "View turn details". Optional — when
-   * not provided the entry is hidden. Implementation typically expands
-   * the trace group + scrolls it into view.
-   */
   onViewTurnDetails?: () => void;
-  /**
-   * Triggered when the user picks "View file changes". Optional + only
-   * meaningful when the turn invoked file-mutating tools.
-   */
   onViewFileChanges?: () => void;
-  /** When true, render the file-changes entry even without a callback. */
   hasFileEdits?: boolean;
 }
 
-/**
- * Per-assistant-turn 3-dot menu shown on hover. Mirrors the user-side
- * copy affordance so both speakers get parity. The menu is intentionally
- * narrow (Copy + maybe one or two domain actions) — adding more makes
- * the chat surface noisy on every turn.
- */
 function AssistantTurnActionsMenu({
   copyText,
   onViewTurnDetails,
@@ -8856,16 +8829,13 @@ function AssistantTurnActionsMenu({
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      // Some embedded WebContents block clipboard from non-user-gesture
-      // contexts. Silent — the menu item exists for the gesture path.
+      // ignore
     }
   }
 
   const showFileChanges = Boolean(onViewFileChanges) && Boolean(hasFileEdits);
   const canCopy = copyText.trim().length > 0;
 
-  // Nothing to show — don't render an empty trigger that just confuses
-  // users when they hover and the menu is empty.
   if (!canCopy && !onViewTurnDetails && !showFileChanges) {
     return null;
   }
@@ -9015,15 +8985,11 @@ function AssistantTurn({
   const showWorkingStatusLine =
     live && showExecutionInternals && renderedSegments.length > 0;
 
-  // Bumped by the per-turn actions menu's "View turn details" item; threads
-  // through every TraceStepGroup in this turn to force-expand them.
   const [forceExpandToken, setForceExpandToken] = useState(0);
   const hasFileEdits = useMemo(
     () => executionItemsHaveFileEdits(executionItems),
     [executionItems],
   );
-  // Plain-text we feed to the Copy menu item — concatenate output segments;
-  // execution segments are noise for paste targets like a doc or message.
   const copyText = useMemo(
     () =>
       renderedSegments
@@ -9062,13 +9028,9 @@ function AssistantTurn({
 
   return (
     <div
-      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-2" : ""}`.trim()}
+      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-6" : ""}`.trim()}
     >
-      <article
-        className={`min-w-0 w-full max-w-4xl ${
-          showSeparator ? "rounded-[1.75rem] bg-muted/35 px-5 py-4" : ""
-        }`.trim()}
-      >
+      <article className="min-w-0 w-full max-w-4xl">
         {showStatusPlaceholder ? renderStatusLine(normalizedStatus) : null}
 
         {renderedSegments.map((segment, index) =>
@@ -9811,9 +9773,6 @@ function LiveStatusLine({
   return (
     <div
       aria-live="polite"
-      // Keyed on the label so a status change ("Thinking" → "Editing
-      // README.md") triggers a fresh fade-in instead of an abrupt swap —
-      // makes long agent runs feel responsive instead of glitchy.
       key={normalizedLabel}
       className={`inline-flex items-baseline gap-0.5 text-xs leading-6 text-muted-foreground animate-in fade-in-0 slide-in-from-bottom-0.5 duration-200 ease-out ${className}`.trim()}
     >
@@ -9960,11 +9919,6 @@ function TraceStepGroup({
   liveOutputStarted?: boolean;
   onLinkClick?: (url: string) => void;
   onLocalLinkClick?: (href: string) => void;
-  /**
-   * Counter the parent bumps to force the group open — used by the per-turn
-   * "View turn details" action so the user lands on a fully expanded trace
-   * even if they had previously collapsed it.
-   */
   forceExpandToken?: number;
 }) {
   const steps = traceStepsFromExecutionItems(items);
@@ -9975,9 +9929,6 @@ function TraceStepGroup({
   const previousLiveOutputStartedRef = useRef(liveOutputStarted);
   const previousForceExpandTokenRef = useRef(forceExpandToken);
 
-  // External force-expand: bump from the per-turn actions menu opens the
-  // group regardless of its previous state. Mounting at token 0 is a no-op
-  // so first paint stays governed by the live/output flow above.
   useEffect(() => {
     if (forceExpandToken !== previousForceExpandTokenRef.current) {
       previousForceExpandTokenRef.current = forceExpandToken;
@@ -10043,11 +9994,7 @@ function TraceStepGroup({
         : latestThinkingItem
           ? summarizeThinking(latestThinkingItem.text)
           : stepCount > 0 && latestStep
-            ? // Done state: surface the last action's title so a user
-              // skimming the chat sees "Edited README.md" / "Searched
-              // marketplace" instead of "Used 5 steps". Step count
-              // moves into a trailing badge.
-              latestStep.title
+            ? latestStep.title
             : "Execution trace";
 
   return (

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -7861,7 +7861,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
             </div>
           ) : null}
           <div
-            className="relative min-h-0 flex-1 overflow-hidden"
+            className="group/chat-scroll relative min-h-0 flex-1 overflow-hidden"
             style={{
               maskImage: chatScrollMaskImage(),
               WebkitMaskImage: chatScrollMaskImage(),
@@ -7893,7 +7893,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
               {hasMessages ? (
                 <div
                   ref={messagesContentRef}
-                  className={`flex min-w-0 w-full flex-col gap-4 px-4 pb-3 pt-5 ${
+                  className={`flex min-w-0 w-full flex-col gap-4 pl-4 pr-7 pb-3 pt-5 ${
                     showHistoryRestoreScreen ? "invisible" : ""
                   }`}
                 >
@@ -8116,7 +8116,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
             </div>
 
             {showCustomChatScrollbar ? (
-              <div className="pointer-events-none absolute inset-y-0 right-1 z-20 w-4">
+              <div className="pointer-events-none absolute inset-y-0 right-1 z-20 w-4 opacity-0 transition-opacity duration-200 group-hover/chat-scroll:opacity-100">
                 <div
                   className="pointer-events-auto absolute inset-x-0 touch-none"
                   style={{
@@ -8512,7 +8512,7 @@ function UserTurn({
           </div>
         ) : null}
         {userBubbleText ? (
-          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-2xl px-5 py-3.5 text-foreground">
+          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-lg px-3 py-1.5 text-foreground">
             <div
               ref={bubbleContentRef}
               className="relative overflow-hidden transition-[max-height] duration-300 ease-out"
@@ -9028,9 +9028,9 @@ function AssistantTurn({
 
   return (
     <div
-      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-6" : ""}`.trim()}
+      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-4" : ""}`.trim()}
     >
-      <article className="min-w-0 w-full max-w-4xl">
+      <article className="min-w-0 w-full max-w-4xl rounded-lg bg-muted/60 px-3 py-2">
         {showStatusPlaceholder ? renderStatusLine(normalizedStatus) : null}
 
         {renderedSegments.map((segment, index) =>

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -1141,12 +1141,13 @@ webview {
 }
 
 .chat-assistant-markdown .md-p {
-  margin-top: 14px;
+  margin-top: 12px;
 }
 
 .chat-assistant-markdown .md-ul,
 .chat-assistant-markdown .md-ol {
-  margin: 14px 0;
+  margin: 12px 0;
+  padding-left: 1.25rem;
 }
 
 .chat-assistant-markdown .md-li,
@@ -1155,35 +1156,35 @@ webview {
 }
 
 .chat-assistant-markdown .md-h1 {
-  font-size: 1.45em;
-  font-weight: var(--font-weight-black);
+  font-size: 1rem;
+  font-weight: var(--font-weight-bold);
   line-height: 1.35;
-  margin-top: 1.6em;
-  margin-bottom: 0.6em;
+  margin-top: 18px;
+  margin-bottom: 10px;
 }
 
 .chat-assistant-markdown .md-h2 {
-  font-size: 1.25em;
-  font-weight: var(--font-weight-black);
+  font-size: 1rem;
+  font-weight: var(--font-weight-semibold);
   line-height: 1.4;
-  margin-top: 1.5em;
-  margin-bottom: 0.5em;
+  margin-top: 16px;
+  margin-bottom: 8px;
 }
 
 .chat-assistant-markdown .md-h3 {
-  font-size: 1.1em;
-  font-weight: var(--font-weight-black);
+  font-size: 0.9375rem;
+  font-weight: var(--font-weight-semibold);
   line-height: 1.45;
-  margin-top: 1.3em;
-  margin-bottom: 0.4em;
+  margin-top: 14px;
+  margin-bottom: 6px;
 }
 
 .chat-assistant-markdown .md-h4 {
-  font-size: 1em;
-  font-weight: var(--font-weight-black);
+  font-size: 0.875rem;
+  font-weight: var(--font-weight-semibold);
   line-height: 1.5;
-  margin-top: 1.1em;
-  margin-bottom: 0.35em;
+  margin-top: 12px;
+  margin-bottom: 4px;
 }
 
 .chat-assistant-markdown .md-h1:first-child,
@@ -1236,11 +1237,11 @@ webview {
 }
 
 .chat-assistant-markdown .md-blockquote {
-  border-left: 2px solid color-mix(in oklch, var(--foreground) 25%, transparent);
-  padding: 0.35em 0 0.35em 1em;
-  margin: 1em 0;
-  color: color-mix(in oklch, var(--foreground) 75%, transparent);
-  font-weight: var(--font-weight-bold);
+  border-left: 2px solid color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+  padding: 0.25em 0 0.25em 0.75em;
+  margin: 12px 0;
+  color: var(--muted-foreground);
+  font-style: italic;
 }
 
 .chat-thinking-markdown {
@@ -1334,6 +1335,7 @@ webview {
 .chat-markdown .md-ul,
 .chat-markdown .md-ol {
   margin: 10px 0;
+  padding-left: 1.25rem;
 }
 
 .chat-markdown .md-li,
@@ -1345,7 +1347,7 @@ webview {
   margin: 10px 0;
   background: color-mix(in oklch, var(--input) 78%, var(--background) 22%);
   border: 1px solid color-mix(in oklch, var(--border) 74%, transparent);
-  border-radius: 14px;
+  border-radius: 8px;
   box-shadow: var(--shadow-subtle-xs);
   color: color-mix(in oklch, var(--foreground) 94%, transparent);
   font-size: 0.725rem;


### PR DESCRIPTION
## Summary

Three interaction-level wins lifted from `craft-agents-oss` into our single-file `ChatPane.tsx`. No structural refactor; everything lands as additive helpers + small wraps so the diff is easy to review.

### 1. Per-assistant-turn actions menu (S / HIGH impact)

Hover-revealed 3-dot menu in each assistant turn's top-right corner via `group/assistant-turn`:

- **Copy message** — concatenates output segments (skips execution noise) and writes to clipboard. Mirrors the user-side affordance.
- **View turn details** — only when the turn has execution items. Bumps a `forceExpandToken` that every `TraceStepGroup` watches → all collapsed traces pop open.
- **View file changes** — only when the turn invoked Edit / Write / Patch / Replace / MultiEdit / Apply / Create-file. Same expansion gesture today; scoped naming makes the affordance discoverable. Future PR can wire it to scroll-to-first-edit + diff inspector.
- Hidden during live streaming — Copy mid-stream is incomplete and confusing.

### 2. Trace summary polish (M / HIGH)

- Done-state collapsed summary surfaces the **last step's title** (`Edited README.md`, `Searched marketplace`) instead of the generic `Used 5 steps`.
- The numeric step count moves into a small trailing badge so the "this turn ran multiple actions" signal isn't lost.

### 3. Streaming feedback fade-in (M / MED)

- `LiveStatusLine` is keyed on its label so each status transition (`Thinking` → `Editing src/foo.ts`) re-mounts with `animate-in fade-in-0 slide-in-from-bottom-0.5 duration-200`. No more abrupt swap mid-run.
- `TypingStatusLine` gets the same fade-in on first paint.
- Uses `tw-animate-css` only — no new dependency.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 15 existing tests pass (workspace-packager + onboarding)
- [ ] Manual: hover an assistant message → 3-dot menu appears; click Copy → clipboard has the text only
- [ ] Manual: turn with edit-tool calls → `View file changes` entry visible
- [ ] Manual: turn without execution → only Copy is offered
- [ ] Manual: trace group collapsed by default once output starts; click `View turn details` → all groups in that turn expand
- [ ] Manual: during streaming, the live status label changes smoothly (no jump cut)
- [ ] Manual: completed turn collapsed-summary shows last action title + step count badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)