### PR TITLE
perf(app): shared theme observer + coalesced ResizeObservers + async fs

### DIFF
--- a/desktop/electron/workspace-git.ts
+++ b/desktop/electron/workspace-git.ts
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -28,6 +27,15 @@ export interface WorkspaceGitBootstrapResult {
   initialCommitCreated: boolean;
   branch: string;
   gitDir: string;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeCommandError(
@@ -84,7 +92,7 @@ export async function ensureWorkspaceGitRepo(
   workspaceDir: string,
 ): Promise<WorkspaceGitBootstrapResult> {
   const gitDir = path.join(workspaceDir, ".git");
-  if (existsSync(gitDir)) {
+  if (await pathExists(gitDir)) {
     return {
       initialized: false,
       initialCommitCreated: false,

--- a/desktop/electron/workspace-packager.ts
+++ b/desktop/electron/workspace-packager.ts
@@ -1,5 +1,4 @@
 import archiver from "archiver";
-import { existsSync, readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import { request as httpRequest } from "node:http";
@@ -214,6 +213,15 @@ function parseHbIgnore(content: string): string[] {
     patterns.push(line);
   }
   return patterns;
+}
+
+async function readHbIgnore(hbIgnorePath: string): Promise<string[]> {
+  try {
+    return parseHbIgnore(await fs.readFile(hbIgnorePath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return [];
+    throw error;
+  }
 }
 
 /**
@@ -509,10 +517,7 @@ export async function previewBundle(
   forceExcludePaths: string[] = [],
 ): Promise<BundlePreview> {
   const hbIgnorePath = path.join(workspaceDir, ".hbignore");
-  let hbPatterns: string[] = [];
-  if (existsSync(hbIgnorePath)) {
-    hbPatterns = parseHbIgnore(readFileSync(hbIgnorePath, "utf8"));
-  }
+  const hbPatterns = await readHbIgnore(hbIgnorePath);
 
   const included: BundleFileEntry[] = [];
   const excluded: BundleExclusion[] = [];
@@ -593,13 +598,8 @@ export async function packageWorkspace(
     automationsFetcher = fetchAndSerializeAutomations,
   } = params;
 
-  // Read .hbignore if present
   const hbIgnorePath = path.join(workspaceDir, ".hbignore");
-  let hbPatterns: string[] = [];
-  if (existsSync(hbIgnorePath)) {
-    const content = readFileSync(hbIgnorePath, "utf8");
-    hbPatterns = parseHbIgnore(content);
-  }
+  const hbPatterns = await readHbIgnore(hbIgnorePath);
 
   // Collect files
   const relPaths = await collectFiles(workspaceDir, workspaceDir, apps, hbPatterns, forceExcludePaths);

--- a/desktop/src/components/dashboard/ChartPanel.tsx
+++ b/desktop/src/components/dashboard/ChartPanel.tsx
@@ -5,7 +5,9 @@ import {
   type LucideIcon,
   PieChart as PieChartIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
+
+import { useIsDarkTheme } from "@/lib/themeAttr";
 import {
   Area,
   AreaChart,
@@ -75,30 +77,8 @@ const SERIES_DARK = [
   "oklch(70.4% 0.04 256.788)",  // slate-400
 ];
 
-function readIsDark(): boolean {
-  if (typeof document === "undefined") return false;
-  const root = document.documentElement;
-  return root.classList.contains("dark") || root.dataset.theme === "dark";
-}
-
-// Subscribes to live theme changes on <html>. Recharts paints into SVG
-// and can't pick up CSS vars at render time, so the palette is plain
-// OKLch literals — meaning charts won't repaint on theme toggle unless
-// the component re-renders. This hook does that via MutationObserver.
 function useSeriesPalette(): string[] {
-  const [isDark, setIsDark] = useState<boolean>(readIsDark);
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    const root = document.documentElement;
-    const update = () => setIsDark(readIsDark());
-    const mo = new MutationObserver(update);
-    mo.observe(root, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme"],
-    });
-    return () => mo.disconnect();
-  }, []);
-  return isDark ? SERIES_DARK : SERIES_LIGHT;
+  return useIsDarkTheme() ? SERIES_DARK : SERIES_LIGHT;
 }
 
 export function ChartPanel({ panel, state }: ChartPanelProps) {

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -4453,24 +4453,32 @@ function AppShellContent() {
     [filesPaneWidth],
   );
 
+  const hasVisibleSpacePanes = visibleSpacePaneIds.length > 0;
   useEffect(() => {
     if (!spaceMode) {
       return;
     }
 
-    const syncDisplayWidth = () => {
+    let frame: number | null = null;
+    const flush = () => {
+      frame = null;
       setSpaceAgentPaneWidth((current) => clampSpaceAgentPaneWidth(current));
+      if (hasVisibleSpacePanes) {
+        syncUtilityPaneWidths();
+      }
+    };
+    const schedule = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(flush);
     };
 
-    syncDisplayWidth();
-    window.addEventListener("resize", syncDisplayWidth);
+    flush();
+    window.addEventListener("resize", schedule);
 
     const host = utilityPaneHostRef.current;
     const observer =
       host && typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(() => {
-            syncDisplayWidth();
-          })
+        ? new ResizeObserver(schedule)
         : null;
     if (observer && host) {
       observer.observe(host);
@@ -4478,9 +4486,17 @@ function AppShellContent() {
 
     return () => {
       observer?.disconnect();
-      window.removeEventListener("resize", syncDisplayWidth);
+      window.removeEventListener("resize", schedule);
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
     };
-  }, [clampSpaceAgentPaneWidth, spaceMode]);
+  }, [
+    clampSpaceAgentPaneWidth,
+    hasVisibleSpacePanes,
+    spaceMode,
+    syncUtilityPaneWidths,
+  ]);
 
   const startSpaceDisplayResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -4639,30 +4655,6 @@ function AppShellContent() {
     [browserPaneWidth, filesPaneWidth, spaceVisibility],
   );
 
-  useEffect(() => {
-    if (visibleSpacePaneIds.length === 0) {
-      return;
-    }
-
-    syncUtilityPaneWidths();
-    window.addEventListener("resize", syncUtilityPaneWidths);
-
-    const host = utilityPaneHostRef.current;
-    const observer =
-      host && typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(() => {
-            syncUtilityPaneWidths();
-          })
-        : null;
-    if (observer && host) {
-      observer.observe(host);
-    }
-
-    return () => {
-      observer?.disconnect();
-      window.removeEventListener("resize", syncUtilityPaneWidths);
-    };
-  }, [syncUtilityPaneWidths, visibleSpacePaneIds.length]);
 
   useEffect(() => {
     const handlePointerMove = (event: PointerEvent) => {

--- a/desktop/src/lib/themeAttr.ts
+++ b/desktop/src/lib/themeAttr.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+type Listener = (isDark: boolean) => void;
+
+let sharedObserver: MutationObserver | null = null;
+let sharedIsDark = false;
+const listeners = new Set<Listener>();
+
+function readIsDarkAttr(): boolean {
+  if (typeof document === "undefined") return false;
+  const root = document.documentElement;
+  return root.classList.contains("dark") || root.dataset.theme === "dark";
+}
+
+function ensureObserver() {
+  if (sharedObserver !== null || typeof document === "undefined") {
+    return;
+  }
+  sharedIsDark = readIsDarkAttr();
+  sharedObserver = new MutationObserver(() => {
+    const next = readIsDarkAttr();
+    if (next === sharedIsDark) return;
+    sharedIsDark = next;
+    for (const listener of listeners) listener(next);
+  });
+  sharedObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme"],
+  });
+}
+
+function subscribe(listener: Listener): () => void {
+  ensureObserver();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && sharedObserver) {
+      sharedObserver.disconnect();
+      sharedObserver = null;
+    }
+  };
+}
+
+export function useIsDarkTheme(): boolean {
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    ensureObserver();
+    return sharedIsDark;
+  });
+  useEffect(() => subscribe(setIsDark), []);
+  return isDark;
+}


### PR DESCRIPTION
## Summary
App-wide perf cleanup, three independent wins that all reduce work on shared paths.

**4. Shared theme observer**
Add `useIsDarkTheme()` backed by one `MutationObserver` on `<html>` that fans out to subscribers (`lib/themeAttr.ts`). Migrate `ChartPanel` off its private observer. Future theme-aware components (e.g. `CodeBlock` from #243) can drop theirs too.

**5. Coalesce AppShell ResizeObservers**
The two effects watching `utilityPaneHostRef` were observing the same host and pairing each with its own \`window.resize\` listener. Merge into one effect: single `ResizeObserver`, single window listener, and rAF-batch so a flurry of resize ticks does at most one layout pass per frame.

**6. Async fs in workspace packager + git bootstrap**
- \`workspace-packager.ts\`: replace sync \`.hbignore\` preflight (\`existsSync\` + \`readFileSync\`) with awaited \`readHbIgnore\` that handles ENOENT. Affects \`previewBundle\` and \`bundleWorkspace\` (publish flow IPC).
- \`workspace-git.ts\`: replace \`existsSync(.git)\` with \`fs.access\` via \`pathExists\`. Affects \`ensureWorkspaceGitRepo\` on the workspace-init IPC path.

Boot-path sync reads (preferences, runtime config cache) and Sentry \`beforeSend\` file checks intentionally remain sync — Sentry hooks are sync-by-API and the boot reads block startup either way.

## Test plan
- [ ] Toggle theme, confirm \`ChartPanel\` palette updates
- [ ] Resize space-mode panes, confirm utility-pane widths still clamp correctly under rapid drag
- [ ] Publish a workspace (with and without \`.hbignore\`) — verify bundle preview + final archive identical
- [ ] Open a fresh workspace folder, confirm git repo bootstraps once and reuses on second open

🤖 Generated with [Claude Code](https://claude.com/claude-code)