### PR TITLE
ChatPane follow-ups: shiki code blocks + user-turn hover overlay

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -28,7 +28,6 @@
         "dotenv": "^16.6.1",
         "electron-updater": "^6.8.3",
         "exceljs": "^4.4.0",
-        "highlight.js": "^11.11.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",
@@ -37,6 +36,7 @@
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.2",
+        "shiki": "^4.0.2",
         "tw-animate-css": "^1.4.0",
         "yaml": "^2.8.3"
       },
@@ -7448,6 +7448,106 @@
         "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "devOptional": true,
@@ -12149,6 +12249,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "license": "MIT",
@@ -12188,13 +12311,6 @@
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "license": "MIT"
-    },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/hono": {
       "version": "4.12.14",
@@ -12239,6 +12355,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -14832,6 +14958,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "11.0.0",
       "license": "MIT",
@@ -15749,6 +15892,30 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "license": "MIT",
@@ -16545,6 +16712,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -78,7 +78,6 @@
     "dotenv": "^16.6.1",
     "electron-updater": "^6.8.3",
     "exceljs": "^4.4.0",
-    "highlight.js": "^11.11.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.542.0",
     "react": "^19.1.1",
@@ -87,6 +86,7 @@
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
+    "shiki": "^4.0.2",
     "tw-animate-css": "^1.4.0",
     "yaml": "^2.8.3"
   },

