### PR TITLE
App perf: rAF-throttle global scroll listener + dedupe resize subscriptions + telemetry ring buffer

### DIFF
--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -246,11 +246,23 @@ export function TopTabsBar({
 
     updateWorkspaceSwitcherPosition();
 
-    const syncPosition = () => updateWorkspaceSwitcherPosition();
+    let rafId: number | null = null;
+    const syncPosition = () => {
+      if (rafId !== null) {
+        return;
+      }
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        updateWorkspaceSwitcherPosition();
+      });
+    };
     window.addEventListener("resize", syncPosition);
     window.addEventListener("scroll", syncPosition, true);
 
     return () => {
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+      }
       window.removeEventListener("resize", syncPosition);
       window.removeEventListener("scroll", syncPosition, true);
     };

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -3177,6 +3177,8 @@ export function ChatPane({
   const [streamTelemetry, setStreamTelemetry] = useState<
     StreamTelemetryEntry[]
   >([]);
+  const streamTelemetryRingRef = useRef<StreamTelemetryEntry[]>([]);
+  const streamTelemetryFlushTimerRef = useRef<number | null>(null);
   const [artifactBrowserOpen, setArtifactBrowserOpen] = useState(false);
   const [artifactBrowserFilter, setArtifactBrowserFilter] =
     useState<ArtifactBrowserFilter>("all");
@@ -3297,14 +3299,27 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
       at,
       ...entry,
     };
-    setStreamTelemetry((prev) => {
-      const merged = [...prev, next];
-      if (merged.length <= STREAM_TELEMETRY_LIMIT) {
-        return merged;
-      }
-      return merged.slice(merged.length - STREAM_TELEMETRY_LIMIT);
-    });
+    const ring = streamTelemetryRingRef.current;
+    ring.push(next);
+    if (ring.length > STREAM_TELEMETRY_LIMIT) {
+      ring.splice(0, ring.length - STREAM_TELEMETRY_LIMIT);
+    }
+    if (streamTelemetryFlushTimerRef.current === null) {
+      streamTelemetryFlushTimerRef.current = window.setTimeout(() => {
+        streamTelemetryFlushTimerRef.current = null;
+        setStreamTelemetry(streamTelemetryRingRef.current.slice());
+      }, 250);
+    }
   }
+
+  useEffect(
+    () => () => {
+      if (streamTelemetryFlushTimerRef.current !== null) {
+        window.clearTimeout(streamTelemetryFlushTimerRef.current);
+      }
+    },
+    [],
+  );
 
   async function closeStreamWithReason(streamId: string, reason: string) {
     appendStreamTelemetry({


### PR DESCRIPTION
## Summary

Three audit findings that smelled like the most likely contributors to the app feeling laggy app-wide (not just inside the chat surface).

### 1. TopTabsBar workspace-switcher repositioning
While the workspace switcher popover was open, every scroll event anywhere in the document (capture phase) called \`updateWorkspaceSwitcherPosition\` synchronously: \`getBoundingClientRect\` + \`setState\` on each tick. Wrapped the listener in an rAF gate so resize/scroll fire it at most once per frame, with a pending-rAF cancel on cleanup.

### 2. Duplicate \`window.resize\` + \`ResizeObserver\` pairs in AppShell
Two layout effects attached both a \`window.addEventListener('resize')\` AND a \`ResizeObserver\` to the same \`utilityPaneHostRef\` element. On any window-driven layout shift, \`syncDisplayWidth\` / \`syncUtilityPaneWidths\` each ran twice in the same tick. Dropped the window listeners; the ResizeObservers already cover both window resize and internal layout change.

### 3. Stream telemetry array allocation per token
\`appendStreamTelemetry\` ran per stream event (i.e. roughly per agent token during long runs) and did \`setStreamTelemetry(prev => [...prev, next])\` — full-array spread on every event, with up to 240 entries retained, plus a full ChatPane re-render per token. Switched to a ref-based ring buffer (\`streamTelemetryRingRef\`) mutated in place; a 250ms-debounced flush copies a snapshot into state so the telemetry pane still updates but the hot path costs ~one push per event.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: open the workspace switcher popover, scroll something inside the app — popover stays anchored, no observable lag
- [ ] Manual: drag a pane resizer — no double-fire (could check via temporary console.log of syncDisplayWidth)
- [ ] Manual: send a long streaming agent reply — chat doesn't feel like it's stuttering token-by-token; telemetry pane (if opened) still updates within ~250ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)