### PR TITLE
feat(dashboard): click row/item/card to open detail dialog

### DIFF
--- a/desktop/src/components/dashboard/BoardView.tsx
+++ b/desktop/src/components/dashboard/BoardView.tsx
@@ -11,6 +11,7 @@ import type { BoardViewSpec, ColorToken } from "@/lib/dashboardSchema";
 
 import { EmptyState } from "./EmptyState";
 import { colorClasses, formatSmartDate, hashToColor, looksLikeDateColumn } from "./format";
+import { RowDetailDialog } from "./RowDetailDialog";
 import { isStatusColumn, StatusBadge } from "./StatusBadge";
 import { usePersistedState } from "./usePersistedState";
 
@@ -58,6 +59,15 @@ export function BoardView({
   const groupableColumns = useMemo(
     () => candidateGroupColumns(columns, view),
     [columns, view],
+  );
+
+  const [selectedRow, setSelectedRow] = useState<Record<string, unknown> | null>(
+    null,
+  );
+
+  const detailColumns = useMemo(
+    () => columns.map((name) => ({ name })),
+    [columns],
   );
 
   if (titleIdx < 0) {
@@ -166,7 +176,26 @@ export function BoardView({
                 // biome-ignore lint/suspicious/noArrayIndexKey: SQL row order is the natural key
                 <article
                   key={rIdx}
-                  className="rounded-md border border-transparent bg-fg-4 px-3 py-2.5 text-xs transition-colors hover:border-border hover:bg-card"
+                  onClick={() => {
+                    const obj: Record<string, unknown> = {};
+                    for (let i = 0; i < columns.length; i += 1) {
+                      obj[columns[i]] = row[i];
+                    }
+                    setSelectedRow(obj);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      const obj: Record<string, unknown> = {};
+                      for (let i = 0; i < columns.length; i += 1) {
+                        obj[columns[i]] = row[i];
+                      }
+                      setSelectedRow(obj);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  className="cursor-pointer rounded-md border border-transparent bg-fg-4 px-3 py-2.5 text-xs transition-colors hover:border-border hover:bg-card focus-visible:border-border focus-visible:bg-card focus-visible:outline-none"
                 >
                   <div className="line-clamp-3 leading-snug text-foreground">
                     {formatCell(row[titleIdx])}
@@ -202,6 +231,24 @@ export function BoardView({
           </div>
         ))}
       </div>
+      <RowDetailDialog
+        open={selectedRow !== null}
+        onOpenChange={(next) => {
+          if (!next) setSelectedRow(null);
+        }}
+        title={
+          selectedRow
+            ? formatCell(selectedRow[view.card_title]) || "Details"
+            : "Details"
+        }
+        subtitle={
+          selectedRow && view.card_subtitle
+            ? formatCell(selectedRow[view.card_subtitle])
+            : undefined
+        }
+        columns={detailColumns}
+        row={selectedRow ?? {}}
+      />
     </div>
   );
 }

--- a/desktop/src/components/dashboard/ListView.tsx
+++ b/desktop/src/components/dashboard/ListView.tsx
@@ -1,10 +1,11 @@
 import { Rows3 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { ListViewSpec } from "@/lib/dashboardSchema";
 
 import { EmptyState } from "./EmptyState";
 import { formatSmartDate, looksLikeDateColumn } from "./format";
+import { RowDetailDialog } from "./RowDetailDialog";
 
 interface ListViewProps {
   view: ListViewSpec;
@@ -21,6 +22,14 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
   const metaIdx = view.meta ? columns.indexOf(view.meta) : -1;
   const metaIsDate = looksLikeDateColumn(view.meta);
   const [shownLimit, setShownLimit] = useState(500);
+  const [selectedRow, setSelectedRow] = useState<Record<string, unknown> | null>(
+    null,
+  );
+
+  const detailColumns = useMemo(
+    () => columns.map((name) => ({ name })),
+    [columns],
+  );
 
   if (primaryIdx < 0) {
     return (
@@ -50,7 +59,26 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
           // biome-ignore lint/suspicious/noArrayIndexKey: SQL row order is the natural key
           <li
             key={idx}
-            className="group flex items-baseline gap-3 px-1 py-2.5 transition-colors hover:bg-fg-4"
+            onClick={() => {
+              const obj: Record<string, unknown> = {};
+              for (let i = 0; i < columns.length; i += 1) {
+                obj[columns[i]] = row[i];
+              }
+              setSelectedRow(obj);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                const obj: Record<string, unknown> = {};
+                for (let i = 0; i < columns.length; i += 1) {
+                  obj[columns[i]] = row[i];
+                }
+                setSelectedRow(obj);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            className="group flex cursor-pointer items-baseline gap-3 px-1 py-2.5 transition-colors hover:bg-fg-4 focus-visible:bg-fg-4 focus-visible:outline-none"
           >
             <div className="min-w-0 flex-1">
               <div className="truncate text-sm font-medium leading-snug text-foreground">
@@ -87,6 +115,22 @@ export function ListView({ view, columns, rows, emptyState }: ListViewProps) {
           </button>
         </li>
       ) : null}
+      <RowDetailDialog
+        open={selectedRow !== null}
+        onOpenChange={(next) => {
+          if (!next) setSelectedRow(null);
+        }}
+        title={
+          selectedRow ? String(selectedRow[view.primary] ?? "Details") : "Details"
+        }
+        subtitle={
+          selectedRow && view.secondary
+            ? String(selectedRow[view.secondary] ?? "")
+            : undefined
+        }
+        columns={detailColumns}
+        row={selectedRow ?? {}}
+      />
     </ul>
   );
 }

--- a/desktop/src/components/dashboard/RowDetailDialog.tsx
+++ b/desktop/src/components/dashboard/RowDetailDialog.tsx
@@ -1,0 +1,187 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+
+import type { ColorToken, TableColumnSpec } from "@/lib/dashboardSchema";
+import { cn } from "@/lib/utils";
+
+import {
+  colorClasses,
+  formatValue,
+  resolveLinkTemplate,
+} from "./format";
+import { isStatusColumn, StatusBadge } from "./StatusBadge";
+
+export interface RowDetailColumn {
+  name: string;
+  label?: string;
+  spec?: TableColumnSpec | null;
+}
+
+interface RowDetailDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subtitle?: string;
+  columns: RowDetailColumn[];
+  row: Record<string, unknown>;
+}
+
+export function RowDetailDialog({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  columns,
+  row,
+}: RowDetailDialogProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-background/70 backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup
+          className={cn(
+            "fixed top-1/2 left-1/2 z-[91] flex max-h-[min(80vh,640px)] w-[min(560px,calc(100vw-32px))] flex-col",
+            "-translate-x-1/2 -translate-y-1/2 rounded-xl border border-border",
+            "bg-popover text-popover-foreground shadow-xl ring-1 ring-foreground/10",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "outline-none",
+          )}
+        >
+          <header className="flex items-start gap-3 border-b border-border/70 px-5 py-4">
+            <div className="min-w-0 flex-1">
+              <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
+                {title || "Details"}
+              </DialogPrimitive.Title>
+              {subtitle ? (
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {subtitle}
+                </p>
+              ) : null}
+            </div>
+            <DialogPrimitive.Close
+              render={
+                <button
+                  type="button"
+                  aria-label="Close"
+                  className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-fg-6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                >
+                  <X size={14} strokeWidth={2} />
+                </button>
+              }
+            />
+          </header>
+          <div className="scrollbar-ghost min-h-0 flex-1 overflow-y-auto px-5 py-3">
+            <dl className="grid grid-cols-[minmax(96px,160px)_1fr] gap-x-4 gap-y-2.5 text-sm">
+              {columns.map((col) => (
+                <DetailRow key={col.name} column={col} row={row} />
+              ))}
+            </dl>
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+function DetailRow({
+  column,
+  row,
+}: {
+  column: RowDetailColumn;
+  row: Record<string, unknown>;
+}) {
+  const value = row[column.name];
+  return (
+    <>
+      <dt className="pt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+        {column.label ?? column.spec?.label ?? column.name}
+      </dt>
+      <dd className="min-w-0 break-words text-foreground">
+        <DetailValue column={column} value={value} row={row} />
+      </dd>
+    </>
+  );
+}
+
+function DetailValue({
+  column,
+  value,
+  row,
+}: {
+  column: RowDetailColumn;
+  value: unknown;
+  row: Record<string, unknown>;
+}) {
+  const spec = column.spec ?? null;
+  const isEmpty = value === null || value === undefined || value === "";
+  if (isEmpty) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  if (spec?.format === "image_url" && typeof value === "string") {
+    return (
+      <img
+        src={value}
+        alt=""
+        className="size-16 rounded-md border border-border/60 object-cover"
+      />
+    );
+  }
+
+  if (spec?.format === "url" && typeof value === "string") {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="break-all text-primary underline-offset-4 hover:underline"
+      >
+        {value}
+      </a>
+    );
+  }
+
+  if (spec?.colors) {
+    const key = String(value);
+    const token = (spec.colors as Record<string, ColorToken>)[key];
+    if (token) {
+      const cls = colorClasses(token);
+      return (
+        <span
+          className={`inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium ${cls.badge}`}
+        >
+          {key}
+        </span>
+      );
+    }
+  }
+
+  if (!spec && isStatusColumn(column.name)) {
+    return <StatusBadge value={String(value)} />;
+  }
+
+  const text = formatValue(value, spec?.format, { currency: spec?.currency });
+
+  if (spec?.link) {
+    const href = resolveLinkTemplate(spec.link, row);
+    if (href) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          {text}
+        </a>
+      );
+    }
+  }
+
+  if (typeof value === "string" && value.includes("\n")) {
+    return <span className="whitespace-pre-wrap leading-relaxed">{text}</span>;
+  }
+
+  return <span className="leading-relaxed">{text}</span>;
+}

--- a/desktop/src/components/dashboard/TableView.tsx
+++ b/desktop/src/components/dashboard/TableView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ColorToken, TableColumnSpec, TableViewSpec } from "@/lib/dashboardSchema";
 
 import { EmptyState } from "./EmptyState";
+import { RowDetailDialog } from "./RowDetailDialog";
 import { isStatusColumn, StatusBadge } from "./StatusBadge";
 import {
   colorClasses,
@@ -90,6 +91,27 @@ export function TableView({
 
   const [shownLimit, setShownLimit] = useState(500);
   const displayRows = sortedRows.slice(0, shownLimit);
+
+  const [selectedRow, setSelectedRow] = useState<Record<string, unknown> | null>(
+    null,
+  );
+
+  const detailColumns = useMemo<
+    Array<{ name: string; label?: string; spec: TableColumnSpec | null }>
+  >(
+    () =>
+      visible.map((c) => ({
+        name: c.name,
+        label: c.spec?.label,
+        spec: c.spec,
+      })),
+    [visible],
+  );
+
+  const detailTitleColumn = useMemo(() => {
+    const heavy = visible.find((c) => TEXT_HEAVY_NAMES.has(c.name.toLowerCase()));
+    return heavy?.name ?? visible[0]?.name ?? null;
+  }, [visible]);
 
   const cycleSort = (column: string) => {
     setSort((prev) => {
@@ -234,7 +256,16 @@ export function TableView({
               // biome-ignore lint/suspicious/noArrayIndexKey: SQL row order is the natural key
               <tr
                 key={rIdx}
-                className="border-b border-border/40 transition-colors hover:bg-fg-4 last:border-b-0"
+                onClick={(e) => {
+                  if (
+                    e.target instanceof HTMLElement &&
+                    e.target.closest("a, button")
+                  ) {
+                    return;
+                  }
+                  setSelectedRow(rowObj);
+                }}
+                className="cursor-pointer border-b border-border/40 transition-colors hover:bg-fg-4 last:border-b-0"
               >
                 {visible.map((c) => (
                   <Cell key={c.name} column={c} value={row[c.index]} row={rowObj} />
@@ -259,6 +290,19 @@ export function TableView({
           </button>
         </div>
       ) : null}
+      <RowDetailDialog
+        open={selectedRow !== null}
+        onOpenChange={(next) => {
+          if (!next) setSelectedRow(null);
+        }}
+        title={
+          selectedRow && detailTitleColumn
+            ? String(selectedRow[detailTitleColumn] ?? "Details")
+            : "Details"
+        }
+        columns={detailColumns}
+        row={selectedRow ?? {}}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Tables, lists, and board cards in dashboard panels now open a detail dialog on click. Reuses the existing format pipeline so links, image_url, color chips, status badges, and link templates render the same way they do in the parent view.

**Shared component**: \`RowDetailDialog\` — Base UI Dialog with a label/value grid body. Empty values become \`—\`, multi-line text preserves line breaks, image_url shows a thumbnail, url renders as a link.

**Per view**:
- \`TableView\`: \`<tr>\` is clickable; clicks bubbling from \`<a>\` / \`<button>\` are ignored so sort headers, resize handles, and url cells still behave as before. Dialog title comes from the first text-heavy column (\`title\` / \`name\` / \`post\` / etc.) if present, else the first visible column.
- \`ListView\`: \`<li>\` becomes \`role=\"button\"\` + \`tabIndex=0\`, Enter/Space open the dialog. Title = \`view.primary\`, subtitle = \`view.secondary\`.
- \`BoardView\`: same treatment on each card \`<article>\`. Title = \`view.card_title\`, subtitle = \`view.card_subtitle\`.

## Test plan
- [ ] Click a row in a table panel — dialog opens with all columns; clicking column-sort headers / resize handles / url-format links does NOT open the dialog
- [ ] Click an item in a list panel; Tab through items and press Enter/Space
- [ ] Click a card in a board panel; switch group_by and confirm cards in the new grouping still open
- [ ] Long text columns wrap inside the dialog; image_url + url + colors-mapped chips render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)