--- a/desktop/src/components/marketplace/CodeBlock.tsx
+++ b/desktop/src/components/marketplace/CodeBlock.tsx
@@ -1,0 +1,236 @@
+import { Check, ChevronDown, Copy } from "lucide-react";
+import {
+  Children,
+  isValidElement,
+  type ReactNode,
+  useEffect,
+  useState,
+} from "react";
+import { type BundledLanguage, bundledLanguages, codeToHtml } from "shiki";
+
+const LONG_BLOCK_LINE_THRESHOLD = 30;
+const HIGHLIGHT_CACHE_MAX = 200;
+const highlightCache = new Map<string, string>();
+
+const LANGUAGE_ALIASES: Record<string, BundledLanguage> = {
+  js: "javascript",
+  ts: "typescript",
+  py: "python",
+  sh: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  rb: "ruby",
+  rs: "rust",
+  kt: "kotlin",
+  objc: "objc",
+};
+
+function isBundledLanguage(lang: string): lang is BundledLanguage {
+  return Object.prototype.hasOwnProperty.call(bundledLanguages, lang);
+}
+
+function resolveLanguage(language: string | undefined): BundledLanguage | "text" {
+  if (!language) return "text";
+  const lower = language.toLowerCase();
+  const aliased = LANGUAGE_ALIASES[lower];
+  if (aliased) return aliased;
+  return isBundledLanguage(lower) ? lower : "text";
+}
+
+function detectLanguage(code: string): BundledLanguage | "text" {
+  const sample = code.slice(0, 600);
+  const firstLine = sample.split("\n", 1)[0] ?? "";
+  if (/<\?php\b/.test(sample)) return "php";
+  if (/^#!\s*\/.*\b(?:bash|sh|zsh)\b/.test(firstLine)) return "bash";
+  if (/^#!\s*\/.*\bpython/.test(firstLine)) return "python";
+  if (/^#!\s*\/.*\bnode/.test(firstLine)) return "javascript";
+  if (/^---\s*$/m.test(sample) && /^\s*\w+:\s/m.test(sample)) return "yaml";
+  if (/<!DOCTYPE\b|<html\b|<head\b/i.test(sample)) return "html";
+  if (sample.trim().startsWith("{") || sample.trim().startsWith("[")) {
+    if (/^[\s\S]*"[^"]+"\s*:/.test(sample)) return "json";
+  }
+  // JSX-only patterns: closing tag, attribute on a Capitalized tag, or
+  // self-closing Capitalized tag. Excludes generics like `<T>` and
+  // `Map<string, User>`.
+  const looksLikeJsx =
+    /<\/[A-Z]\w*>|<[A-Z]\w*\s+[a-z][\w-]*\s*=|<[A-Z]\w*\s*\/>/.test(sample);
+  if (/\b(?:interface\s+\w|type\s+\w+\s*=|export\s+(?:default\s+)?(?:function|class|const|interface|type)|import\s+[\w*{},\s]+from\s+["'])/.test(sample)) {
+    return looksLikeJsx ? "tsx" : "typescript";
+  }
+  if (/\b(?:function\s+\w|const\s+\w+\s*=|=>\s*[{(]|require\s*\()/.test(sample)) {
+    return looksLikeJsx ? "jsx" : "javascript";
+  }
+  if (/\b(?:def\s+\w+\s*\(|^\s*elif\s+|from\s+[\w.]+\s+import\b)/m.test(sample)) {
+    return "python";
+  }
+  if (/\b(?:fn |let mut\b|impl\b|use\s+[\w:]+::|::\w+)/.test(sample)) return "rust";
+  if (/^package\s+\w/m.test(sample) || /\bfunc\s+\w+\s*\(/.test(sample)) return "go";
+  if (/^\s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE\s+TABLE|ALTER\s+TABLE)\b/im.test(sample)) {
+    return "sql";
+  }
+  if (/\$\s*\w|\becho\s+|^\s*[a-z_]+=\S/im.test(sample)) return "bash";
+  return "text";
+}
+
+function pickShikiTheme(): "vitesse-dark" | "vitesse-light" {
+  if (typeof document === "undefined") return "vitesse-light";
+  const themeAttr = document.documentElement.dataset.theme ?? "";
+  return themeAttr.toLowerCase().includes("dark") ? "vitesse-dark" : "vitesse-light";
+}
+
+function extractText(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    return extractText(props.children);
+  }
+  return "";
+}
+
+function findCodeChild(node: ReactNode): {
+  language: string | undefined;
+  code: string;
+} {
+  let language: string | undefined;
+  let code = "";
+  Children.forEach(node, (child) => {
+    if (isValidElement(child) && child.type === "code") {
+      const props = child.props as { className?: string; children?: ReactNode };
+      const match = props.className?.match(/language-([\w-]+)/);
+      if (match) language = match[1];
+      code = extractText(props.children);
+    }
+  });
+  if (!code) code = extractText(node);
+  return { language, code };
+}
+
+interface CodeBlockProps {
+  language?: string;
+  code: string;
+}
+
+export function CodeBlock({ language, code }: CodeBlockProps) {
+  const trimmed = code.replace(/\n$/, "");
+  const lineCount = trimmed.split("\n").length;
+  const isLong = lineCount > LONG_BLOCK_LINE_THRESHOLD;
+  const [expanded, setExpanded] = useState(!isLong);
+  const [copied, setCopied] = useState(false);
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+  const [theme, setTheme] = useState(pickShikiTheme);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => setTheme(pickShikiTheme()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme", "class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const explicitLanguage = resolveLanguage(language);
+  const resolvedLanguage =
+    explicitLanguage === "text" ? detectLanguage(trimmed) : explicitLanguage;
+
+  useEffect(() => {
+    let cancelled = false;
+    const cacheKey = `${theme}:${resolvedLanguage}:${trimmed}`;
+    const cached = highlightCache.get(cacheKey);
+    if (cached) {
+      setHighlighted(cached);
+      return () => {
+        cancelled = true;
+      };
+    }
+    setHighlighted(null);
+
+    void (async () => {
+      try {
+        const html = await codeToHtml(trimmed, {
+          lang: resolvedLanguage,
+          theme,
+        });
+        if (cancelled) return;
+        if (highlightCache.size >= HIGHLIGHT_CACHE_MAX) {
+          const firstKey = highlightCache.keys().next().value;
+          if (firstKey !== undefined) highlightCache.delete(firstKey);
+        }
+        highlightCache.set(cacheKey, html);
+        setHighlighted(html);
+      } catch {
+        if (!cancelled) setHighlighted(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [trimmed, resolvedLanguage, theme]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(trimmed);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  }
+
+  const langLabel = (() => {
+    if (language?.trim()) return language.toLowerCase();
+    if (resolvedLanguage !== "text") return resolvedLanguage;
+    return "code";
+  })();
+
+  return (
+    <div className="md-code-block-wrapper group/code-block">
+      <div className="md-code-block-header">
+        <span className="md-code-block-lang">{langLabel}</span>
+        <button
+          aria-label={copied ? "Copied" : "Copy code"}
+          className="md-code-block-copy"
+          onClick={() => void handleCopy()}
+          type="button"
+        >
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      {highlighted ? (
+        <div
+          className={`md-code-block-shiki ${expanded ? "" : "md-code-block-collapsed"}`.trim()}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+        />
+      ) : (
+        <pre
+          className={`md-code-block ${expanded ? "" : "md-code-block-collapsed"}`.trim()}
+        >
+          <code>{trimmed}</code>
+        </pre>
+      )}
+      {isLong ? (
+        <button
+          className="md-code-block-expand"
+          onClick={() => setExpanded((value) => !value)}
+          type="button"
+        >
+          <ChevronDown
+            className={`size-3 transition-transform ${expanded ? "rotate-180" : ""}`}
+          />
+          {expanded ? "Collapse" : `Show all ${lineCount} lines`}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function codeBlockFromPreNode(children: ReactNode): {
+  language: string | undefined;
+  code: string;
+} {
+  return findCodeChild(children);
+}

--- a/desktop/src/components/marketplace/SimpleMarkdown.tsx
+++ b/desktop/src/components/marketplace/SimpleMarkdown.tsx
@@ -6,6 +6,7 @@
 import { memo, useMemo } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { CodeBlock, codeBlockFromPreNode } from "./CodeBlock";
 import { normalizeWrappedMarkdownFence } from "./markdownFenceNormalization.mjs";
 
 function appendClassName(current: string | undefined, next: string): string {
@@ -107,8 +108,9 @@ function createMarkdownComponents(
   p({ className, ...props }: MdProps) {
     return <p {...props} className={appendClassName(className, "md-p")} />;
   },
-  pre({ className, ...props }: MdProps) {
-    return <pre {...props} className={appendClassName(className, "md-code-block")} />;
+  pre({ children }: MdProps) {
+    const { language, code } = codeBlockFromPreNode(children);
+    return <CodeBlock code={code} language={language} />;
   },
   table({ className, ...props }: MdProps) {
     return <table {...props} className={appendClassName(className, "md-table")} />;

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -8512,7 +8512,7 @@ function UserTurn({
           </div>
         ) : null}
         {userBubbleText ? (
-          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-lg px-3 py-1.5 text-foreground">
+          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-2xl px-5 py-3.5 text-foreground">
             <div
               ref={bubbleContentRef}
               className="relative overflow-hidden transition-[max-height] duration-300 ease-out"
@@ -9028,9 +9028,9 @@ function AssistantTurn({
 
   return (
     <div
-      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-4" : ""}`.trim()}
+      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-6" : ""}`.trim()}
     >
-      <article className="min-w-0 w-full max-w-4xl rounded-lg bg-muted/60 px-3 py-2">
+      <article className="min-w-0 w-full max-w-4xl">
         {showStatusPlaceholder ? renderStatusLine(normalizedStatus) : null}
 
         {renderedSegments.map((segment, index) =>

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -8497,7 +8497,7 @@ function UserTurn({
 
   return (
     <div className="group/user-turn flex min-w-0 justify-end">
-      <div className="flex min-w-0 max-w-[80%] flex-col items-end gap-2">
+      <div className="relative flex min-w-0 max-w-[80%] flex-col items-end gap-2">
         {parsedQuotedSkills.skillIds.length > 0 ? (
           <div className="flex max-w-full flex-wrap justify-end gap-2">
             {parsedQuotedSkills.skillIds.map((skillId) => (
@@ -8557,7 +8557,7 @@ function UserTurn({
           />
         ) : null}
         {canCopy || timeLabel ? (
-          <div className="flex items-center justify-end gap-2 pr-1 text-xs text-muted-foreground opacity-0 pointer-events-none transition duration-150 group-hover/user-turn:opacity-100 group-hover/user-turn:pointer-events-auto group-focus-within/user-turn:opacity-100 group-focus-within/user-turn:pointer-events-auto">
+          <div className="absolute -bottom-7 right-1 flex items-center gap-2 text-xs text-muted-foreground opacity-0 pointer-events-none transition-opacity duration-150 group-hover/user-turn:opacity-100 group-hover/user-turn:pointer-events-auto group-focus-within/user-turn:opacity-100 group-focus-within/user-turn:pointer-events-auto">
             {canCopy ? (
               <Button
                 type="button"

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -8512,7 +8512,7 @@ function UserTurn({
           </div>
         ) : null}
         {userBubbleText ? (
-          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-2xl px-5 py-3.5 text-foreground">
+          <div className="theme-chat-user-bubble inline-flex min-w-0 max-w-full flex-col items-stretch rounded-lg px-3 py-1.5 text-foreground">
             <div
               ref={bubbleContentRef}
               className="relative overflow-hidden transition-[max-height] duration-300 ease-out"
@@ -9028,9 +9028,9 @@ function AssistantTurn({
 
   return (
     <div
-      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-6" : ""}`.trim()}
+      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-4" : ""}`.trim()}
     >
-      <article className="min-w-0 w-full max-w-4xl">
+      <article className="min-w-0 w-full max-w-4xl rounded-lg bg-muted/60 px-3 py-2">
         {showStatusPlaceholder ? renderStatusLine(normalizedStatus) : null}
 
         {renderedSegments.map((segment, index) =>

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -852,68 +852,6 @@ webview {
   height: 100%;
 }
 
-/* ---- Syntax highlighting (highlight.js) ---- */
-
-.hljs {
-  display: block;
-  color: var(--foreground);
-  background: transparent;
-}
-
-.hljs-comment,
-.hljs-quote {
-  color: var(--muted-foreground);
-}
-
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-literal,
-.hljs-section,
-.hljs-link {
-  color: oklch(0.7 0.15 250);
-}
-
-.hljs-string,
-.hljs-doctag,
-.hljs-regexp {
-  color: oklch(0.75 0.14 155);
-}
-
-.hljs-number,
-.hljs-literal,
-.hljs-symbol,
-.hljs-bullet {
-  color: oklch(0.75 0.12 35);
-}
-
-.hljs-title,
-.hljs-title.class_,
-.hljs-title.function_ {
-  color: oklch(0.75 0.12 290);
-}
-
-.hljs-variable,
-.hljs-template-variable,
-.hljs-attr,
-.hljs-attribute {
-  color: oklch(0.75 0.12 340);
-}
-
-.hljs-meta,
-.hljs-meta .hljs-keyword,
-.hljs-type {
-  color: oklch(0.75 0.1 65);
-}
-
-.hljs-built_in,
-.hljs-property {
-  color: oklch(0.7 0.12 230);
-}
-
-.hljs-subst {
-  color: var(--foreground);
-}
-
 /* ---- Simple Markdown ---- */
 
 .simple-markdown {
@@ -1003,11 +941,11 @@ webview {
 }
 
 .simple-markdown .md-code-block {
-  background: color-mix(in oklch, var(--background) 80%, black);
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
   padding: 14px 16px;
-  margin: 12px 0;
+  margin: 0;
   overflow-x: auto;
   font-size: 0.775rem;
   line-height: 1.6;
@@ -1344,20 +1282,119 @@ webview {
 }
 
 .chat-markdown .md-code-block {
-  margin: 10px 0;
-  background: color-mix(in oklch, var(--input) 78%, var(--background) 22%);
-  border: 1px solid color-mix(in oklch, var(--border) 74%, transparent);
-  border-radius: 8px;
-  box-shadow: var(--shadow-subtle-xs);
+  margin: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 12px 14px;
   color: color-mix(in oklch, var(--foreground) 94%, transparent);
   font-size: 0.725rem;
   line-height: 1.62;
   font-family: var(--font-mono);
+  overflow-x: auto;
 }
 
 .chat-markdown .md-code-block > code {
   color: inherit;
   font-family: inherit;
+}
+
+/* ---- Code block wrapper (header + copy + collapse) ---- */
+
+.md-code-block-wrapper {
+  margin: 12px 0;
+  background: color-mix(in oklch, var(--input) 78%, var(--background) 22%);
+  border: 1px solid color-mix(in oklch, var(--border) 74%, transparent);
+  border-radius: 8px;
+  box-shadow: var(--shadow-subtle-xs);
+  overflow: hidden;
+  position: relative;
+}
+
+.md-code-block-shiki {
+  font-family: var(--font-mono);
+  font-size: 0.775rem;
+  line-height: 1.62;
+  overflow-x: auto;
+}
+
+.md-code-block-shiki > pre {
+  margin: 0;
+  padding: 12px 14px;
+  background: transparent !important;
+}
+
+.md-code-block-shiki > pre > code {
+  background: transparent;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.md-code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+
+.md-code-block-lang {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: lowercase;
+  color: var(--muted-foreground);
+  letter-spacing: 0.02em;
+}
+
+.md-code-block-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 0.68rem;
+  color: var(--muted-foreground);
+  opacity: 0;
+  transition: opacity 150ms ease, background-color 150ms ease, color 150ms ease;
+}
+
+.md-code-block-wrapper:hover .md-code-block-copy,
+.md-code-block-wrapper:focus-within .md-code-block-copy {
+  opacity: 1;
+}
+
+.md-code-block-copy:hover {
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
+.md-code-block-collapsed {
+  max-height: 360px;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 78%, transparent);
+  mask-image: linear-gradient(to bottom, black 78%, transparent);
+}
+
+.md-code-block-expand {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-top: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
+  font-size: 0.7rem;
+  color: var(--muted-foreground);
+  background: color-mix(in oklch, var(--foreground) 2%, transparent);
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.md-code-block-expand:hover {
+  background: color-mix(in oklch, var(--foreground) 5%, transparent);
+  color: var(--foreground);
 }
 
 /* ---- File Preview Markdown (document reader — spacing modifier) ---- */


### PR DESCRIPTION
## Summary

Branched off the still-open #240 (\`feat/chatpane-improvements\`) once that PR's scope settled, to keep follow-up work reviewable in isolation.

### Code blocks
- Swap highlight.js for **shiki** (vitesse-light / vitesse-dark themes — same engine VS Code uses, much more accurate than hljs's regex grammars).
- Async \`codeToHtml\` with a 200-entry LRU cache.
- \`MutationObserver\` on \`documentElement.dataset.theme\` so light↔dark switches re-highlight live.
- Header strip with language label + hover-revealed **Copy** button.
- Long blocks (>30 lines) collapse to 360px with a fade mask + \`Show all N lines\` toggle.
- Heuristic language detection when the fence has no language tag — TS/JS checks before Python (so \`class X {\` isn't mis-classified). TSX detection requires JSX-only patterns (closing tag / attribute / self-close) so generics like \`<T>\` and \`Map<string, User>\` stay TS.

### User-turn hover overlay
The Copy + timestamp row under user messages was \`opacity-0 pointer-events-none\` — invisible but **kept layout space** (~30px dead air below every user bubble). Switched to \`absolute -bottom-7\` so the row is removed from the flex flow entirely but still fades in on hover via the opacity transition. User bubble now sits flush against the next assistant turn.

### Cleanup
- Removed 60 lines of \`.hljs-*\` token color CSS — shiki ships theme colors inline.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: agent emits \`\`\`typescript fenced block — vitesse colors apply
- [ ] Manual: agent emits unfenced \`\`\` block of TS code — heuristic picks typescript (not python or tsx)
- [ ] Manual: long code block (>30 lines) shows fade-mask + \`Show all\` button
- [ ] Manual: switch app theme light↔dark — open code blocks re-highlight
- [ ] Manual: hover Copy button → \`Copied\` confirmation, paste preserves code
- [ ] Manual: user message bubble — no hover gap below; on hover, Copy + time fade in beneath the bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)