### PR TITLE
perf(chat): lazy code highlight + rAF-throttle streaming deltas

### DIFF
--- a/desktop/src/components/marketplace/CodeBlock.tsx
+++ b/desktop/src/components/marketplace/CodeBlock.tsx
@@ -4,6 +4,7 @@ import {
   isValidElement,
   type ReactNode,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { type BundledLanguage, bundledLanguages, codeToHtml } from "shiki";
@@ -121,6 +122,14 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
   const [highlighted, setHighlighted] = useState<string | null>(null);
   const [theme, setTheme] = useState(pickShikiTheme);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const explicitLanguage = resolveLanguage(language);
+  const resolvedLanguage =
+    explicitLanguage === "text" ? detectLanguage(trimmed) : explicitLanguage;
+
+  const cacheKey = `${theme}:${resolvedLanguage}:${trimmed}`;
+  const [inView, setInView] = useState(() => highlightCache.has(cacheKey));
 
   useEffect(() => {
     const observer = new MutationObserver(() => setTheme(pickShikiTheme()));
@@ -131,22 +140,43 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
     return () => observer.disconnect();
   }, []);
 
-  const explicitLanguage = resolveLanguage(language);
-  const resolvedLanguage =
-    explicitLanguage === "text" ? detectLanguage(trimmed) : explicitLanguage;
+  useEffect(() => {
+    if (inView) return;
+    if (highlightCache.has(cacheKey)) {
+      setInView(true);
+      return;
+    }
+    const node = wrapperRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: "200px 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [cacheKey, inView]);
 
   useEffect(() => {
-    let cancelled = false;
-    const cacheKey = `${theme}:${resolvedLanguage}:${trimmed}`;
     const cached = highlightCache.get(cacheKey);
     if (cached) {
       setHighlighted(cached);
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
     setHighlighted(null);
+    if (!inView) return;
 
+    let cancelled = false;
     void (async () => {
       try {
         const html = await codeToHtml(trimmed, {
@@ -168,7 +198,7 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
     return () => {
       cancelled = true;
     };
-  }, [trimmed, resolvedLanguage, theme]);
+  }, [cacheKey, inView, resolvedLanguage, theme, trimmed]);
 
   async function handleCopy() {
     try {
@@ -187,7 +217,7 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
   })();
 
   return (
-    <div className="md-code-block-wrapper group/code-block">
+    <div className="md-code-block-wrapper group/code-block" ref={wrapperRef}>
       <div className="md-code-block-header">
         <span className="md-code-block-lang">{langLabel}</span>
         <button

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -3269,6 +3269,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
   const skipNextComposerDraftPublishRef = useRef(false);
   const liveAssistantSegmentsRef = useRef<ChatAssistantSegment[]>([]);
   const liveAssistantTextRef = useRef("");
+  const liveAssistantFlushFrameRef = useRef<number | null>(null);
   const liveExecutionItemsRef = useRef<ChatExecutionTimelineItem[]>([]);
   const historyViewportGenerationRef = useRef(0);
   const [activeSessionId, setActiveSessionId] = useState("");
@@ -3507,6 +3508,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
   }
 
   function resetLiveTurn() {
+    cancelLiveAssistantFlush();
     liveAssistantSegmentsRef.current = [];
     liveAssistantTextRef.current = "";
     liveExecutionItemsRef.current = [];
@@ -4227,6 +4229,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
     if (!liveAssistantTextRef.current) {
       return;
     }
+    cancelLiveAssistantFlush();
     flushSync(() => {
       setLiveAssistantSegmentsState(
         appendAssistantOutputSegment(
@@ -4256,15 +4259,25 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
     });
   }
 
+  function cancelLiveAssistantFlush() {
+    if (liveAssistantFlushFrameRef.current !== null) {
+      window.cancelAnimationFrame(liveAssistantFlushFrameRef.current);
+      liveAssistantFlushFrameRef.current = null;
+    }
+  }
+
+  function scheduleLiveAssistantFlush() {
+    if (liveAssistantFlushFrameRef.current !== null) return;
+    liveAssistantFlushFrameRef.current = window.requestAnimationFrame(() => {
+      liveAssistantFlushFrameRef.current = null;
+      setLiveAssistantText(liveAssistantTextRef.current);
+    });
+  }
+
   function appendLiveAssistantDelta(delta: string) {
     flushLiveExecutionSegment();
-    flushSync(() => {
-      setLiveAssistantText((prev) => {
-        const next = `${prev}${delta}`;
-        liveAssistantTextRef.current = next;
-        return next;
-      });
-    });
+    liveAssistantTextRef.current = `${liveAssistantTextRef.current}${delta}`;
+    scheduleLiveAssistantFlush();
   }
 
   function appendLiveThinkingDelta(delta: string, order: number) {
@@ -5765,6 +5778,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
 
   useEffect(() => {
     return () => {
+      cancelLiveAssistantFlush();
       const activeStreamId = activeStreamIdRef.current;
       if (activeStreamId) {
         void closeStreamWithReason(activeStreamId, "chatpane_unmount");


### PR DESCRIPTION
Stacks on top of #243.

## Summary
**#2 Streaming token throttle.** \`appendLiveAssistantDelta\` was wrapping every incoming token in \`flushSync\`, forcing one synchronous render per token. Re-write it to update the ref synchronously and schedule one rAF flush per burst — auto-scroll + markdown re-render now run at most once per frame. \`flushLiveAssistantOutputSegment\` / \`resetLiveTurn\` / unmount cancel any pending rAF before mutating state, so the visible text stays in lockstep with the committed segments.

**#3 CodeBlock lazy highlight.** Wrap the shiki call in an \`IntersectionObserver\` (200px rootMargin). Off-screen blocks don't warm up the highlighter on mount; cache hits remain eager so re-mounted blocks paint immediately.

**#1 Reverse pagination — already in place.** \`CHAT_HISTORY_PAGE_SIZE = 10\` already caps initial mount to the most recent 10 messages, with \`loadOlderSessionHistory\` triggering on scroll-up at the 96px threshold. No code change required.

## Test plan
- [ ] Stream a long assistant reply — confirm no per-token jank and final segment commits cleanly
- [ ] Cancel mid-stream (Stop) — confirm no orphaned text after reset
- [ ] Scroll a long thread with many code blocks — confirm shiki highlights kick in as blocks enter viewport
- [ ] Re-open a session — confirm cached blocks paint highlighted immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)