### PR TITLE
feat: bundle workspace-scoped runtime state and memory

### DIFF
--- a/desktop/electron/control-plane-owned-state.test.mjs
+++ b/desktop/electron/control-plane-owned-state.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const CONTROL_PLANE_STATE_PATH = new URL(
+  "./control-plane-owned-state.ts",
+  import.meta.url,
+);
+
+test("control-plane-owned state module owns local workspace registry and runtime profile metadata", async () => {
+  const source = await readFile(CONTROL_PLANE_STATE_PATH, "utf8");
+
+  assert.match(source, /export interface LocalWorkspaceRegistry \{/);
+  assert.match(source, /getWorkspaceRecord\(workspaceId: string\): WorkspaceRegistryRecord \| null/);
+  assert.match(source, /listCachedWorkspaces\(\): WorkspaceRegistryListResponse/);
+  assert.match(source, /export function createLocalWorkspaceRegistry\(/);
+  assert.match(source, /new Database\(options\.runtimeDatabasePath\(\), \{\s*readonly: true,\s*\}\)/);
+  assert.match(source, /SELECT[\s\S]*FROM workspaces/);
+  assert.match(source, /export interface LocalRuntimeUserProfileStore \{/);
+  assert.match(source, /getProfile\(\): Promise<RuntimeUserProfileRecord>/);
+  assert.match(source, /setProfile\(payload: RuntimeUserProfileUpdate\): Promise<RuntimeUserProfileRecord>/);
+  assert.match(source, /applyAuthFallback\(/);
+  assert.match(source, /export function createLocalRuntimeUserProfileStore\(/);
+  assert.match(source, /requestJson: <T>\(pathname: string, init\?: RequestInit\) => Promise<T>/);
+});
+
+test("electron main delegates control-plane-owned metadata through the local state module", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(
+    source,
+    /import \{\s*createLocalRuntimeUserProfileStore,\s*createLocalWorkspaceRegistry,\s*\} from "\.\/control-plane-owned-state\.js"/,
+  );
+  assert.match(
+    source,
+    /const localRuntimeUserProfileStore = createLocalRuntimeUserProfileStore\(\{\s*requestJson: runtimeApiRequest,\s*\}\);/,
+  );
+  assert.match(
+    source,
+    /const localWorkspaceRegistry = createLocalWorkspaceRegistry\(\{\s*runtimeDatabasePath: runtimeDatabasePath,\s*location: localWorkspaceLocation\(\),\s*\}\);/,
+  );
+  assert.match(source, /return localRuntimeUserProfileStore\.getProfile\(\);/);
+  assert.match(source, /return localRuntimeUserProfileStore\.setProfile\(payload\);/);
+  assert.match(source, /return localRuntimeUserProfileStore\.applyAuthFallback\(name, profileId\);/);
+  assert.match(source, /return localWorkspaceRegistry\.getWorkspaceRecord\(workspaceId\);/);
+  assert.match(source, /return localWorkspaceRegistry\.listCachedWorkspaces\(\);/);
+});

--- a/desktop/electron/control-plane-owned-state.test.mjs
+++ b/desktop/electron/control-plane-owned-state.test.mjs
@@ -14,15 +14,17 @@ test("control-plane-owned state module owns local workspace registry and runtime
   assert.match(source, /export interface LocalWorkspaceRegistry \{/);
   assert.match(source, /getWorkspaceRecord\(workspaceId: string\): WorkspaceRegistryRecord \| null/);
   assert.match(source, /listCachedWorkspaces\(\): WorkspaceRegistryListResponse/);
+  assert.match(source, /export function bootstrapLocalControlPlaneDatabase\(/);
   assert.match(source, /export function createLocalWorkspaceRegistry\(/);
-  assert.match(source, /new Database\(options\.runtimeDatabasePath\(\), \{\s*readonly: true,\s*\}\)/);
+  assert.match(source, /new Database\(options\.controlPlaneDatabasePath\(\), \{\s*readonly: true,\s*\}\)/);
   assert.match(source, /SELECT[\s\S]*FROM workspaces/);
   assert.match(source, /export interface LocalRuntimeUserProfileStore \{/);
   assert.match(source, /getProfile\(\): Promise<RuntimeUserProfileRecord>/);
   assert.match(source, /setProfile\(payload: RuntimeUserProfileUpdate\): Promise<RuntimeUserProfileRecord>/);
   assert.match(source, /applyAuthFallback\(/);
   assert.match(source, /export function createLocalRuntimeUserProfileStore\(/);
-  assert.match(source, /requestJson: <T>\(pathname: string, init\?: RequestInit\) => Promise<T>/);
+  assert.match(source, /controlPlaneDatabasePath: \(\) => string/);
+  assert.match(source, /SELECT \* FROM runtime_user_profiles WHERE profile_id = \? LIMIT 1/);
 });
 
 test("electron main delegates control-plane-owned metadata through the local state module", async () => {
@@ -30,16 +32,19 @@ test("electron main delegates control-plane-owned metadata through the local sta
 
   assert.match(
     source,
-    /import \{\s*createLocalRuntimeUserProfileStore,\s*createLocalWorkspaceRegistry,\s*\} from "\.\/control-plane-owned-state\.js"/,
+    /import \{\s*bootstrapLocalControlPlaneDatabase,\s*createLocalRuntimeUserProfileStore,\s*createLocalWorkspaceRegistry,\s*\} from "\.\/control-plane-owned-state\.js"/,
   );
   assert.match(
     source,
-    /const localRuntimeUserProfileStore = createLocalRuntimeUserProfileStore\(\{\s*requestJson: runtimeApiRequest,\s*\}\);/,
+    /const localRuntimeUserProfileStore = createLocalRuntimeUserProfileStore\(\{\s*controlPlaneDatabasePath: controlPlaneDatabasePath,\s*\}\);/,
   );
   assert.match(
     source,
-    /const localWorkspaceRegistry = createLocalWorkspaceRegistry\(\{\s*runtimeDatabasePath: runtimeDatabasePath,\s*location: localWorkspaceLocation\(\),\s*\}\);/,
+    /const localWorkspaceRegistry = createLocalWorkspaceRegistry\(\{\s*controlPlaneDatabasePath: controlPlaneDatabasePath,\s*location: localWorkspaceLocation\(\),\s*\}\);/,
   );
+  assert.match(source, /function bootstrapControlPlaneDatabase\(\) \{/);
+  assert.match(source, /bootstrapLocalControlPlaneDatabase\(\{/);
+  assert.match(source, /HOLABOSS_CONTROL_PLANE_DB_PATH: controlPlaneDatabasePath\(\),/);
   assert.match(source, /return localRuntimeUserProfileStore\.getProfile\(\);/);
   assert.match(source, /return localRuntimeUserProfileStore\.setProfile\(payload\);/);
   assert.match(source, /return localRuntimeUserProfileStore\.applyAuthFallback\(name, profileId\);/);

--- a/desktop/electron/control-plane-owned-state.ts
+++ b/desktop/electron/control-plane-owned-state.ts
@@ -1,0 +1,353 @@
+import Database from "better-sqlite3"
+
+export type WorkspaceLocation = "local" | "cloud"
+
+export interface WorkspaceRegistryRecord {
+  id: string
+  location: WorkspaceLocation
+  name: string
+  status: string
+  harness: string | null
+  error_message: string | null
+  onboarding_status: string
+  onboarding_session_id: string | null
+  onboarding_completed_at: string | null
+  onboarding_completion_summary: string | null
+  onboarding_requested_at: string | null
+  onboarding_requested_by: string | null
+  created_at: string | null
+  updated_at: string | null
+  deleted_at_utc: string | null
+  workspace_path?: string | null
+  folder_state?: "healthy" | "missing" | null
+}
+
+export interface WorkspaceRegistryListResponse {
+  items: WorkspaceRegistryRecord[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface LocalWorkspaceRegistry {
+  getWorkspaceRecord(workspaceId: string): WorkspaceRegistryRecord | null
+  listCachedWorkspaces(): WorkspaceRegistryListResponse
+}
+
+export interface LocalWorkspaceRegistryOptions {
+  runtimeDatabasePath: () => string
+  location: WorkspaceLocation
+}
+
+function mapWorkspaceRegistryRow(
+  row: Record<string, unknown>,
+  {
+    location,
+    hasWorkspacePath,
+  }: {
+    location: WorkspaceLocation
+    hasWorkspacePath: boolean
+  },
+): WorkspaceRegistryRecord {
+  return {
+    id: String(row.id ?? ""),
+    location,
+    name: String(row.name ?? ""),
+    status: String(row.status ?? "unknown"),
+    harness: row.harness == null ? null : String(row.harness),
+    error_message: row.error_message == null ? null : String(row.error_message),
+    onboarding_status: String(row.onboarding_status ?? "complete"),
+    onboarding_session_id:
+      row.onboarding_session_id == null
+        ? null
+        : String(row.onboarding_session_id),
+    onboarding_completed_at:
+      row.onboarding_completed_at == null
+        ? null
+        : String(row.onboarding_completed_at),
+    onboarding_completion_summary:
+      row.onboarding_completion_summary == null
+        ? null
+        : String(row.onboarding_completion_summary),
+    onboarding_requested_at:
+      row.onboarding_requested_at == null
+        ? null
+        : String(row.onboarding_requested_at),
+    onboarding_requested_by:
+      row.onboarding_requested_by == null
+        ? null
+        : String(row.onboarding_requested_by),
+    created_at: row.created_at == null ? null : String(row.created_at),
+    updated_at: row.updated_at == null ? null : String(row.updated_at),
+    deleted_at_utc:
+      row.deleted_at_utc == null ? null : String(row.deleted_at_utc),
+    workspace_path:
+      hasWorkspacePath && row.workspace_path != null
+        ? String(row.workspace_path)
+        : null,
+  }
+}
+
+export function createLocalWorkspaceRegistry(
+  options: LocalWorkspaceRegistryOptions,
+): LocalWorkspaceRegistry {
+  function getWorkspaceRecord(
+    workspaceId: string,
+  ): WorkspaceRegistryRecord | null {
+    const database = new Database(options.runtimeDatabasePath(), {
+      readonly: true,
+    })
+    try {
+      const row = database
+        .prepare(
+          `
+          SELECT
+            id,
+            name,
+            status,
+            harness,
+            error_message,
+            onboarding_status,
+            onboarding_session_id,
+            onboarding_completed_at,
+            onboarding_completion_summary,
+            onboarding_requested_at,
+            onboarding_requested_by,
+            created_at,
+            updated_at,
+            deleted_at_utc
+          FROM workspaces
+          WHERE id = @id
+        `,
+        )
+        .get({ id: workspaceId }) as Record<string, unknown> | undefined
+      if (!row) {
+        return null
+      }
+      return mapWorkspaceRegistryRow(row, {
+        location: options.location,
+        hasWorkspacePath: false,
+      })
+    } finally {
+      database.close()
+    }
+  }
+
+  function listCachedWorkspaces(): WorkspaceRegistryListResponse {
+    const empty: WorkspaceRegistryListResponse = {
+      items: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    }
+    let database: Database.Database | null = null
+    try {
+      database = new Database(options.runtimeDatabasePath(), { readonly: true })
+      const tableExists = database
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspaces' LIMIT 1",
+        )
+        .get()
+      if (!tableExists) {
+        return empty
+      }
+      const columns = new Set<string>(
+        (
+          database.prepare("PRAGMA table_info(workspaces)").all() as Array<{
+            name: string
+          }>
+        ).map((row) => row.name),
+      )
+      const hasWorkspacePath = columns.has("workspace_path")
+      const select = hasWorkspacePath
+        ? `SELECT id, name, status, harness, error_message,
+                  onboarding_status, onboarding_session_id,
+                  onboarding_completed_at, onboarding_completion_summary,
+                  onboarding_requested_at, onboarding_requested_by,
+                  created_at, updated_at, deleted_at_utc, workspace_path
+           FROM workspaces
+           WHERE deleted_at_utc IS NULL
+           ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
+           LIMIT 100`
+        : `SELECT id, name, status, harness, error_message,
+                  onboarding_status, onboarding_session_id,
+                  onboarding_completed_at, onboarding_completion_summary,
+                  onboarding_requested_at, onboarding_requested_by,
+                  created_at, updated_at, deleted_at_utc
+           FROM workspaces
+           WHERE deleted_at_utc IS NULL
+           ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
+           LIMIT 100`
+      const rows = database.prepare(select).all() as Array<
+        Record<string, unknown>
+      >
+      const items = rows.map((row) =>
+        mapWorkspaceRegistryRow(row, {
+          location: options.location,
+          hasWorkspacePath,
+        }),
+      )
+      return { items, total: items.length, limit: 100, offset: 0 }
+    } catch {
+      return empty
+    } finally {
+      try {
+        database?.close()
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return {
+    getWorkspaceRecord,
+    listCachedWorkspaces,
+  }
+}
+
+export type RuntimeUserProfileNameSource = "manual" | "agent" | "authFallback"
+
+export interface RuntimeUserProfileRecord {
+  profileId: string
+  name: string | null
+  nameSource: RuntimeUserProfileNameSource | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface RuntimeUserProfileUpdate {
+  profileId?: string | null
+  name?: string | null
+  nameSource?: RuntimeUserProfileNameSource | null
+}
+
+export interface LocalRuntimeUserProfileStore {
+  getProfile(): Promise<RuntimeUserProfileRecord>
+  setProfile(payload: RuntimeUserProfileUpdate): Promise<RuntimeUserProfileRecord>
+  applyAuthFallback(
+    name: string,
+    profileId?: string,
+  ): Promise<RuntimeUserProfileRecord>
+}
+
+export interface LocalRuntimeUserProfileStoreOptions {
+  requestJson: <T>(pathname: string, init?: RequestInit) => Promise<T>
+}
+
+function runtimeUserProfileNameSourceFromApi(
+  value: unknown,
+): RuntimeUserProfileNameSource | null {
+  if (value === "manual" || value === "agent") {
+    return value
+  }
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : ""
+  if (!normalized) {
+    return null
+  }
+  if (normalized === "manual" || normalized === "agent") {
+    return normalized
+  }
+  if (normalized === "auth_fallback") {
+    return "authFallback"
+  }
+  return null
+}
+
+function runtimeUserProfileNameSourceToApi(
+  value: RuntimeUserProfileNameSource | null | undefined,
+): string | null | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (value === null) {
+    return null
+  }
+  if (value === "authFallback") {
+    return "auth_fallback"
+  }
+  return value
+}
+
+function runtimeUserProfilePayloadFromApi(
+  value: unknown,
+): RuntimeUserProfileRecord {
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  return {
+    profileId:
+      typeof record.profile_id === "string" && record.profile_id.trim()
+        ? record.profile_id
+        : "default",
+    name:
+      typeof record.name === "string" && record.name.trim()
+        ? record.name
+        : null,
+    nameSource: runtimeUserProfileNameSourceFromApi(record.name_source),
+    createdAt:
+      typeof record.created_at === "string" && record.created_at.trim()
+        ? record.created_at
+        : null,
+    updatedAt:
+      typeof record.updated_at === "string" && record.updated_at.trim()
+        ? record.updated_at
+        : null,
+  }
+}
+
+export function createLocalRuntimeUserProfileStore(
+  options: LocalRuntimeUserProfileStoreOptions,
+): LocalRuntimeUserProfileStore {
+  return {
+    async getProfile(): Promise<RuntimeUserProfileRecord> {
+      const payload = await options.requestJson<unknown>("/api/v1/runtime/profile", {
+        method: "GET",
+      })
+      return runtimeUserProfilePayloadFromApi(payload)
+    },
+
+    async setProfile(
+      payload: RuntimeUserProfileUpdate,
+    ): Promise<RuntimeUserProfileRecord> {
+      const body: Record<string, unknown> = {}
+      if (typeof payload.profileId === "string" && payload.profileId.trim()) {
+        body.profile_id = payload.profileId.trim()
+      }
+      if (payload.name !== undefined) {
+        body.name = payload.name
+      }
+      if (payload.nameSource !== undefined) {
+        body.name_source = runtimeUserProfileNameSourceToApi(payload.nameSource)
+      }
+      const response = await options.requestJson<unknown>("/api/v1/runtime/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      })
+      return runtimeUserProfilePayloadFromApi(response)
+    },
+
+    async applyAuthFallback(
+      name: string,
+      profileId = "default",
+    ): Promise<RuntimeUserProfileRecord> {
+      const response = await options.requestJson<unknown>(
+        "/api/v1/runtime/profile/auth-fallback",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            profile_id: profileId,
+            name,
+          }),
+        },
+      )
+      return runtimeUserProfilePayloadFromApi(response)
+    },
+  }
+}

--- a/desktop/electron/control-plane-owned-state.ts
+++ b/desktop/electron/control-plane-owned-state.ts
@@ -1,4 +1,6 @@
 import Database from "better-sqlite3"
+import fs from "node:fs"
+import path from "node:path"
 
 export type WorkspaceLocation = "local" | "cloud"
 
@@ -35,19 +37,104 @@ export interface LocalWorkspaceRegistry {
 }
 
 export interface LocalWorkspaceRegistryOptions {
-  runtimeDatabasePath: () => string
+  controlPlaneDatabasePath: () => string
   location: WorkspaceLocation
+}
+
+export interface LocalControlPlaneDatabaseBootstrapOptions {
+  controlPlaneDatabasePath: () => string
+  runtimeDatabasePath: () => string
+  workspaceRoot: () => string
+}
+
+export type RuntimeUserProfileNameSource = "manual" | "agent" | "authFallback"
+
+export interface RuntimeUserProfileRecord {
+  profileId: string
+  name: string | null
+  nameSource: RuntimeUserProfileNameSource | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface RuntimeUserProfileUpdate {
+  profileId?: string | null
+  name?: string | null
+  nameSource?: RuntimeUserProfileNameSource | null
+}
+
+export interface LocalRuntimeUserProfileStore {
+  getProfile(): Promise<RuntimeUserProfileRecord>
+  setProfile(payload: RuntimeUserProfileUpdate): Promise<RuntimeUserProfileRecord>
+  applyAuthFallback(
+    name: string,
+    profileId?: string,
+  ): Promise<RuntimeUserProfileRecord>
+}
+
+export interface LocalRuntimeUserProfileStoreOptions {
+  controlPlaneDatabasePath: () => string
+}
+
+function utcNowIso(): string {
+  return new Date().toISOString()
+}
+
+function tableExists(database: Database.Database, tableName: string): boolean {
+  const row = database
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+    )
+    .get(tableName)
+  return Boolean(row)
+}
+
+function ensureControlPlaneDatabaseSchema(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS workspaces (
+      id TEXT PRIMARY KEY,
+      workspace_path TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      status TEXT NOT NULL,
+      harness TEXT,
+      error_message TEXT,
+      onboarding_status TEXT NOT NULL,
+      onboarding_session_id TEXT,
+      onboarding_completed_at TEXT,
+      onboarding_completion_summary TEXT,
+      onboarding_requested_at TEXT,
+      onboarding_requested_by TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      deleted_at_utc TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspaces_updated
+      ON workspaces (updated_at DESC, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS runtime_user_profiles (
+      profile_id TEXT PRIMARY KEY,
+      name TEXT,
+      name_source TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `)
+}
+
+function openControlPlaneDatabase(controlPlaneDatabasePath: string): Database.Database {
+  fs.mkdirSync(path.dirname(controlPlaneDatabasePath), { recursive: true })
+  const database = new Database(controlPlaneDatabasePath)
+  database.pragma("journal_mode = WAL")
+  database.pragma("busy_timeout = 5000")
+  database.pragma("foreign_keys = ON")
+  ensureControlPlaneDatabaseSchema(database)
+  return database
 }
 
 function mapWorkspaceRegistryRow(
   row: Record<string, unknown>,
-  {
-    location,
-    hasWorkspacePath,
-  }: {
-    location: WorkspaceLocation
-    hasWorkspacePath: boolean
-  },
+  location: WorkspaceLocation,
 ): WorkspaceRegistryRecord {
   return {
     id: String(row.id ?? ""),
@@ -82,9 +169,173 @@ function mapWorkspaceRegistryRow(
     deleted_at_utc:
       row.deleted_at_utc == null ? null : String(row.deleted_at_utc),
     workspace_path:
-      hasWorkspacePath && row.workspace_path != null
-        ? String(row.workspace_path)
+      row.workspace_path == null ? null : String(row.workspace_path),
+  }
+}
+
+function runtimeUserProfileNameSourceFromStored(
+  value: unknown,
+): RuntimeUserProfileNameSource | null {
+  if (value === "manual" || value === "agent") {
+    return value
+  }
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : ""
+  if (!normalized) {
+    return null
+  }
+  if (normalized === "manual" || normalized === "agent") {
+    return normalized
+  }
+  if (normalized === "auth_fallback") {
+    return "authFallback"
+  }
+  return null
+}
+
+function runtimeUserProfileNameSourceToStored(
+  value: RuntimeUserProfileNameSource | null | undefined,
+): string | null | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (value === null) {
+    return null
+  }
+  if (value === "authFallback") {
+    return "auth_fallback"
+  }
+  return value
+}
+
+function mapRuntimeUserProfileRow(
+  row: Record<string, unknown> | undefined,
+  profileId = "default",
+): RuntimeUserProfileRecord {
+  return {
+    profileId:
+      typeof row?.profile_id === "string" && row.profile_id.trim()
+        ? row.profile_id
+        : profileId,
+    name:
+      typeof row?.name === "string" && row.name.trim() ? row.name : null,
+    nameSource: runtimeUserProfileNameSourceFromStored(row?.name_source),
+    createdAt:
+      typeof row?.created_at === "string" && row.created_at.trim()
+        ? row.created_at
         : null,
+    updatedAt:
+      typeof row?.updated_at === "string" && row.updated_at.trim()
+        ? row.updated_at
+        : null,
+  }
+}
+
+function canonicalWorkspacePathFromLegacyRow(
+  row: Record<string, unknown>,
+  workspaceRoot: string,
+): string {
+  const explicitPath =
+    typeof row.workspace_path === "string" && row.workspace_path.trim()
+      ? row.workspace_path.trim()
+      : null
+  if (explicitPath) {
+    return explicitPath
+  }
+  const workspaceId = typeof row.id === "string" ? row.id.trim() : ""
+  return path.join(workspaceRoot, workspaceId)
+}
+
+export function bootstrapLocalControlPlaneDatabase(
+  options: LocalControlPlaneDatabaseBootstrapOptions,
+): void {
+  const controlPlanePath = options.controlPlaneDatabasePath()
+  const runtimePath = options.runtimeDatabasePath()
+  const database = openControlPlaneDatabase(controlPlanePath)
+  try {
+    if (path.resolve(controlPlanePath) === path.resolve(runtimePath)) {
+      return
+    }
+    if (!fs.existsSync(runtimePath)) {
+      return
+    }
+
+    const legacy = new Database(runtimePath, { readonly: true })
+    try {
+      if (tableExists(legacy, "workspaces")) {
+        const rows = legacy.prepare("SELECT * FROM workspaces").all() as Array<
+          Record<string, unknown>
+        >
+        const insert = database.prepare(`
+          INSERT OR IGNORE INTO workspaces (
+            id,
+            workspace_path,
+            name,
+            status,
+            harness,
+            error_message,
+            onboarding_status,
+            onboarding_session_id,
+            onboarding_completed_at,
+            onboarding_completion_summary,
+            onboarding_requested_at,
+            onboarding_requested_by,
+            created_at,
+            updated_at,
+            deleted_at_utc
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `)
+        for (const row of rows) {
+          insert.run(
+            row.id,
+            canonicalWorkspacePathFromLegacyRow(
+              row,
+              options.workspaceRoot(),
+            ),
+            row.name,
+            row.status,
+            row.harness ?? null,
+            row.error_message ?? null,
+            row.onboarding_status ?? "complete",
+            row.onboarding_session_id ?? null,
+            row.onboarding_completed_at ?? null,
+            row.onboarding_completion_summary ?? null,
+            row.onboarding_requested_at ?? null,
+            row.onboarding_requested_by ?? null,
+            row.created_at ?? null,
+            row.updated_at ?? null,
+            row.deleted_at_utc ?? null,
+          )
+        }
+      }
+
+      if (tableExists(legacy, "runtime_user_profiles")) {
+        const rows = legacy
+          .prepare("SELECT * FROM runtime_user_profiles")
+          .all() as Array<Record<string, unknown>>
+        const insert = database.prepare(`
+          INSERT OR IGNORE INTO runtime_user_profiles (
+            profile_id,
+            name,
+            name_source,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?)
+        `)
+        for (const row of rows) {
+          insert.run(
+            row.profile_id,
+            row.name ?? null,
+            row.name_source ?? null,
+            row.created_at,
+            row.updated_at,
+          )
+        }
+      }
+    } finally {
+      legacy.close()
+    }
+  } finally {
+    database.close()
   }
 }
 
@@ -94,7 +345,7 @@ export function createLocalWorkspaceRegistry(
   function getWorkspaceRecord(
     workspaceId: string,
   ): WorkspaceRegistryRecord | null {
-    const database = new Database(options.runtimeDatabasePath(), {
+    const database = new Database(options.controlPlaneDatabasePath(), {
       readonly: true,
     })
     try {
@@ -103,6 +354,7 @@ export function createLocalWorkspaceRegistry(
           `
           SELECT
             id,
+            workspace_path,
             name,
             status,
             harness,
@@ -124,10 +376,7 @@ export function createLocalWorkspaceRegistry(
       if (!row) {
         return null
       }
-      return mapWorkspaceRegistryRow(row, {
-        location: options.location,
-        hasWorkspacePath: false,
-      })
+      return mapWorkspaceRegistryRow(row, options.location)
     } finally {
       database.close()
     }
@@ -142,34 +391,15 @@ export function createLocalWorkspaceRegistry(
     }
     let database: Database.Database | null = null
     try {
-      database = new Database(options.runtimeDatabasePath(), { readonly: true })
-      const tableExists = database
-        .prepare(
-          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspaces' LIMIT 1",
-        )
-        .get()
-      if (!tableExists) {
+      database = new Database(options.controlPlaneDatabasePath(), {
+        readonly: true,
+      })
+      if (!tableExists(database, "workspaces")) {
         return empty
       }
-      const columns = new Set<string>(
-        (
-          database.prepare("PRAGMA table_info(workspaces)").all() as Array<{
-            name: string
-          }>
-        ).map((row) => row.name),
-      )
-      const hasWorkspacePath = columns.has("workspace_path")
-      const select = hasWorkspacePath
-        ? `SELECT id, name, status, harness, error_message,
-                  onboarding_status, onboarding_session_id,
-                  onboarding_completed_at, onboarding_completion_summary,
-                  onboarding_requested_at, onboarding_requested_by,
-                  created_at, updated_at, deleted_at_utc, workspace_path
-           FROM workspaces
-           WHERE deleted_at_utc IS NULL
-           ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
-           LIMIT 100`
-        : `SELECT id, name, status, harness, error_message,
+      const rows = database
+        .prepare(
+          `SELECT id, workspace_path, name, status, harness, error_message,
                   onboarding_status, onboarding_session_id,
                   onboarding_completed_at, onboarding_completion_summary,
                   onboarding_requested_at, onboarding_requested_by,
@@ -177,15 +407,11 @@ export function createLocalWorkspaceRegistry(
            FROM workspaces
            WHERE deleted_at_utc IS NULL
            ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
-           LIMIT 100`
-      const rows = database.prepare(select).all() as Array<
-        Record<string, unknown>
-      >
+           LIMIT 100`,
+        )
+        .all() as Array<Record<string, unknown>>
       const items = rows.map((row) =>
-        mapWorkspaceRegistryRow(row, {
-          location: options.location,
-          hasWorkspacePath,
-        }),
+        mapWorkspaceRegistryRow(row, options.location),
       )
       return { items, total: items.length, limit: 100, offset: 0 }
     } catch {
@@ -205,149 +431,91 @@ export function createLocalWorkspaceRegistry(
   }
 }
 
-export type RuntimeUserProfileNameSource = "manual" | "agent" | "authFallback"
-
-export interface RuntimeUserProfileRecord {
-  profileId: string
-  name: string | null
-  nameSource: RuntimeUserProfileNameSource | null
-  createdAt: string | null
-  updatedAt: string | null
-}
-
-export interface RuntimeUserProfileUpdate {
-  profileId?: string | null
-  name?: string | null
-  nameSource?: RuntimeUserProfileNameSource | null
-}
-
-export interface LocalRuntimeUserProfileStore {
-  getProfile(): Promise<RuntimeUserProfileRecord>
-  setProfile(payload: RuntimeUserProfileUpdate): Promise<RuntimeUserProfileRecord>
-  applyAuthFallback(
-    name: string,
-    profileId?: string,
-  ): Promise<RuntimeUserProfileRecord>
-}
-
-export interface LocalRuntimeUserProfileStoreOptions {
-  requestJson: <T>(pathname: string, init?: RequestInit) => Promise<T>
-}
-
-function runtimeUserProfileNameSourceFromApi(
-  value: unknown,
-): RuntimeUserProfileNameSource | null {
-  if (value === "manual" || value === "agent") {
-    return value
-  }
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : ""
-  if (!normalized) {
-    return null
-  }
-  if (normalized === "manual" || normalized === "agent") {
-    return normalized
-  }
-  if (normalized === "auth_fallback") {
-    return "authFallback"
-  }
-  return null
-}
-
-function runtimeUserProfileNameSourceToApi(
-  value: RuntimeUserProfileNameSource | null | undefined,
-): string | null | undefined {
-  if (value === undefined) {
-    return undefined
-  }
-  if (value === null) {
-    return null
-  }
-  if (value === "authFallback") {
-    return "auth_fallback"
-  }
-  return value
-}
-
-function runtimeUserProfilePayloadFromApi(
-  value: unknown,
-): RuntimeUserProfileRecord {
-  const record =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {}
-  return {
-    profileId:
-      typeof record.profile_id === "string" && record.profile_id.trim()
-        ? record.profile_id
-        : "default",
-    name:
-      typeof record.name === "string" && record.name.trim()
-        ? record.name
-        : null,
-    nameSource: runtimeUserProfileNameSourceFromApi(record.name_source),
-    createdAt:
-      typeof record.created_at === "string" && record.created_at.trim()
-        ? record.created_at
-        : null,
-    updatedAt:
-      typeof record.updated_at === "string" && record.updated_at.trim()
-        ? record.updated_at
-        : null,
-  }
-}
-
 export function createLocalRuntimeUserProfileStore(
   options: LocalRuntimeUserProfileStoreOptions,
 ): LocalRuntimeUserProfileStore {
+  function getProfileRecord(profileId = "default"): RuntimeUserProfileRecord {
+    const database = openControlPlaneDatabase(options.controlPlaneDatabasePath())
+    try {
+      const row = database
+        .prepare(
+          "SELECT * FROM runtime_user_profiles WHERE profile_id = ? LIMIT 1",
+        )
+        .get(profileId) as Record<string, unknown> | undefined
+      return mapRuntimeUserProfileRow(row, profileId)
+    } finally {
+      database.close()
+    }
+  }
+
   return {
     async getProfile(): Promise<RuntimeUserProfileRecord> {
-      const payload = await options.requestJson<unknown>("/api/v1/runtime/profile", {
-        method: "GET",
-      })
-      return runtimeUserProfilePayloadFromApi(payload)
+      return getProfileRecord("default")
     },
 
     async setProfile(
       payload: RuntimeUserProfileUpdate,
     ): Promise<RuntimeUserProfileRecord> {
-      const body: Record<string, unknown> = {}
-      if (typeof payload.profileId === "string" && payload.profileId.trim()) {
-        body.profile_id = payload.profileId.trim()
+      const profileId =
+        typeof payload.profileId === "string" && payload.profileId.trim()
+          ? payload.profileId.trim()
+          : "default"
+      const existing = getProfileRecord(profileId)
+      const now = utcNowIso()
+      const createdAt = existing.createdAt ?? now
+      const normalizedName =
+        typeof payload.name === "string" ? payload.name.trim() : ""
+      const resolvedName = normalizedName || null
+      const resolvedNameSource = resolvedName
+        ? (payload.nameSource ?? existing.nameSource ?? "manual")
+        : null
+
+      const database = openControlPlaneDatabase(options.controlPlaneDatabasePath())
+      try {
+        database
+          .prepare(`
+            INSERT INTO runtime_user_profiles (
+              profile_id,
+              name,
+              name_source,
+              created_at,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(profile_id) DO UPDATE SET
+              name = excluded.name,
+              name_source = excluded.name_source,
+              updated_at = excluded.updated_at
+          `)
+          .run(
+            profileId,
+            resolvedName,
+            runtimeUserProfileNameSourceToStored(resolvedNameSource) ?? null,
+            createdAt,
+            now,
+          )
+      } finally {
+        database.close()
       }
-      if (payload.name !== undefined) {
-        body.name = payload.name
-      }
-      if (payload.nameSource !== undefined) {
-        body.name_source = runtimeUserProfileNameSourceToApi(payload.nameSource)
-      }
-      const response = await options.requestJson<unknown>("/api/v1/runtime/profile", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      })
-      return runtimeUserProfilePayloadFromApi(response)
+      return getProfileRecord(profileId)
     },
 
     async applyAuthFallback(
       name: string,
       profileId = "default",
     ): Promise<RuntimeUserProfileRecord> {
-      const response = await options.requestJson<unknown>(
-        "/api/v1/runtime/profile/auth-fallback",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            profile_id: profileId,
-            name,
-          }),
-        },
-      )
-      return runtimeUserProfilePayloadFromApi(response)
+      const normalizedName = name.trim()
+      if (!normalizedName) {
+        return getProfileRecord(profileId)
+      }
+      const existing = getProfileRecord(profileId)
+      if (existing.name?.trim()) {
+        return existing
+      }
+      return this.setProfile({
+        profileId,
+        name: normalizedName,
+        nameSource: "authFallback",
+      })
     },
   }
 }

--- a/desktop/electron/diagnostics-bundle.ts
+++ b/desktop/electron/diagnostics-bundle.ts
@@ -390,7 +390,7 @@ export async function exportDiagnosticsBundle(
       includedFiles.push("runtime.log");
     }
 
-    const runtimeDbSnapshotPath = path.join(stagingRoot, "runtime.db");
+    const runtimeDbSnapshotPath = path.join(stagingRoot, "host-state.db");
     if (
       await backupRuntimeDatabase(
         params.runtimeDbPath,
@@ -400,9 +400,9 @@ export async function exportDiagnosticsBundle(
     ) {
       entries.push({
         sourcePath: runtimeDbSnapshotPath,
-        archivePath: "runtime.db",
+        archivePath: "host-state.db",
       });
-      includedFiles.push("runtime.db");
+      includedFiles.push("host-state.db");
     }
 
     const redactedConfigPath = path.join(

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -100,7 +100,12 @@ import {
 } from "../shared/model-catalog.js";
 import * as modelCatalog from "../shared/model-catalog.js";
 import { buildAppSdkClient } from "./appSdkClient.js";
+import {
+  createLocalRuntimeUserProfileStore,
+  createLocalWorkspaceRegistry,
+} from "./control-plane-owned-state.js";
 import { ensureWorkspaceGitRepo } from "./workspace-git.js";
+import { createLocalWorkspaceControlPlane } from "./workspace-control-plane.js";
 import {
   createRuntimeClient,
   isTransientRuntimeError as sdkIsTransientRuntimeError,
@@ -2641,8 +2646,11 @@ interface ProactiveIngestItemResultPayload {
   detail?: string | null;
 }
 
+type WorkspaceLocationPayload = "local" | "cloud";
+
 interface WorkspaceRecordPayload {
   id: string;
+  location: WorkspaceLocationPayload;
   name: string;
   status: string;
   harness: string | null;
@@ -3277,6 +3285,18 @@ interface WorkspaceLifecyclePayload {
   phase_label: string;
   phase_detail: string | null;
   blocking_apps: WorkspaceLifecycleBlockingAppPayload[];
+}
+
+interface WorkspaceRuntimeSessionPayload {
+  workspace_id: string;
+  location: WorkspaceLocationPayload;
+  runtime_base_url: string;
+  runtime_auth_token: string | null;
+  workspace_root: string;
+}
+
+interface WorkspaceOpenSessionPayload extends WorkspaceRuntimeSessionPayload {
+  lifecycle: WorkspaceLifecyclePayload;
 }
 
 interface WorkspaceOutputRecordPayload {
@@ -7604,62 +7624,6 @@ function ensureOpenAiCodexRefreshLoop(): void {
   codexOauthRefreshTimer.unref();
 }
 
-function runtimeUserProfileNameSourceFromApi(
-  value: unknown,
-): RuntimeUserProfileNameSource | null {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  if (normalized === "manual" || normalized === "agent") {
-    return normalized;
-  }
-  if (normalized === "auth_fallback") {
-    return "authFallback";
-  }
-  return null;
-}
-
-function runtimeUserProfileNameSourceToApi(
-  value: RuntimeUserProfileNameSource | null | undefined,
-): string | null | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value === null) {
-    return null;
-  }
-  if (value === "authFallback") {
-    return "auth_fallback";
-  }
-  return value;
-}
-
-function runtimeUserProfilePayloadFromApi(
-  value: unknown,
-): RuntimeUserProfilePayload {
-  const record =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
-  return {
-    profileId:
-      typeof record.profile_id === "string" && record.profile_id.trim()
-        ? record.profile_id
-        : "default",
-    name:
-      typeof record.name === "string" && record.name.trim()
-        ? record.name
-        : null,
-    nameSource: runtimeUserProfileNameSourceFromApi(record.name_source),
-    createdAt:
-      typeof record.created_at === "string" && record.created_at.trim()
-        ? record.created_at
-        : null,
-    updatedAt:
-      typeof record.updated_at === "string" && record.updated_at.trim()
-        ? record.updated_at
-        : null,
-  };
-}
-
 async function runtimeApiRequest<T>(
   pathname: string,
   init: RequestInit = {},
@@ -7681,54 +7645,25 @@ async function runtimeApiRequest<T>(
   return (await response.json()) as T;
 }
 
+const localRuntimeUserProfileStore = createLocalRuntimeUserProfileStore({
+  requestJson: runtimeApiRequest,
+});
+
 async function getRuntimeUserProfile(): Promise<RuntimeUserProfilePayload> {
-  const payload = await runtimeApiRequest<unknown>("/api/v1/runtime/profile", {
-    method: "GET",
-  });
-  return runtimeUserProfilePayloadFromApi(payload);
+  return localRuntimeUserProfileStore.getProfile();
 }
 
 async function setRuntimeUserProfile(
   payload: RuntimeUserProfileUpdatePayload,
 ): Promise<RuntimeUserProfilePayload> {
-  const body: Record<string, unknown> = {};
-  if (typeof payload.profileId === "string" && payload.profileId.trim()) {
-    body.profile_id = payload.profileId.trim();
-  }
-  if (payload.name !== undefined) {
-    body.name = payload.name;
-  }
-  if (payload.nameSource !== undefined) {
-    body.name_source = runtimeUserProfileNameSourceToApi(payload.nameSource);
-  }
-  const response = await runtimeApiRequest<unknown>("/api/v1/runtime/profile", {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-  return runtimeUserProfilePayloadFromApi(response);
+  return localRuntimeUserProfileStore.setProfile(payload);
 }
 
 async function applyRuntimeUserProfileAuthFallback(
   name: string,
   profileId = "default",
 ): Promise<RuntimeUserProfilePayload> {
-  const response = await runtimeApiRequest<unknown>(
-    "/api/v1/runtime/profile/auth-fallback",
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        profile_id: profileId,
-        name,
-      }),
-    },
-  );
-  return runtimeUserProfilePayloadFromApi(response);
+  return localRuntimeUserProfileStore.applyAuthFallback(name, profileId);
 }
 
 async function syncRuntimeUserProfileFromAuth(
@@ -11767,23 +11702,26 @@ async function requestRuntimeJsonViaHttp<T>(
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
   payload?: unknown,
   timeoutMs = 15000,
+  extraHeaders?: Record<string, string>,
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const serializedPayload =
       payload === undefined ? null : JSON.stringify(payload);
+    const headers =
+      serializedPayload === null
+        ? extraHeaders
+        : {
+            ...(extraHeaders ?? {}),
+            "Content-Type": "application/json",
+            "Content-Length": String(Buffer.byteLength(serializedPayload)),
+          };
     const request = httpRequest(
       {
         hostname: targetUrl.hostname,
         port: targetUrl.port || "80",
         path: `${targetUrl.pathname}${targetUrl.search}`,
         method,
-        headers:
-          serializedPayload === null
-            ? undefined
-            : {
-                "Content-Type": "application/json",
-                "Content-Length": Buffer.byteLength(serializedPayload),
-              },
+        headers,
         timeout: timeoutMs,
       },
       (response) => {
@@ -11935,6 +11873,172 @@ function forgetWorkspaceDir(workspaceId: string): void {
   } catch {
     // Ignore unsafe ids — they have no cache entry.
   }
+}
+
+const workspaceRuntimeSessionCache = new Map<
+  string,
+  WorkspaceRuntimeSessionPayload
+>();
+
+function localWorkspaceLocation(): WorkspaceLocationPayload {
+  return "local";
+}
+
+function withWorkspaceLocation(
+  workspace:
+    | Omit<WorkspaceRecordPayload, "location">
+    | WorkspaceRecordPayload
+    | null
+    | undefined,
+): WorkspaceRecordPayload | null {
+  if (!workspace) {
+    return null;
+  }
+  return {
+    ...workspace,
+    location: localWorkspaceLocation(),
+  };
+}
+
+function withWorkspaceResponseLocation(
+  response: Omit<WorkspaceResponsePayload, "workspace"> & {
+    workspace: Omit<WorkspaceRecordPayload, "location"> | WorkspaceRecordPayload;
+  },
+): WorkspaceResponsePayload {
+  return {
+    ...response,
+    workspace: withWorkspaceLocation(response.workspace)!,
+  };
+}
+
+function withWorkspaceListLocation(
+  response: Omit<WorkspaceListResponsePayload, "items"> & {
+    items: Array<Omit<WorkspaceRecordPayload, "location"> | WorkspaceRecordPayload>;
+  },
+): WorkspaceListResponsePayload {
+  return {
+    ...response,
+    items: response.items
+      .map((item) => withWorkspaceLocation(item))
+      .filter((item): item is WorkspaceRecordPayload => item !== null),
+  };
+}
+
+function withWorkspaceLifecycleLocation(
+  lifecycle: WorkspaceLifecyclePayload,
+): WorkspaceLifecyclePayload {
+  return {
+    ...lifecycle,
+    workspace: withWorkspaceLocation(lifecycle.workspace)!,
+  };
+}
+
+function cacheWorkspaceRuntimeSession(
+  session: WorkspaceRuntimeSessionPayload,
+): WorkspaceRuntimeSessionPayload {
+  const normalized: WorkspaceRuntimeSessionPayload = {
+    ...session,
+    workspace_id: assertSafeWorkspaceId(session.workspace_id),
+    workspace_root: path.resolve(session.workspace_root),
+  };
+  workspaceRuntimeSessionCache.set(normalized.workspace_id, normalized);
+  return normalized;
+}
+
+function forgetWorkspaceRuntimeSession(workspaceId: string): void {
+  try {
+    workspaceRuntimeSessionCache.delete(assertSafeWorkspaceId(workspaceId));
+  } catch {
+    // Ignore unsafe ids — they have no cache entry.
+  }
+}
+
+function workspaceRuntimeSessionHeaders(
+  session: WorkspaceRuntimeSessionPayload,
+): Record<string, string> | undefined {
+  const authToken = (session.runtime_auth_token ?? "").trim();
+  return authToken ? { "X-API-Key": authToken } : undefined;
+}
+
+async function buildWorkspaceRuntimeSession(
+  workspaceId: string,
+): Promise<WorkspaceRuntimeSessionPayload> {
+  const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
+  const status = await ensureRuntimeReady();
+  return {
+    workspace_id: safeWorkspaceId,
+    location: localWorkspaceLocation(),
+    runtime_base_url: status.url ?? runtimeBaseUrl(),
+    runtime_auth_token: null,
+    workspace_root: path.resolve(await resolveWorkspaceDir(safeWorkspaceId)),
+  };
+}
+
+async function resolveWorkspaceRuntimeSession(
+  workspaceId: string,
+  options: { refresh?: boolean } = {},
+): Promise<WorkspaceRuntimeSessionPayload> {
+  const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
+  if (!options.refresh) {
+    const cached = workspaceRuntimeSessionCache.get(safeWorkspaceId);
+    if (cached) {
+      return cached;
+    }
+  }
+  return cacheWorkspaceRuntimeSession(
+    await buildWorkspaceRuntimeSession(safeWorkspaceId),
+  );
+}
+
+async function requestWorkspaceRuntimeJson<T>(
+  workspaceId: string,
+  {
+    method,
+    path: requestPath,
+    payload,
+    params,
+    timeoutMs,
+    retryTransientErrors = false,
+  }: {
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+    path: string;
+    payload?: unknown;
+    params?: Record<string, string | number | boolean | null | undefined>;
+    timeoutMs?: number;
+    retryTransientErrors?: boolean;
+  },
+): Promise<T> {
+  const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
+  const attempts = method === "GET" || retryTransientErrors ? 3 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const session = await resolveWorkspaceRuntimeSession(safeWorkspaceId, {
+        refresh: attempt > 1,
+      });
+      const url = new URL(`${session.runtime_base_url}${requestPath}`);
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          if (value === undefined || value === null || value === "") {
+            continue;
+          }
+          url.searchParams.set(key, String(value));
+        }
+      }
+      return requestRuntimeJsonViaHttp<T>(
+        url,
+        method,
+        payload,
+        timeoutMs,
+        workspaceRuntimeSessionHeaders(session),
+      );
+    } catch (error) {
+      if (attempt < attempts && isTransientRuntimeError(error)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("Workspace runtime request failed after retries.");
 }
 
 async function resolveWorkspaceDir(workspaceId: string): Promise<string> {
@@ -12655,38 +12759,15 @@ function updateQueuedInputStatus(inputId: string, status: string) {
   }
 }
 
+const localWorkspaceRegistry = createLocalWorkspaceRegistry({
+  runtimeDatabasePath: runtimeDatabasePath,
+  location: localWorkspaceLocation(),
+});
+
 function getWorkspaceRecord(
   workspaceId: string,
 ): WorkspaceRecordPayload | null {
-  const database = openRuntimeDatabase();
-  try {
-    const row = database
-      .prepare(
-        `
-        SELECT
-          id,
-          name,
-          status,
-          harness,
-          error_message,
-          onboarding_status,
-          onboarding_session_id,
-          onboarding_completed_at,
-          onboarding_completion_summary,
-          onboarding_requested_at,
-          onboarding_requested_by,
-          created_at,
-          updated_at,
-          deleted_at_utc
-        FROM workspaces
-        WHERE id = @id
-      `,
-      )
-      .get({ id: workspaceId }) as WorkspaceRecordPayload | undefined;
-    return row ?? null;
-  } finally {
-    database.close();
-  }
+  return localWorkspaceRegistry.getWorkspaceRecord(workspaceId);
 }
 
 async function listWorkspaces(): Promise<WorkspaceListResponsePayload> {
@@ -12709,99 +12790,7 @@ async function listWorkspaces(): Promise<WorkspaceListResponsePayload> {
  * silently falls back to the sidecar path.
  */
 function listWorkspacesFromLocalDb(): WorkspaceListResponsePayload {
-  const empty: WorkspaceListResponsePayload = {
-    items: [],
-    total: 0,
-    limit: 100,
-    offset: 0,
-  };
-  let database: Database.Database | null = null;
-  try {
-    database = new Database(runtimeDatabasePath(), { readonly: true });
-    const tableExists = database
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspaces' LIMIT 1",
-      )
-      .get();
-    if (!tableExists) {
-      return empty;
-    }
-    const columns = new Set<string>(
-      (
-        database.prepare("PRAGMA table_info(workspaces)").all() as Array<{
-          name: string;
-        }>
-      ).map((row) => row.name),
-    );
-    const hasWorkspacePath = columns.has("workspace_path");
-    const select = hasWorkspacePath
-      ? `SELECT id, name, status, harness, error_message,
-                onboarding_status, onboarding_session_id,
-                onboarding_completed_at, onboarding_completion_summary,
-                onboarding_requested_at, onboarding_requested_by,
-                created_at, updated_at, deleted_at_utc, workspace_path
-         FROM workspaces
-         WHERE deleted_at_utc IS NULL
-         ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
-         LIMIT 100`
-      : `SELECT id, name, status, harness, error_message,
-                onboarding_status, onboarding_session_id,
-                onboarding_completed_at, onboarding_completion_summary,
-                onboarding_requested_at, onboarding_requested_by,
-                created_at, updated_at, deleted_at_utc
-         FROM workspaces
-         WHERE deleted_at_utc IS NULL
-         ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC
-         LIMIT 100`;
-    const rows = database.prepare(select).all() as Array<
-      Record<string, unknown>
-    >;
-    const items: WorkspaceRecordPayload[] = rows.map((row) => ({
-      id: String(row.id ?? ""),
-      name: String(row.name ?? ""),
-      status: String(row.status ?? "unknown"),
-      harness: row.harness == null ? null : String(row.harness),
-      error_message: row.error_message == null ? null : String(row.error_message),
-      onboarding_status: String(row.onboarding_status ?? "complete"),
-      onboarding_session_id:
-        row.onboarding_session_id == null
-          ? null
-          : String(row.onboarding_session_id),
-      onboarding_completed_at:
-        row.onboarding_completed_at == null
-          ? null
-          : String(row.onboarding_completed_at),
-      onboarding_completion_summary:
-        row.onboarding_completion_summary == null
-          ? null
-          : String(row.onboarding_completion_summary),
-      onboarding_requested_at:
-        row.onboarding_requested_at == null
-          ? null
-          : String(row.onboarding_requested_at),
-      onboarding_requested_by:
-        row.onboarding_requested_by == null
-          ? null
-          : String(row.onboarding_requested_by),
-      created_at: row.created_at == null ? null : String(row.created_at),
-      updated_at: row.updated_at == null ? null : String(row.updated_at),
-      deleted_at_utc:
-        row.deleted_at_utc == null ? null : String(row.deleted_at_utc),
-      workspace_path:
-        hasWorkspacePath && row.workspace_path != null
-          ? String(row.workspace_path)
-          : null,
-    }));
-    return { items, total: items.length, limit: 100, offset: 0 };
-  } catch {
-    return empty;
-  } finally {
-    try {
-      database?.close();
-    } catch {
-      // ignore
-    }
-  }
+  return localWorkspaceRegistry.listCachedWorkspaces();
 }
 
 async function listWorkspacesViaRuntime(): Promise<WorkspaceListResponsePayload> {
@@ -12816,7 +12805,7 @@ async function listWorkspacesViaRuntime(): Promise<WorkspaceListResponsePayload>
     forgetWorkspaceDir(item.id);
     rememberWorkspaceDir(item.id, item.workspace_path);
   }
-  return response;
+  return withWorkspaceListLocation(response);
 }
 
 const STATIC_APP_CATALOG: Record<
@@ -13265,7 +13254,16 @@ async function listInstalledApps(
 async function listInstalledAppsViaRuntime(
   workspaceId: string,
 ): Promise<InstalledWorkspaceAppListResponsePayload> {
-  return runtimeClient.apps.listInstalled(workspaceId);
+  return requestWorkspaceRuntimeJson<InstalledWorkspaceAppListResponsePayload>(
+    workspaceId,
+    {
+      method: "GET",
+      path: "/api/v1/apps",
+      params: {
+        workspace_id: workspaceId,
+      },
+    },
+  );
 }
 
 async function removeInstalledApp(
@@ -13274,7 +13272,14 @@ async function removeInstalledApp(
 ): Promise<void> {
   const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
   const safeAppId = assertSafeAppId(appId);
-  await runtimeClient.apps.remove(safeWorkspaceId, safeAppId);
+  await requestWorkspaceRuntimeJson<Record<string, unknown>>(safeWorkspaceId, {
+    method: "DELETE",
+    path: `/api/v1/apps/${encodeURIComponent(safeAppId)}`,
+    payload: {
+      workspace_id: safeWorkspaceId,
+    },
+    timeoutMs: 30000,
+  });
 }
 
 async function controlPlaneWorkspaceUserId(): Promise<string | null> {
@@ -13392,11 +13397,27 @@ async function getWorkspaceLifecycle(
 async function activateWorkspace(
   workspaceId: string,
 ): Promise<WorkspaceLifecyclePayload> {
+  return (await openWorkspace(workspaceId)).lifecycle;
+}
+
+async function openWorkspace(
+  workspaceId: string,
+): Promise<WorkspaceOpenSessionPayload> {
   const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
-  // Desktop always activates via local runtime.
-  // Ensure all enabled apps are running in parallel via the runtime.
-  await runtimeClient.workspaces.ensureAppsRunning(safeWorkspaceId);
-  return getWorkspaceLifecycleViaRuntime(safeWorkspaceId);
+  const session = await resolveWorkspaceRuntimeSession(safeWorkspaceId, {
+    refresh: true,
+  });
+  await requestWorkspaceRuntimeJson<Record<string, unknown>>(safeWorkspaceId, {
+    method: "POST",
+    path: "/api/v1/apps/ensure-running",
+    payload: { workspace_id: safeWorkspaceId },
+    timeoutMs: 300000,
+    retryTransientErrors: true,
+  });
+  return {
+    ...session,
+    lifecycle: await getWorkspaceLifecycleViaRuntime(safeWorkspaceId),
+  };
 }
 
 async function getWorkspaceLifecycleViaRuntime(
@@ -13416,7 +13437,7 @@ async function getWorkspaceLifecycleViaRuntime(
   const readiness = workspaceReadinessFromApps(installedApps.apps);
   const phaseState = workspaceLifecyclePhaseFromState(workspace, readiness);
 
-  return {
+  return withWorkspaceLifecycleLocation({
     workspace,
     applications: installedApps.apps,
     ready: readiness.ready,
@@ -13425,7 +13446,7 @@ async function getWorkspaceLifecycleViaRuntime(
     phase_label: phaseState.phase_label,
     phase_detail: phaseState.phase_detail,
     blocking_apps: readiness.blocking_apps,
-  };
+  });
 }
 
 async function listOutputs(
@@ -13771,7 +13792,7 @@ async function createWorkspace(
     throw new Error("Choose a local folder or a marketplace template first.");
   }
   const customWorkspacePath = payload.workspace_path?.trim() || "";
-  let created: WorkspaceResponsePayload;
+  let created: Awaited<ReturnType<typeof runtimeClient.workspaces.create>>;
   stageLog("runtime_post_workspaces.start", {
     hasCustomWorkspacePath: Boolean(customWorkspacePath),
   });
@@ -13795,6 +13816,7 @@ async function createWorkspace(
   }
   const workspaceId = created.workspace.id;
   rememberWorkspaceDir(workspaceId, created.workspace.workspace_path);
+  forgetWorkspaceRuntimeSession(workspaceId);
 
   try {
     const workspaceDir = await resolveWorkspaceDir(workspaceId);
@@ -13885,7 +13907,7 @@ async function createWorkspace(
     }
 
     stageLog("activate_workspace.start", { workspaceId, onboardingStatus });
-    let updated: WorkspaceResponsePayload;
+    let updated: Awaited<ReturnType<typeof runtimeClient.workspaces.update>>;
     try {
       updated = await runtimeClient.workspaces.update(workspaceId, {
         status: "active",
@@ -14046,7 +14068,7 @@ async function createWorkspace(
           `requested_user_id=${requestedHeartbeatUserId || "missing"} runtime_user_id=${runtimeHeartbeatUserId || "missing"}`,
       });
     }
-    return updated;
+    return withWorkspaceResponseLocation(updated);
   } catch (error) {
     await runtimeClient.workspaces
       .update(workspaceId, {
@@ -14068,7 +14090,8 @@ async function deleteWorkspace(
     keepFiles !== undefined ? { keepFiles } : undefined,
   );
   forgetWorkspaceDir(safeWorkspaceId);
-  return response;
+  forgetWorkspaceRuntimeSession(safeWorkspaceId);
+  return withWorkspaceResponseLocation(response);
 }
 
 async function relocateWorkspace(
@@ -14081,15 +14104,28 @@ async function relocateWorkspace(
   });
   forgetWorkspaceDir(safeWorkspaceId);
   rememberWorkspaceDir(safeWorkspaceId, response.workspace.workspace_path);
-  return response;
+  forgetWorkspaceRuntimeSession(safeWorkspaceId);
+  return withWorkspaceResponseLocation(response);
 }
 
 async function activateWorkspaceRecord(
   workspaceId: string,
 ): Promise<WorkspaceResponsePayload> {
   const safeWorkspaceId = assertSafeWorkspaceId(workspaceId);
-  return runtimeClient.workspaces.activate(safeWorkspaceId);
+  return withWorkspaceResponseLocation(
+    await runtimeClient.workspaces.activate(safeWorkspaceId),
+  );
 }
+
+const localWorkspaceControlPlane = createLocalWorkspaceControlPlane({
+  listWorkspaces,
+  workspaceRegistry: localWorkspaceRegistry,
+  createWorkspace,
+  deleteWorkspace,
+  activateWorkspaceRecord,
+  getWorkspaceLifecycle,
+  openWorkspace,
+})
 
 async function pickWorkspaceRelocationFolder(
   workspaceId: string,
@@ -14590,10 +14626,13 @@ async function openSessionOutputStream(
 
   void (async () => {
     try {
-      const status = await ensureRuntimeReady();
+      const workspaceSession = payload.workspaceId
+        ? await resolveWorkspaceRuntimeSession(payload.workspaceId)
+        : null;
+      const status = workspaceSession ? null : await ensureRuntimeReady();
       const url = new URL(
         `/api/v1/agent-sessions/${payload.sessionId}/outputs/stream`,
-        status.url ?? runtimeBaseUrl(),
+        workspaceSession?.runtime_base_url ?? status?.url ?? runtimeBaseUrl(),
       );
       if (payload.inputId) {
         url.searchParams.set("input_id", payload.inputId);
@@ -14627,6 +14666,11 @@ async function openSessionOutputStream(
             method: "GET",
             headers: {
               Accept: "text/event-stream",
+              ...(workspaceSession?.runtime_auth_token
+                ? {
+                    "X-API-Key": workspaceSession.runtime_auth_token,
+                  }
+                : {}),
             },
             // Session output uses a long-lived SSE connection. Let runtime-side
             // queue and runner recovery determine terminal failure instead of
@@ -15913,7 +15957,13 @@ async function getAppHttpUrl(
   appId: string,
 ): Promise<string | null> {
   try {
-    const ports = await runtimeClient.apps.listPorts(workspaceId);
+    const ports = await requestWorkspaceRuntimeJson<
+      Record<string, { http: number; mcp: number }>
+    >(workspaceId, {
+      method: "GET",
+      path: "/api/v1/apps/ports",
+      params: { workspace_id: workspaceId },
+    });
     const appPorts = ports[appId];
     if (!appPorts?.http) {
       return null;
@@ -17735,9 +17785,10 @@ async function resolveWorkspaceScopedExplorerPath(
     };
   }
 
-  const workspaceRoot = path.resolve(
-    await resolveWorkspaceDir(normalizedWorkspaceId),
+  const workspaceSession = await resolveWorkspaceRuntimeSession(
+    normalizedWorkspaceId,
   );
+  const workspaceRoot = path.resolve(workspaceSession.workspace_root);
   const resolvedTargetPath = trimmedTargetPath
     ? path.resolve(
         path.isAbsolute(trimmedTargetPath)
@@ -20697,7 +20748,7 @@ app.whenReady().then(async () => {
     "workspace:activate",
     ["main"],
     async (_event, workspaceId: string) =>
-      activateWorkspaceRecord(workspaceId),
+      localWorkspaceControlPlane.activateWorkspaceRecord(workspaceId),
   );
   handleTrustedIpc(
     "workspace:listImportBrowserProfiles",
@@ -20720,7 +20771,7 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:listWorkspaces",
     ["main", "auth-popup"],
-    async () => listWorkspaces(),
+    async () => localWorkspaceControlPlane.listWorkspaces(),
   );
   // Cached read straight from runtime.db without going through the
   // sidecar — used by the splash to hydrate before the sidecar
@@ -20729,17 +20780,25 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:listWorkspacesCached",
     ["main"],
-    async () => listWorkspacesFromLocalDb(),
+    async () => localWorkspaceControlPlane.listWorkspacesCached(),
   );
   handleTrustedIpc(
     "workspace:getWorkspaceLifecycle",
     ["main"],
-    async (_event, workspaceId: string) => getWorkspaceLifecycle(workspaceId),
+    async (_event, workspaceId: string) =>
+      localWorkspaceControlPlane.getWorkspaceLifecycle(workspaceId),
   );
   handleTrustedIpc(
     "workspace:activateWorkspace",
     ["main"],
-    async (_event, workspaceId: string) => activateWorkspace(workspaceId),
+    async (_event, workspaceId: string) =>
+      localWorkspaceControlPlane.activateWorkspace(workspaceId),
+  );
+  handleTrustedIpc(
+    "workspace:openWorkspace",
+    ["main"],
+    async (_event, workspaceId: string) =>
+      localWorkspaceControlPlane.openWorkspace(workspaceId),
   );
   handleTrustedIpc(
     "workspace:listInstalledApps",
@@ -20828,7 +20887,8 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:getWorkspaceRoot",
     ["main"],
-    async (_event, workspaceId: string) => resolveWorkspaceDir(workspaceId),
+    async (_event, workspaceId: string) =>
+      (await resolveWorkspaceRuntimeSession(workspaceId)).workspace_root,
   );
   handleTrustedIpc(
     "workspace:setOperatorSurfaceContext",
@@ -20853,12 +20913,13 @@ app.whenReady().then(async () => {
     "workspace:createWorkspace",
     ["main"],
     async (_event, payload: HolabossCreateWorkspacePayload) =>
-      createWorkspace(payload),
+      localWorkspaceControlPlane.createWorkspace(payload),
   );
   handleTrustedIpc(
     "workspace:deleteWorkspace",
     ["main"],
-    async (_event, workspaceId: string, keepFiles?: boolean) => deleteWorkspace(workspaceId, keepFiles),
+    async (_event, workspaceId: string, keepFiles?: boolean) =>
+      localWorkspaceControlPlane.deleteWorkspace(workspaceId, keepFiles),
   );
   handleTrustedIpc(
     "workspace:listCronjobs",

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -13218,7 +13218,7 @@ async function runDashboardQuery(params: {
     return { ok: false, error: "Query is empty." };
   }
   const workspaceDir = await resolveWorkspaceDir(workspaceId);
-  const dbPath = path.join(workspaceDir, ".holaboss", "data.db");
+  const dbPath = path.join(workspaceDir, ".holaboss", "state", "data.db");
   if (!existsSync(dbPath)) {
     return {
       ok: false,
@@ -14118,7 +14118,7 @@ async function pickWorkspaceRelocationFolder(
     if (!stat.isDirectory()) {
       throw new Error("Selected path is not a directory.");
     }
-    // Accept if it contains a matching .holaboss/workspace_id identity file.
+    // Accept if it contains a matching .holaboss/state/workspace_id identity file.
     const identityFilePath = path.join(rootPath, ".holaboss", "workspace_id");
     if (existsSync(identityFilePath)) {
       const storedId = readFileSync(identityFilePath, "utf-8").trim();

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -110,6 +110,7 @@ import {
 import * as modelCatalog from "../shared/model-catalog.js";
 import { buildAppSdkClient } from "./appSdkClient.js";
 import {
+  bootstrapLocalControlPlaneDatabase,
   createLocalRuntimeUserProfileStore,
   createLocalWorkspaceRegistry,
 } from "./control-plane-owned-state.js";
@@ -2850,6 +2851,7 @@ interface MemoryUpdateProposalListResponsePayload {
 
 interface MemoryUpdateProposalAcceptPayload {
   proposalId: string;
+  workspaceId: string;
   summary?: string | null;
 }
 
@@ -3805,6 +3807,10 @@ function runtimeDatabasePath() {
   return path.join(runtimeSandboxRoot(), "state", "runtime.db");
 }
 
+function controlPlaneDatabasePath() {
+  return path.join(runtimeSandboxRoot(), "state", "control-plane.db");
+}
+
 function runtimeWorkspaceRoot() {
   return path.join(runtimeSandboxRoot(), "workspace");
 }
@@ -4664,6 +4670,14 @@ async function bootstrapRuntimeDatabase() {
   } finally {
     database.close();
   }
+}
+
+function bootstrapControlPlaneDatabase() {
+  bootstrapLocalControlPlaneDatabase({
+    controlPlaneDatabasePath: controlPlaneDatabasePath,
+    runtimeDatabasePath: runtimeDatabasePath,
+    workspaceRoot: runtimeWorkspaceRoot,
+  });
 }
 
 // `persistRuntimeProcessState` is invoked from ~13 sites and fires every
@@ -7725,7 +7739,7 @@ async function runtimeApiRequest<T>(
 }
 
 const localRuntimeUserProfileStore = createLocalRuntimeUserProfileStore({
-  requestJson: runtimeApiRequest,
+  controlPlaneDatabasePath: controlPlaneDatabasePath,
 });
 
 async function getRuntimeUserProfile(): Promise<RuntimeUserProfilePayload> {
@@ -9438,9 +9452,10 @@ async function acceptMemoryUpdateProposal(
 }
 
 async function dismissMemoryUpdateProposal(
+  workspaceId: string,
   proposalId: string,
 ): Promise<MemoryUpdateProposalDismissResponsePayload> {
-  return runtimeClient.memory.dismissUpdateProposal(proposalId);
+  return runtimeClient.memory.dismissUpdateProposal(workspaceId, proposalId);
 }
 
 async function getProactiveStatus(
@@ -9471,7 +9486,14 @@ async function getProactiveStatus(
 
   let proposalCount = 0;
   let heartbeat = fallbackHeartbeat;
-  const database = openRuntimeDatabase();
+  const workspacePath = getWorkspaceRecord(normalizedWorkspaceId)?.workspace_path?.trim() || "";
+  const workspaceRuntimeDbPath = workspacePath
+    ? path.join(workspacePath, ".holaboss", "state", "runtime.db")
+    : "";
+  const database =
+    workspaceRuntimeDbPath && existsSync(workspaceRuntimeDbPath)
+      ? new Database(workspaceRuntimeDbPath, { readonly: true })
+      : openRuntimeDatabase();
   try {
     const proposalRow = database
       .prepare(
@@ -9635,9 +9657,10 @@ async function listCronjobs(
 }
 
 async function runCronjobNow(
+  workspaceId: string,
   jobId: string,
 ): Promise<CronjobRunResponsePayload> {
-  return runtimeClient.cronjobs.runNow(jobId);
+  return runtimeClient.cronjobs.runNow(workspaceId, jobId);
 }
 
 async function createCronjob(
@@ -9647,14 +9670,18 @@ async function createCronjob(
 }
 
 async function updateCronjob(
+  workspaceId: string,
   jobId: string,
   payload: CronjobUpdatePayload,
 ): Promise<CronjobRecordPayload> {
-  return runtimeClient.cronjobs.update(jobId, payload);
+  return runtimeClient.cronjobs.update(workspaceId, jobId, payload);
 }
 
-async function deleteCronjob(jobId: string): Promise<{ success: boolean }> {
-  return runtimeClient.cronjobs.delete(jobId);
+async function deleteCronjob(
+  workspaceId: string,
+  jobId: string,
+): Promise<{ success: boolean }> {
+  return runtimeClient.cronjobs.delete(workspaceId, jobId);
 }
 
 const runtimeNotificationListCache = new Map<
@@ -9726,10 +9753,12 @@ async function listNotifications(
 }
 
 async function updateNotification(
+  workspaceId: string,
   notificationId: string,
   payload: RuntimeNotificationUpdatePayload,
 ): Promise<RuntimeNotificationRecordPayload> {
   const response = await runtimeClient.notifications.update(
+    workspaceId,
     notificationId,
     payload,
   );
@@ -10971,10 +11000,11 @@ async function setProactiveHeartbeatWorkspaceEnabled(
 }
 
 async function updateTaskProposalState(
+  workspaceId: string,
   proposalId: string,
   state: string,
 ): Promise<TaskProposalStateUpdatePayload> {
-  return runtimeClient.taskProposals.updateState(proposalId, state);
+  return runtimeClient.taskProposals.updateState(workspaceId, proposalId, state);
 }
 
 const LOCAL_TEMPLATE_IGNORE_NAMES = new Set([
@@ -12839,7 +12869,7 @@ function updateQueuedInputStatus(inputId: string, status: string) {
 }
 
 const localWorkspaceRegistry = createLocalWorkspaceRegistry({
-  runtimeDatabasePath: runtimeDatabasePath,
+  controlPlaneDatabasePath: controlPlaneDatabasePath,
   location: localWorkspaceLocation(),
 });
 
@@ -12855,12 +12885,9 @@ async function listWorkspaces(): Promise<WorkspaceListResponsePayload> {
 }
 
 /**
- * Read the workspaces table directly from runtime.db without going
- * through the sidecar. Used to hydrate the splash before the sidecar
- * finishes spawning + schema-ensure. The desktop and runtime share
- * runtime.db; the schema converges after the sidecar runs once on a
- * given machine, but we tolerate a missing `workspace_path` column on
- * the very first launch by reading PRAGMA table_info first.
+ * Read the cached workspace registry directly from control-plane.db
+ * without going through the sidecar. Used to hydrate the splash before
+ * the sidecar finishes spawning + schema-ensure.
  *
  * Synchronous + fast (5-15ms) — better-sqlite3 with WAL allows this
  * read while the sidecar is still booting in another process.
@@ -15593,6 +15620,7 @@ async function startEmbeddedRuntime() {
 
       await fs.mkdir(sandboxRoot, { recursive: true });
       await bootstrapRuntimeDatabase();
+      bootstrapControlPlaneDatabase();
 
       const preflightRuntimePort = await ensureRuntimePortAvailable({
         url,
@@ -15748,6 +15776,7 @@ async function startEmbeddedRuntime() {
           SANDBOX_AGENT_HARNESS: harness,
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
           HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
+          HOLABOSS_CONTROL_PLANE_DB_PATH: controlPlaneDatabasePath(),
           HOLABOSS_RUNTIME_LOG_PATH: runtimeLogsPath(),
           HOLABOSS_RUNTIME_CONFIG_PATH: runtimeConfigPath(),
           HOLABOSS_DESKTOP_LAUNCH_ID: DESKTOP_LAUNCH_ID,
@@ -20334,6 +20363,7 @@ app.whenReady().then(async () => {
 
   await loadBrowserPersistence();
   await bootstrapRuntimeDatabase();
+  bootstrapControlPlaneDatabase();
   ensureOpenAiCodexRefreshLoop();
   void refreshOpenAiCodexProviderCredentials().catch(() => undefined);
 
@@ -21032,18 +21062,20 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:runCronjobNow",
     ["main"],
-    async (_event, jobId: string) => runCronjobNow(jobId),
+    async (_event, workspaceId: string, jobId: string) =>
+      runCronjobNow(workspaceId, jobId),
   );
   handleTrustedIpc(
     "workspace:updateCronjob",
     ["main"],
-    async (_event, jobId: string, payload: CronjobUpdatePayload) =>
-      updateCronjob(jobId, payload),
+    async (_event, workspaceId: string, jobId: string, payload: CronjobUpdatePayload) =>
+      updateCronjob(workspaceId, jobId, payload),
   );
   handleTrustedIpc(
     "workspace:deleteCronjob",
     ["main"],
-    async (_event, jobId: string) => deleteCronjob(jobId),
+    async (_event, workspaceId: string, jobId: string) =>
+      deleteCronjob(workspaceId, jobId),
   );
   handleTrustedIpc(
     "workspace:listNotifications",
@@ -21063,9 +21095,10 @@ app.whenReady().then(async () => {
     ["main"],
     async (
       _event,
+      workspaceId: string,
       notificationId: string,
       payload: RuntimeNotificationUpdatePayload,
-    ) => updateNotification(notificationId, payload),
+    ) => updateNotification(workspaceId, notificationId, payload),
   );
   handleTrustedIpc(
     "workspace:listTaskProposals",
@@ -21105,8 +21138,8 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:dismissMemoryUpdateProposal",
     ["main"],
-    async (_event, proposalId: string) =>
-      dismissMemoryUpdateProposal(proposalId),
+    async (_event, workspaceId: string, proposalId: string) =>
+      dismissMemoryUpdateProposal(workspaceId, proposalId),
   );
   handleTrustedIpc(
     "workspace:getProactiveStatus",
@@ -21116,8 +21149,8 @@ app.whenReady().then(async () => {
   handleTrustedIpc(
     "workspace:updateTaskProposalState",
     ["main"],
-    async (_event, proposalId: string, state: string) =>
-      updateTaskProposalState(proposalId, state),
+    async (_event, workspaceId: string, proposalId: string, state: string) =>
+      updateTaskProposalState(workspaceId, proposalId, state),
   );
   handleTrustedIpc(
     "workspace:requestRemoteTaskProposalGeneration",

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -14177,9 +14177,14 @@ async function pickWorkspaceRelocationFolder(
     if (!stat.isDirectory()) {
       throw new Error("Selected path is not a directory.");
     }
-    // Accept if it contains a matching .holaboss/state/workspace_id identity file.
-    const identityFilePath = path.join(rootPath, ".holaboss", "workspace_id");
-    if (existsSync(identityFilePath)) {
+    // Accept if it contains a matching workspace identity file.
+    for (const identityFilePath of [
+      path.join(rootPath, ".holaboss", "state", "workspace_id"),
+      path.join(rootPath, ".holaboss", "workspace_id"),
+    ]) {
+      if (!existsSync(identityFilePath)) {
+        continue;
+      }
       const storedId = readFileSync(identityFilePath, "utf-8").trim();
       if (storedId === safeWorkspaceId) {
         return { canceled: false, rootPath };

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4065,6 +4065,39 @@ function openRuntimeDiagnosticsDatabase(): Database.Database | null {
   return database;
 }
 
+function openWorkspaceRuntimeDiagnosticsDatabases(): Database.Database[] {
+  const databases: Database.Database[] = [];
+  const seenPaths = new Set<string>();
+  let workspaces: WorkspaceRecordPayload[] = [];
+  try {
+    workspaces = localWorkspaceRegistry.listCachedWorkspaces().items;
+  } catch {
+    return [];
+  }
+  for (const workspace of workspaces) {
+    const workspacePath = workspace.workspace_path?.trim() || "";
+    if (!workspacePath) {
+      continue;
+    }
+    const workspaceRuntimeDbPath = path.join(workspacePath, ".holaboss", "state", "runtime.db");
+    if (!existsSync(workspaceRuntimeDbPath) || seenPaths.has(workspaceRuntimeDbPath)) {
+      continue;
+    }
+    try {
+      const database = new Database(workspaceRuntimeDbPath, {
+        readonly: true,
+        fileMustExist: true,
+      });
+      database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+      databases.push(database);
+      seenPaths.add(workspaceRuntimeDbPath);
+    } catch {
+      // Ignore unhealthy or missing workspace-local runtime DBs in diagnostics snapshots.
+    }
+  }
+  return databases;
+}
+
 function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
   const snapshot: Record<string, unknown> = {
     captured_at: utcNowIso(),
@@ -4094,23 +4127,52 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
     return redactDesktopSentryValue(snapshot) as Record<string, unknown>;
   }
 
+  const workspaceDatabases = openWorkspaceRuntimeDiagnosticsDatabases();
   try {
     const readCount = (sql: string): number => {
       const row = database.prepare(sql).get() as { count?: number } | undefined;
       return Number(row?.count ?? 0);
     };
 
+    const workspaceTerminalSessions = workspaceDatabases.flatMap((workspaceDatabase) =>
+      workspaceDatabase.prepare(`
+        SELECT terminal_id, workspace_id, session_id, input_id, owner, status, title, command, last_activity_at, created_at
+        FROM terminal_sessions
+      `).all() as Array<Record<string, unknown>>
+    );
+    workspaceTerminalSessions.sort((left, right) => {
+      const activityCompare = String(right.last_activity_at ?? "").localeCompare(String(left.last_activity_at ?? ""));
+      if (activityCompare !== 0) {
+        return activityCompare;
+      }
+      const createdCompare = String(right.created_at ?? "").localeCompare(String(left.created_at ?? ""));
+      if (createdCompare !== 0) {
+        return createdCompare;
+      }
+      return String(right.terminal_id ?? "").localeCompare(String(left.terminal_id ?? ""));
+    });
+    const activeTerminalSessionCount = workspaceTerminalSessions.filter((row) =>
+      ["starting", "running"].includes(String(row.status ?? ""))
+    ).length;
+
+    const workspaceAppBuilds = workspaceDatabases.flatMap((workspaceDatabase) =>
+      workspaceDatabase.prepare(`
+        SELECT workspace_id, app_id, status, error, updated_at
+        FROM app_builds
+        WHERE status IN ('running', 'failed')
+      `).all() as Array<Record<string, unknown>>
+    );
+    workspaceAppBuilds.sort((left, right) =>
+      String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? ""))
+    );
+
     snapshot.database = {
       counts: {
         active_sessions: readCount(
           "SELECT COUNT(*) AS count FROM session_runtime_state WHERE status IN ('BUSY', 'QUEUED') OR current_input_id IS NOT NULL",
         ),
-        active_terminal_sessions: readCount(
-          "SELECT COUNT(*) AS count FROM terminal_sessions WHERE status IN ('starting', 'running')",
-        ),
-        failed_app_builds: readCount(
-          "SELECT COUNT(*) AS count FROM app_builds WHERE status IN ('failed', 'running')",
-        ),
+        active_terminal_sessions: activeTerminalSessionCount,
+        failed_app_builds: workspaceAppBuilds.length,
         queued_inputs: readCount(
           "SELECT COUNT(*) AS count FROM agent_session_inputs WHERE status IN ('queued', 'claimed')",
         ),
@@ -4127,25 +4189,21 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
         ORDER BY updated_at DESC
         LIMIT ?
       `).all(SENTRY_RECENT_STATE_LIMIT),
-      terminal_sessions: database.prepare(`
-        SELECT terminal_id, workspace_id, session_id, input_id, owner, status, title, command, last_activity_at
-        FROM terminal_sessions
-        ORDER BY last_activity_at DESC
-        LIMIT ?
-      `).all(SENTRY_RECENT_STATE_LIMIT),
-      app_builds: database.prepare(`
-        SELECT workspace_id, app_id, status, error, updated_at
-        FROM app_builds
-        WHERE status IN ('running', 'failed')
-        ORDER BY updated_at DESC
-        LIMIT ?
-      `).all(SENTRY_RECENT_STATE_LIMIT),
+      terminal_sessions: workspaceTerminalSessions.slice(0, SENTRY_RECENT_STATE_LIMIT),
+      app_builds: workspaceAppBuilds.slice(0, SENTRY_RECENT_STATE_LIMIT),
     };
   } catch (error) {
     snapshot.database = {
       error: error instanceof Error ? error.message : String(error),
     };
   } finally {
+    for (const workspaceDatabase of workspaceDatabases) {
+      try {
+        workspaceDatabase.close();
+      } catch {
+        // Ignore close errors while collecting diagnostics.
+      }
+    }
     database.close();
   }
 

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -3228,6 +3228,7 @@ interface SessionOutputEventPayload {
 }
 
 interface SessionOutputEventListRequestPayload {
+  workspaceId: string;
   sessionId: string;
   inputId?: string | null;
 }
@@ -14470,6 +14471,7 @@ async function getSessionOutputEvents(
   payload: SessionOutputEventListRequestPayload,
 ): Promise<SessionOutputEventListResponsePayload> {
   return runtimeClient.sessions.getOutputEvents({
+    workspaceId: payload.workspaceId,
     sessionId: payload.sessionId,
     inputId: payload.inputId,
   });

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -3804,8 +3804,16 @@ function runtimeModelCatalogCachePath() {
   return path.join(runtimeSandboxRoot(), "state", "runtime-model-catalog.json");
 }
 
-function runtimeDatabasePath() {
+function legacyRuntimeDatabasePath() {
   return path.join(runtimeSandboxRoot(), "state", "runtime.db");
+}
+
+function hostStateDatabasePath() {
+  return path.join(runtimeSandboxRoot(), "state", "host-state.db");
+}
+
+function runtimeDatabasePath() {
+  return hostStateDatabasePath();
 }
 
 function controlPlaneDatabasePath() {
@@ -3814,6 +3822,47 @@ function controlPlaneDatabasePath() {
 
 function runtimeWorkspaceRoot() {
   return path.join(runtimeSandboxRoot(), "workspace");
+}
+
+async function migrateLegacyHostStateDatabaseFiles() {
+  const nextPath = hostStateDatabasePath();
+  const legacyPath = legacyRuntimeDatabasePath();
+  if (nextPath === legacyPath) {
+    return;
+  }
+  try {
+    await fs.access(nextPath);
+    return;
+  } catch {
+    // continue
+  }
+  try {
+    await fs.access(legacyPath);
+  } catch {
+    return;
+  }
+  await fs.mkdir(path.dirname(nextPath), { recursive: true });
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const source = `${legacyPath}${suffix}`;
+    const target = `${nextPath}${suffix}`;
+    try {
+      await fs.access(source);
+    } catch {
+      continue;
+    }
+    try {
+      await fs.access(target);
+      continue;
+    } catch {
+      // continue
+    }
+    try {
+      await fs.rename(source, target);
+    } catch {
+      await fs.copyFile(source, target);
+      await fs.unlink(source);
+    }
+  }
 }
 
 function diagnosticsBundleWorkspaceSegment(
@@ -4098,6 +4147,16 @@ function openWorkspaceRuntimeDiagnosticsDatabases(): Database.Database[] {
   return databases;
 }
 
+function closeRuntimeDatabases(databases: Database.Database[]) {
+  for (const database of databases) {
+    try {
+      database.close();
+    } catch {
+      // Ignore close errors while collecting diagnostics.
+    }
+  }
+}
+
 function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
   const snapshot: Record<string, unknown> = {
     captured_at: utcNowIso(),
@@ -4116,7 +4175,7 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
     runtime_status: runtimeStatus,
     persisted_runtime_process: readPersistedRuntimeProcessState(),
     files: {
-      runtime_db: runtimeSentryFileMetadata(runtimeDatabasePath()),
+      host_state_db: runtimeSentryFileMetadata(runtimeDatabasePath()),
       runtime_log: runtimeSentryFileMetadata(runtimeLogsPath()),
       runtime_config: runtimeSentryFileMetadata(runtimeConfigPath()),
     },
@@ -4129,11 +4188,6 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
 
   const workspaceDatabases = openWorkspaceRuntimeDiagnosticsDatabases();
   try {
-    const readCount = (sql: string): number => {
-      const row = database.prepare(sql).get() as { count?: number } | undefined;
-      return Number(row?.count ?? 0);
-    };
-
     const workspaceTerminalSessions = workspaceDatabases.flatMap((workspaceDatabase) =>
       workspaceDatabase.prepare(`
         SELECT terminal_id, workspace_id, session_id, input_id, owner, status, title, command, last_activity_at, created_at
@@ -4166,16 +4220,42 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
       String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? ""))
     );
 
+    const workspaceRuntimeStateRows = workspaceDatabases.flatMap((workspaceDatabase) =>
+      workspaceDatabase.prepare(`
+        SELECT workspace_id, session_id, status, current_input_id, updated_at
+        FROM session_runtime_state
+      `).all() as Array<Record<string, unknown>>
+    );
+    workspaceRuntimeStateRows.sort((left, right) => {
+      const updatedCompare = String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? ""));
+      if (updatedCompare !== 0) {
+        return updatedCompare;
+      }
+      const sessionCompare = String(right.session_id ?? "").localeCompare(String(left.session_id ?? ""));
+      if (sessionCompare !== 0) {
+        return sessionCompare;
+      }
+      return String(right.workspace_id ?? "").localeCompare(String(left.workspace_id ?? ""));
+    });
+    const activeSessionCount = workspaceRuntimeStateRows.filter((row) => {
+      const status = String(row.status ?? "");
+      return status === "BUSY" || status === "QUEUED" || row.current_input_id != null;
+    }).length;
+    const queuedInputCount = workspaceDatabases.reduce((total, workspaceDatabase) => {
+      const row = workspaceDatabase
+        .prepare(
+          "SELECT COUNT(*) AS count FROM agent_session_inputs WHERE status IN ('queued', 'claimed')",
+        )
+        .get() as { count?: number } | undefined;
+      return total + Number(row?.count ?? 0);
+    }, 0);
+
     snapshot.database = {
       counts: {
-        active_sessions: readCount(
-          "SELECT COUNT(*) AS count FROM session_runtime_state WHERE status IN ('BUSY', 'QUEUED') OR current_input_id IS NOT NULL",
-        ),
+        active_sessions: activeSessionCount,
         active_terminal_sessions: activeTerminalSessionCount,
         failed_app_builds: workspaceAppBuilds.length,
-        queued_inputs: readCount(
-          "SELECT COUNT(*) AS count FROM agent_session_inputs WHERE status IN ('queued', 'claimed')",
-        ),
+        queued_inputs: queuedInputCount,
       },
       recent_event_log: database.prepare(`
         SELECT category, event, outcome, detail, created_at
@@ -4183,12 +4263,7 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
         ORDER BY created_at DESC
         LIMIT ?
       `).all(SENTRY_RECENT_EVENT_LIMIT),
-      session_runtime_state: database.prepare(`
-        SELECT workspace_id, session_id, status, current_input_id, updated_at
-        FROM session_runtime_state
-        ORDER BY updated_at DESC
-        LIMIT ?
-      `).all(SENTRY_RECENT_STATE_LIMIT),
+      session_runtime_state: workspaceRuntimeStateRows.slice(0, SENTRY_RECENT_STATE_LIMIT),
       terminal_sessions: workspaceTerminalSessions.slice(0, SENTRY_RECENT_STATE_LIMIT),
       app_builds: workspaceAppBuilds.slice(0, SENTRY_RECENT_STATE_LIMIT),
     };
@@ -4197,13 +4272,7 @@ function readDesktopRuntimeDiagnosticsSnapshot(): Record<string, unknown> {
       error: error instanceof Error ? error.message : String(error),
     };
   } finally {
-    for (const workspaceDatabase of workspaceDatabases) {
-      try {
-        workspaceDatabase.close();
-      } catch {
-        // Ignore close errors while collecting diagnostics.
-      }
-    }
+    closeRuntimeDatabases(workspaceDatabases);
     database.close();
   }
 
@@ -4508,6 +4577,7 @@ function migrateRuntimeProcessStateTable(database: Database.Database) {
 
 async function bootstrapRuntimeDatabase() {
   await fs.mkdir(path.dirname(runtimeDatabasePath()), { recursive: true });
+  await migrateLegacyHostStateDatabaseFiles();
 
   const database = openRuntimeDatabase();
   try {
@@ -4529,23 +4599,6 @@ async function bootstrapRuntimeDatabase() {
         updated_at TEXT NOT NULL
       );
 
-      CREATE TABLE IF NOT EXISTS agent_runtime_sessions (
-        workspace_id TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        harness TEXT NOT NULL,
-        harness_session_id TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (workspace_id, session_id),
-        UNIQUE (workspace_id, harness, harness_session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_agent_runtime_sessions_workspace_updated
-        ON agent_runtime_sessions (workspace_id, updated_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_agent_runtime_sessions_workspace_harness_session
-        ON agent_runtime_sessions (workspace_id, harness_session_id);
-
       CREATE TABLE IF NOT EXISTS workspaces (
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
@@ -4565,86 +4618,6 @@ async function bootstrapRuntimeDatabase() {
 
       CREATE INDEX IF NOT EXISTS idx_workspaces_updated
         ON workspaces (updated_at DESC);
-
-      CREATE TABLE IF NOT EXISTS agent_session_inputs (
-        input_id TEXT PRIMARY KEY,
-        session_id TEXT NOT NULL,
-        workspace_id TEXT NOT NULL,
-        payload TEXT NOT NULL,
-        status TEXT NOT NULL,
-        priority INTEGER NOT NULL DEFAULT 0,
-        available_at TEXT NOT NULL,
-        attempt INTEGER NOT NULL DEFAULT 0,
-        idempotency_key TEXT,
-        claimed_by TEXT,
-        claimed_until TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_workspace_created
-        ON agent_session_inputs (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_session_status
-        ON agent_session_inputs (session_id, status, available_at);
-
-      CREATE TABLE IF NOT EXISTS session_runtime_state (
-        workspace_id TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        status TEXT NOT NULL CHECK (status IN ('IDLE', 'BUSY', 'WAITING_USER', 'ERROR', 'QUEUED')),
-        current_input_id TEXT,
-        current_worker_id TEXT,
-        lease_until TEXT,
-        heartbeat_at TEXT,
-        last_error TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (workspace_id, session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS session_runtime_state_status_idx
-        ON session_runtime_state (status, lease_until);
-
-      CREATE INDEX IF NOT EXISTS session_runtime_state_session_id_idx
-        ON session_runtime_state (session_id);
-
-      CREATE INDEX IF NOT EXISTS session_runtime_state_workspace_session_idx
-        ON session_runtime_state (workspace_id, session_id);
-
-      CREATE TABLE IF NOT EXISTS sandbox_run_tokens (
-        token TEXT PRIMARY KEY,
-        run_id TEXT NOT NULL UNIQUE,
-        holaboss_user_id TEXT NOT NULL,
-        workspace_id TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        input_id TEXT NOT NULL,
-        scopes TEXT NOT NULL DEFAULT '[]',
-        expires_at TEXT NOT NULL,
-        revoked_at TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS sandbox_run_tokens_run_id_idx
-        ON sandbox_run_tokens (run_id);
-
-      CREATE INDEX IF NOT EXISTS sandbox_run_tokens_expires_at_idx
-        ON sandbox_run_tokens (expires_at);
-
-      CREATE INDEX IF NOT EXISTS sandbox_run_tokens_revoked_at_idx
-        ON sandbox_run_tokens (revoked_at);
-
-      CREATE TABLE IF NOT EXISTS session_messages (
-        id TEXT PRIMARY KEY,
-        workspace_id TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        role TEXT NOT NULL,
-        text TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_session_messages_workspace_session_created
-        ON session_messages (workspace_id, session_id, created_at ASC);
 
       CREATE TABLE IF NOT EXISTS runtime_process_state (
         process_key TEXT PRIMARY KEY,
@@ -7212,10 +7185,10 @@ function listRuntimeRestartBlockingSessions(): Array<{
   status: string;
   currentInputId: string | null;
 }> {
-  const database = openRuntimeDatabase();
+  const databases = openWorkspaceRuntimeDiagnosticsDatabases();
   try {
-    const rows = database
-      .prepare(
+    const rows = databases.flatMap((database) =>
+      database.prepare(
         `
         SELECT
           workspace_id,
@@ -7225,15 +7198,13 @@ function listRuntimeRestartBlockingSessions(): Array<{
         FROM session_runtime_state
         WHERE status IN ('BUSY', 'QUEUED')
            OR current_input_id IS NOT NULL
-        ORDER BY updated_at DESC
       `,
-      )
-      .all() as Array<{
+      ).all() as Array<{
       workspace_id: string;
       session_id: string;
       status: string;
       current_input_id: string | null;
-    }>;
+    }>);
     return rows
       .map((row) => ({
         workspaceId: row.workspace_id.trim(),
@@ -7247,7 +7218,7 @@ function listRuntimeRestartBlockingSessions(): Array<{
       }))
       .filter((row) => row.workspaceId && row.sessionId);
   } finally {
-    database.close();
+    closeRuntimeDatabases(databases);
   }
 }
 
@@ -9549,22 +9520,26 @@ async function getProactiveStatus(
   const workspaceRuntimeDbPath = workspacePath
     ? path.join(workspacePath, ".holaboss", "state", "runtime.db")
     : "";
-  const database =
-    workspaceRuntimeDbPath && existsSync(workspaceRuntimeDbPath)
-      ? new Database(workspaceRuntimeDbPath, { readonly: true })
-      : openRuntimeDatabase();
-  try {
-    const proposalRow = database
-      .prepare(
-        `
+  if (workspaceRuntimeDbPath && existsSync(workspaceRuntimeDbPath)) {
+    const workspaceDatabase = new Database(workspaceRuntimeDbPath, { readonly: true });
+    try {
+      const proposalRow = workspaceDatabase
+        .prepare(
+          `
           SELECT COUNT(*) AS proposal_count
           FROM task_proposals
           WHERE workspace_id = ?
         `,
-      )
-      .get(normalizedWorkspaceId) as { proposal_count?: number } | undefined;
-    proposalCount = Number(proposalRow?.proposal_count ?? 0);
+        )
+        .get(normalizedWorkspaceId) as { proposal_count?: number } | undefined;
+      proposalCount = Number(proposalRow?.proposal_count ?? 0);
+    } finally {
+      workspaceDatabase.close();
+    }
+  }
 
+  const database = openRuntimeDatabase();
+  try {
     const correlationId = `workspace-ready-${normalizedWorkspaceId}`;
     const heartbeatRow = database
       .prepare(
@@ -12597,102 +12572,6 @@ async function stageSessionAttachmentPaths(
   return { attachments };
 }
 
-function insertSessionMessage(message: {
-  id: string;
-  workspaceId: string;
-  sessionId: string;
-  role: string;
-  text: string;
-  createdAt?: string;
-}) {
-  const database = openRuntimeDatabase();
-  try {
-    database
-      .prepare(
-        `
-        INSERT OR REPLACE INTO session_messages (
-          id, workspace_id, session_id, role, text, created_at
-        ) VALUES (
-          @id, @workspace_id, @session_id, @role, @text, @created_at
-        )
-      `,
-      )
-      .run({
-        id: message.id,
-        workspace_id: message.workspaceId,
-        session_id: message.sessionId,
-        role: message.role,
-        text: message.text,
-        created_at: message.createdAt ?? utcNowIso(),
-      });
-  } finally {
-    database.close();
-  }
-}
-
-function upsertRuntimeState(record: {
-  workspaceId: string;
-  sessionId: string;
-  status: "IDLE" | "BUSY" | "WAITING_USER" | "ERROR" | "QUEUED";
-  currentInputId?: string | null;
-  lastError?: Record<string, unknown> | string | null;
-}) {
-  const now = utcNowIso();
-  const database = openRuntimeDatabase();
-  try {
-    database
-      .prepare(
-        `
-        INSERT INTO session_runtime_state (
-          workspace_id,
-          session_id,
-          status,
-          current_input_id,
-          current_worker_id,
-          lease_until,
-          heartbeat_at,
-          last_error,
-          created_at,
-          updated_at
-        ) VALUES (
-          @workspace_id,
-          @session_id,
-          @status,
-          @current_input_id,
-          NULL,
-          NULL,
-          NULL,
-          @last_error,
-          @created_at,
-          @updated_at
-        )
-        ON CONFLICT(workspace_id, session_id) DO UPDATE SET
-          status = excluded.status,
-          current_input_id = excluded.current_input_id,
-          heartbeat_at = excluded.heartbeat_at,
-          last_error = excluded.last_error,
-          updated_at = excluded.updated_at
-      `,
-      )
-      .run({
-        workspace_id: record.workspaceId,
-        session_id: record.sessionId,
-        status: record.status,
-        current_input_id: record.currentInputId ?? null,
-        last_error:
-          typeof record.lastError === "string"
-            ? record.lastError
-            : record.lastError
-              ? JSON.stringify(record.lastError)
-              : null,
-        created_at: now,
-        updated_at: now,
-      });
-  } finally {
-    database.close();
-  }
-}
-
 function cloneRuntimeStateRecord(
   record: SessionRuntimeRecordPayload,
 ): SessionRuntimeRecordPayload {
@@ -12904,27 +12783,6 @@ function runtimeRecordEffectiveStatus(
   return record?.effective_state?.trim().toUpperCase()
     || record?.status?.trim().toUpperCase()
     || "";
-}
-
-function updateQueuedInputStatus(inputId: string, status: string) {
-  const database = openRuntimeDatabase();
-  try {
-    database
-      .prepare(
-        `
-        UPDATE agent_session_inputs
-        SET status = @status, updated_at = @updated_at
-        WHERE input_id = @input_id
-      `,
-      )
-      .run({
-        input_id: inputId,
-        status,
-        updated_at: utcNowIso(),
-      });
-  } finally {
-    database.close();
-  }
 }
 
 const localWorkspaceRegistry = createLocalWorkspaceRegistry({
@@ -14727,61 +14585,6 @@ function emitSessionStreamEvent(payload: HolabossSessionStreamEventPayload) {
   }
 }
 
-function getQueuedInput(inputId: string) {
-  const database = openRuntimeDatabase();
-  try {
-    const row = database
-      .prepare(
-        `
-        SELECT
-          input_id,
-          session_id,
-          workspace_id,
-          payload,
-          status,
-          priority,
-          available_at,
-          attempt,
-          idempotency_key,
-          created_at,
-          updated_at
-        FROM agent_session_inputs
-        WHERE input_id = @input_id
-      `,
-      )
-      .get({ input_id: inputId }) as
-      | {
-          input_id: string;
-          session_id: string;
-          workspace_id: string;
-          payload: string;
-          status: string;
-          priority: number;
-          available_at: string;
-          attempt: number;
-          idempotency_key: string | null;
-          created_at: string;
-          updated_at: string;
-        }
-      | undefined;
-    if (!row) {
-      return null;
-    }
-    let parsedPayload: Record<string, unknown> = {};
-    try {
-      parsedPayload = JSON.parse(row.payload) as Record<string, unknown>;
-    } catch {
-      parsedPayload = {};
-    }
-    return {
-      ...row,
-      payload: parsedPayload,
-    };
-  } finally {
-    database.close();
-  }
-}
-
 async function openSessionOutputStream(
   payload: HolabossStreamSessionOutputsPayload,
 ): Promise<HolabossSessionStreamHandlePayload> {
@@ -15835,6 +15638,7 @@ async function startEmbeddedRuntime() {
           HOLABOSS_EMBEDDED_RUNTIME: "1",
           SANDBOX_AGENT_HARNESS: harness,
           HOLABOSS_RUNTIME_WORKFLOW_BACKEND: workflowBackend,
+          HOLABOSS_HOST_STATE_DB_PATH: runtimeDatabasePath(),
           HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
           HOLABOSS_CONTROL_PLANE_DB_PATH: controlPlaneDatabasePath(),
           HOLABOSS_RUNTIME_LOG_PATH: runtimeLogsPath(),
@@ -20960,7 +20764,7 @@ app.whenReady().then(async () => {
     ["main", "auth-popup"],
     async () => localWorkspaceControlPlane.listWorkspaces(),
   );
-  // Cached read straight from runtime.db without going through the
+  // Cached read straight from control-plane.db without going through the
   // sidecar — used by the splash to hydrate before the sidecar
   // finishes spawning. Returns empty on any failure so the renderer
   // can silently fall back to the live sidecar path.

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1320,6 +1320,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:getWorkspaceLifecycle", workspaceId) as Promise<WorkspaceLifecyclePayload>,
     activateWorkspace: (workspaceId: string) =>
       ipcRenderer.invoke("workspace:activateWorkspace", workspaceId) as Promise<WorkspaceLifecyclePayload>,
+    openWorkspace: (workspaceId: string) =>
+      ipcRenderer.invoke("workspace:openWorkspace", workspaceId) as Promise<WorkspaceOpenSessionPayload>,
     listInstalledApps: (workspaceId: string) =>
       ipcRenderer.invoke("workspace:listInstalledApps", workspaceId) as Promise<InstalledWorkspaceAppListResponsePayload>,
     removeInstalledApp: (workspaceId: string, appId: string) =>

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1347,14 +1347,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:deleteWorkspace", workspaceId, keepFiles) as Promise<WorkspaceResponsePayload>,
     listCronjobs: (workspaceId: string, enabledOnly?: boolean) =>
       ipcRenderer.invoke("workspace:listCronjobs", workspaceId, enabledOnly) as Promise<CronjobListResponsePayload>,
-    runCronjobNow: (jobId: string) =>
-      ipcRenderer.invoke("workspace:runCronjobNow", jobId) as Promise<CronjobRunResponsePayload>,
+    runCronjobNow: (workspaceId: string, jobId: string) =>
+      ipcRenderer.invoke("workspace:runCronjobNow", workspaceId, jobId) as Promise<CronjobRunResponsePayload>,
     createCronjob: (payload: CronjobCreatePayload) =>
       ipcRenderer.invoke("workspace:createCronjob", payload) as Promise<CronjobRecordPayload>,
-    updateCronjob: (jobId: string, payload: CronjobUpdatePayload) =>
-      ipcRenderer.invoke("workspace:updateCronjob", jobId, payload) as Promise<CronjobRecordPayload>,
-    deleteCronjob: (jobId: string) =>
-      ipcRenderer.invoke("workspace:deleteCronjob", jobId) as Promise<{ success: boolean }>,
+    updateCronjob: (workspaceId: string, jobId: string, payload: CronjobUpdatePayload) =>
+      ipcRenderer.invoke("workspace:updateCronjob", workspaceId, jobId, payload) as Promise<CronjobRecordPayload>,
+    deleteCronjob: (workspaceId: string, jobId: string) =>
+      ipcRenderer.invoke("workspace:deleteCronjob", workspaceId, jobId) as Promise<{ success: boolean }>,
     listNotifications: (
       workspaceId?: string | null,
       includeDismissed?: boolean,
@@ -1369,8 +1369,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
         includeDismissed,
         options,
       ) as Promise<RuntimeNotificationListResponsePayload>,
-    updateNotification: (notificationId: string, payload: RuntimeNotificationUpdatePayload) =>
-      ipcRenderer.invoke("workspace:updateNotification", notificationId, payload) as Promise<RuntimeNotificationRecordPayload>,
+    updateNotification: (workspaceId: string, notificationId: string, payload: RuntimeNotificationUpdatePayload) =>
+      ipcRenderer.invoke("workspace:updateNotification", workspaceId, notificationId, payload) as Promise<RuntimeNotificationRecordPayload>,
     listTaskProposals: (workspaceId: string) =>
       ipcRenderer.invoke("workspace:listTaskProposals", workspaceId) as Promise<TaskProposalListResponsePayload>,
     listBackgroundTasks: (payload: BackgroundTaskListRequestPayload) =>
@@ -1383,8 +1383,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:listMemoryUpdateProposals", payload) as Promise<MemoryUpdateProposalListResponsePayload>,
     acceptMemoryUpdateProposal: (payload: MemoryUpdateProposalAcceptPayload) =>
       ipcRenderer.invoke("workspace:acceptMemoryUpdateProposal", payload) as Promise<MemoryUpdateProposalAcceptResponsePayload>,
-    dismissMemoryUpdateProposal: (proposalId: string) =>
-      ipcRenderer.invoke("workspace:dismissMemoryUpdateProposal", proposalId) as Promise<MemoryUpdateProposalDismissResponsePayload>,
+    dismissMemoryUpdateProposal: (workspaceId: string, proposalId: string) =>
+      ipcRenderer.invoke("workspace:dismissMemoryUpdateProposal", workspaceId, proposalId) as Promise<MemoryUpdateProposalDismissResponsePayload>,
     getProactiveStatus: (workspaceId: string) =>
       ipcRenderer.invoke("workspace:getProactiveStatus", workspaceId) as Promise<ProactiveAgentStatusPayload>,
     getProactiveTaskProposalPreference: () =>
@@ -1416,8 +1416,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
         "workspace:setProactiveHeartbeatWorkspaceEnabled",
         payload,
       ) as Promise<ProactiveHeartbeatConfigPayload>,
-    updateTaskProposalState: (proposalId: string, state: string) =>
-      ipcRenderer.invoke("workspace:updateTaskProposalState", proposalId, state) as Promise<TaskProposalStateUpdatePayload>,
+    updateTaskProposalState: (workspaceId: string, proposalId: string, state: string) =>
+      ipcRenderer.invoke("workspace:updateTaskProposalState", workspaceId, proposalId, state) as Promise<TaskProposalStateUpdatePayload>,
     requestRemoteTaskProposalGeneration: (
       payload: RemoteTaskProposalGenerationRequestPayload,
     ) =>

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -760,6 +760,7 @@ interface SessionOutputEventPayload {
 }
 
 interface SessionOutputEventListRequestPayload {
+  workspaceId: string;
   sessionId: string;
   inputId?: string | null;
 }

--- a/desktop/electron/workspace-activation-retry.test.mjs
+++ b/desktop/electron/workspace-activation-retry.test.mjs
@@ -2,15 +2,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const WORKSPACES_METHODS_PATH = new URL(
+  "../../sdk/runtime-client/src/methods/workspaces.ts",
+  import.meta.url,
+);
 
 test("workspace activation opts runtime ensure-running into transient retry handling", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const source = await readFile(WORKSPACES_METHODS_PATH, "utf8");
 
-  assert.match(source, /retryTransientErrors\?: boolean;/);
-  assert.match(source, /const attempts = method === "GET" \|\| retryTransientErrors \? 3 : 1;/);
   assert.match(
     source,
-    /await requestRuntimeJson<Record<string, unknown>>\(\{\s*method: "POST",\s*path: "\/api\/v1\/apps\/ensure-running",[\s\S]*retryTransientErrors: true,/,
+    /ensureAppsRunning\(workspaceId\) \{\s*return request<Record<string, unknown>>\(\{\s*method: "POST",\s*path: "\/api\/v1\/apps\/ensure-running",\s*payload: \{ workspace_id: workspaceId \},\s*timeoutMs: 300000,\s*retryTransientErrors: true,\s*\}\);?\s*\}/,
   );
 });

--- a/desktop/electron/workspace-control-plane.test.mjs
+++ b/desktop/electron/workspace-control-plane.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const CONTROL_PLANE_PATH = new URL("./workspace-control-plane.ts", import.meta.url);
+const PRELOAD_PATH = new URL("./preload.ts", import.meta.url);
+const ELECTRON_D_TS_PATH = new URL("../src/types/electron.d.ts", import.meta.url);
+
+test("workspace control plane source defines the local adapter and open-workspace seam", async () => {
+  const source = await readFile(CONTROL_PLANE_PATH, "utf8");
+
+  assert.match(source, /export type WorkspaceLocation = "local" \| "cloud"/);
+  assert.match(source, /workspaceRoot: string/);
+  assert.match(source, /export interface WorkspaceControlPlane</);
+  assert.match(source, /export interface WorkspaceRegistry<WorkspaceListResponse> \{/);
+  assert.match(source, /workspaceRegistry: WorkspaceRegistry<WorkspaceListResponse>/);
+  assert.match(source, /export class LocalWorkspaceControlPlane</);
+  assert.match(source, /async listWorkspaces\(\): Promise<WorkspaceListResponse> \{/);
+  assert.match(source, /async listWorkspacesCached\(\): Promise<WorkspaceListResponse> \{/);
+  assert.match(source, /async createWorkspace\(/);
+  assert.match(source, /async deleteWorkspace\(/);
+  assert.match(source, /async activateWorkspaceRecord\(/);
+  assert.match(source, /async getWorkspaceLifecycle\(/);
+  assert.match(source, /async activateWorkspace\(/);
+  assert.match(source, /async openWorkspace\(/);
+  assert.match(
+    source,
+    /return Promise\.resolve\(this\.#deps\.workspaceRegistry\.listCachedWorkspaces\(\)\)/,
+  );
+  assert.match(source, /return \(await this\.openWorkspace\(workspaceId\)\)\.lifecycle/);
+  assert.match(source, /return this\.#deps\.openWorkspace\(workspaceId\)/);
+  assert.match(source, /return new LocalWorkspaceControlPlane\(deps\)/);
+});
+
+test("workspace IPC handlers delegate through the local workspace control plane", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(source, /const workspaceRuntimeSessionCache = new Map<\s*string,\s*WorkspaceRuntimeSessionPayload\s*>\(\)/);
+  assert.match(source, /async function resolveWorkspaceRuntimeSession\(/);
+  assert.match(source, /async function requestWorkspaceRuntimeJson<T>\(/);
+  assert.match(
+    source,
+    /const localWorkspaceControlPlane = createLocalWorkspaceControlPlane\(\{\s*listWorkspaces,\s*workspaceRegistry: localWorkspaceRegistry,\s*createWorkspace,\s*deleteWorkspace,\s*activateWorkspaceRecord,\s*getWorkspaceLifecycle,\s*openWorkspace,\s*\}\)/,
+  );
+  assert.match(
+    source,
+    /async function openWorkspace\(\s*workspaceId: string,\s*\): Promise<WorkspaceOpenSessionPayload> \{[\s\S]*const session = await resolveWorkspaceRuntimeSession\(safeWorkspaceId, \{\s*refresh: true,\s*\}\);[\s\S]*await requestWorkspaceRuntimeJson<Record<string, unknown>>\(safeWorkspaceId, \{\s*method: "POST",\s*path: "\/api\/v1\/apps\/ensure-running"/,
+  );
+  assert.match(
+    source,
+    /"workspace:activate"[\s\S]*localWorkspaceControlPlane\.activateWorkspaceRecord\(workspaceId\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:listWorkspaces"[\s\S]*localWorkspaceControlPlane\.listWorkspaces\(\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:listWorkspacesCached"[\s\S]*localWorkspaceControlPlane\.listWorkspacesCached\(\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:getWorkspaceLifecycle"[\s\S]*localWorkspaceControlPlane\.getWorkspaceLifecycle\(workspaceId\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:activateWorkspace"[\s\S]*localWorkspaceControlPlane\.activateWorkspace\(workspaceId\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:openWorkspace"[\s\S]*localWorkspaceControlPlane\.openWorkspace\(workspaceId\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:getWorkspaceRoot"[\s\S]*resolveWorkspaceRuntimeSession\(workspaceId\)\)\.workspace_root/,
+  );
+  assert.match(
+    source,
+    /"workspace:createWorkspace"[\s\S]*localWorkspaceControlPlane\.createWorkspace\(payload\)/,
+  );
+  assert.match(
+    source,
+    /"workspace:deleteWorkspace"[\s\S]*localWorkspaceControlPlane\.deleteWorkspace\(workspaceId, keepFiles\)/,
+  );
+});
+
+test("preload and shared Electron types expose the open-workspace session seam", async () => {
+  const [preloadSource, electronTypesSource] = await Promise.all([
+    readFile(PRELOAD_PATH, "utf8"),
+    readFile(ELECTRON_D_TS_PATH, "utf8"),
+  ]);
+
+  assert.match(
+    preloadSource,
+    /openWorkspace: \(workspaceId: string\) =>\s*ipcRenderer\.invoke\("workspace:openWorkspace", workspaceId\) as Promise<WorkspaceOpenSessionPayload>/,
+  );
+  assert.match(
+    electronTypesSource,
+    /type WorkspaceLocationPayload = "local" \| "cloud";/,
+  );
+  assert.match(electronTypesSource, /interface WorkspaceRecordPayload \{\s*id: string;\s*location: WorkspaceLocationPayload;/s);
+  assert.match(electronTypesSource, /interface WorkspaceRuntimeSessionPayload \{/);
+  assert.match(electronTypesSource, /workspace_root: string;/);
+  assert.match(
+    electronTypesSource,
+    /interface WorkspaceOpenSessionPayload extends WorkspaceRuntimeSessionPayload \{/,
+  );
+  assert.match(electronTypesSource, /workspace_id: string;/);
+  assert.match(electronTypesSource, /runtime_base_url: string;/);
+  assert.match(electronTypesSource, /runtime_auth_token: string \| null;/);
+  assert.match(electronTypesSource, /lifecycle: WorkspaceLifecyclePayload;/);
+  assert.match(
+    electronTypesSource,
+    /openWorkspace: \(workspaceId: string\) => Promise<WorkspaceOpenSessionPayload>;/,
+  );
+});

--- a/desktop/electron/workspace-control-plane.ts
+++ b/desktop/electron/workspace-control-plane.ts
@@ -1,0 +1,172 @@
+export type WorkspaceLocation = "local" | "cloud"
+
+export interface OpenWorkspaceSession<WorkspaceLifecycleResponse> {
+  workspaceId: string
+  location: WorkspaceLocation
+  runtimeBaseUrl: string
+  runtimeAuthToken: string | null
+  workspaceRoot: string
+  lifecycle: WorkspaceLifecycleResponse
+}
+
+export interface WorkspaceControlPlane<
+  WorkspaceListResponse,
+  WorkspaceResponse,
+  WorkspaceLifecycleResponse,
+  CreateWorkspacePayload,
+  WorkspaceOpenSessionResponse extends {
+    lifecycle: WorkspaceLifecycleResponse
+  },
+> {
+  listWorkspaces(): Promise<WorkspaceListResponse>
+  listWorkspacesCached(): Promise<WorkspaceListResponse>
+  createWorkspace(payload: CreateWorkspacePayload): Promise<WorkspaceResponse>
+  deleteWorkspace(
+    workspaceId: string,
+    keepFiles?: boolean,
+  ): Promise<WorkspaceResponse>
+  activateWorkspaceRecord(workspaceId: string): Promise<WorkspaceResponse>
+  getWorkspaceLifecycle(
+    workspaceId: string,
+  ): Promise<WorkspaceLifecycleResponse>
+  activateWorkspace(workspaceId: string): Promise<WorkspaceLifecycleResponse>
+  openWorkspace(workspaceId: string): Promise<WorkspaceOpenSessionResponse>
+}
+
+export interface WorkspaceRegistry<WorkspaceListResponse> {
+  listCachedWorkspaces:
+    | (() => WorkspaceListResponse)
+    | (() => Promise<WorkspaceListResponse>)
+}
+
+export interface LocalWorkspaceControlPlaneDependencies<
+  WorkspaceListResponse,
+  WorkspaceResponse,
+  WorkspaceLifecycleResponse,
+  CreateWorkspacePayload,
+  WorkspaceOpenSessionResponse extends {
+    lifecycle: WorkspaceLifecycleResponse
+  },
+> {
+  listWorkspaces: () => Promise<WorkspaceListResponse>
+  workspaceRegistry: WorkspaceRegistry<WorkspaceListResponse>
+  createWorkspace: (
+    payload: CreateWorkspacePayload,
+  ) => Promise<WorkspaceResponse>
+  deleteWorkspace: (
+    workspaceId: string,
+    keepFiles?: boolean,
+  ) => Promise<WorkspaceResponse>
+  activateWorkspaceRecord: (workspaceId: string) => Promise<WorkspaceResponse>
+  getWorkspaceLifecycle: (
+    workspaceId: string,
+  ) => Promise<WorkspaceLifecycleResponse>
+  openWorkspace: (workspaceId: string) => Promise<WorkspaceOpenSessionResponse>
+}
+
+export class LocalWorkspaceControlPlane<
+  WorkspaceListResponse,
+  WorkspaceResponse,
+  WorkspaceLifecycleResponse,
+  CreateWorkspacePayload,
+  WorkspaceOpenSessionResponse extends {
+    lifecycle: WorkspaceLifecycleResponse
+  },
+> implements
+    WorkspaceControlPlane<
+      WorkspaceListResponse,
+      WorkspaceResponse,
+      WorkspaceLifecycleResponse,
+      CreateWorkspacePayload,
+      WorkspaceOpenSessionResponse
+    >
+{
+  readonly #deps: LocalWorkspaceControlPlaneDependencies<
+    WorkspaceListResponse,
+    WorkspaceResponse,
+    WorkspaceLifecycleResponse,
+    CreateWorkspacePayload,
+    WorkspaceOpenSessionResponse
+  >
+
+  constructor(
+    deps: LocalWorkspaceControlPlaneDependencies<
+      WorkspaceListResponse,
+      WorkspaceResponse,
+      WorkspaceLifecycleResponse,
+      CreateWorkspacePayload,
+      WorkspaceOpenSessionResponse
+    >,
+  ) {
+    this.#deps = deps
+  }
+
+  async listWorkspaces(): Promise<WorkspaceListResponse> {
+    return this.#deps.listWorkspaces()
+  }
+
+  async listWorkspacesCached(): Promise<WorkspaceListResponse> {
+    return Promise.resolve(this.#deps.workspaceRegistry.listCachedWorkspaces())
+  }
+
+  async createWorkspace(
+    payload: CreateWorkspacePayload,
+  ): Promise<WorkspaceResponse> {
+    return this.#deps.createWorkspace(payload)
+  }
+
+  async deleteWorkspace(
+    workspaceId: string,
+    keepFiles?: boolean,
+  ): Promise<WorkspaceResponse> {
+    return this.#deps.deleteWorkspace(workspaceId, keepFiles)
+  }
+
+  async activateWorkspaceRecord(
+    workspaceId: string,
+  ): Promise<WorkspaceResponse> {
+    return this.#deps.activateWorkspaceRecord(workspaceId)
+  }
+
+  async getWorkspaceLifecycle(
+    workspaceId: string,
+  ): Promise<WorkspaceLifecycleResponse> {
+    return this.#deps.getWorkspaceLifecycle(workspaceId)
+  }
+
+  async activateWorkspace(
+    workspaceId: string,
+  ): Promise<WorkspaceLifecycleResponse> {
+    return (await this.openWorkspace(workspaceId)).lifecycle
+  }
+
+  async openWorkspace(workspaceId: string): Promise<WorkspaceOpenSessionResponse> {
+    return this.#deps.openWorkspace(workspaceId)
+  }
+}
+
+export function createLocalWorkspaceControlPlane<
+  WorkspaceListResponse,
+  WorkspaceResponse,
+  WorkspaceLifecycleResponse,
+  CreateWorkspacePayload,
+  WorkspaceOpenSessionResponse extends {
+    lifecycle: WorkspaceLifecycleResponse
+  },
+>(
+  deps: LocalWorkspaceControlPlaneDependencies<
+    WorkspaceListResponse,
+    WorkspaceResponse,
+    WorkspaceLifecycleResponse,
+    CreateWorkspacePayload,
+    WorkspaceOpenSessionResponse
+  >,
+): LocalWorkspaceControlPlane<
+  WorkspaceListResponse,
+  WorkspaceResponse,
+  WorkspaceLifecycleResponse,
+  CreateWorkspacePayload,
+  WorkspaceOpenSessionResponse
+> {
+  return new LocalWorkspaceControlPlane(deps)
+}

--- a/desktop/electron/workspace-delete-local-only.test.mjs
+++ b/desktop/electron/workspace-delete-local-only.test.mjs
@@ -17,7 +17,7 @@ test("workspace deletion is handled locally without calling the control plane", 
 
   assert.match(
     deleteWorkspaceFunction,
-    /requestRuntimeJson<WorkspaceResponsePayload>\(\{[\s\S]*?method: "DELETE",[\s\S]*?path: `\/api\/v1\/workspaces\/\$\{encodeURIComponent\(safeWorkspaceId\)\}`/,
+    /runtimeClient\.workspaces\.delete\(\s*safeWorkspaceId,\s*keepFiles !== undefined \? \{ keepFiles \} : undefined,\s*\)/,
   );
   assert.match(deleteWorkspaceFunction, /forgetWorkspaceDir\(safeWorkspaceId\)/);
   assert.doesNotMatch(deleteWorkspaceFunction, /requestControlPlaneJson/);

--- a/desktop/electron/workspace-git.test.mjs
+++ b/desktop/electron/workspace-git.test.mjs
@@ -29,8 +29,9 @@ test("ensureWorkspaceGitRepo initializes a workspace repo with an initial agent 
     "utf8",
   );
   await fs.mkdir(path.join(workspaceDir, ".holaboss"), { recursive: true });
+  await fs.mkdir(path.join(workspaceDir, ".holaboss", "state"), { recursive: true });
   await fs.writeFile(
-    path.join(workspaceDir, ".holaboss", "workspace_id"),
+    path.join(workspaceDir, ".holaboss", "state", "workspace_id"),
     "workspace-1\n",
     "utf8",
   );

--- a/desktop/electron/workspace-relocation-picker.test.mjs
+++ b/desktop/electron/workspace-relocation-picker.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+test("workspace relocation picker accepts both current and legacy identity marker paths", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /for \(const identityFilePath of \[\s*path\.join\(rootPath, "\.holaboss", "state", "workspace_id"\),\s*path\.join\(rootPath, "\.holaboss", "workspace_id"\),/s,
+  );
+});

--- a/desktop/scripts/check-runtime-status.sh
+++ b/desktop/scripts/check-runtime-status.sh
@@ -6,7 +6,7 @@ set -e
 
 DATA_DIR="${HOLABOSS_DESKTOP_USER_DATA_PATH:-$HOME/.holaboss-desktop}"
 SANDBOX_ROOT="$DATA_DIR/sandbox-host"
-RUNTIME_DB="$SANDBOX_ROOT/state/runtime.db"
+RUNTIME_DB="$SANDBOX_ROOT/state/host-state.db"
 RUNTIME_CONFIG="$SANDBOX_ROOT/state/runtime-config.json"
 RUNTIME_LOG="$DATA_DIR/runtime.log"
 RUNTIME_PORT=5060

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -2335,7 +2335,7 @@ function AppShellContent() {
             seenNotificationIdsRef.current.add(item.id);
             nativeRuntimeNotificationAttemptedAtRef.current.delete(item.id);
             try {
-              await window.electronAPI.workspace.updateNotification(item.id, {
+              await window.electronAPI.workspace.updateNotification(item.workspace_id, item.id, {
                 state: "dismissed",
               });
             } catch {
@@ -2358,7 +2358,7 @@ function AppShellContent() {
             });
           }
           try {
-            await window.electronAPI.workspace.updateNotification(item.id, {
+            await window.electronAPI.workspace.updateNotification(item.workspace_id, item.id, {
               state: "dismissed",
             });
           } catch {
@@ -2371,7 +2371,7 @@ function AppShellContent() {
           consumeControlCenterComposerSubmissionSuppression();
           seenNotificationIdsRef.current.add(item.id);
           try {
-            await window.electronAPI.workspace.updateNotification(item.id, {
+            await window.electronAPI.workspace.updateNotification(item.workspace_id, item.id, {
               state: "dismissed",
             });
           } catch {
@@ -2428,7 +2428,7 @@ function AppShellContent() {
       const nextState = notificationActivationState(notification);
 
       try {
-        await window.electronAPI.workspace.updateNotification(notification.id, {
+        await window.electronAPI.workspace.updateNotification(notification.workspace_id, notification.id, {
           state: nextState,
         });
         await refreshNotifications();
@@ -2487,7 +2487,7 @@ function AppShellContent() {
 
       try {
         dismissNotificationToast(notificationId);
-        await window.electronAPI.workspace.updateNotification(notificationId, {
+        await window.electronAPI.workspace.updateNotification(notification.workspace_id, notificationId, {
           state: "dismissed",
         });
         await refreshNotifications();
@@ -3045,6 +3045,7 @@ function AppShellContent() {
     try {
       const accepted = await window.electronAPI.workspace.acceptTaskProposal({
         proposal_id: proposal.proposal_id,
+        workspace_id: proposal.workspace_id,
         task_name: proposal.task_name,
         task_prompt: proposal.task_prompt,
         parent_session_id: activeChatSessionId?.trim() || null,
@@ -3069,6 +3070,7 @@ function AppShellContent() {
     setTaskProposalStatusMessage("");
     try {
       await window.electronAPI.workspace.updateTaskProposalState(
+        proposal.workspace_id,
         proposal.proposal_id,
         "dismissed",
       );

--- a/desktop/src/components/layout/WorkspaceControlCenter.tsx
+++ b/desktop/src/components/layout/WorkspaceControlCenter.tsx
@@ -490,6 +490,7 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
                   memoryProposalListResult,
                 ] = await Promise.allSettled([
                   window.electronAPI.workspace.getSessionOutputEvents({
+                    workspaceId,
                     sessionId,
                     inputId,
                   }),

--- a/desktop/src/components/panes/AutomationsPane.tsx
+++ b/desktop/src/components/panes/AutomationsPane.tsx
@@ -293,7 +293,7 @@ export function AutomationsPane({
     setBusyJobId(job.id);
     setStatusMessage("");
     try {
-      await window.electronAPI.workspace.deleteCronjob(job.id);
+      await window.electronAPI.workspace.deleteCronjob(job.workspace_id, job.id);
       setCronjobs((previous) => previous.filter((item) => item.id !== job.id));
       setStatusTone("success");
       setStatusMessage(`Deleted "${jobTitle(job)}".`);
@@ -313,7 +313,7 @@ export function AutomationsPane({
     setBusyJobId(job.id);
     setStatusMessage("");
     try {
-      const updated = await window.electronAPI.workspace.updateCronjob(job.id, {
+      const updated = await window.electronAPI.workspace.updateCronjob(job.workspace_id, job.id, {
         enabled: !job.enabled,
       });
       setCronjobs((previous) =>
@@ -339,7 +339,7 @@ export function AutomationsPane({
     setBusyJobId(job.id);
     setStatusMessage("");
     try {
-      const response = await window.electronAPI.workspace.runCronjobNow(job.id);
+      const response = await window.electronAPI.workspace.runCronjobNow(job.workspace_id, job.id);
       setCronjobs((previous) =>
         previous.map((item) =>
           item.id === response.cronjob.id ? response.cronjob : item,

--- a/desktop/src/components/panes/ChatPane.test.mjs
+++ b/desktop/src/components/panes/ChatPane.test.mjs
@@ -288,6 +288,20 @@ test("chat pane blocks overlapping older-history loads before state commits", as
   );
 });
 
+test("chat pane only uses workspace lifecycle blocking state for startup composer disablement", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const readinessMessage =[\s\S]*workspaceBlockingReason \|\|[\s\S]*isActivatingWorkspace[\s\S]*"Preparing workspace apps\.\.\."[\s\S]*"Workspace apps are still starting\."/,
+  );
+  assert.match(
+    source,
+    /if \(!isOnboardingVariant && !workspaceAppsReady\) \{[\s\S]*workspaceBlockingReason \|\| "Workspace apps are still starting\."/,
+  );
+  assert.doesNotMatch(source, /workspaceErrorMessage/);
+});
+
 test("chat pane does not adopt unmatched done or error stream frames and refreshes after matching done", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -3874,6 +3874,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
         const [outputEventsResult, outputListResult, memoryProposalListResult] =
           await Promise.allSettled([
             window.electronAPI.workspace.getSessionOutputEvents({
+              workspaceId: params.workspaceId,
               sessionId: params.sessionId,
               inputId,
             }),

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -4543,6 +4543,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
     try {
       await window.electronAPI.workspace.acceptMemoryUpdateProposal({
         proposalId: proposal.proposal_id,
+        workspaceId: proposal.workspace_id,
         summary: nextSummary,
       });
       setEditingMemoryProposalId((current) =>
@@ -4570,6 +4571,7 @@ const [queuedSessionInputs, setQueuedSessionInputs] = useState<
     });
     try {
       await window.electronAPI.workspace.dismissMemoryUpdateProposal(
+        proposal.workspace_id,
         proposal.proposal_id,
       );
       setEditingMemoryProposalId((current) =>

--- a/desktop/src/lib/workspaceDesktop.test.mjs
+++ b/desktop/src/lib/workspaceDesktop.test.mjs
@@ -38,7 +38,7 @@ test("workspace desktop error normalization unwraps Electron IPC errors before m
   assert.match(source, /return unwrappedMessage;/);
 });
 
-test("workspace desktop rechecks runtime status while bootstrap is waiting for startup", async () => {
+test("workspace desktop hydrates workspace summaries from cached or live sources while bootstrap runs", async () => {
   const source = await readFile(WORKSPACE_DESKTOP_PATH, "utf8");
 
   assert.match(source, /const BOOTSTRAP_IPC_TIMEOUT_MS = 8_000;/);
@@ -58,6 +58,15 @@ test("workspace desktop rechecks runtime status while bootstrap is waiting for s
     source,
     /if \(bootstrapErrors\.length > 0\) \{\s*setWorkspaceErrorMessage\(bootstrapErrors\[0\]\);\s*\}/,
   );
+  assert.match(source, /type WorkspaceListLoadSource = "auto" \| "live" \| "cached";/);
+  assert.match(
+    source,
+    /const workspaceListSource =\s*source === "auto"\s*\?\s*runtimeReadyForWorkspaceData\s*\?\s*"live"\s*:\s*"cached"\s*:\s*source;/,
+  );
+  assert.match(
+    source,
+    /const workspaceResponse = workspaceListSource === "live"\s*\?\s*await window\.electronAPI\.workspace\.listWorkspaces\(\)\s*:\s*await window\.electronAPI\.workspace\.listWorkspacesCached\(\);/,
+  );
   assert.match(
     source,
     /const unsubscribe = window\.electronAPI\.runtime\.onStateChange\(\(status\) => \{/,
@@ -68,17 +77,17 @@ test("workspace desktop rechecks runtime status while bootstrap is waiting for s
   );
   assert.match(
     source,
-    /if \(\s*hasHydratedWorkspaceList \|\|\s*isLoadingBootstrap \|\|\s*runtimeStatus\?\.status !== "starting"\s*\) \{\s*return;\s*\}/,
+    /const workspaceListSource =\s*runtimeReadyForWorkspaceData \? "live" : "cached";/,
   );
   assert.match(
     source,
-    /const refreshStartingRuntimeStatus = \(\) => \{\s*void window\.electronAPI\.runtime[\s\S]*?\.getStatus\(\)[\s\S]*?setRuntimeStatus\(status\);[\s\S]*?\}\s*;\s*\}/,
+    /const result = await loadWorkspaceData\(\{\s*preserveSelection: true,\s*allowEmpty: workspaceListSource === "live",\s*source: workspaceListSource,\s*\}\);/,
   );
   assert.match(
     source,
-    /const timer = window\.setInterval\(refreshStartingRuntimeStatus, 1000\);/,
+    /setHasHydratedWorkspaceList\(\s*\(current\) =>\s*current \|\| result\.source === "live" \|\| result\.resolvedCount > 0,\s*\);/,
   );
-  assert.match(source, /window\.clearInterval\(timer\);/);
+  assert.match(source, /await window\.electronAPI\.workspace\.listWorkspacesCached\(\);/);
 });
 
 test("workspace creation can copy an existing workspace browser profile or import from a browser", async () => {

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -47,6 +47,7 @@ const DEFAULT_WORKSPACE_HARNESS: WorkspaceHarnessId = "pi";
 const BOOTSTRAP_IPC_TIMEOUT_MS = 8_000;
 type TemplateSourceMode = "local" | "marketplace" | "empty" | "empty_onboarding";
 type LifecycleStepState = "pending" | "current" | "done" | "error";
+type WorkspaceListLoadSource = "auto" | "live" | "cached";
 type WorkspaceBrowserBootstrapMode = "fresh" | "copy_workspace" | "import_browser";
 type WorkspaceCreatePhase =
   | "creating_workspace"
@@ -582,9 +583,19 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     };
   }, []);
 
-  async function loadWorkspaceData(options: { preserveSelection?: boolean; allowEmpty?: boolean } = {}) {
-    const { preserveSelection = true, allowEmpty = false } = options;
-    const workspaceResponse = await window.electronAPI.workspace.listWorkspaces();
+  async function loadWorkspaceData(
+    options: { preserveSelection?: boolean; allowEmpty?: boolean; source?: WorkspaceListLoadSource } = {},
+  ) {
+    const { preserveSelection = true, allowEmpty = false, source = "auto" } = options;
+    const workspaceListSource =
+      source === "auto"
+        ? runtimeReadyForWorkspaceData
+          ? "live"
+          : "cached"
+        : source;
+    const workspaceResponse = workspaceListSource === "live"
+      ? await window.electronAPI.workspace.listWorkspaces()
+      : await window.electronAPI.workspace.listWorkspacesCached();
     const nextWorkspaces = workspaceResponse.items;
     const shouldKeepPreviousWorkspaces = !allowEmpty && nextWorkspaces.length === 0 && workspaces.length > 0;
     const resolvedWorkspaces = shouldKeepPreviousWorkspaces ? workspaces : nextWorkspaces;
@@ -598,6 +609,12 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       }
       return resolvedWorkspaces[0]?.id ?? "";
     });
+
+    return {
+      source: workspaceListSource,
+      fetchedCount: nextWorkspaces.length,
+      resolvedCount: resolvedWorkspaces.length,
+    };
   }
 
   async function refreshWorkspaceData() {
@@ -610,9 +627,18 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       ]);
       setRuntimeConfig(nextRuntimeConfig);
       setRuntimeStatus(nextRuntimeStatus);
-      if (nextRuntimeStatus.status === "running") {
-        await loadWorkspaceData({ preserveSelection: true });
-      } else if (nextRuntimeStatus.status === "error" && nextRuntimeStatus.lastError.trim()) {
+      const workspaceListSource =
+        nextRuntimeStatus.status === "running" ? "live" : "cached";
+      const result = await loadWorkspaceData({
+        preserveSelection: true,
+        allowEmpty: workspaceListSource === "live",
+        source: workspaceListSource,
+      });
+      setHasHydratedWorkspaceList(
+        (current) =>
+          current || result.source === "live" || result.resolvedCount > 0,
+      );
+      if (nextRuntimeStatus.status === "error" && nextRuntimeStatus.lastError.trim()) {
         setWorkspaceErrorMessage(nextRuntimeStatus.lastError.trim());
       }
     } catch (error) {
@@ -1142,30 +1168,34 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
   useEffect(() => {
     let cancelled = false;
 
-    // Workspace load no longer waits for `isLoadingBootstrap`. The
-    // bootstrap effect fetches runtimeConfig / clientConfig — neither
-    // is needed to render the workspace list, and on cold launch they
-    // can spend 1.5s+ retrying against a not-yet-healthy sidecar. We
-    // only gate on `runtimeReadyForWorkspaceData` (status === "running"),
-    // which is exactly what listWorkspaces actually depends on; the
-    // bootstrap APIs populate state in the background after the splash
-    // is gone.
-    if (!runtimeReadyForWorkspaceData) {
-      setIsRefreshing(false);
-      setHasHydratedWorkspaceList((current) => current || workspaces.length > 0);
-      if (runtimeStatus?.status === "error" && runtimeStatus.lastError.trim()) {
-        setWorkspaceErrorMessage((current) => current || runtimeStatus.lastError.trim());
-      }
-      return () => {
-        cancelled = true;
-      };
-    }
+    // Workspace summaries can now hydrate from either the live runtime
+    // (`listWorkspaces`) or the cached control-plane-like local registry
+    // (`listWorkspacesCached`). That lets the desktop render the workspace
+    // list before the runtime is fully ready, while still reconciling
+    // against the live runtime once it reaches `running`.
+    const workspaceListSource =
+      runtimeReadyForWorkspaceData ? "live" : "cached";
 
     async function refresh() {
       setIsRefreshing(true);
-      setWorkspaceErrorMessage("");
+      if (workspaceListSource === "live") {
+        setWorkspaceErrorMessage("");
+      }
       try {
-        await loadWorkspaceData({ preserveSelection: true });
+        const result = await loadWorkspaceData({
+          preserveSelection: true,
+          allowEmpty: workspaceListSource === "live",
+          source: workspaceListSource,
+        });
+        if (!cancelled) {
+          setHasHydratedWorkspaceList(
+            (current) =>
+              current || result.source === "live" || result.resolvedCount > 0,
+          );
+          if (runtimeStatus?.status === "error" && runtimeStatus.lastError.trim()) {
+            setWorkspaceErrorMessage((current) => current || runtimeStatus.lastError.trim());
+          }
+        }
       } catch (error) {
         if (!cancelled) {
           setWorkspaceErrorMessage(normalizeErrorMessage(error));
@@ -1173,7 +1203,6 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       } finally {
         if (!cancelled) {
           setIsRefreshing(false);
-          setHasHydratedWorkspaceList(true);
         }
       }
     }

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -445,8 +445,8 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     setWorkspaceBlockingReasonState("");
   }, [selectedWorkspaceId]);
 
-  // Optimistic splash hydration — read the workspaces table directly
-  // from runtime.db on the desktop side, without waiting for the
+  // Optimistic splash hydration — read the cached workspace registry
+  // from control-plane.db on the desktop side, without waiting for the
   // sidecar to spawn or run schema-ensure. Sidecar takes 2-4s on cold
   // launch; this synchronous local read is 5-15ms. If we get any
   // rows, we hydrate the splash immediately; the sidecar's later

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -425,8 +425,11 @@ interface RuntimeNotificationListOptionsPayload {
     spotlight: SpotlightItemPayload[];
   }
 
+  type WorkspaceLocationPayload = "local" | "cloud";
+
   interface WorkspaceRecordPayload {
     id: string;
+    location: WorkspaceLocationPayload;
     name: string;
     status: string;
     harness: string | null;
@@ -1164,6 +1167,18 @@ interface RuntimeNotificationListOptionsPayload {
     blocking_apps: WorkspaceLifecycleBlockingAppPayload[];
   }
 
+  interface WorkspaceRuntimeSessionPayload {
+    workspace_id: string;
+    location: WorkspaceLocationPayload;
+    runtime_base_url: string;
+    runtime_auth_token: string | null;
+    workspace_root: string;
+  }
+
+  interface WorkspaceOpenSessionPayload extends WorkspaceRuntimeSessionPayload {
+    lifecycle: WorkspaceLifecyclePayload;
+  }
+
   interface WorkspaceOutputRecordPayload {
     id: string;
     workspace_id: string;
@@ -1690,6 +1705,7 @@ interface RuntimeNotificationListOptionsPayload {
       listWorkspacesCached: () => Promise<WorkspaceListResponsePayload>;
       getWorkspaceLifecycle: (workspaceId: string) => Promise<WorkspaceLifecyclePayload>;
       activateWorkspace: (workspaceId: string) => Promise<WorkspaceLifecyclePayload>;
+      openWorkspace: (workspaceId: string) => Promise<WorkspaceOpenSessionPayload>;
       listInstalledApps: (workspaceId: string) => Promise<InstalledWorkspaceAppListResponsePayload>;
       removeInstalledApp: (workspaceId: string, appId: string) => Promise<void>;
       listAppCatalog: (params: { source?: "marketplace" | "local" }) => Promise<AppCatalogListResponse>;

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -721,6 +721,7 @@ interface RuntimeNotificationListOptionsPayload {
 
   interface TaskProposalAcceptPayload {
     proposal_id: string;
+    workspace_id: string;
     task_name?: string | null;
     task_prompt?: string | null;
     session_id?: string | null;
@@ -776,6 +777,7 @@ interface RuntimeNotificationListOptionsPayload {
 
   interface MemoryUpdateProposalAcceptPayload {
     proposalId: string;
+    workspaceId: string;
     summary?: string | null;
   }
 
@@ -1719,16 +1721,17 @@ interface RuntimeNotificationListOptionsPayload {
       createWorkspace: (payload: HolabossCreateWorkspacePayload) => Promise<WorkspaceResponsePayload>;
       deleteWorkspace: (workspaceId: string, keepFiles?: boolean) => Promise<WorkspaceResponsePayload>;
       listCronjobs: (workspaceId: string, enabledOnly?: boolean) => Promise<CronjobListResponsePayload>;
-      runCronjobNow: (jobId: string) => Promise<CronjobRunResponsePayload>;
+      runCronjobNow: (workspaceId: string, jobId: string) => Promise<CronjobRunResponsePayload>;
       createCronjob: (payload: CronjobCreatePayload) => Promise<CronjobRecordPayload>;
-      updateCronjob: (jobId: string, payload: CronjobUpdatePayload) => Promise<CronjobRecordPayload>;
-      deleteCronjob: (jobId: string) => Promise<{ success: boolean }>;
+      updateCronjob: (workspaceId: string, jobId: string, payload: CronjobUpdatePayload) => Promise<CronjobRecordPayload>;
+      deleteCronjob: (workspaceId: string, jobId: string) => Promise<{ success: boolean }>;
       listNotifications: (
         workspaceId?: string | null,
         includeDismissed?: boolean,
         options?: RuntimeNotificationListOptionsPayload
       ) => Promise<RuntimeNotificationListResponsePayload>;
       updateNotification: (
+        workspaceId: string,
         notificationId: string,
         payload: RuntimeNotificationUpdatePayload
       ) => Promise<RuntimeNotificationRecordPayload>;
@@ -1746,7 +1749,7 @@ interface RuntimeNotificationListOptionsPayload {
       acceptMemoryUpdateProposal: (
         payload: MemoryUpdateProposalAcceptPayload
       ) => Promise<MemoryUpdateProposalAcceptResponsePayload>;
-      dismissMemoryUpdateProposal: (proposalId: string) => Promise<MemoryUpdateProposalDismissResponsePayload>;
+      dismissMemoryUpdateProposal: (workspaceId: string, proposalId: string) => Promise<MemoryUpdateProposalDismissResponsePayload>;
       getProactiveStatus: (workspaceId: string) => Promise<ProactiveAgentStatusPayload>;
       getProactiveTaskProposalPreference: () => Promise<ProactiveTaskProposalPreferencePayload>;
       setProactiveTaskProposalPreference: (
@@ -1759,7 +1762,11 @@ interface RuntimeNotificationListOptionsPayload {
       setProactiveHeartbeatWorkspaceEnabled: (
         payload: ProactiveHeartbeatWorkspaceUpdatePayload
       ) => Promise<ProactiveHeartbeatConfigPayload>;
-      updateTaskProposalState: (proposalId: string, state: string) => Promise<TaskProposalStateUpdatePayload>;
+      updateTaskProposalState: (
+        workspaceId: string,
+        proposalId: string,
+        state: string
+      ) => Promise<TaskProposalStateUpdatePayload>;
       requestRemoteTaskProposalGeneration: (
         payload: RemoteTaskProposalGenerationRequestPayload
       ) => Promise<RemoteTaskProposalGenerationResponsePayload>;

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -982,6 +982,7 @@ interface RuntimeNotificationListOptionsPayload {
   }
 
   interface SessionOutputEventListRequestPayload {
+    workspaceId: string;
     sessionId: string;
     inputId?: string | null;
   }

--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -587,7 +587,7 @@ test("composeAgentPrompt tells main sessions how to inspect legacy session expor
     sessionMode: "code",
     harnessId: "pi",
     legacySessionHistoryContext: {
-      manifest_path: ".holaboss/legacy-session-histories/index.json",
+      manifest_path: ".holaboss/state/legacy-session-histories/index.json",
       legacy_session_count: 2,
       entries: [
         {
@@ -597,8 +597,8 @@ test("composeAgentPrompt tells main sessions how to inspect legacy session expor
           archived_at: "2026-04-24T06:52:27.419Z",
           message_count: 14,
           output_count: 1,
-          json_path: ".holaboss/legacy-session-histories/session-older.json",
-          markdown_path: ".holaboss/legacy-session-histories/session-older.md",
+          json_path: ".holaboss/state/legacy-session-histories/session-older.json",
+          markdown_path: ".holaboss/state/legacy-session-histories/session-older.md",
         },
       ],
     },
@@ -607,7 +607,7 @@ test("composeAgentPrompt tells main sessions how to inspect legacy session expor
 
   assert.match(prompt.contextMessages.join("\n"), /Legacy session history exports:/);
   assert.match(prompt.contextMessages.join("\n"), /consult the manifest or a directly relevant export before saying that prior session context is unavailable/i);
-  assert.match(prompt.contextMessages.join("\n"), /Manifest path: `\.holaboss\/legacy-session-histories\/index\.json`\./);
+  assert.match(prompt.contextMessages.join("\n"), /Manifest path: `\.holaboss\/state\/legacy-session-histories\/index\.json`\./);
   assert.match(prompt.contextMessages.join("\n"), /Earlier planning chat:/);
 });
 
@@ -739,7 +739,7 @@ test("composeBaseAgentPrompt exposes existing scratchpad metadata without collap
     capabilityManifest,
     scratchpadContext: {
       exists: true,
-      file_path: ".holaboss/scratchpads/session-main.md",
+      file_path: ".holaboss/state/scratchpads/session-main.md",
       updated_at: "2026-04-23T15:00:00.000Z",
       size_bytes: 128,
       preview: "- verified finding\n- open question",
@@ -752,7 +752,7 @@ test("composeBaseAgentPrompt exposes existing scratchpad metadata without collap
     scratchpadMessage,
     /Use the scratchpad as the session's working memory for multi-step execution, interim findings, open questions, candidate lists, and compacted current state\./
   );
-  assert.match(scratchpadMessage, /Path: `\.holaboss\/scratchpads\/session-main\.md`\./);
+  assert.match(scratchpadMessage, /Path: `\.holaboss\/state\/scratchpads\/session-main\.md`\./);
   assert.match(scratchpadMessage, /Preview: - verified finding/);
   assert.match(
     scratchpadMessage,

--- a/runtime/api-server/src/agent-runtime-prompt.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.ts
@@ -465,7 +465,7 @@ function legacySessionHistoryContextPromptSection(
   const entries = Array.isArray(context.entries) ? context.entries : [];
   const lines = [
     "Legacy session history exports:",
-    "Older front-of-house workspace sessions may have been migrated out of the live transcript and exported to `.holaboss/legacy-session-histories`.",
+    "Older front-of-house workspace sessions may have been migrated out of the live transcript and exported to `.holaboss/state/legacy-session-histories`.",
     "These exports are not automatically merged into the current conversation state.",
     "When the user asks about prior workspace conversations, past sessions, or historical context, consult the manifest or a directly relevant export before saying that prior session context is unavailable.",
     "Use `list`, `glob`, and `read` to inspect these legacy exports when needed.",

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -392,14 +392,14 @@ test("browser capability preview mode spills screenshot data and trims browser_g
     );
     assert.match(
       String(body.screenshot.file_path ?? ""),
-      /^\.holaboss\/tool-results\/browser_get_state\/session-main\//,
+      /^\.holaboss\/state\/tool-results\/browser_get_state\/session-main\//,
     );
     assert.equal(body._preview.mode, "preview");
     assert.equal(body._preview.truncated, true);
     assert.equal(body._preview.spilled, true);
     assert.match(
       String(body.full_state_path ?? ""),
-      /^\.holaboss\/tool-results\/browser_get_state\/session-main\//,
+      /^\.holaboss\/state\/tool-results\/browser_get_state\/session-main\//,
     );
     assert.equal(
       fs.existsSync(
@@ -1383,7 +1383,7 @@ test("runtime todo tools read, write, and block session todo state", async () =>
     assert.equal(status.statusCode, 200);
     assert.equal(status.json().blocked, true);
 
-    const todoPath = path.join(workspaceRoot, "workspace-1", ".holaboss", "todos", "session-main.json");
+  const todoPath = path.join(workspaceRoot, "workspace-1", ".holaboss", "state", "todos", "session-main.json");
     const persisted = JSON.parse(fs.readFileSync(todoPath, "utf8"));
     assert.equal(persisted.phases[0]?.tasks[0]?.status, "blocked");
     assert.equal(persisted.phases[0]?.tasks[1]?.status, "pending");
@@ -1414,6 +1414,7 @@ test("runtime scratchpad preview mode clips oversized inline content", async () 
   const scratchpadPath = path.join(
     workspaceDir,
     ".holaboss",
+    "state",
     "scratchpads",
     "session-main.md",
   );
@@ -1436,7 +1437,7 @@ test("runtime scratchpad preview mode clips oversized inline content", async () 
     assert.equal(typeof body.content, "string");
     assert.equal(body.content_truncated, true);
     assert.equal(String(body.content_preview ?? "").includes("[truncated]"), true);
-    assert.equal(body.source_file_path, ".holaboss/scratchpads/session-main.md");
+    assert.equal(body.source_file_path, ".holaboss/state/scratchpads/session-main.md");
     assert.equal(body._preview.mode, "preview");
     assert.equal(body._preview.truncated, true);
   } finally {
@@ -1799,7 +1800,7 @@ test("runtime terminal read preview mode clips large event streams and spills fu
     assert.equal(body._preview.spilled, true);
     assert.match(
       String(body.full_events_path ?? ""),
-      /^\.holaboss\/tool-results\/terminal_session_read\/session-main\//,
+      /^\.holaboss\/state\/tool-results\/terminal_session_read\/session-main\//,
     );
     assert.equal(
       fs.existsSync(
@@ -2928,6 +2929,7 @@ test("ensure-main-session binds one desktop main session and exports legacy fron
   const legacyDir = path.join(
     store.workspaceDir(workspace.id),
     ".holaboss",
+    "state",
     "legacy-session-histories",
   );
   const manifestPath = path.join(legacyDir, "index.json");
@@ -3292,7 +3294,7 @@ test("POST /api/v1/workspaces accepts an explicit workspace_path", async () => {
   assert.equal(created.statusCode, 200);
   const payload = created.json().workspace as { id: string; workspace_path: string | null };
   assert.equal(payload.workspace_path && path.resolve(payload.workspace_path), path.resolve(customPath));
-  assert.equal(fs.existsSync(path.join(customPath, ".holaboss", "workspace_id")), true);
+  assert.equal(fs.existsSync(path.join(customPath, ".holaboss", "state", "workspace_id")), true);
   assert.equal(
     path.resolve(store.workspaceDir(payload.id)),
     path.resolve(customPath)
@@ -3638,9 +3640,9 @@ test("runtime states and history endpoints read TS state store", async () => {
   });
   const sessionMemoryPath = path.join(
     store.workspaceRoot,
-    "memory",
-    "workspace",
     workspace.id,
+    ".holaboss",
+    "memory",
     "runtime",
     "session-memory",
     "session-main.md",

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -4202,12 +4202,16 @@ test("cronjobs, task proposals, and session state routes preserve local payload 
   });
   const runNowJob = await app.inject({
     method: "POST",
-    url: `/api/v1/cronjobs/${jobId}/run`
+    url: `/api/v1/cronjobs/${jobId}/run?workspace_id=${workspace.id}`
   });
   const updatedJob = await app.inject({
     method: "PATCH",
     url: `/api/v1/cronjobs/${jobId}`,
-    payload: { description: "Updated check", instruction: "Say hello louder" }
+    payload: {
+      workspace_id: workspace.id,
+      description: "Updated check",
+      instruction: "Say hello louder"
+    }
   });
   assert.equal(listedJobs.statusCode, 200);
   assert.equal(listedJobs.json().count, 1);
@@ -4248,7 +4252,10 @@ test("cronjobs, task proposals, and session state routes preserve local payload 
   const updatedNotification = await app.inject({
     method: "PATCH",
     url: `/api/v1/notifications/${visibleNotification.id}`,
-    payload: { state: "read" }
+    payload: {
+      workspace_id: workspace.id,
+      state: "read"
+    }
   });
   assert.equal(listedNotifications.statusCode, 200);
   assert.equal(listedNotifications.json().count, 1);
@@ -4296,7 +4303,10 @@ test("cronjobs, task proposals, and session state routes preserve local payload 
   const updatedProposal = await app.inject({
     method: "PATCH",
     url: "/api/v1/task-proposals/proposal-1",
-    payload: { state: "accepted" }
+    payload: {
+      workspace_id: workspace.id,
+      state: "accepted"
+    }
   });
 
   assert.equal(listedProposals.statusCode, 200);
@@ -4340,13 +4350,16 @@ test("cronjobs, task proposals, and session state routes preserve local payload 
     method: "POST",
     url: "/api/v1/memory-update-proposals/memory-proposal-1/accept",
     payload: {
+      workspace_id: workspace.id,
       summary: "Prefer concise responses."
     }
   });
   const dismissedMemoryProposal = await app.inject({
     method: "POST",
     url: "/api/v1/memory-update-proposals/memory-proposal-1/dismiss",
-    payload: {}
+    payload: {
+      workspace_id: workspace.id
+    }
   });
 
   assert.equal(listedMemoryProposals.statusCode, 200);
@@ -6638,6 +6651,7 @@ test("accept task proposal creates a hidden subagent run with queued work", asyn
     method: "POST",
     url: "/api/v1/task-proposals/proposal-1/accept",
     payload: {
+      workspace_id: workspace.id,
       parent_session_id: "session-main",
       task_name: "Follow up",
       task_prompt: "Write the follow-up and send a reminder",
@@ -6714,7 +6728,9 @@ test("accept task proposal creates a hidden subagent run with queued work", asyn
   const secondAccept = await app.inject({
     method: "POST",
     url: "/api/v1/task-proposals/proposal-1/accept",
-    payload: {}
+    payload: {
+      workspace_id: workspace.id
+    }
   });
   assert.equal(secondAccept.statusCode, 409);
 
@@ -6831,6 +6847,7 @@ test("accepting and dismissing evolve task proposals updates linked skill candid
     method: "POST",
     url: "/api/v1/task-proposals/evolve-proposal-1/accept",
     payload: {
+      workspace_id: workspace.id,
       parent_session_id: "session-main",
       created_by: "workspace_user"
     }
@@ -6874,18 +6891,38 @@ test("accepting and dismissing evolve task proposals updates linked skill candid
       task_proposal_id: "evolve-proposal-1",
     },
   });
-  assert.equal(store.getEvolveSkillCandidate("evolve-skill-input-10")?.status, "accepted");
+  assert.equal(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-10"
+    })?.status,
+    "accepted"
+  );
   assert.equal(wakeCount, 1);
 
   const dismissed = await app.inject({
     method: "PATCH",
     url: "/api/v1/task-proposals/evolve-proposal-2",
-    payload: { state: "dismissed" }
+    payload: {
+      workspace_id: workspace.id,
+      state: "dismissed"
+    }
   });
   assert.equal(dismissed.statusCode, 200);
   assert.equal(dismissed.json().proposal.proposal_source, "evolve");
-  assert.equal(store.getEvolveSkillCandidate("evolve-skill-input-11")?.status, "dismissed");
-  assert.ok(store.getEvolveSkillCandidate("evolve-skill-input-11")?.dismissedAt);
+  assert.equal(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-11"
+    })?.status,
+    "dismissed"
+  );
+  assert.ok(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-11"
+    })?.dismissedAt
+  );
 
   await app.close();
   store.close();

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -3506,6 +3506,54 @@ test("DELETE workspace at managed path still wipes the whole directory", async (
   store.close();
 });
 
+test("POST /api/v1/workspaces revives a kept workspace bundle instead of rejecting the preserved folder", async () => {
+  const root = makeTempDir("hb-runtime-api-");
+  const customRoot = makeTempDir("hb-runtime-api-custom-ws-");
+  const customPath = path.join(customRoot, "revive-me");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+  const app = buildTestRuntimeApiServer({ store });
+
+  const created = await app.inject({
+    method: "POST",
+    url: "/api/v1/workspaces",
+    payload: {
+      name: "Original",
+      harness: "pi",
+      workspace_path: customPath
+    }
+  });
+  assert.equal(created.statusCode, 200);
+  const original = created.json().workspace as { id: string; workspace_path: string };
+  fs.writeFileSync(path.join(customPath, "AGENTS.md"), "preserved\n");
+
+  const deleted = await app.inject({
+    method: "DELETE",
+    url: `/api/v1/workspaces/${original.id}`
+  });
+  assert.equal(deleted.statusCode, 200);
+
+  const revived = await app.inject({
+    method: "POST",
+    url: "/api/v1/workspaces",
+    payload: {
+      name: "Ignored",
+      harness: "pi",
+      workspace_path: customPath
+    }
+  });
+  assert.equal(revived.statusCode, 200);
+  const revivedWorkspace = revived.json().workspace as { id: string; workspace_path: string | null };
+  assert.equal(revivedWorkspace.id, original.id);
+  assert.equal(path.resolve(revivedWorkspace.workspace_path ?? ""), path.resolve(customPath));
+  assert.equal(fs.readFileSync(path.join(customPath, "AGENTS.md"), "utf8"), "preserved\n");
+
+  await app.close();
+  store.close();
+});
+
 test("POST /api/v1/workspaces rejects a non-empty workspace_path", async () => {
   const root = makeTempDir("hb-runtime-api-");
   const customRoot = makeTempDir("hb-runtime-api-custom-ws-");

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -908,7 +908,7 @@ test("runtime subagent capability routes create and cancel hidden background tas
     requested_tools: ["web", "browser"],
   });
 
-  const run = store.getSubagentRun({ subagentId: task.subagent_id });
+  const run = store.getSubagentRun({ workspaceId: workspace.id, subagentId: task.subagent_id });
   assert.ok(run);
   assert.equal(run?.parentSessionId, "session-main");
   assert.equal(run?.parentInputId, parentInput.inputId);
@@ -1011,7 +1011,7 @@ test("runtime subagent capability routes create and cancel hidden background tas
   assert.equal(cancelled.statusCode, 200);
   assert.equal(cancelled.json().status, "cancelled");
 
-  const cancelledRun = store.getSubagentRun({ subagentId: task.subagent_id });
+  const cancelledRun = store.getSubagentRun({ workspaceId: workspace.id, subagentId: task.subagent_id });
   assert.equal(cancelledRun?.status, "cancelled");
   const cancelledInput = run?.currentChildInputId ? store.getInput(run.currentChildInputId) : null;
   assert.equal(cancelledInput?.status, "DONE");
@@ -1086,7 +1086,7 @@ test("delegated subagents use the configured global subagent model instead of re
 
   assert.equal(created.statusCode, 200);
   const task = created.json().tasks[0];
-  const run = store.getSubagentRun({ subagentId: task.subagent_id });
+  const run = store.getSubagentRun({ workspaceId: workspace.id, subagentId: task.subagent_id });
   const childInput = run?.currentChildInputId
     ? store.getInput(run.currentChildInputId)
     : null;
@@ -6709,6 +6709,7 @@ test("accept task proposal creates a hidden subagent run with queued work", asyn
     evolve_candidate: null,
   });
   const subagentRun = store.getSubagentRun({
+    workspaceId: workspace.id,
     subagentId: String(childContext.subagent_id),
   });
   assert.ok(subagentRun);

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -477,11 +477,11 @@ test("terminal session routes proxy to the terminal session manager", async () =
       };
       return currentSession;
     },
-    getSession(params: { terminalId: string; workspaceId?: string }) {
+    getSession(params: { terminalId: string; workspaceId: string }) {
       if (params.terminalId !== currentSession.terminalId) {
         return null;
       }
-      if (params.workspaceId && params.workspaceId !== currentSession.workspaceId) {
+      if (params.workspaceId !== currentSession.workspaceId) {
         return null;
       }
       return currentSession;
@@ -489,19 +489,34 @@ test("terminal session routes proxy to the terminal session manager", async () =
     listSessions() {
       return [currentSession];
     },
-    listEvents(params: { terminalId: string; afterSequence?: number }) {
+    listEvents(params: { workspaceId: string; terminalId: string; afterSequence?: number }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        return [];
+      }
       return events.filter((event) => event.terminalId === params.terminalId && event.sequence > (params.afterSequence ?? 0));
     },
-    async sendInput() {
+    async sendInput(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       return currentSession;
     },
-    async resize() {
+    async resize(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       return currentSession;
     },
-    async signal() {
+    async signal(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       return currentSession;
     },
-    async closeSession() {
+    async closeSession(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       currentSession = {
         ...currentSession,
         status: "closed",
@@ -547,7 +562,7 @@ test("terminal session routes proxy to the terminal session manager", async () =
 
   const eventsResponse = await app.inject({
     method: "GET",
-    url: "/api/v1/terminal-sessions/term-1/events?after_sequence=0",
+    url: "/api/v1/terminal-sessions/term-1/events?workspace_id=workspace-1&after_sequence=0",
   });
   assert.equal(eventsResponse.statusCode, 200);
   assert.equal(eventsResponse.json().events.length, 1);
@@ -556,6 +571,9 @@ test("terminal session routes proxy to the terminal session manager", async () =
   const closeResponse = await app.inject({
     method: "POST",
     url: "/api/v1/terminal-sessions/term-1/close",
+    payload: {
+      workspace_id: "workspace-1",
+    },
   });
   assert.equal(closeResponse.statusCode, 200);
   assert.equal(closeResponse.json().status, "closed");
@@ -638,7 +656,7 @@ test("terminal session stream route replays history and forwards live events", a
   };
   const app = buildTestRuntimeApiServer({ store, terminalSessionManager });
   const baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
-  const wsUrl = `${String(baseUrl).replace(/^http/, "ws")}/api/v1/terminal-sessions/term-1/stream`;
+  const wsUrl = `${String(baseUrl).replace(/^http/, "ws")}/api/v1/terminal-sessions/term-1/stream?workspace_id=workspace-1`;
   const socket = new WebSocket(wsUrl);
   const messages: Array<Record<string, unknown>> = [];
   const waitForMessageCount = async (expectedCount: number) => {
@@ -1506,11 +1524,11 @@ test("runtime terminal session tools proxy terminal session manager operations",
       };
       return currentSession;
     },
-    getSession(params: { terminalId: string; workspaceId?: string }) {
+    getSession(params: { terminalId: string; workspaceId: string }) {
       if (params.terminalId !== currentSession.terminalId) {
         return null;
       }
-      if (params.workspaceId && params.workspaceId !== currentSession.workspaceId) {
+      if (params.workspaceId !== currentSession.workspaceId) {
         return null;
       }
       return currentSession;
@@ -1518,22 +1536,34 @@ test("runtime terminal session tools proxy terminal session manager operations",
     listSessions() {
       return [currentSession];
     },
-    listEvents(params: { terminalId: string; afterSequence?: number; limit?: number }) {
+    listEvents(params: { workspaceId: string; terminalId: string; afterSequence?: number; limit?: number }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        return [];
+      }
       return events
         .filter((event) => event.terminalId === params.terminalId && event.sequence > (params.afterSequence ?? 0))
         .slice(0, params.limit ?? events.length);
     },
-    async sendInput() {
+    async sendInput(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       currentSession = {
         ...currentSession,
         lastActivityAt: "2026-01-01T00:00:02.000Z",
       };
       return currentSession;
     },
-    async resize() {
+    async resize(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       return currentSession;
     },
-    async signal() {
+    async signal(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       currentSession = {
         ...currentSession,
         status: "failed",
@@ -1541,7 +1571,10 @@ test("runtime terminal session tools proxy terminal session manager operations",
       };
       return currentSession;
     },
-    async closeSession() {
+    async closeSession(params: { workspaceId: string }) {
+      if (params.workspaceId !== currentSession.workspaceId) {
+        throw new Error("workspace mismatch");
+      }
       currentSession = {
         ...currentSession,
         status: "closed",

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -939,7 +939,9 @@ test("runtime subagent capability routes create and cancel hidden background tas
   });
   assert.equal(childSession?.kind, "subagent");
 
-  const childInput = run?.currentChildInputId ? store.getInput(run.currentChildInputId) : null;
+  const childInput = run?.currentChildInputId
+    ? store.getInput({ workspaceId: workspace.id, inputId: run.currentChildInputId })
+    : null;
   assert.ok(childInput);
   assert.equal(
     childInput?.payload.text,
@@ -1031,7 +1033,9 @@ test("runtime subagent capability routes create and cancel hidden background tas
 
   const cancelledRun = store.getSubagentRun({ workspaceId: workspace.id, subagentId: task.subagent_id });
   assert.equal(cancelledRun?.status, "cancelled");
-  const cancelledInput = run?.currentChildInputId ? store.getInput(run.currentChildInputId) : null;
+  const cancelledInput = run?.currentChildInputId
+    ? store.getInput({ workspaceId: workspace.id, inputId: run.currentChildInputId })
+    : null;
   assert.equal(cancelledInput?.status, "DONE");
 
   const archived = await app.inject({
@@ -1106,7 +1110,7 @@ test("delegated subagents use the configured global subagent model instead of re
   const task = created.json().tasks[0];
   const run = store.getSubagentRun({ workspaceId: workspace.id, subagentId: task.subagent_id });
   const childInput = run?.currentChildInputId
-    ? store.getInput(run.currentChildInputId)
+    ? store.getInput({ workspaceId: workspace.id, inputId: run.currentChildInputId })
     : null;
 
   assert.equal(run?.requestedModel, "gemini_direct/gemini-2.5-pro");
@@ -6089,7 +6093,7 @@ test("queue route persists input and runtime state without writing session histo
   const sessionId = response.json().session_id;
   assert.ok(typeof sessionId === "string" && sessionId.trim().length > 0);
 
-  const queued = store.getInput(response.json().input_id);
+  const queued = store.getInput({ workspaceId: workspace.id, inputId: response.json().input_id });
   assert.ok(queued);
   assert.equal(queued.payload.text, "hello world");
   assert.equal("holaboss_user_id" in queued.payload, false);
@@ -6146,10 +6150,14 @@ test("queue route preserves the active claimed input while adding later queued w
     sessionId: "session-main",
     payload: { text: "currently running" },
   });
-  store.updateInput(active.inputId, {
-    status: "CLAIMED",
-    claimedBy: "worker-1",
-    claimedUntil: "2026-04-17T12:00:00.000Z",
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: active.inputId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-1",
+      claimedUntil: "2026-04-17T12:00:00.000Z",
+    },
   });
   store.updateRuntimeState({
     workspaceId: workspace.id,
@@ -6274,8 +6282,8 @@ test("queue route folds pending background updates into the next main-session in
   });
 
   assert.equal(response.statusCode, 200);
-  const queued = store.getInput(response.json().input_id);
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const queued = store.getInput({ workspaceId: workspace.id, inputId: response.json().input_id });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
   const context = (queued?.payload.context ?? {}) as Record<string, unknown>;
 
   assert.ok(queued);
@@ -6380,7 +6388,7 @@ test("queued input edit route updates queued input text without writing session 
   assert.equal(response.json().status, "QUEUED");
   assert.equal(response.json().text, "draft this second");
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   assert.ok(updated);
   assert.equal(updated?.payload.text, "draft this second");
   const history = store.listSessionMessages({
@@ -6419,10 +6427,14 @@ test("queued input edit route rejects edits after the input is claimed", async (
       context: {},
     },
   });
-  store.updateInput(queued.inputId, {
-    status: "CLAIMED",
-    claimedBy: "worker-1",
-    claimedUntil: "2026-04-17T12:00:00.000Z",
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: queued.inputId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-1",
+      claimedUntil: "2026-04-17T12:00:00.000Z",
+    },
   });
 
   const response = await app.inject({
@@ -6721,7 +6733,7 @@ test("accept task proposal creates a hidden subagent run with queued work", asyn
   assert.equal(childRuntimeState.status, "QUEUED");
   assert.equal(childRuntimeState.currentInputId, body.input.input_id);
 
-  const childInput = store.getInput(body.input.input_id);
+  const childInput = store.getInput({ workspaceId: workspace.id, inputId: body.input.input_id });
   assert.ok(childInput);
   assert.equal(childInput.sessionId, body.session.session_id);
   assert.equal(childInput.priority, 2);
@@ -6890,7 +6902,7 @@ test("accepting and dismissing evolve task proposals updates linked skill candid
   const acceptedBody = accepted.json();
   assert.equal(acceptedBody.proposal.proposal_source, "evolve");
   assert.equal(acceptedBody.session.kind, "subagent");
-  const acceptedInput = store.getInput(acceptedBody.input.input_id);
+  const acceptedInput = store.getInput({ workspaceId: workspace.id, inputId: acceptedBody.input.input_id });
   assert.ok(acceptedInput);
   const acceptedContext = acceptedInput.payload.context as Record<string, unknown>;
   assert.deepEqual(acceptedContext, {
@@ -7070,7 +7082,7 @@ test("queue route accepts staged file and folder attachments and history hydrate
   });
 
   assert.equal(response.statusCode, 200);
-  const queued = store.getInput(response.json().input_id);
+  const queued = store.getInput({ workspaceId: workspace.id, inputId: response.json().input_id });
   assert.ok(queued);
   assert.deepEqual(queued.payload.attachments, [
     {

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -3938,15 +3938,15 @@ test("output events endpoint supports incremental fetches and tail mode", async 
 
   const incremental = await app.inject({
     method: "GET",
-    url: "/api/v1/agent-sessions/session-main/outputs/events?input_id=input-1&after_event_id=1"
+    url: "/api/v1/agent-sessions/session-main/outputs/events?workspace_id=workspace-1&input_id=input-1&after_event_id=1"
   });
   const tailed = await app.inject({
     method: "GET",
-    url: "/api/v1/agent-sessions/session-main/outputs/events?input_id=input-1&include_history=false"
+    url: "/api/v1/agent-sessions/session-main/outputs/events?workspace_id=workspace-1&input_id=input-1&include_history=false"
   });
   const withNative = await app.inject({
     method: "GET",
-    url: "/api/v1/agent-sessions/session-main/outputs/events?input_id=input-1&after_event_id=0&include_native=true"
+    url: "/api/v1/agent-sessions/session-main/outputs/events?workspace_id=workspace-1&input_id=input-1&after_event_id=0&include_native=true"
   });
 
   assert.equal(incremental.statusCode, 200);
@@ -4011,7 +4011,7 @@ test("output stream endpoint emits SSE events and stops on terminal", async () =
 
   const response = await app.inject({
     method: "GET",
-    url: "/api/v1/agent-sessions/session-main/outputs/stream?input_id=input-1"
+    url: "/api/v1/agent-sessions/session-main/outputs/stream?workspace_id=workspace-1&input_id=input-1"
   });
   const body = response.body;
 
@@ -4022,7 +4022,7 @@ test("output stream endpoint emits SSE events and stops on terminal", async () =
 
   const responseWithNative = await app.inject({
     method: "GET",
-    url: "/api/v1/agent-sessions/session-main/outputs/stream?input_id=input-1&include_native=true"
+    url: "/api/v1/agent-sessions/session-main/outputs/stream?workspace_id=workspace-1&input_id=input-1&include_native=true"
   });
 
   assert.equal(responseWithNative.statusCode, 200);

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -3042,8 +3042,8 @@ test("PATCH workspace_path accepts a folder with matching identity (move case)",
   const workspaceId = (created.json().workspace as { id: string }).id;
 
   // Simulate the user moving the whole workspace folder elsewhere.
-  fs.mkdirSync(path.join(movedPath, ".holaboss"), { recursive: true });
-  fs.writeFileSync(path.join(movedPath, ".holaboss", "workspace_id"), workspaceId);
+  fs.mkdirSync(path.join(movedPath, ".holaboss", "state"), { recursive: true });
+  fs.writeFileSync(path.join(movedPath, ".holaboss", "state", "workspace_id"), workspaceId);
   fs.writeFileSync(path.join(movedPath, "AGENTS.md"), "preserved");
 
   const resp = await app.inject({
@@ -3053,6 +3053,40 @@ test("PATCH workspace_path accepts a folder with matching identity (move case)",
   });
   assert.equal(resp.statusCode, 200);
   assert.equal(fs.readFileSync(path.join(movedPath, "AGENTS.md"), "utf-8"), "preserved");
+
+  await app.close();
+  store.close();
+});
+
+test("PATCH workspace_path still accepts a folder with the legacy identity path", async () => {
+  const root = makeTempDir("hb-runtime-api-");
+  const customRoot = makeTempDir("hb-custom-ws-");
+  const movedPath = path.join(customRoot, "moved-legacy");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+  const app = buildTestRuntimeApiServer({ store });
+  const created = await app.inject({
+    method: "POST",
+    url: "/api/v1/workspaces",
+    payload: { name: "M", harness: "pi" }
+  });
+  const workspaceId = (created.json().workspace as { id: string }).id;
+
+  fs.mkdirSync(path.join(movedPath, ".holaboss"), { recursive: true });
+  fs.writeFileSync(path.join(movedPath, ".holaboss", "workspace_id"), workspaceId);
+
+  const resp = await app.inject({
+    method: "PATCH",
+    url: `/api/v1/workspaces/${workspaceId}`,
+    payload: { workspace_path: movedPath }
+  });
+  assert.equal(resp.statusCode, 200);
+  assert.equal(
+    fs.readFileSync(path.join(movedPath, ".holaboss", "state", "workspace_id"), "utf-8").trim(),
+    workspaceId,
+  );
 
   await app.close();
   store.close();
@@ -3357,6 +3391,7 @@ test("DELETE ?keep_files=true preserves files even for managed workspaces", asyn
   const workspaceId = (created.json().workspace as { id: string }).id;
   const workspaceDir = store.workspaceDir(workspaceId);
   fs.writeFileSync(path.join(workspaceDir, "important.txt"), "keep me");
+  const identityPath = path.join(workspaceDir, ".holaboss", "state", "workspace_id");
 
   const resp = await app.inject({
     method: "DELETE",
@@ -3364,7 +3399,7 @@ test("DELETE ?keep_files=true preserves files even for managed workspaces", asyn
   });
   assert.equal(resp.statusCode, 200);
   assert.equal(fs.existsSync(path.join(workspaceDir, "important.txt")), true);
-  assert.equal(fs.existsSync(path.join(workspaceDir, ".holaboss")), false);
+  assert.equal(fs.existsSync(identityPath), true);
 
   await app.close();
   store.close();
@@ -3398,7 +3433,7 @@ test("DELETE ?keep_files=false wipes files even for custom-path workspaces", asy
   store.close();
 });
 
-test("DELETE workspace at custom path preserves user files, wipes only metadata", async () => {
+test("DELETE workspace at custom path preserves user files and the workspace bundle", async () => {
   const root = makeTempDir("hb-runtime-api-");
   const customRoot = makeTempDir("hb-runtime-api-custom-ws-");
   const customPath = path.join(customRoot, "user-folder");
@@ -3422,6 +3457,7 @@ test("DELETE workspace at custom path preserves user files, wipes only metadata"
 
   // User drops a file into their own folder after creation.
   fs.writeFileSync(path.join(customPath, "my-notes.txt"), "keep me");
+  const identityPath = path.join(customPath, ".holaboss", "state", "workspace_id");
 
   const deleted = await app.inject({
     method: "DELETE",
@@ -3431,8 +3467,8 @@ test("DELETE workspace at custom path preserves user files, wipes only metadata"
 
   // User's file survives.
   assert.equal(fs.existsSync(path.join(customPath, "my-notes.txt")), true);
-  // Runtime's metadata is gone.
-  assert.equal(fs.existsSync(path.join(customPath, ".holaboss")), false);
+  // Workspace runtime state and memory survive too.
+  assert.equal(fs.existsSync(identityPath), true);
   // The user's folder itself is preserved.
   assert.equal(fs.existsSync(customPath), true);
 

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -3589,47 +3589,6 @@ test("workspace delete stops installed apps and clears local workspace files", a
     dbPath: path.join(root, "runtime.db"),
     workspaceRoot
   });
-
-  const workspace = store.createWorkspace({
-    workspaceId: "workspace-1",
-    name: "Workspace 1",
-    harness: "pi",
-    status: "active",
-  });
-  const workspaceDir = store.workspaceDir(workspace.id);
-  const appId = "app-a";
-  const appDir = path.join(workspaceDir, "apps", appId);
-  fs.mkdirSync(appDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(workspaceDir, "workspace.yaml"),
-    `applications:\n  - app_id: ${appId}\n    config_path: apps/${appId}/app.runtime.yaml\n`,
-    "utf8"
-  );
-  fs.writeFileSync(
-    path.join(appDir, "app.runtime.yaml"),
-    [
-      `app_id: ${appId}`,
-      "mcp:",
-      "  transport: http-sse",
-      "  port: 4100",
-      "  path: /mcp",
-      "healthchecks:",
-      "  mcp:",
-      "    path: /health",
-      "    timeout_s: 60",
-      "    interval_s: 5",
-      "lifecycle:",
-      "  setup: ''",
-      "  start: npm run start",
-      "  stop: npm run stop"
-    ].join("\n"),
-    "utf8"
-  );
-  store.upsertAppBuild({ workspaceId: workspace.id, appId, status: "running" });
-  store.allocateAppPort({ workspaceId: workspace.id, appId: `${appId}__http` });
-  store.allocateAppPort({ workspaceId: workspace.id, appId: `${appId}__mcp` });
-  assert.equal(store.listAppPorts({ workspaceId: workspace.id }).length, 2);
-
   const stopCalls: Array<{ appId: string; appDir?: string; hasResolvedApp: boolean }> = [];
   const executor: AppLifecycleExecutorLike = {
     async startApp() {
@@ -3654,26 +3613,68 @@ test("workspace delete stops installed apps and clears local workspace files", a
   };
   const app = buildTestRuntimeApiServer({ store, appLifecycleExecutor: executor });
 
-  const deleted = await app.inject({ method: "DELETE", url: `/api/v1/workspaces/${workspace.id}` });
+  try {
+    const workspace = store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    const workspaceDir = store.workspaceDir(workspace.id);
+    const appId = "app-a";
+    const appDir = path.join(workspaceDir, "apps", appId);
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, "workspace.yaml"),
+      `applications:\n  - app_id: ${appId}\n    config_path: apps/${appId}/app.runtime.yaml\n`,
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(appDir, "app.runtime.yaml"),
+      [
+        `app_id: ${appId}`,
+        "mcp:",
+        "  transport: http-sse",
+        "  port: 4100",
+        "  path: /mcp",
+        "healthchecks:",
+        "  mcp:",
+        "    path: /health",
+        "    timeout_s: 60",
+        "    interval_s: 5",
+        "lifecycle:",
+        "  setup: ''",
+        "  start: npm run start",
+        "  stop: npm run stop"
+      ].join("\n"),
+      "utf8"
+    );
+    store.upsertAppBuild({ workspaceId: workspace.id, appId, status: "running" });
+    store.allocateAppPort({ workspaceId: workspace.id, appId: `${appId}__http` });
+    store.allocateAppPort({ workspaceId: workspace.id, appId: `${appId}__mcp` });
+    assert.equal(store.listAppPorts({ workspaceId: workspace.id }).length, 2);
 
-  assert.equal(deleted.statusCode, 200);
-  assert.equal(deleted.json().workspace.status, "deleted");
-  assert.equal(stopCalls.length, 1);
-  assert.deepEqual(stopCalls[0], {
-    appId,
-    appDir,
-    hasResolvedApp: true
-  });
-  assert.equal(store.getAppBuild({ workspaceId: workspace.id, appId }), null);
-  assert.equal(store.listAppPorts({ workspaceId: workspace.id }).length, 0);
-  assert.equal(fs.existsSync(workspaceDir), false);
-  const deletedWorkspace = store.getWorkspace(workspace.id, { includeDeleted: true });
-  assert.ok(deletedWorkspace);
-  assert.equal(deletedWorkspace.status, "deleted");
-  assert.ok(deletedWorkspace.deletedAtUtc);
+    const deleted = await app.inject({ method: "DELETE", url: `/api/v1/workspaces/${workspace.id}` });
 
-  await app.close();
-  store.close();
+    assert.equal(deleted.statusCode, 200);
+    assert.equal(deleted.json().workspace.status, "deleted");
+    assert.equal(stopCalls.length, 1);
+    assert.deepEqual(stopCalls[0], {
+      appId,
+      appDir,
+      hasResolvedApp: true
+    });
+    assert.equal(store.getAppBuild({ workspaceId: workspace.id, appId }), null);
+    assert.equal(store.listAppPorts({ workspaceId: workspace.id }).length, 0);
+    assert.equal(fs.existsSync(workspaceDir), false);
+    const deletedWorkspace = store.getWorkspace(workspace.id, { includeDeleted: true });
+    assert.ok(deletedWorkspace);
+    assert.equal(deletedWorkspace.status, "deleted");
+    assert.ok(deletedWorkspace.deletedAtUtc);
+  } finally {
+    await app.close();
+    store.close();
+  }
 });
 
 test("runtime states and history endpoints read TS state store", async () => {

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -85,6 +85,10 @@ import {
   type MemoryServiceLike
 } from "./memory.js";
 import {
+  migrateLegacyWorkspaceStatePath,
+  resolveMemoryFilePath,
+} from "./workspace-bundle-paths.js";
+import {
   FileRuntimeConfigService,
   RuntimeConfigServiceError,
   type RuntimeConfigServiceLike
@@ -445,17 +449,6 @@ function optionalDict(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined;
 }
 
-function resolveMemoryRootDir(workspaceRoot: string): string {
-  const configured = (process.env.MEMORY_ROOT_DIR ?? "").trim();
-  if (!configured) {
-    return path.join(workspaceRoot, "memory");
-  }
-  if (path.isAbsolute(configured)) {
-    return path.resolve(configured);
-  }
-  return path.resolve(path.join(workspaceRoot, configured));
-}
-
 function sessionMemoryPath(workspaceId: string, sessionId: string): string {
   const sanitizedSessionId =
     sessionId
@@ -479,8 +472,12 @@ function loadSessionResumeContextForApi(params: {
   sessionId: string;
 }): { session_memory_path: string; session_memory_excerpt: string } | null {
   const relPath = sessionMemoryPath(params.workspaceId, params.sessionId);
-  const memoryRoot = resolveMemoryRootDir(params.workspaceRoot);
-  const targetPath = path.join(memoryRoot, relPath);
+  const targetPath = resolveMemoryFilePath({
+    workspaceRoot: params.workspaceRoot,
+    workspaceDir: path.join(params.workspaceRoot, params.workspaceId),
+    workspaceId: params.workspaceId,
+    relPath,
+  });
   if (
     !fs.existsSync(targetPath) ||
     !fs.statSync(targetPath, { throwIfNoEntry: false })?.isFile()
@@ -1309,7 +1306,11 @@ function workspaceLegacySessionHistoryDir(
 ): string | null {
   try {
     const workspaceDir = store.assertWorkspaceFolderHealthy(workspaceId);
-    return path.join(workspaceDir, ".holaboss", "legacy-session-histories");
+    return migrateLegacyWorkspaceStatePath({
+      workspaceDir,
+      relativeSegments: ["legacy-session-histories"],
+      legacyRelativeSegments: [".holaboss", "legacy-session-histories"],
+    });
   } catch {
     return null;
   }
@@ -5760,7 +5761,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   // Workspaces activated in the current runtime boot. First activation
-  // per workspace per boot reads the .holaboss/workspace_id identity file
+  // per workspace per boot reads the .holaboss/state/workspace_id identity file
   // to confirm the folder on disk really belongs to this workspace. We
   // don't re-check on every write — users are free to edit AGENTS.md,
   // skills, workspace.yaml, apps, etc.

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -2634,7 +2634,10 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   // race-write app.runtime.yaml producing corrupt state.
   const appInstallTasks = new Map<string, Promise<unknown>>();
   const appLifecycleExecutor = options.appLifecycleExecutor ?? new RuntimeAppLifecycleExecutor({ store });
-  const memoryService = options.memoryService ?? new FilesystemMemoryService({ workspaceRoot: store.workspaceRoot });
+  const memoryService = options.memoryService ?? new FilesystemMemoryService({
+    workspaceRoot: store.workspaceRoot,
+    resolveWorkspaceDir: (workspaceId) => store.workspaceDir(workspaceId),
+  });
   const runtimeConfigService = options.runtimeConfigService ?? new FileRuntimeConfigService();
   const browserToolService = options.browserToolService ?? new DesktopBrowserToolService({ artifactStore: store });
   const terminalSessionManager =

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -534,7 +534,7 @@ function requiredCapabilityWorkspaceId(params: {
 function requireTerminalSession(params: {
   manager: TerminalSessionManagerLike | null | undefined;
   terminalId: string;
-  workspaceId?: string;
+  workspaceId: string;
 }) {
   if (!params.manager) {
     throw new Error("terminal session capability is not available");
@@ -3570,11 +3570,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const params = request.params as { terminalId: string };
     const query = isRecord(request.query) ? request.query : {};
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        query,
+      });
       const session = terminalSessionManager?.getSession({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId:
-          headerString(request.headers as Record<string, unknown>, "x-holaboss-workspace-id") ||
-          optionalString(query.workspace_id),
+        workspaceId,
       });
       if (!session) {
         return sendError(reply, 404, "terminal session not found");
@@ -3592,16 +3594,19 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const params = request.params as { terminalId: string };
     const query = isRecord(request.query) ? request.query : {};
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        query,
+      });
       return {
         terminal:
           terminalSessionManager?.getSession({
             terminalId: requiredString(params.terminalId, "terminalId"),
-            workspaceId:
-              headerString(request.headers as Record<string, unknown>, "x-holaboss-workspace-id") ||
-              optionalString(query.workspace_id),
+            workspaceId,
           }) ?? null,
         events:
           terminalSessionManager?.listEvents({
+            workspaceId,
             terminalId: requiredString(params.terminalId, "terminalId"),
             afterSequence: optionalInteger(query.after_sequence, 0),
             limit: optionalInteger(query.limit, 0) || undefined,
@@ -3621,7 +3626,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { terminalId: string };
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        body: request.body,
+      });
       return await terminalSessionManager?.sendInput({
+        workspaceId,
         terminalId: requiredString(params.terminalId, "terminalId"),
         data: requiredString(request.body.data, "data"),
       });
@@ -3639,7 +3649,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { terminalId: string };
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        body: request.body,
+      });
       return await terminalSessionManager?.resize({
+        workspaceId,
         terminalId: requiredString(params.terminalId, "terminalId"),
         cols: optionalInteger(request.body.cols, DEFAULT_TERMINAL_COLS),
         rows: optionalInteger(request.body.rows, DEFAULT_TERMINAL_ROWS),
@@ -3658,7 +3673,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { terminalId: string };
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        body: request.body,
+      });
       return await terminalSessionManager?.signal({
+        workspaceId,
         terminalId: requiredString(params.terminalId, "terminalId"),
         signal: nullableString(request.body.signal),
       });
@@ -3673,7 +3693,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   app.post("/api/v1/terminal-sessions/:terminalId/close", async (request, reply) => {
     const params = request.params as { terminalId: string };
     try {
+      const workspaceId = requiredCapabilityWorkspaceId({
+        headers: request.headers as Record<string, unknown>,
+        body: isRecord(request.body) ? request.body : null,
+      });
       return await terminalSessionManager?.closeSession({
+        workspaceId,
         terminalId: requiredString(params.terminalId, "terminalId"),
       });
     } catch (error) {
@@ -3697,10 +3722,11 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       wsHandler: (socket, request) => {
         const params = request.params as { terminalId: string };
         const query = isRecord(request.query) ? request.query : {};
-        const workspaceId =
-          headerString(request.headers as Record<string, unknown>, "x-holaboss-workspace-id") ||
-          optionalString(query.workspace_id);
         try {
+          const workspaceId = requiredCapabilityWorkspaceId({
+            headers: request.headers as Record<string, unknown>,
+            query,
+          });
           const terminal = requireTerminalSession({
             manager: terminalSessionManager,
             terminalId: requiredString(params.terminalId, "terminalId"),
@@ -3710,6 +3736,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
           const snapshotSequence = terminal.lastEventSeq;
           socket.send(JSON.stringify({ type: "connected", terminal }));
           const replayEvents = (terminalSessionManager?.listEvents({
+            workspaceId: terminal.workspaceId,
             terminalId: terminal.terminalId,
             afterSequence,
           }) ?? []).filter((event) => event.sequence <= snapshotSequence);
@@ -4931,7 +4958,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     try {
       return runtimeAgentToolsService.getTerminalSession({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId: capabilityWorkspaceId({
+        workspaceId: requiredCapabilityWorkspaceId({
           headers: request.headers as Record<string, unknown>,
           query: isRecord(request.query) ? request.query : null,
         }),
@@ -4950,7 +4977,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { terminalId: string };
     try {
-      const workspaceId = capabilityWorkspaceId({
+      const requiredWorkspaceId = requiredCapabilityWorkspaceId({
         headers: request.headers as Record<string, unknown>,
         body: request.body,
       });
@@ -4960,7 +4987,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       });
       const result = runtimeAgentToolsService.readTerminalSession({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId,
+        workspaceId: requiredWorkspaceId,
         afterSequence: hasOwn(request.body, "after_sequence")
           ? optionalInteger(request.body.after_sequence, 0)
           : undefined,
@@ -4972,7 +4999,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         headers: request.headers as Record<string, unknown>,
         toolId: "terminal_session_read",
         payload: result,
-        workspaceId,
+        workspaceId: requiredWorkspaceId,
         sessionId,
       });
     } catch (error) {
@@ -4989,7 +5016,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
     const params = request.params as { terminalId: string };
     try {
-      const workspaceId = capabilityWorkspaceId({
+      const workspaceId = requiredCapabilityWorkspaceId({
         headers: request.headers as Record<string, unknown>,
         body: request.body,
       });
@@ -5033,7 +5060,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     try {
       return await runtimeAgentToolsService.sendTerminalSessionInput({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId: capabilityWorkspaceId({
+        workspaceId: requiredCapabilityWorkspaceId({
           headers: request.headers as Record<string, unknown>,
           body: request.body,
         }),
@@ -5055,7 +5082,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     try {
       return await runtimeAgentToolsService.signalTerminalSession({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId: capabilityWorkspaceId({
+        workspaceId: requiredCapabilityWorkspaceId({
           headers: request.headers as Record<string, unknown>,
           body: request.body,
         }),
@@ -5074,7 +5101,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     try {
       return await runtimeAgentToolsService.closeTerminalSession({
         terminalId: requiredString(params.terminalId, "terminalId"),
-        workspaceId: capabilityWorkspaceId({
+        workspaceId: requiredCapabilityWorkspaceId({
           headers: request.headers as Record<string, unknown>,
           body: isRecord(request.body) ? request.body : null,
         }),

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -7553,8 +7553,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.get("/api/v1/output-folders/:folderId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { folderId: string };
-    const folder = store.getOutputFolder(params.folderId);
+    const folder = store.getOutputFolder({ workspaceId, folderId: params.folderId });
     if (!folder) {
       return sendError(reply, 404, "Folder not found");
     }
@@ -7566,7 +7571,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     const params = request.params as { folderId: string };
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
     const folder = store.updateOutputFolder({
+      workspaceId,
       folderId: params.folderId,
       name: nullableString(request.body.name),
       position:
@@ -7581,8 +7588,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.delete("/api/v1/output-folders/:folderId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { folderId: string };
-    const deleted = store.deleteOutputFolder(params.folderId);
+    const deleted = store.deleteOutputFolder({ workspaceId, folderId: params.folderId });
     if (!deleted) {
       return sendError(reply, 404, "Folder not found");
     }
@@ -7619,8 +7631,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.get("/api/v1/outputs/:outputId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { outputId: string };
-    const output = store.getOutput(params.outputId);
+    const output = store.getOutput({ workspaceId, outputId: params.outputId });
     if (!output) {
       return sendError(reply, 404, "Output not found");
     }
@@ -7660,12 +7677,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     const params = request.params as { outputId: string };
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
     let patchMetadata: Record<string, unknown> | undefined;
     if (hasOwn(request.body, "metadata")) {
       const incoming = optionalDict(request.body.metadata) ?? {};
       // Preserve origin_type from existing output if not provided in the patch,
       // so that app updates don't accidentally strip it.
-      const existing = store.getOutput(params.outputId);
+      const existing = store.getOutput({ workspaceId, outputId: params.outputId });
       if (existing && !incoming.origin_type && existing.metadata.origin_type) {
         incoming.origin_type = existing.metadata.origin_type;
       }
@@ -7679,6 +7697,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       patchMetadata = incoming;
     }
     const output = store.updateOutput({
+      workspaceId,
       outputId: params.outputId,
       title: nullableString(request.body.title),
       status: nullableString(request.body.status),
@@ -7695,8 +7714,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.delete("/api/v1/outputs/:outputId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { outputId: string };
-    const deleted = store.deleteOutput(params.outputId);
+    const deleted = store.deleteOutput({ workspaceId, outputId: params.outputId });
     if (!deleted) {
       return sendError(reply, 404, "Output not found");
     }
@@ -7729,7 +7753,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     const params = request.params as { notificationId: string };
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
     const updated = store.updateRuntimeNotification({
+      workspaceId,
       notificationId: requiredString(params.notificationId, "notificationId"),
       state: nullableString(request.body.state) as "unread" | "read" | "dismissed" | null | undefined
     });
@@ -7778,8 +7804,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.get("/api/v1/cronjobs/:jobId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { jobId: string };
-    const job = store.getCronjob(params.jobId);
+    const job = store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!job) {
       return sendError(reply, 404, "Cronjob not found");
     }
@@ -7787,8 +7818,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.post("/api/v1/cronjobs/:jobId/run", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { jobId: string };
-    const job = store.getCronjob(params.jobId);
+    const job = store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!job) {
       return sendError(reply, 404, "Cronjob not found");
     }
@@ -7802,6 +7838,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         () => queueWorker?.wake(),
       );
       const updated = store.updateCronjob({
+        workspaceId,
         jobId: job.id,
         lastRunAt: now.toISOString(),
         nextRunAt: cronjobNextRunAt(job.cron, now),
@@ -7822,6 +7859,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       const message =
         error instanceof Error ? error.message : "cronjob run failed";
       store.updateCronjob({
+        workspaceId,
         jobId: job.id,
         lastRunAt: now.toISOString(),
         nextRunAt: cronjobNextRunAt(job.cron, now),
@@ -7837,7 +7875,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     const params = request.params as { jobId: string };
-    const existing = store.getCronjob(params.jobId);
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
+    const existing = store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!existing) {
       return sendError(reply, 404, "Cronjob not found");
     }
@@ -7857,6 +7896,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
           ? description
           : undefined;
     const job = store.updateCronjob({
+      workspaceId,
       jobId: params.jobId,
       name: nullableString(request.body.name),
       cron,
@@ -7874,8 +7914,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.delete("/api/v1/cronjobs/:jobId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { jobId: string };
-    const deleted = store.deleteCronjob(params.jobId);
+    const deleted = store.deleteCronjob({ workspaceId, jobId: params.jobId });
     if (!deleted) {
       return sendError(reply, 404, "Cronjob not found");
     }
@@ -8099,7 +8144,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
 
     const params = request.params as { proposalId: string };
-    const proposal = store.getTaskProposal(params.proposalId);
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
+    const proposal = store.getTaskProposal({ workspaceId, proposalId: params.proposalId });
     if (!proposal) {
       return sendError(reply, 404, "Task proposal not found");
     }
@@ -8150,7 +8196,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
 
     const evolveCandidate =
-      proposal.proposalSource === "evolve" ? store.getEvolveSkillCandidateByTaskProposalId(proposal.proposalId) : null;
+      proposal.proposalSource === "evolve"
+        ? store.getEvolveSkillCandidateByTaskProposalId({
+            workspaceId: proposal.workspaceId,
+            proposalId: proposal.proposalId,
+          })
+        : null;
     let evolveCandidateMarkdown: string | null = null;
     if (evolveCandidate) {
       try {
@@ -8260,6 +8311,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     });
 
     const updatedProposal = store.updateTaskProposal({
+      workspaceId: proposal.workspaceId,
       proposalId: proposal.proposalId,
       fields: {
         taskName,
@@ -8272,6 +8324,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     });
     if (evolveCandidate) {
       store.updateEvolveSkillCandidate({
+        workspaceId: evolveCandidate.workspaceId,
         candidateId: evolveCandidate.candidateId,
         fields: {
           status: "accepted",
@@ -8293,8 +8346,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.get("/api/v1/task-proposals/:proposalId", async (request, reply) => {
+    const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const params = request.params as { proposalId: string };
-    const proposal = store.getTaskProposal(params.proposalId);
+    const proposal = store.getTaskProposal({ workspaceId, proposalId: params.proposalId });
     if (!proposal) {
       return sendError(reply, 404, "Task proposal not found");
     }
@@ -8306,7 +8364,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     const params = request.params as { proposalId: string };
+    const workspaceId = requiredString(request.body.workspace_id, "workspace_id");
     const proposal = store.updateTaskProposalState({
+      workspaceId,
       proposalId: params.proposalId,
       state: requiredString(request.body.state, "state")
     });
@@ -8314,9 +8374,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 404, "Task proposal not found");
     }
     if (proposal.proposalSource === "evolve" && proposal.state === "dismissed") {
-      const candidate = store.getEvolveSkillCandidateByTaskProposalId(proposal.proposalId);
+      const candidate = store.getEvolveSkillCandidateByTaskProposalId({
+        workspaceId: proposal.workspaceId,
+        proposalId: proposal.proposalId,
+      });
       if (candidate) {
         store.updateEvolveSkillCandidate({
+          workspaceId: candidate.workspaceId,
           candidateId: candidate.candidateId,
           fields: {
             status: "dismissed",
@@ -8352,7 +8416,8 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   app.post("/api/v1/memory-update-proposals/:proposalId/accept", async (request, reply) => {
     const body = isRecord(request.body) ? request.body : {};
     const params = request.params as { proposalId: string };
-    const proposal = store.getMemoryUpdateProposal(params.proposalId);
+    const workspaceId = requiredString(body.workspace_id, "workspace_id");
+    const proposal = store.getMemoryUpdateProposal({ workspaceId, proposalId: params.proposalId });
     if (!proposal) {
       return sendError(reply, 404, "Memory update proposal not found");
     }
@@ -8402,6 +8467,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
 
     const updatedProposal = store.updateMemoryUpdateProposal({
+      workspaceId: proposal.workspaceId,
       proposalId: proposal.proposalId,
       fields: {
         summary,
@@ -8417,8 +8483,10 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.post("/api/v1/memory-update-proposals/:proposalId/dismiss", async (request, reply) => {
+    const body = isRecord(request.body) ? request.body : {};
+    const workspaceId = requiredString(body.workspace_id, "workspace_id");
     const params = request.params as { proposalId: string };
-    const proposal = store.getMemoryUpdateProposal(params.proposalId);
+    const proposal = store.getMemoryUpdateProposal({ workspaceId, proposalId: params.proposalId });
     if (!proposal) {
       return sendError(reply, 404, "Memory update proposal not found");
     }
@@ -8429,6 +8497,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 409, "Memory update proposal has already been dismissed");
     }
     const updatedProposal = store.updateMemoryUpdateProposal({
+      workspaceId: proposal.workspaceId,
       proposalId: proposal.proposalId,
       fields: {
         state: "dismissed",

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -7204,6 +7204,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 422, "workspace_id and profile_id must match when both are provided");
     }
     const resolvedWorkspaceId = workspaceId ?? profileId;
+    if (!resolvedWorkspaceId) {
+      return sendError(reply, 422, "workspace_id or profile_id is required");
+    }
     const runtimeState = store.getRuntimeState({
       sessionId: params.sessionId,
       workspaceId: resolvedWorkspaceId
@@ -7449,13 +7452,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 422, "workspace_id and profile_id must match when both are provided");
     }
     const resolvedWorkspaceId = workspaceId ?? profileId;
-    const outputWorkspaceId = resolvedWorkspaceId ?? store.getRuntimeState({ sessionId: params.sessionId })?.workspaceId ?? null;
-    if (!outputWorkspaceId) {
-      return { items: [], count: 0 };
+    if (!resolvedWorkspaceId) {
+      return sendError(reply, 422, "workspace_id or profile_id is required");
     }
     const items = store
       .listOutputs({
-        workspaceId: outputWorkspaceId,
+        workspaceId: resolvedWorkspaceId,
         sessionId: params.sessionId,
         limit: 500,
         offset: 0,

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -8511,9 +8511,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     };
   });
 
-  app.get("/api/v1/agent-sessions/:sessionId/outputs/events", async (request) => {
+  app.get("/api/v1/agent-sessions/:sessionId/outputs/events", async (request, reply) => {
     const params = request.params as { sessionId: string };
     const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const inputId = optionalString(query.input_id);
     const includeHistory = optionalBoolean(query.include_history, true);
     const includeNative = optionalBoolean(query.include_native, false);
@@ -8521,6 +8525,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     let afterEventId = Math.max(0, optionalInteger(query.after_event_id, 0));
     if (!includeHistory && afterEventId <= 0) {
       afterEventId = store.latestOutputEventId({
+        workspaceId,
         sessionId: params.sessionId,
         inputId,
         excludedEventTypes
@@ -8529,6 +8534,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
     const items = store
       .listOutputEvents({
+        workspaceId,
         sessionId: params.sessionId,
         inputId,
         includeHistory: true,
@@ -8549,6 +8555,10 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   app.get("/api/v1/agent-sessions/:sessionId/outputs/stream", async (request, reply) => {
     const params = request.params as { sessionId: string };
     const query = isRecord(request.query) ? request.query : {};
+    const workspaceId = optionalString(query.workspace_id);
+    if (!workspaceId) {
+      return sendError(reply, 400, "workspace_id is required");
+    }
     const inputId = optionalString(query.input_id);
     const includeHistory = optionalBoolean(query.include_history, true);
     const includeNative = optionalBoolean(query.include_native, false);
@@ -8565,6 +8575,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         let lastEventId = includeHistory
           ? 0
           : store.latestOutputEventId({
+              workspaceId,
               sessionId: params.sessionId,
               inputId,
               excludedEventTypes
@@ -8573,6 +8584,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
         while (true) {
           const events = store.listOutputEvents({
+            workspaceId,
             sessionId: params.sessionId,
             inputId,
             includeHistory: true,

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -1440,7 +1440,12 @@ function exportLegacySessionHistory(params: {
     .map((message) => {
       const inputId = message.role === "user" && message.id.startsWith("user-") ? message.id.slice(5) : "";
       const attachments = inputId
-        ? attachmentsFromInputPayload(params.store.getInput(inputId)?.payload.attachments)
+        ? attachmentsFromInputPayload(
+            params.store.getInput({
+              workspaceId: params.workspace.id,
+              inputId,
+            })?.payload.attachments
+          )
         : [];
       return {
         id: message.id,
@@ -1780,11 +1785,15 @@ function runtimeStateHasClaimedActiveInput(
   store: RuntimeStateStore,
   runtimeState: SessionRuntimeStateRecord | null,
 ): boolean {
+  const workspaceId = runtimeState?.workspaceId?.trim() ?? "";
   const currentInputId = runtimeState?.currentInputId?.trim() ?? "";
-  if (!currentInputId) {
+  if (!currentInputId || !workspaceId) {
     return false;
   }
-  return store.getInput(currentInputId)?.status === "CLAIMED";
+  return store.getInput({
+    workspaceId,
+    inputId: currentInputId,
+  })?.status === "CLAIMED";
 }
 
 function runnerOutputEventPayload(record: OutputEventRecord): Record<string, unknown> {
@@ -7026,6 +7035,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         existingSession?.kind ?? inferredKind,
       )
         ? store.listPendingMainSessionEvents({
+            workspaceId,
             ownerMainSessionId: resolvedSessionId,
             deliveryBucket: "background_update",
             limit: 200,
@@ -7061,6 +7071,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     });
     if (inlineBackgroundUpdateIds.length > 0) {
       store.markMainSessionEventsMaterialized({
+        workspaceId,
         eventIds: inlineBackgroundUpdateIds,
         materializedInputId: record.inputId,
       });
@@ -7159,7 +7170,10 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 404, "workspace not found");
     }
 
-    const input = store.getInput(params.inputId);
+    const input = store.getInput({
+      workspaceId,
+      inputId: params.inputId,
+    });
     if (
       !input ||
       input.workspaceId !== workspaceId ||
@@ -7180,10 +7194,14 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 422, "text or attachments are required");
     }
 
-    const updated = store.updateInput(params.inputId, {
-      payload: {
-        ...existingPayload,
-        text: trimmedText,
+    const updated = store.updateInput({
+      workspaceId,
+      inputId: params.inputId,
+      fields: {
+        payload: {
+          ...existingPayload,
+          text: trimmedText,
+        },
       },
     });
     if (!updated) {
@@ -7305,7 +7323,14 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       })
       .map((message: SessionMessageRecord) => {
         const inputId = message.role === "user" && message.id.startsWith("user-") ? message.id.slice(5) : "";
-        const inputAttachments = inputId ? attachmentsFromInputPayload(store.getInput(inputId)?.payload.attachments) : [];
+        const inputAttachments = inputId
+          ? attachmentsFromInputPayload(
+              store.getInput({
+                workspaceId,
+                inputId,
+              })?.payload.attachments
+            )
+          : [];
         const metadata = inputAttachments.length > 0 ? { ...message.metadata, attachments: inputAttachments } : message.metadata;
         return sessionMessagePayload(message, metadata);
       });

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -5716,8 +5716,6 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const workspace = store.getWorkspace(params.workspaceId, { includeDeleted: true });
     if (!workspace || workspace.deletedAtUtc) {
       // Idempotent: workspace already gone or never existed — treat as success
-      const workspaceDir = store.workspaceDir(params.workspaceId);
-      fs.rmSync(workspaceDir, { recursive: true, force: true });
       return {
         workspace: {
           id: params.workspaceId,
@@ -5747,7 +5745,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       });
       const deletedWorkspace = store.deleteWorkspace(params.workspaceId);
       // Decide whether to wipe the folder. Three cases:
-      //   keep_files=true  → never wipe, only remove .holaboss metadata
+      //   keep_files=true  → never wipe; preserve the full workspace bundle
       //   keep_files=false → always wipe the whole folder
       //   unspecified      → default: managed paths wipe, custom paths keep
       const isManagedPath = isPathWithinWorkspaceRoot(workspaceDir, store.workspaceRoot);
@@ -5759,9 +5757,6 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
             : isManagedPath;
       if (shouldWipe) {
         fs.rmSync(workspaceDir, { recursive: true, force: true });
-      } else {
-        const metadataDir = path.join(workspaceDir, ".holaboss");
-        fs.rmSync(metadataDir, { recursive: true, force: true });
       }
       return { workspace: workspaceRecordPayload(deletedWorkspace, workspaceDir, "missing") };
     } catch (error) {

--- a/runtime/api-server/src/bridge-worker.test.ts
+++ b/runtime/api-server/src/bridge-worker.test.ts
@@ -355,8 +355,14 @@ test("executeBridgeJobNatively creates task proposals in the TS state store", as
 
   assert.equal(result.status, "succeeded");
   assert.deepEqual(result.output, { proposal_id: "job-1" });
-  assert.equal(store.getTaskProposal("job-1")?.taskName, "Review workspace");
-  assert.equal(store.getTaskProposal("job-1")?.proposalSource, "proactive");
+  assert.equal(
+    store.getTaskProposal({ workspaceId: "workspace-1", proposalId: "job-1" })?.taskName,
+    "Review workspace"
+  );
+  assert.equal(
+    store.getTaskProposal({ workspaceId: "workspace-1", proposalId: "job-1" })?.proposalSource,
+    "proactive"
+  );
   store.close();
 });
 

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -112,6 +112,37 @@ function writeRuntimeConfigDocument(document: Record<string, unknown>): string {
   return configPath;
 }
 
+function outputEventsForInput(
+  store: RuntimeStateStore,
+  record: { workspaceId: string; sessionId: string; inputId: string },
+) {
+  return store.listOutputEvents({
+    workspaceId: record.workspaceId,
+    sessionId: record.sessionId,
+    inputId: record.inputId,
+  });
+}
+
+function turnResultForInput(
+  store: RuntimeStateStore,
+  record: { workspaceId: string; inputId: string },
+) {
+  return store.getTurnResult({
+    workspaceId: record.workspaceId,
+    inputId: record.inputId,
+  });
+}
+
+function turnRequestSnapshotForInput(
+  store: RuntimeStateStore,
+  record: { workspaceId: string; inputId: string },
+) {
+  return store.getTurnRequestSnapshot({
+    workspaceId: record.workspaceId,
+    inputId: record.inputId,
+  });
+}
+
 function createSubagentRunFixture(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -189,11 +220,8 @@ test("claimed input marks missing workspace failed and runtime error", async () 
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "FAILED");
@@ -278,12 +306,9 @@ test("claimed input persists runner events, assistant text, and idle state on su
   ): ReturnType<typeof store.updateInput> => {
     const [inputId, fields] = args;
     if (inputId === queued.inputId && fields.status === "DONE") {
-      terminalPersistedBeforeDone = store
-        .listOutputEvents({
-          sessionId: "session-main",
-          inputId: queued.inputId,
-        })
-        .some((event) => event.eventType === "run_completed");
+      terminalPersistedBeforeDone = outputEventsForInput(store, queued).some(
+        (event) => event.eventType === "run_completed"
+      );
     }
     return originalUpdateInput(...args);
   }) as typeof store.updateInput;
@@ -295,12 +320,9 @@ test("claimed input persists runner events, assistant text, and idle state on su
     memoryService,
     runEvolveTasksFn: async (options) => {
       scheduledEvolveTasks += 1;
-      eventTypesAtSchedule = store
-        .listOutputEvents({
-          sessionId: options.record.sessionId,
-          inputId: options.record.inputId,
-        })
-        .map((event) => event.eventType);
+      eventTypesAtSchedule = outputEventsForInput(store, options.record).map(
+        (event) => event.eventType
+      );
     },
   });
 
@@ -309,15 +331,12 @@ test("claimed input persists runner events, assistant text, and idle state on su
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
+  const events = outputEventsForInput(store, queued);
   const messages = store.listSessionMessages({
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "DONE");
@@ -414,7 +433,7 @@ test("claimed input persists runner events, assistant text, and idle state on su
     input_tokens: 12,
     output_tokens: 34,
   });
-  const snapshot = store.getTurnRequestSnapshot({ inputId: queued.inputId });
+  const snapshot = turnRequestSnapshotForInput(store, queued);
   assert.equal(snapshot, null);
 
   store.close();
@@ -540,11 +559,8 @@ test("claimed input persists context-budget telemetry from replay clipping and c
     runEvolveTasksFn: async () => {},
   });
 
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
+  const turnResult = turnResultForInput(store, queued);
+  const events = outputEventsForInput(store, queued);
   const terminalEvent = events.at(-1);
   const terminalBudgetDecisions = recordValue(
     terminalEvent?.payload.context_budget_decisions,
@@ -601,7 +617,7 @@ test("claimed input summarizes browser tool usage and browser telemetry", async 
     claimedBy: "sandbox-agent-ts-worker",
   });
 
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
   assert.ok(turnResult);
   assert.deepEqual(turnResult.toolUsageSummary, {
     total_calls: 3,
@@ -931,7 +947,7 @@ test("claimed input persists waiting_user terminal status for harnesses that sup
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "DONE");
@@ -983,10 +999,7 @@ test("claimed input persists a paused turn when the run is aborted mid-execution
 
   for (let attempt = 0; attempt < 50; attempt += 1) {
     if (
-      store.listOutputEvents({
-        sessionId: "session-main",
-        inputId: queued.inputId,
-      }).length > 0
+      outputEventsForInput(store, queued).length > 0
     ) {
       break;
     }
@@ -1000,11 +1013,8 @@ test("claimed input persists a paused turn when the run is aborted mid-execution
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
   const completedBudgetDecisions = recordValue(
     events[1]?.payload.context_budget_decisions,
   );
@@ -2036,15 +2046,12 @@ test("claimed input honors a persisted failure terminal after claim recovery abo
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
+  const events = outputEventsForInput(store, queued);
   const messages = store.listSessionMessages({
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "FAILED");
@@ -2282,7 +2289,7 @@ test("claimed input records skill-policy denial audit in tool usage summary", as
     },
   });
 
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
   assert.ok(turnResult);
   assert.deepEqual(turnResult.toolUsageSummary, {
     total_calls: 1,
@@ -2344,11 +2351,8 @@ test("claimed input synthesizes run_failed when runner exits without terminal ev
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "FAILED");
@@ -2408,11 +2412,8 @@ test("claimed input succeeds when runner emits terminal event but keeps the proc
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "DONE");
@@ -2468,11 +2469,8 @@ test("claimed input fails when runner becomes idle after run_started", async () 
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
 
   assert.ok(updated);
   assert.equal(updated.status, "FAILED");
@@ -2573,15 +2571,12 @@ test("claimed input stops without overwriting state after it loses its claim mid
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
+  const events = outputEventsForInput(store, queued);
   const messages = store.listSessionMessages({
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = turnResultForInput(store, queued);
 
   assert.equal(updated?.status, "FAILED");
   assert.equal(updated?.claimedBy, null);
@@ -2879,10 +2874,7 @@ test("claimed input hydrates runtime exec context from runtime config", async ()
     },
   });
 
-  const events = store.listOutputEvents({
-    sessionId: "session-main",
-    inputId: queued.inputId,
-  });
+  const events = outputEventsForInput(store, queued);
   assert.equal(events.length, 2);
   const runtimeExecContext = events[0].payload.runtime_exec_context as Record<
     string,

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -1196,7 +1196,7 @@ test("claimed input writes completed subagent results and queues a background up
     },
   });
 
-  const updatedRun = store.getSubagentRun({ subagentId: run.subagentId });
+  const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
   const queuedEvents = store.listPendingMainSessionEvents({
     ownerMainSessionId: "session-main",
   });
@@ -1291,7 +1291,7 @@ test("claimed input writes waiting-on-user subagent blockers and queues a blocke
     },
   });
 
-  const updatedRun = store.getSubagentRun({ subagentId: run.subagentId });
+  const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
   const queuedEvents = store.listPendingMainSessionEvents({
     ownerMainSessionId: "session-main",
   });
@@ -1372,7 +1372,7 @@ test("claimed input treats recoverable login blockers as waiting-on-user subagen
     },
   });
 
-  const updatedRun = store.getSubagentRun({ subagentId: run.subagentId });
+  const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
   const queuedEvents = store.listPendingMainSessionEvents({
     ownerMainSessionId: "session-main",
   });
@@ -1447,7 +1447,7 @@ test("claimed input writes failed subagent results and queues a failure update",
     },
   });
 
-  const updatedRun = store.getSubagentRun({ subagentId: run.subagentId });
+  const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
   const queuedEvents = store.listPendingMainSessionEvents({
     ownerMainSessionId: "session-main",
   });

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -215,7 +215,7 @@ test("claimed input marks missing workspace failed and runtime error", async () 
     record: claimed[0],
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -304,8 +304,8 @@ test("claimed input persists runner events, assistant text, and idle state on su
   store.updateInput = ((
     ...args: Parameters<typeof store.updateInput>
   ): ReturnType<typeof store.updateInput> => {
-    const [inputId, fields] = args;
-    if (inputId === queued.inputId && fields.status === "DONE") {
+    const [params] = args;
+    if (params.inputId === queued.inputId && params.fields.status === "DONE") {
       terminalPersistedBeforeDone = outputEventsForInput(store, queued).some(
         (event) => event.eventType === "run_completed"
       );
@@ -326,7 +326,7 @@ test("claimed input persists runner events, assistant text, and idle state on su
     },
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -745,8 +745,7 @@ test("claimed input creates a completion notification for successful cronjob ses
   const notifications = store.listRuntimeNotifications({
     workspaceId: workspace.id,
   });
-  const queuedEvents = store.listPendingMainSessionEvents({
-    ownerMainSessionId: "session-main",
+  const queuedEvents = store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main",
   });
 
   assert.equal(notifications.length, 1);
@@ -942,7 +941,7 @@ test("claimed input persists waiting_user terminal status for harnesses that sup
     claimedBy: "sandbox-agent-ts-worker",
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -1008,7 +1007,7 @@ test("claimed input persists a paused turn when the run is aborted mid-execution
   controller.abort("user_requested_pause");
   await execution;
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -1197,8 +1196,7 @@ test("claimed input writes completed subagent results and queues a background up
   });
 
   const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
-  const queuedEvents = store.listPendingMainSessionEvents({
-    ownerMainSessionId: "session-main",
+  const queuedEvents = store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main",
   });
 
   assert.ok(updatedRun);
@@ -1292,8 +1290,7 @@ test("claimed input writes waiting-on-user subagent blockers and queues a blocke
   });
 
   const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
-  const queuedEvents = store.listPendingMainSessionEvents({
-    ownerMainSessionId: "session-main",
+  const queuedEvents = store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main",
   });
 
   assert.ok(updatedRun);
@@ -1373,8 +1370,7 @@ test("claimed input treats recoverable login blockers as waiting-on-user subagen
   });
 
   const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
-  const queuedEvents = store.listPendingMainSessionEvents({
-    ownerMainSessionId: "session-main",
+  const queuedEvents = store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main",
   });
 
   assert.ok(updatedRun);
@@ -1448,8 +1444,7 @@ test("claimed input writes failed subagent results and queues a failure update",
   });
 
   const updatedRun = store.getSubagentRun({ workspaceId: run.workspaceId, subagentId: run.subagentId });
-  const queuedEvents = store.listPendingMainSessionEvents({
-    ownerMainSessionId: "session-main",
+  const queuedEvents = store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main",
   });
 
   assert.ok(updatedRun);
@@ -1504,6 +1499,7 @@ test("claimed input delivers materialized main-session event batches without ins
     idempotencyKey: `main-session-event-batch:${event.eventId}`,
   });
   store.markMainSessionEventsMaterialized({
+    workspaceId: workspace.id,
     eventIds: [event.eventId],
     materializedInputId: queued.inputId,
   });
@@ -1547,7 +1543,7 @@ test("claimed input delivers materialized main-session event batches without ins
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
 
   assert.equal(messages.length, 1);
   assert.equal(messages[0]?.role, "assistant");
@@ -1600,6 +1596,7 @@ test("claimed input requeues materialized main-session event batches when the re
     idempotencyKey: `main-session-event-batch:${event.eventId}`,
   });
   store.markMainSessionEventsMaterialized({
+    workspaceId: workspace.id,
     eventIds: [event.eventId],
     materializedInputId: queued.inputId,
   });
@@ -1612,7 +1609,7 @@ test("claimed input requeues materialized main-session event batches when the re
     },
   });
 
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
 
   assert.equal(updatedEvent?.status, "pending");
   assert.equal(updatedEvent?.materializedInputId, null);
@@ -1714,6 +1711,7 @@ test("claimed input folds attached background updates into a normal user turn", 
     },
   });
   store.markMainSessionEventsMaterialized({
+    workspaceId: workspace.id,
     eventIds: [event.eventId],
     materializedInputId: queued.inputId,
   });
@@ -1761,7 +1759,7 @@ test("claimed input folds attached background updates into a normal user turn", 
     workspaceId: workspace.id,
     sessionId: "session-main",
   });
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
   const outputs = store.listOutputs({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -1831,7 +1829,7 @@ test("claimed input renews its claim lease while the runner is still healthy", a
     executeRunnerRequestFn: async (payload, options = {}) => {
       await options.onHeartbeat?.();
       claimedUntilDuringRun =
-        store.getInput(String(payload.input_id))?.claimedUntil ?? null;
+        store.getInput({ workspaceId: workspace.id, inputId: String(payload.input_id) })?.claimedUntil ?? null;
       await options.onEvent?.({
         session_id: payload.session_id,
         input_id: payload.input_id,
@@ -1953,7 +1951,7 @@ test("claimed input treats streamed runner events as lease activity", async () =
         payload: {},
       });
       claimedUntilDuringRun =
-        store.getInput(String(payload.input_id))?.claimedUntil ?? null;
+        store.getInput({ workspaceId: workspace.id, inputId: String(payload.input_id) })?.claimedUntil ?? null;
       await options.onEvent?.({
         session_id: payload.session_id,
         input_id: payload.input_id,
@@ -2041,7 +2039,7 @@ test("claimed input honors a persisted failure terminal after claim recovery abo
     },
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -2346,7 +2344,7 @@ test("claimed input synthesizes run_failed when runner exits without terminal ev
     claimedBy: "sandbox-agent-ts-worker",
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -2407,7 +2405,7 @@ test("claimed input succeeds when runner emits terminal event but keeps the proc
     claimedBy: "sandbox-agent-ts-worker",
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -2464,7 +2462,7 @@ test("claimed input fails when runner becomes idle after run_started", async () 
     claimedBy: "sandbox-agent-ts-worker",
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -2518,11 +2516,11 @@ test("claimed input stops without overwriting state after it loses its claim mid
         event_type: "run_started",
         payload: {},
       });
-      store.updateInput(queued.inputId, {
+      store.updateInput({ workspaceId: queued.workspaceId, inputId: queued.inputId, fields: {
         status: "FAILED",
         claimedBy: null,
         claimedUntil: null,
-      });
+      } });
       store.updateRuntimeState({
         workspaceId: workspace.id,
         sessionId: "session-main",
@@ -2566,7 +2564,7 @@ test("claimed input stops without overwriting state after it loses its claim mid
     },
   });
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: workspace.id, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: workspace.id,
     sessionId: "session-main",
@@ -3940,11 +3938,15 @@ test("claimed input waits for an in-flight session checkpoint before starting th
   let checkpointReleased = false;
   setTimeout(() => {
     checkpointReleased = true;
-    store.updatePostRunJob(checkpointJob.jobId, {
-      status: "DONE",
-      claimedBy: null,
-      claimedUntil: null,
-      lastError: null,
+    store.updatePostRunJob({
+      workspaceId: workspace.id,
+      jobId: checkpointJob.jobId,
+      fields: {
+        status: "DONE",
+        claimedBy: null,
+        claimedUntil: null,
+        lastError: null,
+      },
     });
   }, 50);
 
@@ -3980,7 +3982,10 @@ test("claimed input waits for an in-flight session checkpoint before starting th
   });
 
   assert.equal(runnerStarted, true);
-  assert.equal(store.getPostRunJob(checkpointJob.jobId)?.status, "DONE");
+  assert.equal(
+    store.getPostRunJob({ workspaceId: workspace.id, jobId: checkpointJob.jobId })?.status,
+    "DONE",
+  );
 
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -2459,6 +2459,7 @@ function supersedePendingSubagentEvents(params: {
 }): void {
   const pending = params.store
     .listPendingMainSessionEvents({
+      workspaceId: params.run.workspaceId,
       ownerMainSessionId: params.run.ownerMainSessionId,
       limit: 500,
     })
@@ -2467,6 +2468,7 @@ function supersedePendingSubagentEvents(params: {
     return;
   }
   params.store.markMainSessionEventsSuperseded({
+    workspaceId: params.run.workspaceId,
     eventIds: pending.map((event) => event.eventId),
   });
 }
@@ -2627,6 +2629,7 @@ function maybeFinalizeMainSessionEvents(params: {
     new Date().toISOString();
   if (params.turnResult.status !== "failed") {
     params.store.markMainSessionEventsDelivered({
+      workspaceId: params.record.workspaceId,
       eventIds,
       deliveredAt: now,
     });
@@ -2634,6 +2637,7 @@ function maybeFinalizeMainSessionEvents(params: {
   }
   for (const eventId of eventIds) {
     params.store.updateMainSessionEvent({
+      workspaceId: params.record.workspaceId,
       eventId,
       fields: {
         status: "pending",
@@ -2826,10 +2830,14 @@ export async function processClaimedInput(params: {
   }
   const workspace = store.getWorkspace(record.workspaceId);
   if (!workspace) {
-    store.updateInput(record.inputId, {
-      status: "FAILED",
-      claimedBy: null,
-      claimedUntil: null,
+    store.updateInput({
+      workspaceId: record.workspaceId,
+      inputId: record.inputId,
+      fields: {
+        status: "FAILED",
+        claimedBy: null,
+        claimedUntil: null,
+      },
     });
     store.updateRuntimeState({
       workspaceId: record.workspaceId,
@@ -2912,7 +2920,10 @@ export async function processClaimedInput(params: {
       if (!shouldTrackClaimOwnership) {
         return true;
       }
-      const currentRecord = store.getInput(record.inputId);
+      const currentRecord = store.getInput({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+      });
       return (
         currentRecord?.status === "CLAIMED" &&
         currentRecord.claimedBy === claimedBy
@@ -2951,7 +2962,11 @@ export async function processClaimedInput(params: {
         extras: {
           source,
           claimed_by: claimedBy,
-          claimed_until: store.getInput(record.inputId)?.claimedUntil ?? null,
+          claimed_until:
+            store.getInput({
+              workspaceId: record.workspaceId,
+              inputId: record.inputId,
+            })?.claimedUntil ?? null,
         },
       });
       return true;
@@ -2971,6 +2986,7 @@ export async function processClaimedInput(params: {
 
       if (shouldTrackClaimOwnership) {
         const renewedClaim = store.renewInputClaim({
+          workspaceId: record.workspaceId,
           inputId: record.inputId,
           claimedBy,
           leaseSeconds,
@@ -3287,6 +3303,7 @@ export async function processClaimedInput(params: {
 
       if (shouldTrackClaimOwnership) {
         const renewedClaim = store.renewInputClaim({
+          workspaceId: record.workspaceId,
           inputId: record.inputId,
           claimedBy,
           leaseSeconds,
@@ -3892,15 +3909,19 @@ export async function processClaimedInput(params: {
         deferredTerminalEvent = null;
       }
 
-      store.updateInput(record.inputId, {
-        status:
-          terminalStatus === "ERROR"
-            ? "FAILED"
-            : terminalStatus === "PAUSED"
-              ? "PAUSED"
-              : "DONE",
-        claimedBy: null,
-        claimedUntil: null,
+      store.updateInput({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+        fields: {
+          status:
+            terminalStatus === "ERROR"
+              ? "FAILED"
+              : terminalStatus === "PAUSED"
+                ? "PAUSED"
+                : "DONE",
+          claimedBy: null,
+          claimedUntil: null,
+        },
       });
       store.updateRuntimeState({
         workspaceId: record.workspaceId,
@@ -4095,10 +4116,14 @@ export async function processClaimedInput(params: {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
-      store.updateInput(record.inputId, {
-        status: "FAILED",
-        claimedBy: null,
-        claimedUntil: null,
+      store.updateInput({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+        fields: {
+          status: "FAILED",
+          claimedBy: null,
+          claimedUntil: null,
+        },
       });
       store.appendOutputEvent({
         workspaceId: record.workspaceId,

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -1414,11 +1414,13 @@ function claimLeaseUntilIso(
 
 function latestPersistedTerminalOutputEvent(params: {
   store: RuntimeStateStore;
+  workspaceId: string;
   sessionId: string;
   inputId: string;
 }) {
   return params.store
     .listOutputEvents({
+      workspaceId: params.workspaceId,
       sessionId: params.sessionId,
       inputId: params.inputId,
     })
@@ -3620,6 +3622,7 @@ export async function processClaimedInput(params: {
 
       const persistedTerminalEvent = latestPersistedTerminalOutputEvent({
         store,
+        workspaceId: record.workspaceId,
         sessionId: record.sessionId,
         inputId: record.inputId,
       });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -1818,7 +1818,10 @@ function maybeQueueCronjobCompletionFollowup(params: {
     return;
   }
 
-  const job = params.store.getCronjob(cronjobId);
+  const job = params.store.getCronjob({
+    workspaceId: params.record.workspaceId,
+    jobId: cronjobId,
+  });
   const workspace = params.store.getWorkspace(params.record.workspaceId);
   if (!job || !workspace) {
     return;
@@ -1942,7 +1945,10 @@ function maybeCreateCronjobCompletionNotification(params: {
     return;
   }
 
-  const job = params.store.getCronjob(cronjobId);
+  const job = params.store.getCronjob({
+    workspaceId: params.record.workspaceId,
+    jobId: cronjobId,
+  });
   const workspace = params.store.getWorkspace(params.record.workspaceId);
   if (!job || !workspace) {
     return;
@@ -2058,6 +2064,7 @@ async function maybePromoteAcceptedEvolveSkillCandidate(params: {
   await promoteAcceptedSkillCandidate({
     store: params.store,
     memoryService: params.memoryService,
+    workspaceId: params.record.workspaceId,
     candidateId,
   });
 }

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -2510,6 +2510,7 @@ function updateSubagentRunFromTurnResult(params: {
   if (!status) {
     return (
       params.store.updateSubagentRun({
+        workspaceId: run.workspaceId,
         subagentId: run.subagentId,
         fields,
       }) ?? run
@@ -2565,6 +2566,7 @@ function updateSubagentRunFromTurnResult(params: {
 
   const updated =
     params.store.updateSubagentRun({
+      workspaceId: run.workspaceId,
       subagentId: run.subagentId,
       fields,
     }) ?? run;

--- a/runtime/api-server/src/cron-worker.test.ts
+++ b/runtime/api-server/src/cron-worker.test.ts
@@ -156,7 +156,7 @@ test("runtime cron worker queues due session_run cronjobs as hidden subagents an
   });
 
   const processed = await worker.processDueCronjobsOnce(new Date("2025-01-01T09:30:00Z"));
-  const updated = store.getCronjob(job.id);
+  const updated = store.getCronjob({ workspaceId: workspace.id, jobId: job.id });
   const runs = store.listSubagentRunsByWorkspace({ workspaceId: workspace.id });
   const run = runs[0];
   const runtimeState = run
@@ -348,7 +348,7 @@ test("runtime cron worker persists system_notification cronjobs as unread notifi
   const worker = new RuntimeCronWorker({ store });
   const processed = await worker.processDueCronjobsOnce(new Date("2025-01-01T09:30:00Z"));
   const notifications = store.listRuntimeNotifications({ workspaceId: workspace.id });
-  const updated = store.getCronjob(job.id);
+  const updated = store.getCronjob({ workspaceId: workspace.id, jobId: job.id });
 
   assert.equal(processed, 1);
   assert.equal(notifications.length, 1);
@@ -389,7 +389,7 @@ test("runtime cron worker records failures for unsupported delivery channels", a
 
   const worker = new RuntimeCronWorker({ store });
   const processed = await worker.processDueCronjobsOnce(new Date("2025-01-01T09:30:00Z"));
-  const updated = store.getCronjob(job.id);
+  const updated = store.getCronjob({ workspaceId: "workspace-1", jobId: job.id });
 
   assert.equal(processed, 1);
   assert.ok(updated);
@@ -512,7 +512,7 @@ test("runtime cron worker does not execute a newly created cronjob before next_r
   });
 
   const processed = await worker.processDueCronjobsOnce(new Date("2025-01-01T09:30:00Z"));
-  const updated = store.getCronjob(job.id);
+  const updated = store.getCronjob({ workspaceId: "workspace-1", jobId: job.id });
   const runs = store.listSubagentRunsByWorkspace({ workspaceId: workspace.id });
   const notifications = store.listRuntimeNotifications({ workspaceId: workspace.id });
 

--- a/runtime/api-server/src/cron-worker.test.ts
+++ b/runtime/api-server/src/cron-worker.test.ts
@@ -428,36 +428,38 @@ test("cronjob routes compute next_run_at and cron worker lifecycle hooks run", a
       }
     }
   });
+  try {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/cronjobs",
+      payload: {
+        workspace_id: workspace.id,
+        initiated_by: "workspace_agent",
+        cron: "0 9 * * *",
+        description: "Daily check",
+        delivery: { channel: "session_run" }
+      }
+    });
+    const body = created.json() as { id: string; next_run_at: string | null };
+    const updated = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/cronjobs/${body.id}`,
+      payload: {
+        workspace_id: workspace.id,
+        cron: "0 10 * * *"
+      }
+    });
 
-  const created = await app.inject({
-    method: "POST",
-    url: "/api/v1/cronjobs",
-    payload: {
-      workspace_id: workspace.id,
-      initiated_by: "workspace_agent",
-      cron: "0 9 * * *",
-      description: "Daily check",
-      delivery: { channel: "session_run" }
-    }
-  });
-  const body = created.json() as { id: string; next_run_at: string | null };
-  const updated = await app.inject({
-    method: "PATCH",
-    url: `/api/v1/cronjobs/${body.id}`,
-    payload: {
-      cron: "0 10 * * *"
-    }
-  });
-
-  assert.equal(startCalls, 1);
-  assert.equal(created.statusCode, 200);
-  assert.ok(body.next_run_at);
-  assert.equal(updated.statusCode, 200);
-  assert.ok(updated.json().next_run_at);
-
-  await app.close();
-  assert.equal(closeCalls, 1);
-  store.close();
+    assert.equal(startCalls, 1);
+    assert.equal(created.statusCode, 200);
+    assert.ok(body.next_run_at);
+    assert.equal(updated.statusCode, 200);
+    assert.ok(updated.json().next_run_at);
+  } finally {
+    await app.close();
+    assert.equal(closeCalls, 1);
+    store.close();
+  }
 });
 
 test("runtime cron worker does not execute a newly created cronjob before next_run_at", async () => {

--- a/runtime/api-server/src/cron-worker.ts
+++ b/runtime/api-server/src/cron-worker.ts
@@ -530,6 +530,7 @@ export class RuntimeCronWorker implements CronWorkerLike {
       }
 
       this.#store.updateCronjob({
+        workspaceId: job.workspaceId,
         jobId: job.id,
         lastRunAt: now.toISOString(),
         nextRunAt: cronjobNextRunAt(job.cron, now),

--- a/runtime/api-server/src/evolve-skill-review.ts
+++ b/runtime/api-server/src/evolve-skill-review.ts
@@ -612,7 +612,10 @@ export async function persistSkillCandidate(params: {
   draft: SkillCandidateDraft;
 }): Promise<EvolveSkillCandidateRecord> {
   const candidateId = skillCandidateIdForInput(params.turnResult.inputId);
-  const existingById = params.store.getEvolveSkillCandidate(candidateId);
+  const existingById = params.store.getEvolveSkillCandidate({
+    workspaceId: params.turnResult.workspaceId,
+    candidateId,
+  });
   if (existingById) {
     return existingById;
   }
@@ -654,9 +657,13 @@ export async function persistSkillCandidate(params: {
 export async function promoteAcceptedSkillCandidate(params: {
   store: RuntimeStateStore;
   memoryService: MemoryServiceLike;
+  workspaceId: string;
   candidateId: string;
 }): Promise<SkillCandidatePromotionResult> {
-  const candidate = params.store.getEvolveSkillCandidate(params.candidateId);
+  const candidate = params.store.getEvolveSkillCandidate({
+    workspaceId: params.workspaceId,
+    candidateId: params.candidateId,
+  });
   if (!candidate || !["skill_create", "skill_patch"].includes(candidate.kind)) {
     return { status: "missing_candidate", targetSkillPath: null };
   }
@@ -675,6 +682,7 @@ export async function promoteAcceptedSkillCandidate(params: {
       removeFileAndEmptyParents(misplacedDraft.filePath, workspaceDir);
     }
     params.store.updateEvolveSkillCandidate({
+      workspaceId: candidate.workspaceId,
       candidateId: candidate.candidateId,
       fields: {
         status: "promoted",
@@ -718,6 +726,7 @@ export async function promoteAcceptedSkillCandidate(params: {
   }
 
   params.store.updateEvolveSkillCandidate({
+    workspaceId: candidate.workspaceId,
     candidateId: candidate.candidateId,
     fields: {
       status: "promoted",

--- a/runtime/api-server/src/evolve-worker.ts
+++ b/runtime/api-server/src/evolve-worker.ts
@@ -117,11 +117,15 @@ export class RuntimeEvolveWorker implements DurableMemoryWorkerLike {
       claimed.map(async (record) => {
         try {
           await this.#executeClaimedJob(record);
-          this.#store.updatePostRunJob(record.jobId, {
-            status: "DONE",
-            claimedBy: null,
-            claimedUntil: null,
-            lastError: null,
+          this.#store.updatePostRunJob({
+            workspaceId: record.workspaceId,
+            jobId: record.jobId,
+            fields: {
+              status: "DONE",
+              claimedBy: null,
+              claimedUntil: null,
+              lastError: null,
+            },
           });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -176,13 +180,17 @@ export class RuntimeEvolveWorker implements DurableMemoryWorkerLike {
   #requeueOrFail(record: PostRunJobRecord, message: string): void {
     const nextAttempt = record.attempt + 1;
     const shouldFail = nextAttempt >= this.#maxAttempts;
-    this.#store.updatePostRunJob(record.jobId, {
-      status: shouldFail ? "FAILED" : "QUEUED",
-      attempt: nextAttempt,
-      claimedBy: null,
-      claimedUntil: null,
-      availableAt: shouldFail ? record.availableAt : new Date(Date.now() + this.#retryDelayMs).toISOString(),
-      lastError: { message },
+    this.#store.updatePostRunJob({
+      workspaceId: record.workspaceId,
+      jobId: record.jobId,
+      fields: {
+        status: shouldFail ? "FAILED" : "QUEUED",
+        attempt: nextAttempt,
+        claimedBy: null,
+        claimedUntil: null,
+        availableAt: shouldFail ? record.availableAt : new Date(Date.now() + this.#retryDelayMs).toISOString(),
+        lastError: { message },
+      },
     });
   }
 }

--- a/runtime/api-server/src/evolve.test.ts
+++ b/runtime/api-server/src/evolve.test.ts
@@ -155,7 +155,13 @@ test("createEvolveTaskProposal tags task proposals with the evolve source", () =
   });
 
   assert.equal(proposal.proposalSource, "evolve");
-  assert.equal(store.getTaskProposal("proposal-evolve-1")?.proposalSource, "evolve");
+  assert.equal(
+    store.getTaskProposal({
+      workspaceId: "workspace-1",
+      proposalId: "proposal-evolve-1"
+    })?.proposalSource,
+    "evolve"
+  );
   store.close();
 });
 
@@ -516,8 +522,19 @@ test("processClaimedInput promotes accepted evolve skill candidates into live wo
 
   const liveSkillPath = path.join(workspaceDir, "skills", "release-verification", "SKILL.md");
   assert.equal(fs.readFileSync(liveSkillPath, "utf8"), draftMarkdown);
-  assert.equal(store.getEvolveSkillCandidate("evolve-skill-input-10")?.status, "promoted");
-  assert.ok(store.getEvolveSkillCandidate("evolve-skill-input-10")?.promotedAt);
+  assert.equal(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-10"
+    })?.status,
+    "promoted"
+  );
+  assert.ok(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-10"
+    })?.promotedAt
+  );
   store.close();
 });
 
@@ -664,7 +681,13 @@ test("processClaimedInput promotes misplaced evolve workspace skill files into t
     path: "workspace/workspace-1/evolve/skills/evolve-skill-input-10/SKILL.md",
   });
   assert.equal(updatedDraft.text, misplacedMarkdown);
-  assert.equal(store.getEvolveSkillCandidate("evolve-skill-input-10")?.status, "promoted");
+  assert.equal(
+    store.getEvolveSkillCandidate({
+      workspaceId: "workspace-1",
+      candidateId: "evolve-skill-input-10"
+    })?.status,
+    "promoted"
+  );
   store.close();
 });
 

--- a/runtime/api-server/src/evolve.test.ts
+++ b/runtime/api-server/src/evolve.test.ts
@@ -767,7 +767,10 @@ test("sample completed turn queues durable memory work until the evolve worker r
 
   const immediateCapture = await memoryService.capture({ workspace_id: "workspace-1" });
   const immediateFiles = immediateCapture.files as Record<string, string>;
-  const queuedJob = store.getPostRunJobByIdempotencyKey(`${EVOLVE_JOB_TYPE}:${queued.inputId}`);
+  const queuedJob = store.getPostRunJobByIdempotencyKey({
+    workspaceId: "workspace-1",
+    idempotencyKey: `${EVOLVE_JOB_TYPE}:${queued.inputId}`,
+  });
 
   assert.ok(queuedJob);
   assert.equal(queuedJob.status, "QUEUED");
@@ -776,7 +779,10 @@ test("sample completed turn queues durable memory work until the evolve worker r
   assert.ok(!immediateFiles["workspace/workspace-1/knowledge/procedures/release-procedure.md"]);
 
   const processed = await worker.processAvailableJobsOnce();
-  const updatedJob = store.getPostRunJobByIdempotencyKey(`${EVOLVE_JOB_TYPE}:${queued.inputId}`);
+  const updatedJob = store.getPostRunJobByIdempotencyKey({
+    workspaceId: "workspace-1",
+    idempotencyKey: `${EVOLVE_JOB_TYPE}:${queued.inputId}`,
+  });
   const finalCapture = await memoryService.capture({ workspace_id: "workspace-1" });
   const finalFiles = finalCapture.files as Record<string, string>;
 
@@ -860,7 +866,7 @@ test("evolve memory worker marks claimed jobs done after successful execution", 
   });
 
   const processed = await worker.processAvailableJobsOnce();
-  const updated = store.getPostRunJob(queued.jobId);
+  const updated = store.getPostRunJob({ workspaceId: "workspace-1", jobId: queued.jobId });
 
   assert.equal(processed, 1);
   assert.deepEqual(seen, [queued.jobId]);
@@ -893,9 +899,9 @@ test("evolve memory worker retries once and then marks persistent failures faile
   });
 
   const firstProcessed = await worker.processAvailableJobsOnce();
-  const firstUpdated = store.getPostRunJob(queued.jobId);
+  const firstUpdated = store.getPostRunJob({ workspaceId: "workspace-1", jobId: queued.jobId });
   const secondProcessed = await worker.processAvailableJobsOnce();
-  const secondUpdated = store.getPostRunJob(queued.jobId);
+  const secondUpdated = store.getPostRunJob({ workspaceId: "workspace-1", jobId: queued.jobId });
 
   assert.equal(firstProcessed, 1);
   assert.ok(firstUpdated);

--- a/runtime/api-server/src/evolve.ts
+++ b/runtime/api-server/src/evolve.ts
@@ -100,9 +100,18 @@ export function enqueueEvolveJob(params: {
   const legacyReinforceIdempotencyKey = `${LEGACY_REINFORCE_MEMORY_WRITEBACK_JOB_TYPE}:${params.inputId}`;
   const legacyIdempotencyKey = `${LEGACY_DURABLE_MEMORY_WRITEBACK_JOB_TYPE}:${params.inputId}`;
   const existing =
-    params.store.getPostRunJobByIdempotencyKey(evolveIdempotencyKey) ??
-    params.store.getPostRunJobByIdempotencyKey(legacyReinforceIdempotencyKey) ??
-    params.store.getPostRunJobByIdempotencyKey(legacyIdempotencyKey);
+    params.store.getPostRunJobByIdempotencyKey({
+      workspaceId: params.workspaceId,
+      idempotencyKey: evolveIdempotencyKey,
+    }) ??
+    params.store.getPostRunJobByIdempotencyKey({
+      workspaceId: params.workspaceId,
+      idempotencyKey: legacyReinforceIdempotencyKey,
+    }) ??
+    params.store.getPostRunJobByIdempotencyKey({
+      workspaceId: params.workspaceId,
+      idempotencyKey: legacyIdempotencyKey,
+    });
   if (existing) {
     params.wakeWorker?.();
     return existing;

--- a/runtime/api-server/src/evolve.ts
+++ b/runtime/api-server/src/evolve.ts
@@ -133,7 +133,10 @@ export async function processEvolveJob(params: {
   ) {
     throw new Error(`unsupported evolve job type: ${params.record.jobType}`);
   }
-  const turnResult = params.store.getTurnResult({ inputId: params.record.inputId });
+  const turnResult = params.store.getTurnResult({
+    workspaceId: params.record.workspaceId,
+    inputId: params.record.inputId,
+  });
   if (!turnResult) {
     throw new Error(`turn result not found for evolve job input ${params.record.inputId}`);
   }

--- a/runtime/api-server/src/evolve.ts
+++ b/runtime/api-server/src/evolve.ts
@@ -35,7 +35,12 @@ export function createEvolveTaskProposal(params: {
   createdAt?: string;
   state?: string;
 }): TaskProposalRecord {
-  const existing = params.proposalId ? params.store.getTaskProposal(params.proposalId) : null;
+  const existing = params.proposalId
+    ? params.store.getTaskProposal({
+        workspaceId: params.workspaceId,
+        proposalId: params.proposalId,
+      })
+    : null;
   if (existing) {
     return existing;
   }
@@ -182,6 +187,7 @@ export async function processEvolveJob(params: {
     sourceEventIds: candidate.sourceTurnInputIds,
   });
   params.store.updateEvolveSkillCandidate({
+    workspaceId: candidate.workspaceId,
     candidateId: candidate.candidateId,
     fields: {
       taskProposalId: proposal.proposalId,

--- a/runtime/api-server/src/main-session-event-worker.test.ts
+++ b/runtime/api-server/src/main-session-event-worker.test.ts
@@ -100,10 +100,10 @@ test("main-session event worker materializes waiting-user events into one queued
   });
 
   const processed = await worker.processAvailableEventsOnce();
-  const firstUpdated = store.getMainSessionEvent({ eventId: first.eventId });
-  const secondUpdated = store.getMainSessionEvent({ eventId: second.eventId });
+  const firstUpdated = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: first.eventId });
+  const secondUpdated = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: second.eventId });
   const batchInput = firstUpdated?.materializedInputId
-    ? store.getInput(firstUpdated.materializedInputId)
+    ? store.getInput({ workspaceId: workspace.id, inputId: firstUpdated.materializedInputId })
     : null;
 
   assert.equal(processed, 2);
@@ -158,7 +158,7 @@ test("main-session event worker does not materialize when the main session is bu
 
   assert.equal(processed, 0);
   assert.equal(
-    store.listPendingMainSessionEvents({ ownerMainSessionId: "session-main" })
+    store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main" })
       .length,
     1,
   );
@@ -180,6 +180,7 @@ test("main-session event worker defers its first startup scan until after the in
     payload: { summary: "Done." },
   });
   const initialEvent = store.listPendingMainSessionEvents({
+    workspaceId: workspace.id,
     ownerMainSessionId: "session-main",
   })[0];
 
@@ -192,7 +193,7 @@ test("main-session event worker defers its first startup scan until after the in
     await worker.start();
 
     assert.equal(
-      store.listPendingMainSessionEvents({ ownerMainSessionId: "session-main" })
+      store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main" })
         .length,
       1,
     );
@@ -207,7 +208,7 @@ test("main-session event worker defers its first startup scan until after the in
     await sleep(250);
 
     const updatedEvent = initialEvent
-      ? store.getMainSessionEvent({ eventId: initialEvent.eventId })
+      ? store.getMainSessionEvent({ workspaceId: workspace.id, eventId: initialEvent.eventId })
       : null;
     assert.equal(updatedEvent?.status, "materialized");
     assert.ok(updatedEvent?.materializedInputId);
@@ -237,10 +238,14 @@ test("main-session event worker inherits the owner main session model and thinki
       context: {},
     },
   });
-  store.updateInput(latestUserInput.inputId, {
-    status: "DONE",
-    claimedBy: null,
-    claimedUntil: null,
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: latestUserInput.inputId,
+    fields: {
+      status: "DONE",
+      claimedBy: null,
+      claimedUntil: null,
+    },
   });
   const event = store.enqueueMainSessionEvent({
     workspaceId: workspace.id,
@@ -280,9 +285,9 @@ test("main-session event worker inherits the owner main session model and thinki
 
   const worker = new RuntimeMainSessionEventWorker({ store });
   const processed = await worker.processAvailableEventsOnce();
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
   const batchInput = updatedEvent?.materializedInputId
-    ? store.getInput(updatedEvent.materializedInputId)
+    ? store.getInput({ workspaceId: workspace.id, inputId: updatedEvent.materializedInputId })
     : null;
 
   assert.equal(processed, 1);
@@ -332,10 +337,14 @@ test("main-session event worker recovers failed materialized events and retries 
       context: {},
     },
   });
-  store.updateInput(latestUserInput.inputId, {
-    status: "DONE",
-    claimedBy: null,
-    claimedUntil: null,
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: latestUserInput.inputId,
+    fields: {
+      status: "DONE",
+      claimedBy: null,
+      claimedUntil: null,
+    },
   });
   const event = store.enqueueMainSessionEvent({
     workspaceId: workspace.id,
@@ -361,21 +370,26 @@ test("main-session event worker recovers failed materialized events and retries 
     },
     idempotencyKey: `main-session-event-batch:${event.eventId}@${event.updatedAt}`,
   });
-  store.updateInput(failedBatchInput.inputId, {
-    status: "FAILED",
-    claimedBy: null,
-    claimedUntil: null,
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: failedBatchInput.inputId,
+    fields: {
+      status: "FAILED",
+      claimedBy: null,
+      claimedUntil: null,
+    },
   });
   store.markMainSessionEventsMaterialized({
+    workspaceId: workspace.id,
     eventIds: [event.eventId],
     materializedInputId: failedBatchInput.inputId,
   });
 
   const worker = new RuntimeMainSessionEventWorker({ store });
   const processed = await worker.processAvailableEventsOnce();
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
   const retriedInput = updatedEvent?.materializedInputId
-    ? store.getInput(updatedEvent.materializedInputId)
+    ? store.getInput({ workspaceId: workspace.id, inputId: updatedEvent.materializedInputId })
     : null;
 
   assert.equal(processed, 1);
@@ -401,17 +415,18 @@ test("main-session event worker ignores already materialized events", async () =
     payload: { summary: "Done." },
   });
   store.markMainSessionEventsMaterialized({
+    workspaceId: workspace.id,
     eventIds: [event.eventId],
     materializedInputId: "main-input-1",
   });
 
   const worker = new RuntimeMainSessionEventWorker({ store });
   const processed = await worker.processAvailableEventsOnce();
-  const updatedEvent = store.getMainSessionEvent({ eventId: event.eventId });
+  const updatedEvent = store.getMainSessionEvent({ workspaceId: workspace.id, eventId: event.eventId });
 
   assert.equal(processed, 0);
   assert.equal(
-    store.listPendingMainSessionEvents({ ownerMainSessionId: "session-main" })
+    store.listPendingMainSessionEvents({ workspaceId: workspace.id, ownerMainSessionId: "session-main" })
       .length,
     0,
   );

--- a/runtime/api-server/src/main-session-event-worker.ts
+++ b/runtime/api-server/src/main-session-event-worker.ts
@@ -264,6 +264,7 @@ export class RuntimeMainSessionEventWorker
           },
         });
         this.#store.markMainSessionEventsMaterialized({
+          workspaceId: workspace.id,
           eventIds,
           materializedInputId: input.inputId,
         });

--- a/runtime/api-server/src/memory-embedding-index.test.ts
+++ b/runtime/api-server/src/memory-embedding-index.test.ts
@@ -31,7 +31,7 @@ function makeMemoryEntry(
 ): MemoryEntryRecord {
   return {
     memoryId: overrides.memoryId,
-    workspaceId: overrides.workspaceId ?? "workspace-1",
+    workspaceId: overrides.workspaceId === undefined ? "workspace-1" : overrides.workspaceId,
     sessionId: overrides.sessionId ?? "session-1",
     scope: overrides.scope,
     memoryType: overrides.memoryType,
@@ -119,7 +119,10 @@ test("syncDurableMemoryEmbedding indexes markdown leaves and skips unchanged con
     },
   });
 
-  const indexed = store.getMemoryEmbeddingIndexByMemoryId(entry.memoryId);
+  const indexed = store.getMemoryEmbeddingIndexByMemoryId({
+    memoryId: entry.memoryId,
+    workspaceId: entry.workspaceId,
+  });
   assert.equal(first, "indexed");
   assert.ok(indexed);
   assert.equal(indexed?.path, entry.path);

--- a/runtime/api-server/src/memory-embedding-index.ts
+++ b/runtime/api-server/src/memory-embedding-index.ts
@@ -128,7 +128,10 @@ export async function syncDurableMemoryEmbedding(params: {
     tags: params.entry.tags,
     excerpt,
   });
-  const existing = params.store.getMemoryEmbeddingIndexByMemoryId(params.entry.memoryId);
+  const existing = params.store.getMemoryEmbeddingIndexByMemoryId({
+    memoryId: params.entry.memoryId,
+    workspaceId: params.entry.workspaceId,
+  });
   if (
     existing &&
     existing.contentFingerprint === contentFingerprint &&

--- a/runtime/api-server/src/memory-recall-manifest.test.ts
+++ b/runtime/api-server/src/memory-recall-manifest.test.ts
@@ -7,6 +7,10 @@ import { afterEach, test } from "node:test";
 import { RuntimeStateStore, type MemoryEntryRecord } from "@holaboss/runtime-state-store";
 
 import { recalledMemoryContextFromManifest } from "./memory-recall-manifest.js";
+import {
+  globalMemoryDirForWorkspaceRoot,
+  workspaceMemoryDir,
+} from "./workspace-bundle-paths.js";
 
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -15,7 +19,11 @@ afterEach(() => {
 });
 
 function writeMemoryFile(workspaceRoot: string, relPath: string, content: string): void {
-  const absPath = path.join(workspaceRoot, "memory", ...relPath.split("/"));
+  const normalized = relPath.replaceAll("\\", "/").replace(/^\/+/, "");
+  const match = /^workspace\/([^/]+)\/(.+)$/.exec(normalized);
+  const absPath = match
+    ? path.join(workspaceMemoryDir(path.join(workspaceRoot, match[1])), match[2])
+    : path.join(globalMemoryDirForWorkspaceRoot(workspaceRoot), ...normalized.split("/"));
   fs.mkdirSync(path.dirname(absPath), { recursive: true });
   fs.writeFileSync(absPath, content, "utf8");
 }

--- a/runtime/api-server/src/memory-recall-manifest.test.ts
+++ b/runtime/api-server/src/memory-recall-manifest.test.ts
@@ -34,7 +34,7 @@ function makeMemoryEntry(
 ): MemoryEntryRecord {
   return {
     memoryId: overrides.memoryId,
-    workspaceId: overrides.workspaceId ?? "workspace-1",
+    workspaceId: overrides.workspaceId === undefined ? "workspace-1" : overrides.workspaceId,
     sessionId: overrides.sessionId ?? "session-1",
     scope: overrides.scope,
     memoryType: overrides.memoryType,

--- a/runtime/api-server/src/memory-recall-manifest.ts
+++ b/runtime/api-server/src/memory-recall-manifest.ts
@@ -10,6 +10,7 @@ import type {
   RuntimeStateStore,
 } from "@holaboss/runtime-state-store";
 import yaml from "js-yaml";
+import { resolveMemoryFilePath } from "./workspace-bundle-paths.js";
 
 import type { AgentRecalledMemoryContext } from "./agent-runtime-prompt.js";
 import { governanceRuleForMemoryType, assessMemoryFreshness } from "./memory-governance.js";
@@ -130,15 +131,17 @@ function normalizeRelPath(value: string): string {
   return value.split(path.sep).join("/");
 }
 
-function resolveMemoryRootDir(workspaceRoot: string, workspaceId: string): string {
-  const configured = (process.env.MEMORY_ROOT_DIR ?? "").trim();
-  if (!configured) {
-    return path.join(workspaceRoot, "memory");
-  }
-  if (path.isAbsolute(configured)) {
-    return path.resolve(configured);
-  }
-  return path.resolve(path.join(workspaceRoot, configured));
+function resolveMemoryAbsolutePath(params: {
+  workspaceRoot: string;
+  workspaceId: string;
+  relPath: string;
+}): string {
+  return resolveMemoryFilePath({
+    workspaceRoot: params.workspaceRoot,
+    workspaceDir: path.join(params.workspaceRoot, params.workspaceId),
+    workspaceId: params.workspaceId,
+    relPath: params.relPath,
+  });
 }
 
 function frontmatterBlock(value: string): string | null {
@@ -311,7 +314,6 @@ function identityMemoryIndexPath(): string {
 }
 
 function indexFiles(workspaceRoot: string, workspaceId: string): IndexFileRecord[] {
-  const memoryRootDir = resolveMemoryRootDir(workspaceRoot, workspaceId);
   const records: Array<{ path: string; scope: RecallScope | "root" }> = [
     { path: rootMemoryIndexPath(), scope: "root" },
     { path: workspaceMemoryIndexPath(workspaceId), scope: "workspace" },
@@ -319,7 +321,11 @@ function indexFiles(workspaceRoot: string, workspaceId: string): IndexFileRecord
     { path: identityMemoryIndexPath(), scope: "identity" },
   ];
   return records.map((record) => {
-    const absPath = path.join(memoryRootDir, record.path);
+    const absPath = resolveMemoryAbsolutePath({
+      workspaceRoot,
+      workspaceId,
+      relPath: record.path,
+    });
     return {
       path: record.path,
       absPath,
@@ -730,8 +736,11 @@ function readLeafMemoryRecord(params: {
   if (!recallScope) {
     return null;
   }
-  const memoryRootDir = resolveMemoryRootDir(params.workspaceRoot, params.workspaceId);
-  const absPath = path.join(memoryRootDir, params.relPath);
+  const absPath = resolveMemoryAbsolutePath({
+    workspaceRoot: params.workspaceRoot,
+    workspaceId: params.workspaceId,
+    relPath: params.relPath,
+  });
   if (!fs.existsSync(absPath)) {
     return null;
   }

--- a/runtime/api-server/src/memory-recall.test.ts
+++ b/runtime/api-server/src/memory-recall.test.ts
@@ -8,7 +8,7 @@ import { recalledMemoryContextFromEntries } from "./memory-recall.js";
 function makeMemoryEntry(overrides: Partial<MemoryEntryRecord> & Pick<MemoryEntryRecord, "memoryId" | "scope" | "memoryType" | "path" | "title" | "summary">): MemoryEntryRecord {
   return {
     memoryId: overrides.memoryId,
-    workspaceId: overrides.workspaceId ?? "workspace-1",
+    workspaceId: overrides.workspaceId === undefined ? "workspace-1" : overrides.workspaceId,
     sessionId: overrides.sessionId ?? "session-1",
     scope: overrides.scope,
     memoryType: overrides.memoryType,

--- a/runtime/api-server/src/memory.test.ts
+++ b/runtime/api-server/src/memory.test.ts
@@ -85,6 +85,8 @@ test("filesystem memory service preserves search/get/upsert/status/sync payload 
     workspace_id: "workspace-1",
     path: "MEMORY.md"
   });
+  const captured = await service.capture({ workspace_id: "workspace-1" });
+  const capturedFiles = captured.files as Record<string, string>;
 
   assert.equal(Array.isArray(searched.results), true);
   assert.equal((searched.results as Array<Record<string, unknown>>).length >= 1, true);
@@ -109,6 +111,9 @@ test("filesystem memory service preserves search/get/upsert/status/sync payload 
     path: "MEMORY.md",
     text: "# Memory Index\n"
   });
+  assert.equal(capturedFiles["workspace/workspace-1/notes.md"], "# Notes\ncoffee preference\nsecond line\n");
+  assert.equal(capturedFiles["workspace/workspace-1/new.md"], "hello");
+  assert.equal(capturedFiles["MEMORY.md"], "# Memory Index\n");
   assert.equal(status.backend, "builtin");
   assert.equal(
     fs.existsSync(path.join(workspaceMemoryDir(path.join(workspaceRoot, "workspace-1")), "notes.md")),

--- a/runtime/api-server/src/memory.test.ts
+++ b/runtime/api-server/src/memory.test.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { afterEach, test } from "node:test";
 
 import { FilesystemMemoryService as MemoryService } from "./memory.js";
+import {
+  globalMemoryDirForWorkspaceRoot,
+  workspaceMemoryDir,
+} from "./workspace-bundle-paths.js";
 
 const tempDirs: string[] = [];
 const envNames = ["MEMORY_BACKEND", "MEMORY_ROOT_DIR"] as const;
@@ -37,14 +41,15 @@ function makeTempDir(prefix: string): string {
 test("filesystem memory service preserves search/get/upsert/status/sync payload shape", async () => {
   const root = makeTempDir("hb-memory-");
   const workspaceRoot = path.join(root, "workspace");
-  fs.mkdirSync(path.join(workspaceRoot, "memory", "workspace", "workspace-1"), { recursive: true });
-  fs.mkdirSync(path.join(workspaceRoot, "memory", "preference"), { recursive: true });
+  const legacyMemoryRoot = globalMemoryDirForWorkspaceRoot(workspaceRoot);
+  fs.mkdirSync(path.join(legacyMemoryRoot, "workspace", "workspace-1"), { recursive: true });
+  fs.mkdirSync(path.join(legacyMemoryRoot, "preference"), { recursive: true });
   fs.writeFileSync(
-    path.join(workspaceRoot, "memory", "workspace", "workspace-1", "notes.md"),
+    path.join(legacyMemoryRoot, "workspace", "workspace-1", "notes.md"),
     "# Notes\ncoffee preference\nsecond line\n",
     "utf8"
   );
-  fs.writeFileSync(path.join(workspaceRoot, "memory", "preference", "profile.md"), "coffee and tea\n", "utf8");
+  fs.writeFileSync(path.join(legacyMemoryRoot, "preference", "profile.md"), "coffee and tea\n", "utf8");
 
   const service = new MemoryService({ workspaceRoot });
 
@@ -105,6 +110,14 @@ test("filesystem memory service preserves search/get/upsert/status/sync payload 
     text: "# Memory Index\n"
   });
   assert.equal(status.backend, "builtin");
+  assert.equal(
+    fs.existsSync(path.join(workspaceMemoryDir(path.join(workspaceRoot, "workspace-1")), "notes.md")),
+    true,
+  );
+  assert.equal(
+    fs.existsSync(path.join(legacyMemoryRoot, "workspace", "workspace-1", "notes.md")),
+    false,
+  );
   assert.deepEqual(synced, {
     success: true,
     status

--- a/runtime/api-server/src/memory.test.ts
+++ b/runtime/api-server/src/memory.test.ts
@@ -129,6 +129,47 @@ test("filesystem memory service preserves search/get/upsert/status/sync payload 
   });
 });
 
+test("filesystem memory service resolves workspace-local bundles from the registered custom workspace path", async () => {
+  const root = makeTempDir("hb-memory-custom-");
+  const workspaceRoot = path.join(root, "workspace");
+  const customWorkspaceDir = path.join(root, "custom-workspace");
+  const service = new MemoryService({
+    workspaceRoot,
+    resolveWorkspaceDir(workspaceId) {
+      assert.equal(workspaceId, "workspace-custom");
+      return customWorkspaceDir;
+    },
+  });
+
+  await service.upsert({
+    workspace_id: "workspace-custom",
+    path: "workspace/workspace-custom/notes.md",
+    content: "custom workspace memory\n",
+    append: false,
+  });
+
+  const fetched = await service.get({
+    workspace_id: "workspace-custom",
+    path: "workspace/workspace-custom/notes.md",
+  });
+  const captured = await service.capture({ workspace_id: "workspace-custom" });
+  const capturedFiles = captured.files as Record<string, string>;
+
+  assert.deepEqual(fetched, {
+    path: "workspace/workspace-custom/notes.md",
+    text: "custom workspace memory\n",
+  });
+  assert.equal(
+    fs.existsSync(path.join(workspaceMemoryDir(customWorkspaceDir), "notes.md")),
+    true,
+  );
+  assert.equal(
+    fs.existsSync(path.join(workspaceRoot, "workspace-custom", ".holaboss", "memory", "notes.md")),
+    false,
+  );
+  assert.equal(capturedFiles["workspace/workspace-custom/notes.md"], "custom workspace memory\n");
+});
+
 test("filesystem memory service reports generic fallback metadata for unsupported backends", async () => {
   const root = makeTempDir("hb-memory-");
   process.env.MEMORY_BACKEND = "sqlite";

--- a/runtime/api-server/src/memory.ts
+++ b/runtime/api-server/src/memory.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import {
+  globalMemoryDirForWorkspaceRoot,
+  migrateLegacyWorkspaceMemoryIfNeeded,
+  workspaceMemoryDir,
+} from "./workspace-bundle-paths.js";
 
 const MEMORY_BACKEND_ENV = "MEMORY_BACKEND";
 const MEMORY_ROOT_DIR_ENV = "MEMORY_ROOT_DIR";
@@ -135,18 +140,6 @@ function workspaceDirForWorkspaceId(workspaceRoot: string, workspaceId: string):
   return workspaceDir;
 }
 
-function resolveMemoryRootDir(workspaceDir: string): string {
-  const configured = (process.env[MEMORY_ROOT_DIR_ENV] ?? "").trim();
-  const baseDir = path.dirname(path.resolve(workspaceDir));
-  if (!configured) {
-    return path.resolve(baseDir, "memory");
-  }
-  if (path.isAbsolute(configured)) {
-    return path.resolve(configured);
-  }
-  return path.resolve(baseDir, configured);
-}
-
 function listMarkdownFiles(root: string): string[] {
   if (!fs.existsSync(root)) {
     return [];
@@ -263,23 +256,82 @@ function resolveMemoryBackend(): ResolvedMemoryBackend {
   };
 }
 
-function memoryFiles(memoryRootDir: string, workspaceId: string): string[] {
+function workspaceMemoryFiles(workspaceMemoryRootDir: string): string[] {
   const files: string[] = [];
-  const rootEntrypoint = path.join(memoryRootDir, "MEMORY.md");
+  const rootEntrypoint = path.join(workspaceMemoryRootDir, "MEMORY.md");
   if (fs.existsSync(rootEntrypoint) && fs.statSync(rootEntrypoint).isFile()) {
     files.push(rootEntrypoint);
   }
-  files.push(...listMarkdownFiles(path.join(memoryRootDir, workspaceScopePrefix(workspaceId).replace(/\/$/, ""))));
-  if (fs.existsSync(memoryRootDir) && fs.statSync(memoryRootDir).isDirectory()) {
-    const entries = fs.readdirSync(memoryRootDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  files.push(...listMarkdownFiles(path.join(workspaceMemoryRootDir, "runtime")));
+  files.push(...listMarkdownFiles(path.join(workspaceMemoryRootDir, "knowledge")));
+  return files;
+}
+
+function globalMemoryFiles(globalMemoryRootDir: string): string[] {
+  const files: string[] = [];
+  const rootEntrypoint = path.join(globalMemoryRootDir, "MEMORY.md");
+  if (fs.existsSync(rootEntrypoint) && fs.statSync(rootEntrypoint).isFile()) {
+    files.push(rootEntrypoint);
+  }
+  if (fs.existsSync(globalMemoryRootDir) && fs.statSync(globalMemoryRootDir).isDirectory()) {
+    const entries = fs.readdirSync(globalMemoryRootDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name === "workspace") {
         continue;
       }
-      files.push(...listMarkdownFiles(path.join(memoryRootDir, entry.name)));
+      files.push(...listMarkdownFiles(path.join(globalMemoryRootDir, entry.name)));
     }
   }
   return files;
+}
+
+type ResolvedMemoryRoots = {
+  workspaceDir: string;
+  workspaceMemoryRootDir: string;
+  globalMemoryRootDir: string;
+  migratedWorkspaceMemory: boolean;
+};
+
+function resolveMemoryRoots(params: {
+  workspaceRoot: string;
+  workspaceId: string;
+}): ResolvedMemoryRoots {
+  const workspaceDir = workspaceDirForWorkspaceId(params.workspaceRoot, params.workspaceId);
+  const migration = migrateLegacyWorkspaceMemoryIfNeeded({
+    workspaceRoot: params.workspaceRoot,
+    workspaceDir,
+    workspaceId: params.workspaceId,
+  });
+  return {
+    workspaceDir,
+    workspaceMemoryRootDir: workspaceMemoryDir(workspaceDir),
+    globalMemoryRootDir: globalMemoryDirForWorkspaceRoot(params.workspaceRoot),
+    migratedWorkspaceMemory: migration.migrated,
+  };
+}
+
+function workspaceScopedRelativePath(relPath: string, workspaceId: string): string | null {
+  const prefix = workspaceScopePrefix(workspaceId);
+  return relPath.startsWith(prefix) ? relPath.slice(prefix.length) : null;
+}
+
+function resolveMemoryTargetPath(params: {
+  normalizedPath: string;
+  workspaceId: string;
+  workspaceMemoryRootDir: string;
+  globalMemoryRootDir: string;
+}): { storageRoot: string; absolutePath: string } {
+  const workspaceRelativePath = workspaceScopedRelativePath(params.normalizedPath, params.workspaceId);
+  if (workspaceRelativePath !== null) {
+    return {
+      storageRoot: params.workspaceMemoryRootDir,
+      absolutePath: path.resolve(params.workspaceMemoryRootDir, workspaceRelativePath),
+    };
+  }
+  return {
+    storageRoot: params.globalMemoryRootDir,
+    absolutePath: path.resolve(params.globalMemoryRootDir, params.normalizedPath),
+  };
 }
 
 function relativePosixPath(root: string, targetPath: string): string {
@@ -289,10 +341,15 @@ function relativePosixPath(root: string, targetPath: string): string {
 function statusPayload(params: {
   workspaceDir: string;
   workspaceId: string;
-  memoryRootDir: string;
+  workspaceMemoryRootDir: string;
+  globalMemoryRootDir: string;
+  migratedWorkspaceMemory?: boolean;
 }): Record<string, unknown> {
   const backend = resolveMemoryBackend();
-  const files = memoryFiles(params.memoryRootDir, params.workspaceId);
+  const files = [
+    ...workspaceMemoryFiles(params.workspaceMemoryRootDir),
+    ...globalMemoryFiles(params.globalMemoryRootDir),
+  ];
   const payload: Record<string, unknown> = {
     backend: "builtin",
     provider: "filesystem",
@@ -307,8 +364,10 @@ function statusPayload(params: {
     sources: ["memory"],
     fallback: null,
     custom: {
-      memory_root_dir: params.memoryRootDir,
-      workspace_scope: workspaceScopePrefix(params.workspaceId).replace(/\/$/, "")
+      workspace_memory_root_dir: params.workspaceMemoryRootDir,
+      global_memory_root_dir: params.globalMemoryRootDir,
+      workspace_scope: workspaceScopePrefix(params.workspaceId).replace(/\/$/, ""),
+      migrated_workspace_memory: Boolean(params.migratedWorkspaceMemory),
     }
   };
   if (backend.requestedProvider && backend.fallbackReason) {
@@ -323,13 +382,28 @@ function statusPayload(params: {
 function capturePayload(params: {
   workspaceDir: string;
   workspaceId: string;
-  memoryRootDir: string;
+  workspaceMemoryRootDir: string;
+  globalMemoryRootDir: string;
+  migratedWorkspaceMemory?: boolean;
 }): Record<string, unknown> {
   const status = statusPayload(params);
   const files: Record<string, string> = {};
   let totalChars = 0;
-  for (const filePath of memoryFiles(params.memoryRootDir, params.workspaceId)) {
-    const relativePath = relativePosixPath(params.memoryRootDir, filePath);
+  for (const filePath of workspaceMemoryFiles(params.workspaceMemoryRootDir)) {
+    const relativePath = path.posix.join(
+      workspaceScopePrefix(params.workspaceId).replace(/\/$/, ""),
+      relativePosixPath(params.workspaceMemoryRootDir, filePath),
+    );
+    try {
+      const text = fs.readFileSync(filePath, "utf8");
+      files[relativePath] = text;
+      totalChars += text.length;
+    } catch {
+      // Ignore unreadable files in bundle capture.
+    }
+  }
+  for (const filePath of globalMemoryFiles(params.globalMemoryRootDir)) {
+    const relativePath = relativePosixPath(params.globalMemoryRootDir, filePath);
     try {
       const text = fs.readFileSync(filePath, "utf8");
       files[relativePath] = text;
@@ -363,11 +437,10 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     const query = requiredString(payload.query, "query");
     const maxResults = optionalInteger(payload.max_results, 6);
     const minScore = optionalNumber(payload.min_score, 0.0);
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
     const results: Array<Record<string, unknown>> = [];
 
-    for (const filePath of memoryFiles(memoryRootDir, workspaceId)) {
+    for (const filePath of workspaceMemoryFiles(roots.workspaceMemoryRootDir)) {
       let text: string;
       try {
         text = fs.readFileSync(filePath, "utf8");
@@ -380,7 +453,33 @@ export class FilesystemMemoryService implements MemoryServiceLike {
       }
       const snippet = snippetForMatch(text, query);
       results.push({
-        path: relativePosixPath(memoryRootDir, filePath),
+        path: path.posix.join(
+          workspaceScopePrefix(workspaceId).replace(/\/$/, ""),
+          relativePosixPath(roots.workspaceMemoryRootDir, filePath),
+        ),
+        start_line: snippet.startLine,
+        end_line: snippet.endLine,
+        score,
+        snippet: snippet.snippet,
+        source: "memory",
+        citation: null
+      });
+    }
+
+    for (const filePath of globalMemoryFiles(roots.globalMemoryRootDir)) {
+      let text: string;
+      try {
+        text = fs.readFileSync(filePath, "utf8");
+      } catch {
+        continue;
+      }
+      const score = scoreText(query, text);
+      if (score < minScore) {
+        continue;
+      }
+      const snippet = snippetForMatch(text, query);
+      results.push({
+        path: relativePosixPath(roots.globalMemoryRootDir, filePath),
         start_line: snippet.startLine,
         end_line: snippet.endLine,
         score,
@@ -404,7 +503,13 @@ export class FilesystemMemoryService implements MemoryServiceLike {
 
     return {
       results: results.slice(0, Math.max(1, maxResults)),
-      status: statusPayload({ workspaceDir, workspaceId, memoryRootDir })
+      status: statusPayload({
+        workspaceDir: roots.workspaceDir,
+        workspaceId,
+        workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+        globalMemoryRootDir: roots.globalMemoryRootDir,
+        migratedWorkspaceMemory: roots.migratedWorkspaceMemory,
+      })
     };
   }
 
@@ -415,16 +520,23 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     if (!isMemoryPath(normalized, workspaceId)) {
       throw new MemoryServiceError(400, MEMORY_ALLOWED_PATHS_MESSAGE);
     }
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
-    const target = path.resolve(memoryRootDir, normalized);
-    if (target !== memoryRootDir && !target.startsWith(`${memoryRootDir}${path.sep}`)) {
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const resolvedTarget = resolveMemoryTargetPath({
+      normalizedPath: normalized,
+      workspaceId,
+      workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+      globalMemoryRootDir: roots.globalMemoryRootDir,
+    });
+    if (
+      resolvedTarget.absolutePath !== resolvedTarget.storageRoot &&
+      !resolvedTarget.absolutePath.startsWith(`${resolvedTarget.storageRoot}${path.sep}`)
+    ) {
       throw new MemoryServiceError(400, "path escapes memory root");
     }
-    if (!fs.existsSync(target) || !fs.statSync(target).isFile()) {
+    if (!fs.existsSync(resolvedTarget.absolutePath) || !fs.statSync(resolvedTarget.absolutePath).isFile()) {
       return { path: normalized, text: "" };
     }
-    const text = fs.readFileSync(target, "utf8");
+    const text = fs.readFileSync(resolvedTarget.absolutePath, "utf8");
     return {
       path: normalized,
       text: readLineWindow(
@@ -444,48 +556,70 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     }
     const content = typeof payload.content === "string" ? payload.content : "";
     const append = optionalBoolean(payload.append, false);
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
-    const target = path.resolve(memoryRootDir, normalized);
-    if (target !== memoryRootDir && !target.startsWith(`${memoryRootDir}${path.sep}`)) {
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const resolvedTarget = resolveMemoryTargetPath({
+      normalizedPath: normalized,
+      workspaceId,
+      workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+      globalMemoryRootDir: roots.globalMemoryRootDir,
+    });
+    if (
+      resolvedTarget.absolutePath !== resolvedTarget.storageRoot &&
+      !resolvedTarget.absolutePath.startsWith(`${resolvedTarget.storageRoot}${path.sep}`)
+    ) {
       throw new MemoryServiceError(400, "path escapes memory root");
     }
-    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.mkdirSync(path.dirname(resolvedTarget.absolutePath), { recursive: true });
 
-    if (append && fs.existsSync(target)) {
-      const existing = fs.readFileSync(target, "utf8");
+    if (append && fs.existsSync(resolvedTarget.absolutePath)) {
+      const existing = fs.readFileSync(resolvedTarget.absolutePath, "utf8");
       const prefix = existing && !existing.endsWith("\n") ? "\n" : "";
-      fs.writeFileSync(target, `${existing}${prefix}${content}`, "utf8");
+      fs.writeFileSync(resolvedTarget.absolutePath, `${existing}${prefix}${content}`, "utf8");
     } else {
-      fs.writeFileSync(target, content, "utf8");
+      fs.writeFileSync(resolvedTarget.absolutePath, content, "utf8");
     }
     return {
       path: normalized,
-      text: fs.readFileSync(target, "utf8")
+      text: fs.readFileSync(resolvedTarget.absolutePath, "utf8")
     };
   }
 
   async status(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
-    return statusPayload({ workspaceDir, workspaceId, memoryRootDir });
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    return statusPayload({
+      workspaceDir: roots.workspaceDir,
+      workspaceId,
+      workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+      globalMemoryRootDir: roots.globalMemoryRootDir,
+      migratedWorkspaceMemory: roots.migratedWorkspaceMemory,
+    });
   }
 
   async sync(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
     return {
       success: true,
-      status: statusPayload({ workspaceDir, workspaceId, memoryRootDir })
+      status: statusPayload({
+        workspaceDir: roots.workspaceDir,
+        workspaceId,
+        workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+        globalMemoryRootDir: roots.globalMemoryRootDir,
+        migratedWorkspaceMemory: roots.migratedWorkspaceMemory,
+      })
     };
   }
 
   async capture(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const workspaceDir = workspaceDirForWorkspaceId(this.#workspaceRoot, workspaceId);
-    const memoryRootDir = resolveMemoryRootDir(workspaceDir);
-    return capturePayload({ workspaceDir, workspaceId, memoryRootDir });
+    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    return capturePayload({
+      workspaceDir: roots.workspaceDir,
+      workspaceId,
+      workspaceMemoryRootDir: roots.workspaceMemoryRootDir,
+      globalMemoryRootDir: roots.globalMemoryRootDir,
+      migratedWorkspaceMemory: roots.migratedWorkspaceMemory,
+    });
   }
 }

--- a/runtime/api-server/src/memory.ts
+++ b/runtime/api-server/src/memory.ts
@@ -257,14 +257,7 @@ function resolveMemoryBackend(): ResolvedMemoryBackend {
 }
 
 function workspaceMemoryFiles(workspaceMemoryRootDir: string): string[] {
-  const files: string[] = [];
-  const rootEntrypoint = path.join(workspaceMemoryRootDir, "MEMORY.md");
-  if (fs.existsSync(rootEntrypoint) && fs.statSync(rootEntrypoint).isFile()) {
-    files.push(rootEntrypoint);
-  }
-  files.push(...listMarkdownFiles(path.join(workspaceMemoryRootDir, "runtime")));
-  files.push(...listMarkdownFiles(path.join(workspaceMemoryRootDir, "knowledge")));
-  return files;
+  return listMarkdownFiles(workspaceMemoryRootDir);
 }
 
 function globalMemoryFiles(globalMemoryRootDir: string): string[] {

--- a/runtime/api-server/src/memory.ts
+++ b/runtime/api-server/src/memory.ts
@@ -288,8 +288,10 @@ type ResolvedMemoryRoots = {
 function resolveMemoryRoots(params: {
   workspaceRoot: string;
   workspaceId: string;
+  resolveWorkspaceDir?: ((workspaceId: string) => string) | null;
 }): ResolvedMemoryRoots {
-  const workspaceDir = workspaceDirForWorkspaceId(params.workspaceRoot, params.workspaceId);
+  const workspaceDir = params.resolveWorkspaceDir?.(params.workspaceId)
+    ?? workspaceDirForWorkspaceId(params.workspaceRoot, params.workspaceId);
   const migration = migrateLegacyWorkspaceMemoryIfNeeded({
     workspaceRoot: params.workspaceRoot,
     workspaceDir,
@@ -416,13 +418,16 @@ function capturePayload(params: {
 
 export interface FilesystemMemoryServiceOptions {
   workspaceRoot: string;
+  resolveWorkspaceDir?: ((workspaceId: string) => string) | null;
 }
 
 export class FilesystemMemoryService implements MemoryServiceLike {
   readonly #workspaceRoot: string;
+  readonly #resolveWorkspaceDir: ((workspaceId: string) => string) | null;
 
   constructor(options: FilesystemMemoryServiceOptions) {
     this.#workspaceRoot = options.workspaceRoot;
+    this.#resolveWorkspaceDir = options.resolveWorkspaceDir ?? null;
   }
 
   async search(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -430,7 +435,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     const query = requiredString(payload.query, "query");
     const maxResults = optionalInteger(payload.max_results, 6);
     const minScore = optionalNumber(payload.min_score, 0.0);
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     const results: Array<Record<string, unknown>> = [];
 
     for (const filePath of workspaceMemoryFiles(roots.workspaceMemoryRootDir)) {
@@ -513,7 +522,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     if (!isMemoryPath(normalized, workspaceId)) {
       throw new MemoryServiceError(400, MEMORY_ALLOWED_PATHS_MESSAGE);
     }
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     const resolvedTarget = resolveMemoryTargetPath({
       normalizedPath: normalized,
       workspaceId,
@@ -549,7 +562,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
     }
     const content = typeof payload.content === "string" ? payload.content : "";
     const append = optionalBoolean(payload.append, false);
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     const resolvedTarget = resolveMemoryTargetPath({
       normalizedPath: normalized,
       workspaceId,
@@ -579,7 +596,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
 
   async status(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     return statusPayload({
       workspaceDir: roots.workspaceDir,
       workspaceId,
@@ -591,7 +612,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
 
   async sync(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     return {
       success: true,
       status: statusPayload({
@@ -606,7 +631,11 @@ export class FilesystemMemoryService implements MemoryServiceLike {
 
   async capture(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceId = requiredString(payload.workspace_id, "workspace_id");
-    const roots = resolveMemoryRoots({ workspaceRoot: this.#workspaceRoot, workspaceId });
+    const roots = resolveMemoryRoots({
+      workspaceRoot: this.#workspaceRoot,
+      workspaceId,
+      resolveWorkspaceDir: this.#resolveWorkspaceDir,
+    });
     return capturePayload({
       workspaceDir: roots.workspaceDir,
       workspaceId,

--- a/runtime/api-server/src/queue-worker.test.ts
+++ b/runtime/api-server/src/queue-worker.test.ts
@@ -52,6 +52,27 @@ async function waitFor(
   }
 }
 
+function outputEventsForInput(
+  store: RuntimeStateStore,
+  record: { workspaceId: string; sessionId: string; inputId: string },
+) {
+  return store.listOutputEvents({
+    workspaceId: record.workspaceId,
+    sessionId: record.sessionId,
+    inputId: record.inputId,
+  });
+}
+
+function turnResultForInput(
+  store: RuntimeStateStore,
+  record: { workspaceId: string; inputId: string },
+) {
+  return store.getTurnResult({
+    workspaceId: record.workspaceId,
+    inputId: record.inputId,
+  });
+}
+
 test("runtime queue worker claims queued inputs and executes them in claim order", async () => {
   const root = makeTempDir("hb-runtime-queue-worker-");
   const store = new RuntimeStateStore({
@@ -325,10 +346,14 @@ test("runtime queue worker can pause a queued session input before it is claimed
     sessionId: "session-main",
   });
   const events = store.listOutputEvents({
+    workspaceId: queued.workspaceId,
     sessionId: "session-main",
     inputId: queued.inputId,
   });
-  const turnResult = store.getTurnResult({ inputId: queued.inputId });
+  const turnResult = store.getTurnResult({
+    workspaceId: queued.workspaceId,
+    inputId: queued.inputId,
+  });
 
   assert.deepEqual(paused, {
     inputId: queued.inputId,
@@ -434,6 +459,7 @@ test("runtime queue worker recovers expired claimed input before processing fres
     sessionId: "session-main"
   });
   const staleEvents = store.listOutputEvents({
+    workspaceId: stale.workspaceId,
     sessionId: "session-main",
     inputId: stale.inputId
   });
@@ -527,6 +553,7 @@ test("runtime queue worker recovers a stale claimed input from another worker be
   const staleUpdated = store.getInput(stale.inputId);
   const freshUpdated = store.getInput(fresh.inputId);
   const events = store.listOutputEvents({
+    workspaceId: stale.workspaceId,
     sessionId: "session-main",
     inputId: stale.inputId
   });
@@ -615,6 +642,7 @@ test("runtime queue worker requeues a stale claimed input when execution never s
     sessionId: "session-main",
   });
   const events = store.listOutputEvents({
+    workspaceId: stale.workspaceId,
     sessionId: "session-main",
     inputId: stale.inputId,
   });
@@ -754,6 +782,7 @@ test("runtime queue worker aborts an active run when recovering an expired claim
     sessionId: "session-main"
   });
   const events = store.listOutputEvents({
+    workspaceId: queued.workspaceId,
     sessionId: "session-main",
     inputId: queued.inputId
   });
@@ -865,6 +894,7 @@ test("runtime queue worker renews an expired claimed input while it waits on a s
 
   const updated = store.getInput(queued.inputId);
   const events = store.listOutputEvents({
+    workspaceId: queued.workspaceId,
     sessionId: "session-main",
     inputId: queued.inputId,
   });

--- a/runtime/api-server/src/queue-worker.test.ts
+++ b/runtime/api-server/src/queue-worker.test.ts
@@ -103,11 +103,11 @@ test("runtime queue worker claims queued inputs and executes them in claim order
     store,
     executeClaimedInput: async (record) => {
       seen.push(record.inputId);
-      store.updateInput(record.inputId, {
+      store.updateInput({ workspaceId: record.workspaceId, inputId: record.inputId, fields: {
         status: "DONE",
         claimedBy: null,
         claimedUntil: null,
-      });
+      } });
     }
   });
 
@@ -238,8 +238,8 @@ test("runtime queue worker claims later queued work from another session while o
   await bStarted.promise;
 
   assert.deepEqual(seenSessions.sort(), ["session-a", "session-b"]);
-  assert.equal(store.getInput(sessionASecond.inputId)?.status, "QUEUED");
-  assert.equal(store.getInput(sessionBFirst.inputId)?.status, "CLAIMED");
+  assert.equal(store.getInput({ workspaceId: sessionASecond.workspaceId, inputId: sessionASecond.inputId })?.status, "QUEUED");
+  assert.equal(store.getInput({ workspaceId: sessionBFirst.workspaceId, inputId: sessionBFirst.inputId })?.status, "CLAIMED");
 
   release.resolve();
   await worker.close();
@@ -283,7 +283,7 @@ test("runtime queue worker marks claimed input failed when delegated execution r
   });
 
   const processed = await worker.processAvailableInputsOnce();
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main"
@@ -340,7 +340,7 @@ test("runtime queue worker can pause a queued session input before it is claimed
     workspaceId: "workspace-1",
     sessionId: "session-main",
   });
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main",
@@ -415,9 +415,9 @@ test("runtime queue worker recovers expired claimed input before processing fres
     eventType: "run_started",
     payload: { status: "running" },
   });
-  store.updateInput(stale.inputId, {
+  store.updateInput({ workspaceId: stale.workspaceId, inputId: stale.inputId, fields: {
     claimedUntil: "2000-01-01T00:00:00.000Z"
-  });
+  } });
   store.updateRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main",
@@ -433,11 +433,11 @@ test("runtime queue worker recovers expired claimed input before processing fres
     store,
     executeClaimedInput: async (record) => {
       seen.push(record.inputId);
-      store.updateInput(record.inputId, {
+      store.updateInput({ workspaceId: record.workspaceId, inputId: record.inputId, fields: {
         status: "DONE",
         claimedBy: null,
         claimedUntil: null
-      });
+      } });
       store.updateRuntimeState({
         workspaceId: record.workspaceId,
         sessionId: record.sessionId,
@@ -452,8 +452,8 @@ test("runtime queue worker recovers expired claimed input before processing fres
   });
 
   const processed = await worker.processAvailableInputsOnce();
-  const staleUpdated = store.getInput(stale.inputId);
-  const freshUpdated = store.getInput(fresh.inputId);
+  const staleUpdated = store.getInput({ workspaceId: stale.workspaceId, inputId: stale.inputId });
+  const freshUpdated = store.getInput({ workspaceId: fresh.workspaceId, inputId: fresh.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main"
@@ -531,11 +531,11 @@ test("runtime queue worker recovers a stale claimed input from another worker be
     claimStaleHeartbeatMs: 1_000,
     executeClaimedInput: async (record) => {
       seen.push(record.inputId);
-      store.updateInput(record.inputId, {
+      store.updateInput({ workspaceId: record.workspaceId, inputId: record.inputId, fields: {
         status: "DONE",
         claimedBy: null,
         claimedUntil: null
-      });
+      } });
       store.updateRuntimeState({
         workspaceId: record.workspaceId,
         sessionId: record.sessionId,
@@ -550,8 +550,8 @@ test("runtime queue worker recovers a stale claimed input from another worker be
   });
 
   const processed = await worker.processAvailableInputsOnce();
-  const staleUpdated = store.getInput(stale.inputId);
-  const freshUpdated = store.getInput(fresh.inputId);
+  const staleUpdated = store.getInput({ workspaceId: stale.workspaceId, inputId: stale.inputId });
+  const freshUpdated = store.getInput({ workspaceId: fresh.workspaceId, inputId: fresh.inputId });
   const events = store.listOutputEvents({
     workspaceId: stale.workspaceId,
     sessionId: "session-main",
@@ -616,11 +616,11 @@ test("runtime queue worker requeues a stale claimed input when execution never s
     claimStaleHeartbeatMs: 1_000,
     executeClaimedInput: async (record) => {
       seen.push(record.inputId);
-      store.updateInput(record.inputId, {
+      store.updateInput({ workspaceId: record.workspaceId, inputId: record.inputId, fields: {
         status: "DONE",
         claimedBy: null,
         claimedUntil: null,
-      });
+      } });
       store.updateRuntimeState({
         workspaceId: record.workspaceId,
         sessionId: record.sessionId,
@@ -636,7 +636,7 @@ test("runtime queue worker requeues a stale claimed input when execution never s
 
   const processed = await worker.processAvailableInputsOnce();
 
-  const updated = store.getInput(stale.inputId);
+  const updated = store.getInput({ workspaceId: stale.workspaceId, inputId: stale.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main",
@@ -708,8 +708,8 @@ test("runtime queue worker does not recover a claimed input from another worker 
   const processed = await worker.processAvailableInputsOnce();
 
   assert.equal(processed, 0);
-  assert.equal(store.getInput(active.inputId)?.status, "CLAIMED");
-  assert.equal(store.getInput(blocked.inputId)?.status, "QUEUED");
+  assert.equal(store.getInput({ workspaceId: active.workspaceId, inputId: active.inputId })?.status, "CLAIMED");
+  assert.equal(store.getInput({ workspaceId: blocked.workspaceId, inputId: blocked.inputId })?.status, "QUEUED");
 
   store.close();
 });
@@ -759,9 +759,9 @@ test("runtime queue worker aborts an active run when recovering an expired claim
   assert.equal(firstProcessed, 1);
   await started.promise;
 
-  store.updateInput(queued.inputId, {
+  store.updateInput({ workspaceId: queued.workspaceId, inputId: queued.inputId, fields: {
     claimedUntil: "2000-01-01T00:00:00.000Z"
-  });
+  } });
   store.updateRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main",
@@ -776,7 +776,7 @@ test("runtime queue worker aborts an active run when recovering an expired claim
   const secondProcessed = await worker.processAvailableInputsOnce();
   await worker.close();
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId });
   const runtimeState = store.getRuntimeState({
     workspaceId: "workspace-1",
     sessionId: "session-main"
@@ -823,11 +823,11 @@ test("runtime queue worker renews an expired claimed input while it waits on a s
       },
     },
   });
-  store.updatePostRunJob(checkpointJob.jobId, {
+  store.updatePostRunJob({ workspaceId: checkpointJob.workspaceId, jobId: checkpointJob.jobId, fields: {
     status: "CLAIMED",
     claimedBy: "memory-worker",
     claimedUntil: new Date(Date.now() + 60_000).toISOString(),
-  });
+  } });
   const queued = store.enqueueInput({
     workspaceId: "workspace-1",
     sessionId: "session-main",
@@ -851,11 +851,11 @@ test("runtime queue worker renews an expired claimed input while it waits on a s
           }).length === 0,
         5_000,
       );
-      store.updateInput(record.inputId, {
+      store.updateInput({ workspaceId: record.workspaceId, inputId: record.inputId, fields: {
         status: "DONE",
         claimedBy: null,
         claimedUntil: null,
-      });
+      } });
       store.updateRuntimeState({
         workspaceId: record.workspaceId,
         sessionId: record.sessionId,
@@ -872,27 +872,32 @@ test("runtime queue worker renews an expired claimed input while it waits on a s
   await worker.start();
   worker.wake();
 
-  await waitFor(() => store.getInput(queued.inputId)?.status === "CLAIMED");
+  await waitFor(
+    () => store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId })?.status === "CLAIMED",
+  );
   await sleep(1_250);
 
-  const claimedWhileWaiting = store.getInput(queued.inputId);
+  const claimedWhileWaiting = store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId });
   assert.ok(claimedWhileWaiting);
   assert.equal(claimedWhileWaiting.status, "CLAIMED");
   assert.ok(claimedWhileWaiting.claimedUntil);
   assert.ok(Date.parse(claimedWhileWaiting.claimedUntil) > Date.now());
 
-  store.updatePostRunJob(checkpointJob.jobId, {
+  store.updatePostRunJob({ workspaceId: checkpointJob.workspaceId, jobId: checkpointJob.jobId, fields: {
     status: "DONE",
     claimedBy: null,
     claimedUntil: null,
     lastError: null,
-  });
+  } });
   worker.wake();
 
-  await waitFor(() => store.getInput(queued.inputId)?.status === "DONE", 5_000);
+  await waitFor(
+    () => store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId })?.status === "DONE",
+    5_000,
+  );
   await worker.close();
 
-  const updated = store.getInput(queued.inputId);
+  const updated = store.getInput({ workspaceId: queued.workspaceId, inputId: queued.inputId });
   const events = store.listOutputEvents({
     workspaceId: queued.workspaceId,
     sessionId: "session-main",

--- a/runtime/api-server/src/queue-worker.ts
+++ b/runtime/api-server/src/queue-worker.ts
@@ -361,6 +361,7 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
 
       activeRun?.controller.abort("claim_expired");
       const events = this.#store.listOutputEvents({
+        workspaceId: record.workspaceId,
         sessionId: record.sessionId,
         inputId: record.inputId
       });
@@ -551,7 +552,10 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
     record: SessionInputRecord,
     events: Array<{ eventType: string }>,
   ): boolean {
-    const turnResult = this.#store.getTurnResult({ inputId: record.inputId });
+    const turnResult = this.#store.getTurnResult({
+      workspaceId: record.workspaceId,
+      inputId: record.inputId,
+    });
     if (turnResult) {
       return false;
     }
@@ -561,6 +565,7 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
   #persistPausedQueuedInput(record: SessionInputRecord): void {
     const completedAt = utcNowIso();
     const events = this.#store.listOutputEvents({
+      workspaceId: record.workspaceId,
       sessionId: record.sessionId,
       inputId: record.inputId,
     });

--- a/runtime/api-server/src/queue-worker.ts
+++ b/runtime/api-server/src/queue-worker.ts
@@ -177,7 +177,10 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
       return null;
     }
 
-    const record = this.#store.getInput(inputId);
+    const record = this.#store.getInput({
+      workspaceId: params.workspaceId,
+      inputId,
+    });
     if (!record || record.workspaceId !== params.workspaceId || record.sessionId !== params.sessionId) {
       return null;
     }
@@ -278,10 +281,14 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
           sessionId: record.sessionId,
           error: message
         });
-        this.#store.updateInput(record.inputId, {
-          status: "FAILED",
-          claimedBy: null,
-          claimedUntil: null
+        this.#store.updateInput({
+          workspaceId: record.workspaceId,
+          inputId: record.inputId,
+          fields: {
+            status: "FAILED",
+            claimedBy: null,
+            claimedUntil: null
+          }
         });
         this.#store.updateRuntimeState({
           workspaceId: record.workspaceId,
@@ -329,6 +336,7 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
         }).length > 0;
       if (waitingForSessionCheckpoint) {
         const renewedClaim = this.#store.renewInputClaim({
+          workspaceId: record.workspaceId,
           inputId: record.inputId,
           claimedBy: record.claimedBy ?? this.#claimedBy,
           leaseSeconds: this.#leaseSeconds,
@@ -371,12 +379,16 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
         !hasTerminal &&
         this.#shouldRequeueRecoveredClaim(record, events);
       if (shouldRequeue) {
-        this.#store.updateInput(record.inputId, {
-          status: "QUEUED",
-          claimedBy: null,
-          claimedUntil: null,
-          availableAt: utcNowIso(),
-          attempt: record.attempt + 1,
+        this.#store.updateInput({
+          workspaceId: record.workspaceId,
+          inputId: record.inputId,
+          fields: {
+            status: "QUEUED",
+            claimedBy: null,
+            claimedUntil: null,
+            availableAt: utcNowIso(),
+            attempt: record.attempt + 1,
+          },
         });
 
         const runtimeStateAfterRecovery = this.#store.getRuntimeState({
@@ -454,10 +466,14 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
         });
       }
 
-      this.#store.updateInput(record.inputId, {
-        status: "FAILED",
-        claimedBy: null,
-        claimedUntil: null
+      this.#store.updateInput({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+        fields: {
+          status: "FAILED",
+          claimedBy: null,
+          claimedUntil: null
+        }
       });
 
       const runtimeStateAfterRecovery = this.#store.getRuntimeState({
@@ -588,10 +604,14 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
       payload: completed.payload as Record<string, unknown>,
       createdAt: completedAt,
     });
-    this.#store.updateInput(record.inputId, {
-      status: "PAUSED",
-      claimedBy: null,
-      claimedUntil: null,
+    this.#store.updateInput({
+      workspaceId: record.workspaceId,
+      inputId: record.inputId,
+      fields: {
+        status: "PAUSED",
+        claimedBy: null,
+        claimedUntil: null,
+      },
     });
     this.#store.updateRuntimeState({
       workspaceId: record.workspaceId,

--- a/runtime/api-server/src/runtime-agent-tools.test.ts
+++ b/runtime/api-server/src/runtime-agent-tools.test.ts
@@ -1096,7 +1096,7 @@ test("createDataTable writes rows into the shared workspace data.db", () => {
   assert.equal(result.table_name, "demo_dashboard_data");
   assert.equal(result.row_count, 3);
   assert.equal(result.column_count, 4);
-  assert.equal(result.db_path, ".holaboss/data.db");
+  assert.equal(result.db_path, ".holaboss/state/data.db");
   assert.equal(fs.existsSync(path.join(harness.workspaceDir, "data.db")), false);
 
   const tables = harness.service.listDataTables({ workspaceId: harness.workspaceId })

--- a/runtime/api-server/src/runtime-agent-tools.test.ts
+++ b/runtime/api-server/src/runtime-agent-tools.test.ts
@@ -70,7 +70,7 @@ test("continueSubagent queues a new input onto the same completed child session"
       sessionId: childSessionId,
       payload: { text: "search the web for AI" },
     });
-    store.updateInput(firstInput.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: firstInput.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -136,7 +136,7 @@ test("continueSubagent queues a new input onto the same completed child session"
     const session = store.getSession({ workspaceId, sessionId: childSessionId });
     assert.equal(session?.archivedAt, null);
     const nextInputId = String(result.latest_child_input_id);
-    const nextInput = store.getInput(nextInputId);
+    const nextInput = store.getInput({ workspaceId, inputId: nextInputId });
     assert.ok(nextInput);
     assert.equal(nextInput?.sessionId, childSessionId);
     assert.equal(nextInput?.payload.model, "gpt-test");
@@ -214,7 +214,7 @@ test("continueSubagent inherits the composer-selected thinking value for the eff
         thinking_value: "medium",
       },
     });
-    store.updateInput(firstInput.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: firstInput.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -256,7 +256,7 @@ test("continueSubagent inherits the composer-selected thinking value for the eff
       selectedModel: "openai/gpt-5.5",
     }) as Record<string, unknown>;
 
-    const nextInput = store.getInput(String(result.latest_child_input_id));
+    const nextInput = store.getInput({ workspaceId, inputId: String(result.latest_child_input_id) });
     assert.equal(nextInput?.payload.model, "openai/gpt-5.5");
     assert.equal(nextInput?.payload.thinking_value, "medium");
   } finally {
@@ -325,12 +325,14 @@ test("delegateTask only opts into the user browser surface when the parent input
       ],
     }) as { tasks?: Array<Record<string, unknown>> };
 
-    const explicitInput = store.getInput(
-      String(explicitResult.tasks?.[0]?.latest_child_input_id ?? ""),
-    );
-    const implicitInput = store.getInput(
-      String(implicitResult.tasks?.[0]?.latest_child_input_id ?? ""),
-    );
+    const explicitInput = store.getInput({
+      workspaceId,
+      inputId: String(explicitResult.tasks?.[0]?.latest_child_input_id ?? ""),
+    });
+    const implicitInput = store.getInput({
+      workspaceId,
+      inputId: String(implicitResult.tasks?.[0]?.latest_child_input_id ?? ""),
+    });
 
     assert.equal(
       (explicitInput?.payload.context as Record<string, unknown> | undefined)
@@ -401,7 +403,7 @@ test("delegateTask inherits the composer-selected model and thinking when no sub
 
     const tasks = result.tasks ?? [];
     assert.equal(tasks.length, 1);
-    const childInput = store.getInput(String(tasks[0]?.latest_child_input_id ?? ""));
+    const childInput = store.getInput({ workspaceId, inputId: String(tasks[0]?.latest_child_input_id ?? "") });
     assert.equal(childInput?.payload.model, "openai/gpt-5.5");
     assert.equal(childInput?.payload.thinking_value, "medium");
   } finally {
@@ -453,7 +455,7 @@ test("continueSubagent preserves the user browser surface flag for follow-up wor
         },
       },
     });
-    store.updateInput(firstInput.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: firstInput.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -493,7 +495,7 @@ test("continueSubagent preserves the user browser surface flag for follow-up wor
       instruction: "Try again now that the page is ready.",
     }) as Record<string, unknown>;
 
-    const nextInput = store.getInput(String(result.latest_child_input_id));
+    const nextInput = store.getInput({ workspaceId, inputId: String(result.latest_child_input_id) });
     assert.equal(
       (nextInput?.payload.context as Record<string, unknown> | undefined)
         ?.use_user_browser_surface,
@@ -541,7 +543,7 @@ test("background task sync preserves persisted waiting-on-user blockers", async 
       sessionId: childSessionId,
       payload: { text: "check account stats" },
     });
-    store.updateInput(input.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: input.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -644,7 +646,7 @@ test("resumeSubagent preserves the user browser surface flag while waiting on us
         },
       },
     });
-    store.updateInput(blockedInput.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: blockedInput.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -686,7 +688,7 @@ test("resumeSubagent preserves the user browser surface flag while waiting on us
       answer: "Logged in now.",
     }) as Record<string, unknown>;
 
-    const resumedInput = store.getInput(String(result.latest_child_input_id));
+    const resumedInput = store.getInput({ workspaceId, inputId: String(result.latest_child_input_id) });
     assert.equal(
       (resumedInput?.payload.context as Record<string, unknown> | undefined)
         ?.use_user_browser_surface,
@@ -747,7 +749,7 @@ test("resumeSubagent preserves the prior child thinking value", async () => {
         },
       },
     });
-    store.updateInput(blockedInput.inputId, { status: "DONE" });
+    store.updateInput({ workspaceId, inputId: blockedInput.inputId, fields: { status: "DONE" } });
     store.upsertTurnResult({
       workspaceId,
       sessionId: childSessionId,
@@ -790,7 +792,7 @@ test("resumeSubagent preserves the prior child thinking value", async () => {
       answer: "Logged in now.",
     }) as Record<string, unknown>;
 
-    const resumedInput = store.getInput(String(result.latest_child_input_id));
+    const resumedInput = store.getInput({ workspaceId, inputId: String(result.latest_child_input_id) });
     assert.equal(resumedInput?.payload.model, "openai/gpt-5.5");
     assert.equal(resumedInput?.payload.thinking_value, "medium");
   } finally {
@@ -836,11 +838,11 @@ test("cancelSubagent waits for a claimed child runtime to settle before returnin
       sessionId: childSessionId,
       payload: { text: "do work" },
     });
-    store.updateInput(queued.inputId, {
+    store.updateInput({ workspaceId, inputId: queued.inputId, fields: {
       status: "CLAIMED",
       claimedBy: "worker-1",
       claimedUntil: new Date(Date.now() + 60_000).toISOString(),
-    });
+    } });
     store.updateRuntimeState({
       workspaceId,
       sessionId: childSessionId,
@@ -879,11 +881,11 @@ test("cancelSubagent waits for a claimed child runtime to settle before returnin
           pauseCalls += 1;
           setTimeout(() => {
             const pausedAt = utcNowIso();
-            store.updateInput(queued.inputId, {
+            store.updateInput({ workspaceId, inputId: queued.inputId, fields: {
               status: "PAUSED",
               claimedBy: null,
               claimedUntil: null,
-            });
+            } });
             store.updateRuntimeState({
               workspaceId,
               sessionId: childSessionId,

--- a/runtime/api-server/src/runtime-agent-tools.test.ts
+++ b/runtime/api-server/src/runtime-agent-tools.test.ts
@@ -585,7 +585,7 @@ test("background task sync preserves persisted waiting-on-user blockers", async 
       statuses: ["waiting_on_user"],
     }) as Record<string, unknown>;
     const tasks = result.tasks as Array<Record<string, unknown>>;
-    const updatedRun = store.getSubagentRun({ subagentId });
+    const updatedRun = store.getSubagentRun({ workspaceId, subagentId });
 
     assert.equal(result.count, 1);
     assert.equal(tasks[0]?.status, "waiting_on_user");

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -3301,7 +3301,7 @@ export class RuntimeAgentToolsService {
         row_count: rows.length,
         column_count: columns.length,
         replaced_existing: exists && replaceExisting,
-        db_path: ".holaboss/data.db",
+        db_path: ".holaboss/state/data.db",
       };
     } catch (error) {
       if (error instanceof RuntimeAgentToolsServiceError) {

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -2943,7 +2943,12 @@ export class RuntimeAgentToolsService {
       normalizedString(run.initialChildInputId);
     const currentInput = currentInputId ? this.store.getInput(currentInputId) : null;
     const latestInput = latestInputId ? this.store.getInput(latestInputId) : null;
-    const latestTurnResult = latestInputId ? this.store.getTurnResult({ inputId: latestInputId }) : null;
+    const latestTurnResult = latestInputId
+      ? this.store.getTurnResult({
+          workspaceId: run.workspaceId,
+          inputId: latestInputId,
+        })
+      : null;
 
     const runtimeStatus = normalizedString(runtimeState?.status).toUpperCase();
     const currentInputStatus = normalizedString(currentInput?.status).toUpperCase();

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -2773,15 +2773,24 @@ export class RuntimeAgentToolsService {
   }
 
   getTerminalSession(params: RuntimeAgentToolsGetTerminalSessionParams): JsonObject {
-    return terminalSessionPayload(this.requireTerminalSession(params));
+    return terminalSessionPayload(
+      this.requireTerminalSession({
+        terminalId: params.terminalId,
+        workspaceId: normalizedString(params.workspaceId),
+      })
+    );
   }
 
   readTerminalSession(params: RuntimeAgentToolsReadTerminalSessionParams): JsonObject {
     const manager = this.requireTerminalSessionManager();
-    const terminal = this.requireTerminalSession(params);
+    const terminal = this.requireTerminalSession({
+      terminalId: params.terminalId,
+      workspaceId: normalizedString(params.workspaceId),
+    });
     const afterSequence = normalizedInteger(params.afterSequence, 0, 0, Number.MAX_SAFE_INTEGER);
     const limit = normalizedInteger(params.limit, 200, 1, 1000);
     const events = manager.listEvents({
+      workspaceId: terminal.workspaceId,
       terminalId: terminal.terminalId,
       afterSequence,
       limit,
@@ -2791,17 +2800,24 @@ export class RuntimeAgentToolsService {
 
   async waitTerminalSession(params: RuntimeAgentToolsWaitTerminalSessionParams): Promise<JsonObject> {
     const manager = this.requireTerminalSessionManager();
-    const initialTerminal = this.requireTerminalSession(params);
+    const initialTerminal = this.requireTerminalSession({
+      terminalId: params.terminalId,
+      workspaceId: normalizedString(params.workspaceId),
+    });
     const afterSequence = normalizedInteger(params.afterSequence, 0, 0, Number.MAX_SAFE_INTEGER);
     const limit = normalizedInteger(params.limit, 200, 1, 1000);
     const timeoutMs = normalizedInteger(params.timeoutMs, 15_000, 1, 60_000);
     const immediateEvents = manager.listEvents({
+      workspaceId: initialTerminal.workspaceId,
       terminalId: initialTerminal.terminalId,
       afterSequence,
       limit,
     });
     if (immediateEvents.length > 0 || !["starting", "running"].includes(initialTerminal.status)) {
-      const terminal = this.requireTerminalSession(params);
+      const terminal = this.requireTerminalSession({
+        terminalId: params.terminalId,
+        workspaceId: normalizedString(params.workspaceId),
+      });
       return terminalSessionReadPayload({
         terminal,
         events: immediateEvents,
@@ -2823,8 +2839,12 @@ export class RuntimeAgentToolsService {
           clearTimeout(timeoutHandle);
         }
         unsubscribe();
-        const terminal = this.requireTerminalSession(params);
+        const terminal = this.requireTerminalSession({
+          terminalId: params.terminalId,
+          workspaceId: normalizedString(params.workspaceId),
+        });
         const events = manager.listEvents({
+          workspaceId: terminal.workspaceId,
           terminalId: terminal.terminalId,
           afterSequence,
           limit,
@@ -2851,8 +2871,12 @@ export class RuntimeAgentToolsService {
   }
 
   async sendTerminalSessionInput(params: RuntimeAgentToolsSendTerminalSessionInputParams): Promise<JsonObject> {
-    this.requireTerminalSession(params);
+    const terminal = this.requireTerminalSession({
+      terminalId: params.terminalId,
+      workspaceId: normalizedString(params.workspaceId),
+    });
     const session = await this.requireTerminalSessionManager().sendInput({
+      workspaceId: terminal.workspaceId,
       terminalId: normalizedString(params.terminalId),
       data: params.data,
     });
@@ -2860,8 +2884,12 @@ export class RuntimeAgentToolsService {
   }
 
   async signalTerminalSession(params: RuntimeAgentToolsSignalTerminalSessionParams): Promise<JsonObject> {
-    this.requireTerminalSession(params);
+    const terminal = this.requireTerminalSession({
+      terminalId: params.terminalId,
+      workspaceId: normalizedString(params.workspaceId),
+    });
     const session = await this.requireTerminalSessionManager().signal({
+      workspaceId: terminal.workspaceId,
       terminalId: normalizedString(params.terminalId),
       signal: normalizedString(params.signal) || null,
     });
@@ -2869,8 +2897,12 @@ export class RuntimeAgentToolsService {
   }
 
   async closeTerminalSession(params: RuntimeAgentToolsCloseTerminalSessionParams): Promise<JsonObject> {
-    this.requireTerminalSession(params);
+    const terminal = this.requireTerminalSession({
+      terminalId: params.terminalId,
+      workspaceId: normalizedString(params.workspaceId),
+    });
     const session = await this.requireTerminalSessionManager().closeSession({
+      workspaceId: terminal.workspaceId,
       terminalId: normalizedString(params.terminalId),
     });
     return terminalSessionPayload(session);
@@ -3181,15 +3213,19 @@ export class RuntimeAgentToolsService {
 
   private requireTerminalSession(params: {
     terminalId: string;
-    workspaceId?: string | null;
+    workspaceId: string;
   }): TerminalSessionRecord {
     const terminalId = normalizedString(params.terminalId);
     if (!terminalId) {
       throw new RuntimeAgentToolsServiceError(400, "terminal_session_id_required", "terminal_id is required");
     }
+    const workspaceId = normalizedString(params.workspaceId);
+    if (!workspaceId) {
+      throw new RuntimeAgentToolsServiceError(400, "workspace_id_required", "workspace_id is required");
+    }
     const terminal = this.requireTerminalSessionManager().getSession({
       terminalId,
-      workspaceId: normalizedString(params.workspaceId) || undefined,
+      workspaceId,
     });
     if (!terminal) {
       throw new RuntimeAgentToolsServiceError(404, "terminal_session_not_found", "terminal session not found");

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -1818,6 +1818,7 @@ export class RuntimeAgentToolsService {
       });
       const updatedRun =
         this.store.updateSubagentRun({
+          workspaceId: params.workspaceId,
           subagentId: createdRun.subagentId,
           fields: {
             initialChildInputId: input.inputId,
@@ -1907,6 +1908,7 @@ export class RuntimeAgentToolsService {
       null;
     const updated =
       this.store.updateSubagentRun({
+        workspaceId: params.workspaceId,
         subagentId: state.run.subagentId,
         fields: {
           status: "cancelled",
@@ -1982,6 +1984,7 @@ export class RuntimeAgentToolsService {
     });
     const updated =
       this.store.updateSubagentRun({
+        workspaceId: params.workspaceId,
         subagentId: state.run.subagentId,
         fields: {
           ownerMainSessionId: controllerSession.sessionId,
@@ -2110,6 +2113,7 @@ export class RuntimeAgentToolsService {
     const nextTitle = normalizedSubagentTaskTitle(params.title, instruction);
     const updated =
       this.store.updateSubagentRun({
+        workspaceId: params.workspaceId,
         subagentId: state.run.subagentId,
         fields: {
           parentInputId: normalizedString(params.inputId) || state.run.parentInputId,
@@ -2900,8 +2904,8 @@ export class RuntimeAgentToolsService {
     if (!subagentId) {
       throw new RuntimeAgentToolsServiceError(400, "subagent_id_required", "subagent_id is required");
     }
-    const run = this.store.getSubagentRun({ subagentId });
-    if (!run || run.workspaceId !== params.workspaceId) {
+    const run = this.store.getSubagentRun({ workspaceId: params.workspaceId, subagentId });
+    if (!run) {
       throw new RuntimeAgentToolsServiceError(404, "subagent_not_found", "subagent not found");
     }
     return run;
@@ -2920,6 +2924,7 @@ export class RuntimeAgentToolsService {
     if (ownerMainSessionId && run.ownerMainSessionId !== ownerMainSessionId) {
       run =
         this.store.transferSubagentOwnership({
+          workspaceId: params.workspaceId,
           subagentId: run.subagentId,
           ownerMainSessionId,
         }) ?? run;
@@ -3042,6 +3047,7 @@ export class RuntimeAgentToolsService {
     const syncedRun =
       Object.keys(updates).length > 0
         ? (this.store.updateSubagentRun({
+            workspaceId: run.workspaceId,
             subagentId: run.subagentId,
             fields: updates,
           }) ?? run)

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -1592,7 +1592,8 @@ export class RuntimeAgentToolsService {
     jobId: string;
     workspaceId?: string | null;
   }): JsonObject | null {
-    const job = this.store.getCronjob(params.jobId);
+    const workspaceId = this.requireWorkspaceId(params.workspaceId);
+    const job = this.store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!job) {
       return null;
     }
@@ -1639,8 +1640,12 @@ export class RuntimeAgentToolsService {
   }
 
   updateCronjob(params: RuntimeAgentToolsUpdateCronjobParams): JsonObject {
-    const existing = this.requireCronjob(params.jobId);
-    this.assertCronjobBelongsToWorkspace(existing, params.workspaceId);
+    const workspaceId = this.requireWorkspaceId(params.workspaceId);
+    const existing = this.requireCronjob({
+      workspaceId,
+      jobId: params.jobId,
+    });
+    this.assertCronjobBelongsToWorkspace(existing, workspaceId);
     const cron = params.cron == null ? null : normalizedString(params.cron);
     if (params.cron !== undefined && !cron) {
       throw new RuntimeAgentToolsServiceError(400, "cronjob_cron_required", "cron is required");
@@ -1654,6 +1659,7 @@ export class RuntimeAgentToolsService {
       throw new RuntimeAgentToolsServiceError(400, "cronjob_instruction_required", "instruction is required");
     }
     const updated = this.store.updateCronjob({
+      workspaceId,
       jobId: params.jobId,
       name: params.name === undefined ? undefined : normalizedString(params.name),
       cron,
@@ -1681,12 +1687,13 @@ export class RuntimeAgentToolsService {
     jobId: string;
     workspaceId?: string | null;
   }): JsonObject {
-    const existing = this.store.getCronjob(params.jobId);
+    const workspaceId = this.requireWorkspaceId(params.workspaceId);
+    const existing = this.store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!existing) {
       return { success: false };
     }
     this.assertCronjobBelongsToWorkspace(existing, params.workspaceId);
-    return { success: this.store.deleteCronjob(params.jobId) };
+    return { success: this.store.deleteCronjob({ workspaceId, jobId: params.jobId }) };
   }
 
   delegateTask(params: RuntimeAgentToolsDelegateTaskParams): JsonObject {
@@ -3121,8 +3128,17 @@ export class RuntimeAgentToolsService {
     return workspace;
   }
 
-  private requireCronjob(jobId: string): CronjobRecord {
-    const job = this.store.getCronjob(jobId);
+  private requireWorkspaceId(workspaceId?: string | null): string {
+    const normalized = normalizedString(workspaceId);
+    if (!normalized) {
+      throw new RuntimeAgentToolsServiceError(400, "workspace_id_required", "workspace_id is required");
+    }
+    return normalized;
+  }
+
+  private requireCronjob(params: { workspaceId?: string | null; jobId: string }): CronjobRecord {
+    const workspaceId = this.requireWorkspaceId(params.workspaceId);
+    const job = this.store.getCronjob({ workspaceId, jobId: params.jobId });
     if (!job) {
       throw new RuntimeAgentToolsServiceError(404, "cronjob_not_found", "cronjob not found");
     }

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -1727,7 +1727,12 @@ export class RuntimeAgentToolsService {
       const childSessionId = `subagent-${randomUUID()}`;
       const title = normalizedSubagentTaskTitle(task.title, task.goal);
       const requestedModel = task.model || null;
-      const parentInput = parentInputId ? this.store.getInput(parentInputId) : null;
+      const parentInput = parentInputId
+        ? this.store.getInput({
+            workspaceId: params.workspaceId,
+            inputId: parentInputId,
+          })
+        : null;
       const allowUserBrowserSurface = textExplicitlyRequestsUserBrowserSurface(
         inputTextValue(parentInput),
       );
@@ -1850,10 +1855,14 @@ export class RuntimeAgentToolsService {
     }
     const now = utcNowIso();
     if (state.currentInput?.status === "QUEUED") {
-      this.store.updateInput(state.currentInput.inputId, {
-        status: "DONE",
-        claimedBy: null,
-        claimedUntil: null,
+      this.store.updateInput({
+        workspaceId: params.workspaceId,
+        inputId: state.currentInput.inputId,
+        fields: {
+          status: "DONE",
+          claimedBy: null,
+          claimedUntil: null,
+        },
       });
       this.store.updateRuntimeState({
         workspaceId: params.workspaceId,
@@ -1941,7 +1950,10 @@ export class RuntimeAgentToolsService {
       );
     }
     const previousChildInput = normalizedString(state.run.latestChildInputId)
-      ? this.store.getInput(normalizedString(state.run.latestChildInputId))
+      ? this.store.getInput({
+          workspaceId: params.workspaceId,
+          inputId: normalizedString(state.run.latestChildInputId),
+        })
       : null;
     const effectiveProfile = resolveSubagentExecutionProfile({
       selectedModel:
@@ -1972,7 +1984,7 @@ export class RuntimeAgentToolsService {
         },
       },
     });
-    this.store.updateRuntimeState({
+      this.store.updateRuntimeState({
       workspaceId: params.workspaceId,
       sessionId: state.run.childSessionId,
       status: "QUEUED",
@@ -1998,6 +2010,7 @@ export class RuntimeAgentToolsService {
       }) ?? state.run;
     const staleWaitingEventIds = this.store
       .listPendingMainSessionEvents({
+        workspaceId: params.workspaceId,
         ownerMainSessionId: controllerSession.sessionId,
         deliveryBucket: "waiting_on_user",
         limit: 500,
@@ -2006,6 +2019,7 @@ export class RuntimeAgentToolsService {
       .map((event) => event.eventId);
     if (staleWaitingEventIds.length > 0) {
       this.store.markMainSessionEventsSuperseded({
+        workspaceId: params.workspaceId,
         eventIds: staleWaitingEventIds,
       });
     }
@@ -2040,10 +2054,16 @@ export class RuntimeAgentToolsService {
       );
     }
     const parentInput = normalizedString(params.inputId)
-      ? this.store.getInput(normalizedString(params.inputId))
+      ? this.store.getInput({
+          workspaceId: params.workspaceId,
+          inputId: normalizedString(params.inputId),
+        })
       : null;
     const previousChildInput = normalizedString(state.run.latestChildInputId)
-      ? this.store.getInput(normalizedString(state.run.latestChildInputId))
+      ? this.store.getInput({
+          workspaceId: params.workspaceId,
+          inputId: normalizedString(state.run.latestChildInputId),
+        })
       : null;
     const effectiveProfile = resolveSubagentExecutionProfile({
       selectedModel:
@@ -2978,8 +2998,19 @@ export class RuntimeAgentToolsService {
       normalizedString(run.latestChildInputId) ||
       currentInputId ||
       normalizedString(run.initialChildInputId);
-    const currentInput = currentInputId ? this.store.getInput(currentInputId) : null;
-    const latestInput = latestInputId ? this.store.getInput(latestInputId) : null;
+    const workspaceId = run.workspaceId;
+    const currentInput = currentInputId
+      ? this.store.getInput({
+          workspaceId,
+          inputId: currentInputId,
+        })
+      : null;
+    const latestInput = latestInputId
+      ? this.store.getInput({
+          workspaceId,
+          inputId: latestInputId,
+        })
+      : null;
     const latestTurnResult = latestInputId
       ? this.store.getTurnResult({
           workspaceId: run.workspaceId,

--- a/runtime/api-server/src/runtime-sentry.test.ts
+++ b/runtime/api-server/src/runtime-sentry.test.ts
@@ -12,6 +12,7 @@ import {
 
 const tempDirs: string[] = [];
 const ENV_KEYS = [
+  "HOLABOSS_HOST_STATE_DB_PATH",
   "HOLABOSS_RUNTIME_DB_PATH",
   "HOLABOSS_RUNTIME_LOG_PATH",
   "HOLABOSS_RUNTIME_CONFIG_PATH",
@@ -45,11 +46,11 @@ function makeTempDir(prefix: string): string {
 
 test("runtime sentry diagnostics redact config and log attachments", () => {
   const root = makeTempDir("hb-runtime-sentry-");
-  const runtimeDbPath = path.join(root, "runtime.db");
+  const hostStateDbPath = path.join(root, "host-state.db");
   const runtimeLogPath = path.join(root, "runtime.log");
   const runtimeConfigPath = path.join(root, "runtime-config.json");
 
-  fs.writeFileSync(runtimeDbPath, "");
+  fs.writeFileSync(hostStateDbPath, "");
   fs.writeFileSync(
     runtimeLogPath,
     'token=abc123\ncookie=session-secret\nnormal line\n',
@@ -70,7 +71,7 @@ test("runtime sentry diagnostics redact config and log attachments", () => {
     "utf8",
   );
 
-  process.env.HOLABOSS_RUNTIME_DB_PATH = runtimeDbPath;
+  process.env.HOLABOSS_HOST_STATE_DB_PATH = hostStateDbPath;
   process.env.HOLABOSS_RUNTIME_LOG_PATH = runtimeLogPath;
   process.env.HOLABOSS_RUNTIME_CONFIG_PATH = runtimeConfigPath;
   process.env.HOLABOSS_RUNTIME_VERSION = "holaboss-desktop-2026.420.1";

--- a/runtime/api-server/src/runtime-sentry.ts
+++ b/runtime/api-server/src/runtime-sentry.ts
@@ -276,7 +276,9 @@ function readFileTail(filePath: string, maxBytes: number): string | null {
 }
 
 function runtimeSentrySnapshot(): Record<string, unknown> {
-  const runtimeDbPath = envPath("HOLABOSS_RUNTIME_DB_PATH");
+  const runtimeDbPath =
+    envPath("HOLABOSS_HOST_STATE_DB_PATH")
+    || envPath("HOLABOSS_RUNTIME_DB_PATH");
   const runtimeLogPath = envPath("HOLABOSS_RUNTIME_LOG_PATH");
   const runtimeConfigPath = envPath("HOLABOSS_RUNTIME_CONFIG_PATH");
   return {
@@ -295,7 +297,7 @@ function runtimeSentrySnapshot(): Record<string, unknown> {
       cwd: process.cwd(),
     },
     files: {
-      runtime_db: safeStat(runtimeDbPath),
+      host_state_db: safeStat(runtimeDbPath),
       runtime_log: safeStat(runtimeLogPath),
       runtime_config: safeStat(runtimeConfigPath),
     },

--- a/runtime/api-server/src/session-checkpoint.test.ts
+++ b/runtime/api-server/src/session-checkpoint.test.ts
@@ -342,7 +342,7 @@ test("session checkpoint merges snapshot compaction into a live session that onl
     assert.equal(latestEntry.summary, "Compacted older context.");
     assert.ok(branch.some((entry: FakeSessionEntry) => entry.id === baseLeafId));
 
-    const updatedJob = store.getPostRunJob(queued!.jobId);
+    const updatedJob = store.getPostRunJob({ workspaceId: workspace.id, jobId: queued!.jobId });
     assert.equal(
       (
         updatedJob?.payload.checkpoint_result as { outcome?: string } | undefined
@@ -507,7 +507,7 @@ test("session checkpoint re-resolves model client auth while preserving snapshot
       "X-Holaboss-Run-Id": `${workspace.id}:session-auth:input-auth`,
     });
 
-    const updatedJob = store.getPostRunJob(queued!.jobId);
+    const updatedJob = store.getPostRunJob({ workspaceId: workspace.id, jobId: queued!.jobId });
     assert.equal(
       (
         updatedJob?.payload.checkpoint_result as { outcome?: string } | undefined
@@ -604,7 +604,7 @@ test("session checkpoint records not_compacted when PI reports a compaction no-o
       }),
     });
 
-    const updatedJob = store.getPostRunJob(queued!.jobId);
+    const updatedJob = store.getPostRunJob({ workspaceId: workspace.id, jobId: queued!.jobId });
     assert.equal(
       (
         updatedJob?.payload.checkpoint_result as
@@ -740,7 +740,7 @@ test("session checkpoint treats provider 422 summarization failures as a soft no
     const branch = requireFakeSessionState(sessions, liveSessionFile).entries;
     assert.equal(branch.at(-1)?.type, "message");
 
-    const updatedJob = store.getPostRunJob(queued!.jobId);
+    const updatedJob = store.getPostRunJob({ workspaceId: workspace.id, jobId: queued!.jobId });
     assert.equal(
       (
         updatedJob?.payload.checkpoint_result as { outcome?: string } | undefined

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -809,6 +809,7 @@ export async function processSessionCheckpointJob(params: {
   }
 
   const snapshot = params.store.getTurnRequestSnapshot({
+    workspaceId: params.record.workspaceId,
     inputId: params.record.inputId,
   });
   if (!snapshot) {

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -287,8 +287,12 @@ function recordSessionCheckpointResult(params: {
       compaction: params.compaction ?? null,
     } satisfies SessionCheckpointResultRecord,
   };
-  params.store.updatePostRunJob(params.record.jobId, {
-    payload: nextPayload,
+  params.store.updatePostRunJob({
+    workspaceId: params.record.workspaceId,
+    jobId: params.record.jobId,
+    fields: {
+      payload: nextPayload,
+    },
   });
 }
 
@@ -397,7 +401,10 @@ export function enqueueSessionCheckpointJob(params: {
     params.sessionOps ?? defaultSessionCheckpointSessionOps
   ).currentLeafCheckpointState(harnessSessionId);
   const idempotencyKey = `${SESSION_CHECKPOINT_JOB_TYPE}:${params.sessionId}:${harnessSessionId}:${checkpointState.leafId ?? "root"}`;
-  const existing = params.store.getPostRunJobByIdempotencyKey(idempotencyKey);
+  const existing = params.store.getPostRunJobByIdempotencyKey({
+    workspaceId: params.workspaceId,
+    idempotencyKey,
+  });
   if (existing) {
     params.wakeWorker?.();
     return existing;

--- a/runtime/api-server/src/session-scratchpad.ts
+++ b/runtime/api-server/src/session-scratchpad.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  migrateLegacyWorkspaceStatePath,
+  workspaceRuntimeRelativePath,
+  workspaceStateRelativePath,
+} from "./workspace-bundle-paths.js";
 
-const SESSION_SCRATCHPAD_DIR_SEGMENTS = [".holaboss", "scratchpads"] as const;
+const SESSION_SCRATCHPAD_DIR_SEGMENTS = ["scratchpads"] as const;
 const SESSION_SCRATCHPAD_PREVIEW_CHARS = 280;
 
 export type SessionScratchpadWriteOperation = "append" | "replace" | "clear";
@@ -51,7 +56,7 @@ function sanitizeSessionScratchpadSegment(sessionId: string): string {
 }
 
 export function sessionScratchpadRelativePath(sessionId: string): string {
-  return path.posix.join(
+  return workspaceStateRelativePath(
     ...SESSION_SCRATCHPAD_DIR_SEGMENTS,
     `${sanitizeSessionScratchpadSegment(sessionId)}.md`,
   );
@@ -61,10 +66,20 @@ function sessionScratchpadAbsolutePath(params: {
   workspaceRoot: string;
   workspaceId: string;
   sessionId: string;
-}): { absolutePath: string; relativePath: string } {
+}): { absolutePath: string; legacyAbsolutePath: string; relativePath: string } {
   const relativePath = sessionScratchpadRelativePath(params.sessionId);
+  const workspaceDir = path.join(params.workspaceRoot, params.workspaceId);
+  const fileName = `${sanitizeSessionScratchpadSegment(params.sessionId)}.md`;
   return {
-    absolutePath: path.join(params.workspaceRoot, params.workspaceId, relativePath),
+    absolutePath: migrateLegacyWorkspaceStatePath({
+      workspaceDir,
+      relativeSegments: [...SESSION_SCRATCHPAD_DIR_SEGMENTS, fileName],
+      legacyRelativeSegments: [".holaboss", "scratchpads", fileName],
+    }),
+    legacyAbsolutePath: path.join(
+      workspaceDir,
+      workspaceRuntimeRelativePath("scratchpads", fileName),
+    ),
     relativePath,
   };
 }
@@ -75,7 +90,7 @@ export async function readSessionScratchpad(params: {
   sessionId: string;
   includeContent?: boolean;
 }): Promise<SessionScratchpadPayload> {
-  const { absolutePath, relativePath } = sessionScratchpadAbsolutePath(params);
+  const { absolutePath, legacyAbsolutePath, relativePath } = sessionScratchpadAbsolutePath(params);
   try {
     const stat = await fs.stat(absolutePath);
     if (!stat.isFile()) {
@@ -120,7 +135,7 @@ export async function writeSessionScratchpad(params: {
   op: SessionScratchpadWriteOperation;
   content?: string | null;
 }): Promise<SessionScratchpadPayload> {
-  const { absolutePath } = sessionScratchpadAbsolutePath(params);
+  const { absolutePath, legacyAbsolutePath } = sessionScratchpadAbsolutePath(params);
   if (params.op === "clear") {
     try {
       await fs.unlink(absolutePath);
@@ -129,6 +144,7 @@ export async function writeSessionScratchpad(params: {
         throw error;
       }
     }
+    await fs.rm(legacyAbsolutePath, { force: true }).catch(() => {});
     return readSessionScratchpad({
       workspaceRoot: params.workspaceRoot,
       workspaceId: params.workspaceId,
@@ -158,6 +174,7 @@ export async function writeSessionScratchpad(params: {
   const tempPath = `${absolutePath}.tmp`;
   await fs.writeFile(tempPath, resolvedContent, "utf8");
   await fs.rename(tempPath, absolutePath);
+  await fs.rm(legacyAbsolutePath, { force: true }).catch(() => {});
 
   return readSessionScratchpad({
     workspaceRoot: params.workspaceRoot,

--- a/runtime/api-server/src/session-todo.test.ts
+++ b/runtime/api-server/src/session-todo.test.ts
@@ -105,7 +105,7 @@ test("session todo persists phased state and reads back an empty session indepen
       },
     ]);
 
-    const persistedStatePath = path.join(workspaceRoot, workspaceId, ".holaboss", "todos", "session-1.json");
+    const persistedStatePath = path.join(workspaceRoot, workspaceId, ".holaboss", "state", "todos", "session-1.json");
     assert.deepEqual(JSON.parse(fs.readFileSync(persistedStatePath, "utf8")), {
       version: 2,
       session_id: "session-1",

--- a/runtime/api-server/src/session-todo.ts
+++ b/runtime/api-server/src/session-todo.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  migrateLegacyWorkspaceStatePath,
+  workspaceStateRelativePath,
+} from "./workspace-bundle-paths.js";
 
-const SESSION_TODO_DIR_SEGMENTS = [".holaboss", "todos"] as const;
+const SESSION_TODO_DIR_SEGMENTS = ["todos"] as const;
+const LEGACY_SESSION_TODO_DIR_SEGMENTS = [".holaboss", "todos"] as const;
 const LEGACY_PI_TODO_DIR_SEGMENTS = [".holaboss", "pi-agent", "todos"] as const;
 const SESSION_TODO_STATE_VERSION = 2;
 
@@ -47,8 +52,8 @@ export interface SessionTodoState {
 type TodoPathResolution = {
   relativePath: string;
   absolutePath: string;
-  legacyRelativePath: string;
-  legacyAbsolutePath: string;
+  legacyRelativePaths: string[];
+  legacyAbsolutePaths: string[];
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -80,13 +85,29 @@ function todoPaths(params: {
   sessionId: string;
 }): TodoPathResolution {
   const fileName = `${sanitizeSessionTodoSegment(params.sessionId)}.json`;
-  const relativePath = path.posix.join(...SESSION_TODO_DIR_SEGMENTS, fileName);
-  const legacyRelativePath = path.posix.join(...LEGACY_PI_TODO_DIR_SEGMENTS, fileName);
+  const workspaceDir = path.join(params.workspaceRoot, params.workspaceId);
+  const relativePath = workspaceStateRelativePath(...SESSION_TODO_DIR_SEGMENTS, fileName);
+  const legacyRelativePaths = [
+    path.posix.join(...LEGACY_SESSION_TODO_DIR_SEGMENTS, fileName),
+    path.posix.join(...LEGACY_PI_TODO_DIR_SEGMENTS, fileName),
+  ];
+  let absolutePath = migrateLegacyWorkspaceStatePath({
+    workspaceDir,
+    relativeSegments: [...SESSION_TODO_DIR_SEGMENTS, fileName],
+    legacyRelativeSegments: [...LEGACY_SESSION_TODO_DIR_SEGMENTS, fileName],
+  });
+  absolutePath = migrateLegacyWorkspaceStatePath({
+    workspaceDir,
+    relativeSegments: [...SESSION_TODO_DIR_SEGMENTS, fileName],
+    legacyRelativeSegments: [...LEGACY_PI_TODO_DIR_SEGMENTS, fileName],
+  });
   return {
     relativePath,
-    absolutePath: path.join(params.workspaceRoot, params.workspaceId, relativePath),
-    legacyRelativePath,
-    legacyAbsolutePath: path.join(params.workspaceRoot, params.workspaceId, legacyRelativePath),
+    absolutePath,
+    legacyRelativePaths,
+    legacyAbsolutePaths: legacyRelativePaths.map((legacyRelativePath) =>
+      path.join(workspaceDir, legacyRelativePath),
+    ),
   };
 }
 
@@ -263,11 +284,13 @@ async function readExistingStateText(paths: TodoPathResolution): Promise<string 
       throw error;
     }
   }
-  try {
-    return await fs.readFile(paths.legacyAbsolutePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
+  for (const legacyAbsolutePath of paths.legacyAbsolutePaths) {
+    try {
+      return await fs.readFile(legacyAbsolutePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
     }
   }
   return null;
@@ -355,7 +378,9 @@ async function writeSessionTodoState(params: {
   const tempPath = `${paths.absolutePath}.tmp`;
   await fs.writeFile(tempPath, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
   await fs.rename(tempPath, paths.absolutePath);
-  await fs.rm(paths.legacyAbsolutePath, { force: true }).catch(() => {});
+  for (const legacyAbsolutePath of paths.legacyAbsolutePaths) {
+    await fs.rm(legacyAbsolutePath, { force: true }).catch(() => {});
+  }
   return nextState;
 }
 

--- a/runtime/api-server/src/terminal-session-manager.test.ts
+++ b/runtime/api-server/src/terminal-session-manager.test.ts
@@ -138,12 +138,12 @@ test("terminal session manager persists started output and exit events", async (
   ptyProcess.emitExit({ exitCode: 0 });
 
   await waitFor(() => {
-    const current = manager.getSession({ terminalId: session.terminalId });
+    const current = manager.getSession({ workspaceId: "workspace-1", terminalId: session.terminalId });
     return current?.status === "exited";
   });
 
-  const current = manager.getSession({ terminalId: session.terminalId });
-  const events = manager.listEvents({ terminalId: session.terminalId });
+  const current = manager.getSession({ workspaceId: "workspace-1", terminalId: session.terminalId });
+  const events = manager.listEvents({ workspaceId: "workspace-1", terminalId: session.terminalId });
 
   assert.ok(current);
   assert.equal(current.status, "exited");
@@ -184,17 +184,17 @@ test("terminal session manager proxies input resize and close operations", async
   });
   const ptyProcess = requirePty(currentPty);
 
-  await manager.sendInput({ terminalId: session.terminalId, data: "npm run dev\r" });
-  await manager.resize({ terminalId: session.terminalId, cols: 140, rows: 48 });
-  await manager.closeSession({ terminalId: session.terminalId });
+  await manager.sendInput({ workspaceId: "workspace-1", terminalId: session.terminalId, data: "npm run dev\r" });
+  await manager.resize({ workspaceId: "workspace-1", terminalId: session.terminalId, cols: 140, rows: 48 });
+  await manager.closeSession({ workspaceId: "workspace-1", terminalId: session.terminalId });
 
-  await waitFor(() => manager.getSession({ terminalId: session.terminalId })?.status === "closed");
+  await waitFor(() => manager.getSession({ workspaceId: "workspace-1", terminalId: session.terminalId })?.status === "closed");
 
   assert.deepEqual(ptyProcess.writeCalls, ["npm run dev\r"]);
   assert.deepEqual(ptyProcess.resizeCalls, [{ cols: 140, rows: 48 }]);
   assert.deepEqual(ptyProcess.killCalls, ["SIGTERM"]);
   assert.deepEqual(
-    manager.listEvents({ terminalId: session.terminalId }).map((event) => event.eventType),
+    manager.listEvents({ workspaceId: "workspace-1", terminalId: session.terminalId }).map((event) => event.eventType),
     ["started", "input", "resize", "signal", "exit"],
   );
 
@@ -229,8 +229,8 @@ test("terminal session manager reconciles stale running sessions on startup", as
   const manager = new TerminalSessionManager({ store });
   await manager.start();
 
-  const stale = manager.getSession({ terminalId: "term-stale" });
-  const events = manager.listEvents({ terminalId: "term-stale" });
+  const stale = manager.getSession({ workspaceId: "workspace-1", terminalId: "term-stale" });
+  const events = manager.listEvents({ workspaceId: "workspace-1", terminalId: "term-stale" });
 
   assert.ok(stale);
   assert.equal(stale.status, "interrupted");
@@ -287,7 +287,7 @@ test("terminal session manager captures output persistence failures instead of c
     ptyProcess.emitData("terminal-ready\n");
   });
 
-  await waitFor(() => manager.getSession({ terminalId: session.terminalId })?.status === "closed");
+  await waitFor(() => manager.getSession({ workspaceId: "workspace-1", terminalId: session.terminalId })?.status === "closed");
 
   assert.equal(sentryCaptures.length, 1);
   assert.equal(

--- a/runtime/api-server/src/terminal-session-manager.ts
+++ b/runtime/api-server/src/terminal-session-manager.ts
@@ -24,6 +24,7 @@ interface LoggerLike {
 
 interface LiveTerminalSession {
   terminalId: string;
+  workspaceId: string;
   ptyProcess: TerminalSessionPtyProcess;
   finalized: boolean;
   requestedClose: boolean;
@@ -51,13 +52,13 @@ export interface TerminalSessionManagerLike {
   start(): Promise<void>;
   close(): Promise<void>;
   createSession(params: TerminalSessionManagerCreateParams): Promise<TerminalSessionRecord>;
-  getSession(params: { terminalId: string; workspaceId?: string }): TerminalSessionRecord | null;
+  getSession(params: { terminalId: string; workspaceId: string }): TerminalSessionRecord | null;
   listSessions(params?: { workspaceId?: string; sessionId?: string; statuses?: TerminalSessionStatus[] }): TerminalSessionRecord[];
-  listEvents(params: { terminalId: string; afterSequence?: number; limit?: number }): TerminalSessionEventRecord[];
-  sendInput(params: { terminalId: string; data: string }): Promise<TerminalSessionRecord>;
-  resize(params: { terminalId: string; cols: number; rows: number }): Promise<TerminalSessionRecord>;
-  signal(params: { terminalId: string; signal?: NodeJS.Signals | string | null }): Promise<TerminalSessionRecord>;
-  closeSession(params: { terminalId: string }): Promise<TerminalSessionRecord>;
+  listEvents(params: { workspaceId: string; terminalId: string; afterSequence?: number; limit?: number }): TerminalSessionEventRecord[];
+  sendInput(params: { workspaceId: string; terminalId: string; data: string }): Promise<TerminalSessionRecord>;
+  resize(params: { workspaceId: string; terminalId: string; cols: number; rows: number }): Promise<TerminalSessionRecord>;
+  signal(params: { workspaceId: string; terminalId: string; signal?: NodeJS.Signals | string | null }): Promise<TerminalSessionRecord>;
+  closeSession(params: { workspaceId: string; terminalId: string }): Promise<TerminalSessionRecord>;
   subscribe(terminalId: string, listener: (event: TerminalSessionEventRecord) => void): () => void;
 }
 
@@ -135,7 +136,7 @@ function resolveWorkspaceScopedCwd(workspaceDir: string, cwd: string | null | un
 
 function requireTerminalSession(
   store: RuntimeStateStore,
-  params: { terminalId: string; workspaceId?: string }
+  params: { terminalId: string; workspaceId: string }
 ): TerminalSessionRecord {
   const record = store.getTerminalSession(params);
   if (!record) {
@@ -181,6 +182,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     });
     for (const session of staleSessions) {
       const event = this.appendTerminalSessionEventWithCapture({
+        workspaceId: session.workspaceId,
         terminalId: session.terminalId,
         eventType: "exit",
         payload: {
@@ -233,7 +235,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     this.started = false;
   }
 
-  getSession(params: { terminalId: string; workspaceId?: string }): TerminalSessionRecord | null {
+  getSession(params: { terminalId: string; workspaceId: string }): TerminalSessionRecord | null {
     return this.options.store.getTerminalSession(params);
   }
 
@@ -241,8 +243,11 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     return this.options.store.listTerminalSessions(params);
   }
 
-  listEvents(params: { terminalId: string; afterSequence?: number; limit?: number }): TerminalSessionEventRecord[] {
-    requireTerminalSession(this.options.store, { terminalId: params.terminalId });
+  listEvents(params: { workspaceId: string; terminalId: string; afterSequence?: number; limit?: number }): TerminalSessionEventRecord[] {
+    requireTerminalSession(this.options.store, {
+      workspaceId: params.workspaceId,
+      terminalId: params.terminalId,
+    });
     return this.options.store.listTerminalSessionEvents(params);
   }
 
@@ -297,6 +302,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       });
     } catch (error) {
       const event = this.options.store.appendTerminalSessionEvent({
+        workspaceId: record.workspaceId,
         terminalId: record.terminalId,
         eventType: "error",
         payload: { message: error instanceof Error ? error.message : String(error) },
@@ -314,6 +320,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
 
     const live: LiveTerminalSession = {
       terminalId: record.terminalId,
+      workspaceId: record.workspaceId,
       ptyProcess,
       finalized: false,
       requestedClose: false,
@@ -327,6 +334,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
         return;
       }
       const event = this.appendTerminalSessionEventWithCapture({
+        workspaceId: record.workspaceId,
         terminalId: record.terminalId,
         eventType: "output",
         payload: { data },
@@ -369,6 +377,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     });
 
     const startedEvent = this.options.store.appendTerminalSessionEvent({
+      workspaceId: record.workspaceId,
       terminalId: record.terminalId,
       eventType: "started",
       payload: {
@@ -382,10 +391,14 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     });
     this.emit(startedEvent);
 
-    return requireTerminalSession(this.options.store, { terminalId: record.terminalId });
+    return requireTerminalSession(this.options.store, { workspaceId: record.workspaceId, terminalId: record.terminalId });
   }
 
-  async sendInput(params: { terminalId: string; data: string }): Promise<TerminalSessionRecord> {
+  async sendInput(params: { workspaceId: string; terminalId: string; data: string }): Promise<TerminalSessionRecord> {
+    const terminal = requireTerminalSession(this.options.store, {
+      workspaceId: params.workspaceId,
+      terminalId: params.terminalId,
+    });
     const live = this.requireLiveSession(params.terminalId);
     try {
       live.ptyProcess.write(params.data);
@@ -397,15 +410,20 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       );
     }
     const event = this.options.store.appendTerminalSessionEvent({
+      workspaceId: terminal.workspaceId,
       terminalId: params.terminalId,
       eventType: "input",
       payload: { data: params.data },
     });
     this.emit(event);
-    return requireTerminalSession(this.options.store, { terminalId: params.terminalId });
+    return requireTerminalSession(this.options.store, { workspaceId: terminal.workspaceId, terminalId: params.terminalId });
   }
 
-  async resize(params: { terminalId: string; cols: number; rows: number }): Promise<TerminalSessionRecord> {
+  async resize(params: { workspaceId: string; terminalId: string; cols: number; rows: number }): Promise<TerminalSessionRecord> {
+    const terminal = requireTerminalSession(this.options.store, {
+      workspaceId: params.workspaceId,
+      terminalId: params.terminalId,
+    });
     const live = this.requireLiveSession(params.terminalId);
     const cols = normalizedPositiveInteger(params.cols, DEFAULT_COLS, 20, 400);
     const rows = normalizedPositiveInteger(params.rows, DEFAULT_ROWS, 5, 200);
@@ -419,15 +437,20 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       );
     }
     const event = this.options.store.appendTerminalSessionEvent({
+      workspaceId: terminal.workspaceId,
       terminalId: params.terminalId,
       eventType: "resize",
       payload: { cols, rows },
     });
     this.emit(event);
-    return requireTerminalSession(this.options.store, { terminalId: params.terminalId });
+    return requireTerminalSession(this.options.store, { workspaceId: terminal.workspaceId, terminalId: params.terminalId });
   }
 
-  async signal(params: { terminalId: string; signal?: NodeJS.Signals | string | null }): Promise<TerminalSessionRecord> {
+  async signal(params: { workspaceId: string; terminalId: string; signal?: NodeJS.Signals | string | null }): Promise<TerminalSessionRecord> {
+    const terminal = requireTerminalSession(this.options.store, {
+      workspaceId: params.workspaceId,
+      terminalId: params.terminalId,
+    });
     const live = this.requireLiveSession(params.terminalId);
     const signal = normalizedSignal(params.signal);
     try {
@@ -440,15 +463,20 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       );
     }
     const event = this.options.store.appendTerminalSessionEvent({
+      workspaceId: terminal.workspaceId,
       terminalId: params.terminalId,
       eventType: "signal",
       payload: { signal },
     });
     this.emit(event);
-    return requireTerminalSession(this.options.store, { terminalId: params.terminalId });
+    return requireTerminalSession(this.options.store, { workspaceId: terminal.workspaceId, terminalId: params.terminalId });
   }
 
-  async closeSession(params: { terminalId: string }): Promise<TerminalSessionRecord> {
+  async closeSession(params: { workspaceId: string; terminalId: string }): Promise<TerminalSessionRecord> {
+    const terminal = requireTerminalSession(this.options.store, {
+      workspaceId: params.workspaceId,
+      terminalId: params.terminalId,
+    });
     const live = this.requireLiveSession(params.terminalId);
     live.requestedClose = true;
     try {
@@ -461,12 +489,13 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
       );
     }
     const event = this.options.store.appendTerminalSessionEvent({
+      workspaceId: terminal.workspaceId,
       terminalId: params.terminalId,
       eventType: "signal",
       payload: { signal: "SIGTERM", requested_close: true },
     });
     this.emit(event);
-    return requireTerminalSession(this.options.store, { terminalId: params.terminalId });
+    return requireTerminalSession(this.options.store, { workspaceId: terminal.workspaceId, terminalId: params.terminalId });
   }
 
   private requireLiveSession(terminalId: string): LiveTerminalSession {
@@ -518,6 +547,7 @@ export class TerminalSessionManager implements TerminalSessionManagerLike {
     live.finalized = true;
     this.liveSessions.delete(live.terminalId);
     const event = this.appendTerminalSessionEventWithCapture({
+      workspaceId: live.workspaceId,
       terminalId: live.terminalId,
       eventType: params.eventType,
       payload: params.payload,

--- a/runtime/api-server/src/tool-result-preview.test.ts
+++ b/runtime/api-server/src/tool-result-preview.test.ts
@@ -76,7 +76,7 @@ test("shapeCapabilityToolResultPayload spills browser screenshots in preview mod
     const shaped = payload as Record<string, unknown>;
     const screenshot = shaped.screenshot as Record<string, unknown>;
     assert.equal(Object.prototype.hasOwnProperty.call(screenshot, "base64"), false);
-    assert.match(String(screenshot.file_path ?? ""), /^\.holaboss\/tool-results\/browser_get_state\//);
+    assert.match(String(screenshot.file_path ?? ""), /^\.holaboss\/state\/tool-results\/browser_get_state\//);
     assert.equal(
       fs.existsSync(
         path.join(
@@ -98,7 +98,7 @@ test("shapeCapabilityToolResultPayload spills browser screenshots in preview mod
     assert.equal(state.media_total, 45);
     assert.equal(state.media_has_more, true);
     assert.equal(state.next_media_offset, 22);
-    assert.match(String(shaped.full_state_path ?? ""), /^\.holaboss\/tool-results\/browser_get_state\//);
+    assert.match(String(shaped.full_state_path ?? ""), /^\.holaboss\/state\/tool-results\/browser_get_state\//);
     assert.equal(
       fs.existsSync(
         path.join(
@@ -146,7 +146,7 @@ test("shapeCapabilityToolResultPayload clips and spills terminal events in previ
     assert.equal(shaped.has_more, true);
     assert.equal(shaped.next_after_sequence, 40);
     assert.equal(shaped.remaining_event_count, 45);
-    assert.match(String(shaped.full_events_path ?? ""), /^\.holaboss\/tool-results\/terminal_session_read\//);
+    assert.match(String(shaped.full_events_path ?? ""), /^\.holaboss\/state\/tool-results\/terminal_session_read\//);
     assert.equal(
       fs.existsSync(
         path.join(
@@ -170,7 +170,7 @@ test("shapeCapabilityToolResultPayload trims oversized scratchpad content in pre
     workspaceId: "workspace-1",
     sessionId: "session-main",
     payload: {
-      file_path: ".holaboss/scratchpads/session-main.md",
+      file_path: ".holaboss/state/scratchpads/session-main.md",
       content: "x".repeat(24000),
     },
   });

--- a/runtime/api-server/src/tool-result-preview.ts
+++ b/runtime/api-server/src/tool-result-preview.ts
@@ -17,6 +17,7 @@ import {
   TOOL_RESULT_PREVIEW_TEXT_MAX_CHARS,
   TOOL_RESULT_PREVIEW_TEXT_TRIM_THRESHOLD_CHARS,
 } from "./tool-result-budget.js";
+import { workspaceStateRelativePath } from "./workspace-bundle-paths.js";
 
 export const TOOL_RESULT_MODE_HEADER = "x-holaboss-tool-result-mode";
 export const TOOL_RESULT_MODE_PREVIEW = "preview";
@@ -145,8 +146,7 @@ async function writeToolResultArtifact(params: {
     params.extension,
     "txt",
   )}`;
-  const relativePath = path.posix.join(
-    ".holaboss",
+  const relativePath = workspaceStateRelativePath(
     "tool-results",
     toolToken,
     sessionToken,

--- a/runtime/api-server/src/ts-runner-session-state.test.ts
+++ b/runtime/api-server/src/ts-runner-session-state.test.ts
@@ -128,8 +128,8 @@ test("clearWorkspaceHarnessSessionId removes only the targeted harness entry", (
   assert.equal(readWorkspaceHarnessSessionId({ workspaceDir, harness: "other" }), "session-123");
 });
 
-test("workspaceDataDbPath places data.db under the workspace `.holaboss` folder", () => {
+test("workspaceDataDbPath places data.db under the workspace `.holaboss/state` folder", () => {
   const workspaceDir = path.join(os.tmpdir(), "hb-ts-runner-data-db-test");
   const dbPath = workspaceDataDbPath(workspaceDir);
-  assert.equal(dbPath, path.join(path.resolve(workspaceDir), ".holaboss", "data.db"));
+  assert.equal(dbPath, path.join(path.resolve(workspaceDir), ".holaboss", "state", "data.db"));
 });

--- a/runtime/api-server/src/ts-runner-session-state.ts
+++ b/runtime/api-server/src/ts-runner-session-state.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import {
+  migrateLegacyWorkspaceStatePath,
+} from "./workspace-bundle-paths.js";
 
 const WORKSPACE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-const SESSION_STATE_DIR_NAME = ".holaboss";
 const SESSION_STATE_FILE_NAME = "harness-session-state.json";
 const SESSION_STATE_VERSION = 2;
 const SESSION_STATE_SESSION_KEY = "session_id";
@@ -45,7 +47,11 @@ export function workspaceDirForId(workspaceId: string): string {
 }
 
 export function workspaceSessionStatePath(workspaceDir: string): string {
-  return path.join(path.resolve(workspaceDir), SESSION_STATE_DIR_NAME, SESSION_STATE_FILE_NAME);
+  return migrateLegacyWorkspaceStatePath({
+    workspaceDir,
+    relativeSegments: [SESSION_STATE_FILE_NAME],
+    legacyRelativeSegments: [".holaboss", SESSION_STATE_FILE_NAME],
+  });
 }
 
 /** Filesystem path of the workspace's shared data SQLite. Single file
@@ -53,7 +59,11 @@ export function workspaceSessionStatePath(workspaceDir: string): string {
  *  (twitter_posts, linkedin_posts, …). The path is injected into app
  *  processes via the WORKSPACE_DB_PATH env var. */
 export function workspaceDataDbPath(workspaceDir: string): string {
-  return path.join(path.resolve(workspaceDir), SESSION_STATE_DIR_NAME, "data.db");
+  return migrateLegacyWorkspaceStatePath({
+    workspaceDir,
+    relativeSegments: ["data.db"],
+    legacyRelativeSegments: [".holaboss", "data.db"],
+  });
 }
 
 /** Ensure the workspace's shared data SQLite exists, with WAL enabled

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -28,6 +28,10 @@ import {
   persistWorkspaceHarnessSessionId,
   readWorkspaceHarnessSessionId,
 } from "./ts-runner-session-state.js";
+import {
+  globalMemoryDirForWorkspaceRoot,
+  workspaceMemoryDir,
+} from "./workspace-bundle-paths.js";
 
 const ORIGINAL_SANDBOX_ROOT = process.env.HB_SANDBOX_ROOT;
 const ORIGINAL_EMBEDDED_SKILLS_DIR = process.env.HOLABOSS_EMBEDDED_SKILLS_DIR;
@@ -106,7 +110,11 @@ function writeMemoryFile(
   relPath: string,
   content: string,
 ): void {
-  const absPath = path.join(workspaceRoot, "memory", ...relPath.split("/"));
+  const normalized = relPath.replaceAll("\\", "/").replace(/^\/+/, "");
+  const match = /^workspace\/([^/]+)\/(.+)$/.exec(normalized);
+  const absPath = match
+    ? path.join(workspaceMemoryDir(path.join(workspaceRoot, match[1])), match[2])
+    : path.join(globalMemoryDirForWorkspaceRoot(workspaceRoot), ...normalized.split("/"));
   fs.mkdirSync(path.dirname(absPath), { recursive: true });
   fs.writeFileSync(absPath, content, "utf8");
 }
@@ -497,7 +505,7 @@ test("relayTsRunnerEvent persists harness_session_id from terminal events", asyn
   assert.deepEqual(
     JSON.parse(
       fs.readFileSync(
-        path.join(workspaceDir, ".holaboss", "harness-session-state.json"),
+        path.join(workspaceDir, ".holaboss", "state", "harness-session-state.json"),
         "utf8",
       ),
     ),
@@ -628,6 +636,7 @@ test("runTsRunnerCli relays harness-host events after run_claimed", async () => 
           "workspace",
           "workspace-1",
           ".holaboss",
+          "state",
           "harness-session-state.json",
         ),
         "utf8",
@@ -746,6 +755,7 @@ test("runTsRunnerCli persists pi harness session ids when runtime context select
           "workspace",
           "workspace-1",
           ".holaboss",
+          "state",
           "harness-session-state.json",
         ),
         "utf8",
@@ -2608,6 +2618,7 @@ test("runTsRunnerCli loads legacy session history exports into main-session prom
   const legacyDir = path.join(
     workspaceDir,
     ".holaboss",
+    "state",
     "legacy-session-histories",
   );
   fs.mkdirSync(legacyDir, { recursive: true });
@@ -2684,7 +2695,7 @@ test("runTsRunnerCli loads legacy session history exports into main-session prom
   ).legacy_session_history_context;
   assert.equal(
     legacyContext.manifest_path,
-    ".holaboss/legacy-session-histories/index.json",
+    ".holaboss/state/legacy-session-histories/index.json",
   );
   assert.equal(legacyContext.legacy_session_count, 1);
   assert.deepEqual(legacyContext.entries, [
@@ -2695,8 +2706,8 @@ test("runTsRunnerCli loads legacy session history exports into main-session prom
       archived_at: "2026-04-24T06:52:27.419Z",
       message_count: 14,
       output_count: 1,
-      json_path: ".holaboss/legacy-session-histories/session-older.json",
-      markdown_path: ".holaboss/legacy-session-histories/session-older.md",
+      json_path: ".holaboss/state/legacy-session-histories/session-older.json",
+      markdown_path: ".holaboss/state/legacy-session-histories/session-older.md",
     },
   ]);
 });

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -64,6 +64,10 @@ import {
   workspaceDirForId,
 } from "./ts-runner-session-state.js";
 import {
+  migrateLegacyWorkspaceStatePath,
+  workspaceStateRelativePath,
+} from "./workspace-bundle-paths.js";
+import {
   prepareInstructionWithQuotedWorkspaceSkills,
   resolveWorkspaceSkills,
 } from "./workspace-skills.js";
@@ -890,12 +894,12 @@ async function loadLegacySessionHistoryContext(params: {
   workspaceDir: string;
   logger?: LoggerLike;
 }): Promise<AgentLegacySessionHistoryContext | null> {
-  const manifestPath = path.join(
-    params.workspaceDir,
-    ".holaboss",
-    "legacy-session-histories",
-    "index.json",
-  );
+  const legacySessionHistoryDir = migrateLegacyWorkspaceStatePath({
+    workspaceDir: params.workspaceDir,
+    relativeSegments: ["legacy-session-histories"],
+    legacyRelativeSegments: [".holaboss", "legacy-session-histories"],
+  });
+  const manifestPath = path.join(legacySessionHistoryDir, "index.json");
   try {
     const raw = await fs.promises.readFile(manifestPath, "utf8");
     const parsed = JSON.parse(raw);
@@ -940,7 +944,7 @@ async function loadLegacySessionHistoryContext(params: {
         workspaceRelativePath({
           workspaceDir: params.workspaceDir,
           filePath: manifestPath,
-        }) ?? ".holaboss/legacy-session-histories/index.json",
+        }) ?? workspaceStateRelativePath("legacy-session-histories", "index.json"),
       legacy_session_count: entries.length,
       entries: entries.slice(0, 25),
     };

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { RuntimeStateStore } from "@holaboss/runtime-state-store";
+import { RuntimeStateStore, hostStateDbPath } from "@holaboss/runtime-state-store";
 
 import {
   RuntimeAppLifecycleExecutor,
@@ -303,6 +303,10 @@ function turnRequestSnapshotFingerprint(
   return fingerprintJsonValue(sanitizeSnapshotValue(payload));
 }
 
+function defaultHostStateDbPathForSandbox(sandboxRoot: string): string {
+  return hostStateDbPath({ sandboxRoot });
+}
+
 function persistTurnRequestSnapshot(params: {
   workspaceRoot: string;
   workspaceId: string;
@@ -318,7 +322,7 @@ function persistTurnRequestSnapshot(params: {
   >;
   const fingerprint = fingerprintJsonValue(sanitizedPayload);
   const sandboxRoot = path.dirname(params.workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   try {
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   } catch (error) {
@@ -525,7 +529,7 @@ async function loadRecalledMemoryContext(params: {
   logger?: LoggerLike;
 }): Promise<AgentRecalledMemoryContext | null> {
   const sandboxRoot = path.dirname(params.workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   const store = fs.existsSync(dbPath)
     ? new RuntimeStateStore({
         workspaceRoot: params.workspaceRoot,
@@ -672,7 +676,7 @@ function loadCurrentUserContext(params: {
   logger?: LoggerLike;
 }): AgentCurrentUserContext | null {
   const sandboxRoot = path.dirname(params.workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   const defaultContext: AgentCurrentUserContext = {
     profile_id: "default",
     name: null,
@@ -714,7 +718,7 @@ function loadPendingUserMemoryContext(params: {
   logger?: LoggerLike;
 }): AgentPendingUserMemoryContext | null {
   const sandboxRoot = path.dirname(params.workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   if (!fs.existsSync(dbPath)) {
     return null;
   }
@@ -820,7 +824,7 @@ function loadRecentRuntimeContext(params: {
     return null;
   }
   const sandboxRoot = path.dirname(params.workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   let staleBrowserRefusal = false;
 
   if (fs.existsSync(dbPath)) {
@@ -1664,7 +1668,7 @@ function resolveRegisteredWorkspaceDir(
 ): string {
   const workspaceRoot = managedWorkspaceRoot();
   const sandboxRoot = path.dirname(workspaceRoot);
-  const dbPath = path.join(sandboxRoot, "state", "runtime.db");
+  const dbPath = defaultHostStateDbPathForSandbox(sandboxRoot);
   if (!fs.existsSync(dbPath)) {
     return workspaceDirForId(workspaceId);
   }

--- a/runtime/api-server/src/turn-memory-writeback.ts
+++ b/runtime/api-server/src/turn-memory-writeback.ts
@@ -1378,7 +1378,12 @@ export async function writeTurnDurableMemory(params: {
   });
   const durableCandidates = mergeDurableCandidates(acceptedExtractedCandidates, heuristicDurableCandidates);
   if (durableCandidates.length === 0) {
-    return params.store.getTurnResult({ inputId: context.turnResult.inputId }) ?? context.turnResult;
+    return (
+      params.store.getTurnResult({
+        workspaceId: context.turnResult.workspaceId,
+        inputId: context.turnResult.inputId,
+      }) ?? context.turnResult
+    );
   }
   const changedWorkspaceIds = new Set<string>();
   let rebuildPreference = false;
@@ -1416,7 +1421,12 @@ export async function writeTurnDurableMemory(params: {
       rebuildRoot,
     });
   }
-  return params.store.getTurnResult({ inputId: context.turnResult.inputId }) ?? context.turnResult;
+  return (
+    params.store.getTurnResult({
+      workspaceId: context.turnResult.workspaceId,
+      inputId: context.turnResult.inputId,
+    }) ?? context.turnResult
+  );
 }
 
 export async function writeTurnMemory(params: {
@@ -1433,6 +1443,11 @@ export async function writeTurnMemory(params: {
       modelContext: params.modelContext ?? null,
     });
   } catch {
-    return params.store.getTurnResult({ inputId: params.turnResult.inputId }) ?? params.turnResult;
+    return (
+      params.store.getTurnResult({
+        workspaceId: params.turnResult.workspaceId,
+        inputId: params.turnResult.inputId,
+      }) ?? params.turnResult
+    );
   }
 }

--- a/runtime/api-server/src/turn-semantic-artifacts.ts
+++ b/runtime/api-server/src/turn-semantic-artifacts.ts
@@ -60,6 +60,7 @@ export function assistantTextFromTurnArtifacts(
 ): string {
   const deltas = store
     .listOutputEvents({
+      workspaceId: turnResult.workspaceId,
       sessionId: turnResult.sessionId,
       inputId: turnResult.inputId,
     })
@@ -89,6 +90,7 @@ export function permissionDenialsFromTurnArtifacts(
   const seen = new Set<string>();
   const denials: Array<Record<string, unknown>> = [];
   for (const event of store.listOutputEvents({
+    workspaceId: turnResult.workspaceId,
     sessionId: turnResult.sessionId,
     inputId: turnResult.inputId,
   })) {
@@ -127,6 +129,7 @@ export function toolUsageSummaryFromTurnArtifacts(
     }
   >();
   for (const event of store.listOutputEvents({
+    workspaceId: turnResult.workspaceId,
     sessionId: turnResult.sessionId,
     inputId: turnResult.inputId,
   })) {

--- a/runtime/api-server/src/workspace-bundle-paths.ts
+++ b/runtime/api-server/src/workspace-bundle-paths.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const WORKSPACE_RUNTIME_DIRNAME = ".holaboss";
+export const WORKSPACE_STATE_DIRNAME = "state";
+export const WORKSPACE_MEMORY_DIRNAME = "memory";
+export const LEGACY_GLOBAL_MEMORY_WORKSPACE_DIRNAME = "workspace";
+
+function ensureDir(targetPath: string): string {
+  fs.mkdirSync(targetPath, { recursive: true });
+  return targetPath;
+}
+
+export function workspaceRuntimeDir(workspaceDir: string): string {
+  return path.join(path.resolve(workspaceDir), WORKSPACE_RUNTIME_DIRNAME);
+}
+
+export function workspaceStateDir(workspaceDir: string): string {
+  return path.join(workspaceRuntimeDir(workspaceDir), WORKSPACE_STATE_DIRNAME);
+}
+
+export function workspaceMemoryDir(workspaceDir: string): string {
+  return path.join(workspaceRuntimeDir(workspaceDir), WORKSPACE_MEMORY_DIRNAME);
+}
+
+export function workspaceRuntimeRelativePath(...relativeSegments: string[]): string {
+  return path.posix.join(WORKSPACE_RUNTIME_DIRNAME, ...relativeSegments);
+}
+
+export function workspaceStateRelativePath(...relativeSegments: string[]): string {
+  return path.posix.join(
+    WORKSPACE_RUNTIME_DIRNAME,
+    WORKSPACE_STATE_DIRNAME,
+    ...relativeSegments,
+  );
+}
+
+export function globalMemoryDirForWorkspaceRoot(workspaceRoot: string): string {
+  const configured = (process.env.MEMORY_ROOT_DIR ?? "").trim();
+  if (!configured) {
+    return path.join(path.dirname(path.resolve(workspaceRoot)), WORKSPACE_MEMORY_DIRNAME);
+  }
+  if (path.isAbsolute(configured)) {
+    return path.resolve(configured);
+  }
+  return path.resolve(path.join(workspaceRoot, configured));
+}
+
+export function legacyWorkspaceMemoryDir(params: {
+  workspaceRoot: string;
+  workspaceId: string;
+}): string {
+  return path.join(
+    globalMemoryDirForWorkspaceRoot(params.workspaceRoot),
+    LEGACY_GLOBAL_MEMORY_WORKSPACE_DIRNAME,
+    params.workspaceId,
+  );
+}
+
+export function migrateLegacyWorkspaceMemoryIfNeeded(params: {
+  workspaceRoot: string;
+  workspaceDir: string;
+  workspaceId: string;
+}): { migrated: boolean; workspaceMemoryDir: string; globalMemoryDir: string } {
+  const nextWorkspaceMemoryDir = workspaceMemoryDir(params.workspaceDir);
+  const globalMemoryDir = globalMemoryDirForWorkspaceRoot(params.workspaceRoot);
+  const legacyDir = legacyWorkspaceMemoryDir({
+    workspaceRoot: params.workspaceRoot,
+    workspaceId: params.workspaceId,
+  });
+
+  if (!fs.existsSync(legacyDir) || !fs.statSync(legacyDir).isDirectory()) {
+    return { migrated: false, workspaceMemoryDir: nextWorkspaceMemoryDir, globalMemoryDir };
+  }
+
+  ensureDir(nextWorkspaceMemoryDir);
+  for (const childName of fs.readdirSync(legacyDir)) {
+    const sourcePath = path.join(legacyDir, childName);
+    const targetPath = path.join(nextWorkspaceMemoryDir, childName);
+    if (fs.existsSync(targetPath)) {
+      continue;
+    }
+    fs.renameSync(sourcePath, targetPath);
+  }
+  if (fs.existsSync(legacyDir) && fs.readdirSync(legacyDir).length === 0) {
+    fs.rmSync(legacyDir, { recursive: true, force: true });
+  }
+  const legacyParent = path.dirname(legacyDir);
+  if (fs.existsSync(legacyParent) && fs.statSync(legacyParent).isDirectory() && fs.readdirSync(legacyParent).length === 0) {
+    fs.rmSync(legacyParent, { recursive: true, force: true });
+  }
+  return { migrated: true, workspaceMemoryDir: nextWorkspaceMemoryDir, globalMemoryDir };
+}
+
+export function resolveMemoryFilePath(params: {
+  workspaceRoot: string;
+  workspaceDir: string;
+  workspaceId: string;
+  relPath: string;
+}): string {
+  const normalized = params.relPath.replaceAll("\\", "/").replace(/^\/+/, "");
+  const workspacePrefix = `workspace/${params.workspaceId}/`;
+  if (normalized.startsWith(workspacePrefix)) {
+    migrateLegacyWorkspaceMemoryIfNeeded({
+      workspaceRoot: params.workspaceRoot,
+      workspaceDir: params.workspaceDir,
+      workspaceId: params.workspaceId,
+    });
+    return path.join(workspaceMemoryDir(params.workspaceDir), normalized.slice(workspacePrefix.length));
+  }
+  return path.join(globalMemoryDirForWorkspaceRoot(params.workspaceRoot), normalized);
+}
+
+export function workspaceStatePath(workspaceDir: string, ...relativeSegments: string[]): string {
+  return path.join(workspaceStateDir(workspaceDir), ...relativeSegments);
+}
+
+export function migrateLegacyWorkspaceStatePath(params: {
+  workspaceDir: string;
+  relativeSegments: string[];
+  legacyRelativeSegments: string[];
+  isDirectory?: boolean;
+}): string {
+  const targetPath = workspaceStatePath(params.workspaceDir, ...params.relativeSegments);
+  const legacyPath = path.join(path.resolve(params.workspaceDir), ...params.legacyRelativeSegments);
+  if (fs.existsSync(targetPath)) {
+    return targetPath;
+  }
+  if (!fs.existsSync(legacyPath)) {
+    return targetPath;
+  }
+  ensureDir(path.dirname(targetPath));
+  fs.renameSync(legacyPath, targetPath);
+  return targetPath;
+}
+
+export function ensureWorkspaceStateDir(workspaceDir: string): string {
+  return ensureDir(workspaceStateDir(workspaceDir));
+}
+
+export function ensureWorkspaceMemoryDir(workspaceDir: string): string {
+  return ensureDir(workspaceMemoryDir(workspaceDir));
+}

--- a/runtime/api-server/src/workspace-mcp-sidecar.test.ts
+++ b/runtime/api-server/src/workspace-mcp-sidecar.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, test } from "node:test";
 
 import { runWorkspaceMcpSidecarCli, startWorkspaceMcpSidecar } from "./workspace-mcp-sidecar.js";
+import { workspaceStateDir } from "./workspace-bundle-paths.js";
 
 const tempDirs: string[] = [];
 
@@ -87,10 +88,10 @@ test("startWorkspaceMcpSidecar reuses a ready persisted sidecar", async () => {
 test("startWorkspaceMcpSidecar terminates stale state, spawns, and persists the new sidecar", async () => {
   const { root, workspaceDir } = makeTempWorkspaceRoot("hb-workspace-mcp-spawn-");
   const request = makeRequest(workspaceDir);
-  const stateDir = path.join(root, ".holaboss");
-  fs.mkdirSync(stateDir, { recursive: true });
+  const legacyStateDir = path.join(root, ".holaboss");
+  fs.mkdirSync(legacyStateDir, { recursive: true });
   fs.writeFileSync(
-    path.join(stateDir, "workspace-mcp-sidecar-state.json"),
+    path.join(legacyStateDir, "workspace-mcp-sidecar-state.json"),
     JSON.stringify(
       {
         version: 1,
@@ -168,6 +169,7 @@ test("startWorkspaceMcpSidecar terminates stale state, spawns, and persists the 
   assert.equal(capturedSpawnCall.options.detached, true);
   assert.equal(Array.isArray(capturedSpawnCall.options.stdio), true);
 
+  const stateDir = workspaceStateDir(workspaceDir);
   const state = JSON.parse(fs.readFileSync(path.join(stateDir, "workspace-mcp-sidecar-state.json"), "utf8"));
   assert.deepEqual(state, {
     version: 1,
@@ -183,6 +185,7 @@ test("startWorkspaceMcpSidecar terminates stale state, spawns, and persists the 
   });
   assert.equal(fs.readFileSync(path.join(stateDir, "workspace-local.workspace-mcp-sidecar.stdout.log"), "utf8"), "");
   assert.equal(fs.readFileSync(path.join(stateDir, "workspace-local.workspace-mcp-sidecar.stderr.log"), "utf8"), "");
+  assert.equal(fs.existsSync(path.join(legacyStateDir, "workspace-mcp-sidecar-state.json")), false);
 });
 
 test("startWorkspaceMcpSidecar terminates a spawned sidecar if readiness never succeeds", async () => {
@@ -212,7 +215,7 @@ test("startWorkspaceMcpSidecar terminates a spawned sidecar if readiness never s
   );
 
   assert.deepEqual(terminated, [5555]);
-  const statePath = path.join(root, ".holaboss", "workspace-mcp-sidecar-state.json");
+  const statePath = path.join(workspaceStateDir(workspaceDir), "workspace-mcp-sidecar-state.json");
   assert.equal(fs.existsSync(statePath), false);
 });
 

--- a/runtime/api-server/src/workspace-mcp-sidecar.test.ts
+++ b/runtime/api-server/src/workspace-mcp-sidecar.test.ts
@@ -188,6 +188,79 @@ test("startWorkspaceMcpSidecar terminates stale state, spawns, and persists the 
   assert.equal(fs.existsSync(path.join(legacyStateDir, "workspace-mcp-sidecar-state.json")), false);
 });
 
+test("startWorkspaceMcpSidecar migrates only the matching legacy sidecar entry for this workspace", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hb-workspace-mcp-shared-"));
+  tempDirs.push(root);
+  const workspaceADir = path.join(root, "workspace-a");
+  const workspaceBDir = path.join(root, "workspace-b");
+  fs.mkdirSync(workspaceADir, { recursive: true });
+  fs.mkdirSync(workspaceBDir, { recursive: true });
+  const request = makeRequest(workspaceADir);
+  const legacyStateDir = path.join(root, ".holaboss");
+  fs.mkdirSync(legacyStateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(legacyStateDir, "workspace-mcp-sidecar-state.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        sidecars: {
+          [request.physical_server_id]: {
+            physical_server_id: request.physical_server_id,
+            url: "http://127.0.0.1:9001/mcp",
+            pid: 2001,
+            config_fingerprint: request.expected_fingerprint,
+            updated_at: "2026-03-25T00:00:00.000Z"
+          },
+          "workspace-other": {
+            physical_server_id: "workspace-other",
+            url: "http://127.0.0.1:9002/mcp",
+            pid: 2002,
+            config_fingerprint: "fp-2",
+            updated_at: "2026-03-25T00:00:00.000Z"
+          }
+        }
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const result = await startWorkspaceMcpSidecar(request, {
+    pidAlive(pid) {
+      assert.equal(pid, 2001);
+      return true;
+    },
+    async isReady(url) {
+      assert.equal(url, "http://127.0.0.1:9001/mcp");
+      return true;
+    },
+    spawnProcess() {
+      throw new Error("should not spawn");
+    }
+  });
+
+  assert.deepEqual(result, {
+    url: "http://127.0.0.1:9001/mcp",
+    pid: 2001,
+    reused: true
+  });
+
+  const workspaceAState = JSON.parse(
+    fs.readFileSync(path.join(workspaceStateDir(workspaceADir), "workspace-mcp-sidecar-state.json"), "utf8")
+  );
+  const remainingLegacyState = JSON.parse(
+    fs.readFileSync(path.join(legacyStateDir, "workspace-mcp-sidecar-state.json"), "utf8")
+  );
+
+  assert.deepEqual(Object.keys(workspaceAState.sidecars), [request.physical_server_id]);
+  assert.deepEqual(Object.keys(remainingLegacyState.sidecars), ["workspace-other"]);
+  assert.equal(
+    fs.existsSync(path.join(workspaceStateDir(workspaceBDir), "workspace-mcp-sidecar-state.json")),
+    false,
+  );
+});
+
 test("startWorkspaceMcpSidecar terminates a spawned sidecar if readiness never succeeds", async () => {
   const { root, workspaceDir } = makeTempWorkspaceRoot("hb-workspace-mcp-timeout-");
   const request = makeRequest(workspaceDir);

--- a/runtime/api-server/src/workspace-mcp-sidecar.ts
+++ b/runtime/api-server/src/workspace-mcp-sidecar.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { spawn } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { ensureWorkspaceStateDir } from "./workspace-bundle-paths.js";
 
 const WORKSPACE_MCP_STATE_VERSION = 1;
 const WORKSPACE_MCP_READY_POLL_MS = 200;
@@ -57,7 +58,27 @@ function sanitizeId(value: string): string {
 }
 
 function stateDirForWorkspace(workspaceDir: string): string {
-  return path.join(path.dirname(path.resolve(workspaceDir)), ".holaboss");
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const targetStateDir = ensureWorkspaceStateDir(resolvedWorkspaceDir);
+  const legacySharedDir = path.join(path.dirname(resolvedWorkspaceDir), ".holaboss");
+  const legacyStatePath = path.join(legacySharedDir, "workspace-mcp-sidecar-state.json");
+  const nextStatePath = path.join(targetStateDir, "workspace-mcp-sidecar-state.json");
+  if (fs.existsSync(legacyStatePath) && !fs.existsSync(nextStatePath)) {
+    fs.renameSync(legacyStatePath, nextStatePath);
+  }
+  if (fs.existsSync(legacySharedDir) && fs.statSync(legacySharedDir).isDirectory()) {
+    for (const childName of fs.readdirSync(legacySharedDir)) {
+      if (!childName.endsWith(".workspace-mcp-sidecar.stdout.log") && !childName.endsWith(".workspace-mcp-sidecar.stderr.log")) {
+        continue;
+      }
+      const sourcePath = path.join(legacySharedDir, childName);
+      const targetPath = path.join(targetStateDir, childName);
+      if (!fs.existsSync(targetPath)) {
+        fs.renameSync(sourcePath, targetPath);
+      }
+    }
+  }
+  return targetStateDir;
 }
 
 function workspaceMcpStatePath(workspaceDir: string): string {

--- a/runtime/api-server/src/workspace-mcp-sidecar.ts
+++ b/runtime/api-server/src/workspace-mcp-sidecar.ts
@@ -59,26 +59,7 @@ function sanitizeId(value: string): string {
 
 function stateDirForWorkspace(workspaceDir: string): string {
   const resolvedWorkspaceDir = path.resolve(workspaceDir);
-  const targetStateDir = ensureWorkspaceStateDir(resolvedWorkspaceDir);
-  const legacySharedDir = path.join(path.dirname(resolvedWorkspaceDir), ".holaboss");
-  const legacyStatePath = path.join(legacySharedDir, "workspace-mcp-sidecar-state.json");
-  const nextStatePath = path.join(targetStateDir, "workspace-mcp-sidecar-state.json");
-  if (fs.existsSync(legacyStatePath) && !fs.existsSync(nextStatePath)) {
-    fs.renameSync(legacyStatePath, nextStatePath);
-  }
-  if (fs.existsSync(legacySharedDir) && fs.statSync(legacySharedDir).isDirectory()) {
-    for (const childName of fs.readdirSync(legacySharedDir)) {
-      if (!childName.endsWith(".workspace-mcp-sidecar.stdout.log") && !childName.endsWith(".workspace-mcp-sidecar.stderr.log")) {
-        continue;
-      }
-      const sourcePath = path.join(legacySharedDir, childName);
-      const targetPath = path.join(targetStateDir, childName);
-      if (!fs.existsSync(targetPath)) {
-        fs.renameSync(sourcePath, targetPath);
-      }
-    }
-  }
-  return targetStateDir;
+  return ensureWorkspaceStateDir(resolvedWorkspaceDir);
 }
 
 function workspaceMcpStatePath(workspaceDir: string): string {
@@ -96,21 +77,7 @@ function ensureStateDir(workspaceDir: string): string {
   return stateDir;
 }
 
-function decodeCliRequest(encoded: string): WorkspaceMcpSidecarCliRequest {
-  const trimmed = encoded.trim();
-  if (!trimmed) {
-    throw new Error("request_base64 is required");
-  }
-  const raw = Buffer.from(trimmed, "base64").toString("utf8");
-  const parsed = JSON.parse(raw);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("request payload must be an object");
-  }
-  return parsed as WorkspaceMcpSidecarCliRequest;
-}
-
-function readWorkspaceMcpSidecarState(workspaceDir: string): Record<string, SidecarStateEntry> {
-  const statePath = workspaceMcpStatePath(workspaceDir);
+function readSidecarStateFile(statePath: string): Record<string, SidecarStateEntry> {
   if (!fs.existsSync(statePath)) {
     return {};
   }
@@ -137,6 +104,76 @@ function readWorkspaceMcpSidecarState(workspaceDir: string): Record<string, Side
   } catch {
     return {};
   }
+}
+
+function writeSidecarStateFile(statePath: string, entries: Record<string, SidecarStateEntry>): void {
+  if (Object.keys(entries).length === 0) {
+    fs.rmSync(statePath, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(
+    statePath,
+    JSON.stringify(
+      {
+        version: WORKSPACE_MCP_STATE_VERSION,
+        sidecars: entries,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function migrateLegacySidecarArtifactsForWorkspace(workspaceDir: string, physicalServerId: string): void {
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const legacySharedDir = path.join(path.dirname(resolvedWorkspaceDir), ".holaboss");
+  const legacyStatePath = path.join(legacySharedDir, "workspace-mcp-sidecar-state.json");
+  const targetStatePath = workspaceMcpStatePath(resolvedWorkspaceDir);
+
+  const legacyEntries = readSidecarStateFile(legacyStatePath);
+  const matchingEntry = legacyEntries[physicalServerId];
+  if (matchingEntry) {
+    const nextEntries = readSidecarStateFile(targetStatePath);
+    if (!nextEntries[physicalServerId]) {
+      nextEntries[physicalServerId] = matchingEntry;
+      writeSidecarStateFile(targetStatePath, nextEntries);
+    }
+    delete legacyEntries[physicalServerId];
+    writeSidecarStateFile(legacyStatePath, legacyEntries);
+  }
+
+  if (fs.existsSync(legacySharedDir) && fs.statSync(legacySharedDir).isDirectory()) {
+    for (const stream of ["stdout", "stderr"] as const) {
+      const basename = stream === "stdout"
+        ? "workspace-mcp-sidecar.stdout.log"
+        : "workspace-mcp-sidecar.stderr.log";
+      const childName = `${sanitizeId(physicalServerId)}.${basename}`;
+      const sourcePath = path.join(legacySharedDir, childName);
+      const targetPath = path.join(stateDirForWorkspace(resolvedWorkspaceDir), childName);
+      if (fs.existsSync(sourcePath) && !fs.existsSync(targetPath)) {
+        fs.renameSync(sourcePath, targetPath);
+      }
+    }
+  }
+}
+
+function decodeCliRequest(encoded: string): WorkspaceMcpSidecarCliRequest {
+  const trimmed = encoded.trim();
+  if (!trimmed) {
+    throw new Error("request_base64 is required");
+  }
+  const raw = Buffer.from(trimmed, "base64").toString("utf8");
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("request payload must be an object");
+  }
+  return parsed as WorkspaceMcpSidecarCliRequest;
+}
+
+function readWorkspaceMcpSidecarState(workspaceDir: string): Record<string, SidecarStateEntry> {
+  return readSidecarStateFile(workspaceMcpStatePath(workspaceDir));
 }
 
 function writeWorkspaceMcpSidecarState(workspaceDir: string, entries: Record<string, SidecarStateEntry>): void {
@@ -268,6 +305,7 @@ export async function startWorkspaceMcpSidecar(
   deps: WorkspaceMcpSidecarDeps = {}
 ): Promise<WorkspaceMcpSidecarCliResponse> {
   const workspaceDir = path.resolve(request.workspace_dir);
+  migrateLegacySidecarArtifactsForWorkspace(workspaceDir, request.physical_server_id);
   const stateEntries = readWorkspaceMcpSidecarState(workspaceDir);
   const stateEntry = stateEntries[request.physical_server_id];
   const pidAlive = deps.pidAlive ?? workspaceMcpPidAlive;

--- a/runtime/harnesses/src/runtime-agent-tools.ts
+++ b/runtime/harnesses/src/runtime-agent-tools.ts
@@ -174,19 +174,19 @@ export const RUNTIME_AGENT_TOOL_DEFINITIONS = [
   {
     id: "list_data_tables",
     description:
-      "List the user-facing tables in the workspace's shared SQLite at `.holaboss/data.db` so you can compose SQL for `create_dashboard`. The runtime already provisions that DB file; if this returns count=0, the DB exists but no user-facing tables have been created yet. Each row reports a table's name, its columns with types, and approximate row count. Module apps write app-namespaced tables (e.g. twitter_posts, linkedin_posts, twitter_post_metrics) — read across them freely; never create a separate root `./data.db` yourself. App-internal tables (publish queues, scheduler logs, api usage counters, settings flags) are hidden by default — pass include_system=true if you actually need them, but they're rarely useful for dashboards.",
+      "List the user-facing tables in the workspace's shared SQLite at `.holaboss/state/data.db` so you can compose SQL for `create_dashboard`. The runtime already provisions that DB file; if this returns count=0, the DB exists but no user-facing tables have been created yet. Each row reports a table's name, its columns with types, and approximate row count. Module apps write app-namespaced tables (e.g. twitter_posts, linkedin_posts, twitter_post_metrics) — read across them freely; never create a separate root `./data.db` yourself. App-internal tables (publish queues, scheduler logs, api usage counters, settings flags) are hidden by default — pass include_system=true if you actually need them, but they're rarely useful for dashboards.",
     policy: "inspect"
   },
   {
     id: "create_data_table",
     description:
-      "Create a user-facing table in the workspace's shared SQLite at `.holaboss/data.db`, optionally inserting rows at the same time. Use this when you need sample or lightweight structured data before calling `create_dashboard`. The runtime already provisions the shared DB file, so write through this tool instead of creating a separate root `./data.db`.",
+      "Create a user-facing table in the workspace's shared SQLite at `.holaboss/state/data.db`, optionally inserting rows at the same time. Use this when you need sample or lightweight structured data before calling `create_dashboard`. The runtime already provisions the shared DB file, so write through this tool instead of creating a separate root `./data.db`.",
     policy: "mutate"
   },
   {
     id: "create_dashboard",
     description:
-      "Author a `.dashboard` file for the current workspace from a structured spec (title, optional description, list of panels). Panels are either `kpi` (single-value SELECT, prefer aliasing the answer as `value`) or `data_view` (one SELECT shared across one or more views — `table` or read-only `board`; for board, set `group_by` to a low-cardinality enum-like column like status/category). Each query is validated against the shared workspace DB at `.holaboss/data.db` before the file is written. Use `list_data_tables` first to discover what's queryable, or `create_data_table` first when you need sample data.",
+      "Author a `.dashboard` file for the current workspace from a structured spec (title, optional description, list of panels). Panels are either `kpi` (single-value SELECT, prefer aliasing the answer as `value`) or `data_view` (one SELECT shared across one or more views — `table` or read-only `board`; for board, set `group_by` to a low-cardinality enum-like column like status/category). Each query is validated against the shared workspace DB at `.holaboss/state/data.db` before the file is written. Use `list_data_tables` first to discover what's queryable, or `create_data_table` first when you need sample data.",
     policy: "mutate"
   }
 ] as const;

--- a/runtime/harnesses/src/runtime-capability-tools.ts
+++ b/runtime/harnesses/src/runtime-capability-tools.ts
@@ -681,7 +681,7 @@ function runtimeToolParameters(toolId: RuntimeAgentToolId): Record<string, unkno
           name: {
             type: "string",
             description:
-              "SQL-safe table name to create inside the shared workspace DB at `.holaboss/data.db`.",
+              "SQL-safe table name to create inside the shared workspace DB at `.holaboss/state/data.db`.",
           },
           columns: {
             type: "array",
@@ -752,7 +752,7 @@ function runtimeToolParameters(toolId: RuntimeAgentToolId): Record<string, unkno
                 query: {
                   type: "string",
                   description:
-                    "Read-only SQL against the shared workspace DB at `.holaboss/data.db`. For kpi, prefer aliasing the answer as `value`.",
+                    "Read-only SQL against the shared workspace DB at `.holaboss/state/data.db`. For kpi, prefer aliasing the answer as `value`.",
                 },
                 views: {
                   type: "array",

--- a/runtime/state-store/src/cli.test.ts
+++ b/runtime/state-store/src/cli.test.ts
@@ -240,6 +240,7 @@ test("handleRequest maps cronjobs and task proposals to snake_case payloads", ()
   }) as Record<string, unknown>;
   const updatedJob = handleRequest("update-cronjob", {
     options,
+    workspace_id: "workspace-1",
     job_id: String(job.id),
     description: "Updated check",
     instruction: "Say hello louder"
@@ -256,6 +257,7 @@ test("handleRequest maps cronjobs and task proposals to snake_case payloads", ()
   }) as Record<string, unknown>;
   const updatedProposal = handleRequest("update-task-proposal-state", {
     options,
+    workspace_id: "workspace-1",
     proposal_id: "proposal-1",
     state: "accepted"
   }) as Record<string, unknown>;

--- a/runtime/state-store/src/cli.test.ts
+++ b/runtime/state-store/src/cli.test.ts
@@ -150,11 +150,13 @@ test("handleRequest maps output event operations to snake_case payloads", () => 
 
   const latest = handleRequest("latest-output-event-id", {
     options,
+    workspace_id: "workspace-1",
     session_id: "session-main",
     input_id: "input-1"
   });
   const incremental = handleRequest("list-output-events", {
     options,
+    workspace_id: "workspace-1",
     session_id: "session-main",
     input_id: "input-1",
     after_event_id: 1

--- a/runtime/state-store/src/cli.ts
+++ b/runtime/state-store/src/cli.ts
@@ -458,12 +458,14 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
         return { ok: true };
       case "latest-output-event-id":
         return store.latestOutputEventId({
+          workspaceId: String(envelope.workspace_id),
           sessionId: String(envelope.session_id),
           inputId: typeof envelope.input_id === "string" ? envelope.input_id : undefined
         });
       case "list-output-events":
         return store
           .listOutputEvents({
+            workspaceId: String(envelope.workspace_id),
             sessionId: String(envelope.session_id),
             inputId: typeof envelope.input_id === "string" ? envelope.input_id : undefined,
             includeHistory: typeof envelope.include_history === "boolean" ? envelope.include_history : true,

--- a/runtime/state-store/src/cli.ts
+++ b/runtime/state-store/src/cli.ts
@@ -554,6 +554,7 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           .map((record) => toOutputFolderRecord(record));
       case "update-output-folder": {
         const record = store.updateOutputFolder({
+          workspaceId: String(envelope.workspace_id),
           folderId: String(envelope.folder_id),
           name: typeof envelope.name === "string" ? envelope.name : null,
           position: typeof envelope.position === "number" ? envelope.position : null
@@ -561,11 +562,17 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
         return record ? toOutputFolderRecord(record) : null;
       }
       case "get-output-folder": {
-        const record = store.getOutputFolder(String(envelope.folder_id));
+        const record = store.getOutputFolder({
+          workspaceId: String(envelope.workspace_id),
+          folderId: String(envelope.folder_id),
+        });
         return record ? toOutputFolderRecord(record) : null;
       }
       case "delete-output-folder":
-        return store.deleteOutputFolder(String(envelope.folder_id));
+        return store.deleteOutputFolder({
+          workspaceId: String(envelope.workspace_id),
+          folderId: String(envelope.folder_id),
+        });
       case "create-output":
         return toOutputRecord(
           store.createOutput({
@@ -601,11 +608,15 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           })
           .map((record) => toOutputRecord(record));
       case "get-output": {
-        const record = store.getOutput(String(envelope.output_id));
+        const record = store.getOutput({
+          workspaceId: String(envelope.workspace_id),
+          outputId: String(envelope.output_id),
+        });
         return record ? toOutputRecord(record) : null;
       }
       case "update-output": {
         const record = store.updateOutput({
+          workspaceId: String(envelope.workspace_id),
           outputId: String(envelope.output_id),
           title: typeof envelope.title === "string" ? envelope.title : null,
           status: typeof envelope.status === "string" ? envelope.status : null,
@@ -618,7 +629,10 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
         return record ? toOutputRecord(record) : null;
       }
       case "delete-output":
-        return store.deleteOutput(String(envelope.output_id));
+        return store.deleteOutput({
+          workspaceId: String(envelope.workspace_id),
+          outputId: String(envelope.output_id),
+        });
       case "get-output-counts":
         return store.getOutputCounts({ workspaceId: String(envelope.workspace_id) }) as JsonValue;
       case "create-cronjob":
@@ -638,7 +652,10 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           })
         );
       case "get-cronjob": {
-        const record = store.getCronjob(String(envelope.job_id));
+        const record = store.getCronjob({
+          workspaceId: String(envelope.workspace_id),
+          jobId: String(envelope.job_id),
+        });
         return record ? toCronjobRecord(record) : null;
       }
       case "list-cronjobs":
@@ -650,6 +667,7 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           .map((record) => toCronjobRecord(record));
       case "update-cronjob": {
         const record = store.updateCronjob({
+          workspaceId: String(envelope.workspace_id),
           jobId: String(envelope.job_id),
           name: typeof envelope.name === "string" ? envelope.name : null,
           cron: typeof envelope.cron === "string" ? envelope.cron : null,
@@ -667,7 +685,10 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
         return record ? toCronjobRecord(record) : null;
       }
       case "delete-cronjob":
-        return store.deleteCronjob(String(envelope.job_id));
+        return store.deleteCronjob({
+          workspaceId: String(envelope.workspace_id),
+          jobId: String(envelope.job_id),
+        });
       case "upsert-app-build":
         return toAppBuildRecord(
           store.upsertAppBuild({
@@ -706,7 +727,10 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           })
         );
       case "get-task-proposal": {
-        const record = store.getTaskProposal(String(envelope.proposal_id));
+        const record = store.getTaskProposal({
+          workspaceId: String(envelope.workspace_id),
+          proposalId: String(envelope.proposal_id),
+        });
         return record ? toTaskProposalRecord(record) : null;
       }
       case "list-task-proposals":
@@ -719,6 +743,7 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           .map((record) => toTaskProposalRecord(record));
       case "update-task-proposal-state": {
         const record = store.updateTaskProposalState({
+          workspaceId: String(envelope.workspace_id),
           proposalId: String(envelope.proposal_id),
           state: String(envelope.state)
         });

--- a/runtime/state-store/src/cli.ts
+++ b/runtime/state-store/src/cli.ts
@@ -419,9 +419,12 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
       case "list-runtime-states":
         return store.listRuntimeStates(String(envelope.workspace_id)).map((record) => toRuntimeStateRecord(record));
       case "get-runtime-state": {
+        if (typeof envelope.workspace_id !== "string" || !envelope.workspace_id.trim()) {
+          throw new Error("workspace_id is required");
+        }
         const record = store.getRuntimeState({
           sessionId: String(envelope.session_id),
-          workspaceId: typeof envelope.workspace_id === "string" ? envelope.workspace_id : undefined
+          workspaceId: envelope.workspace_id
         });
         return record ? toRuntimeStateRecord(record) : null;
       }

--- a/runtime/state-store/src/cli.ts
+++ b/runtime/state-store/src/cli.ts
@@ -352,28 +352,38 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
           })
         );
       case "get-input": {
-        const record = store.getInput(String(envelope.input_id));
+        const record = store.getInput({
+          workspaceId: String(envelope.workspace_id),
+          inputId: String(envelope.input_id),
+        });
         return record ? toInputRecord(record) : null;
       }
       case "get-input-by-idempotency-key": {
-        const record = store.getInputByIdempotencyKey(String(envelope.idempotency_key));
+        const record = store.getInputByIdempotencyKey({
+          workspaceId: String(envelope.workspace_id),
+          idempotencyKey: String(envelope.idempotency_key),
+        });
         return record ? toInputRecord(record) : null;
       }
       case "update-input": {
         const fields = (envelope.fields as JsonObject | undefined) ?? {};
-        const record = store.updateInput(String(envelope.input_id), {
-          sessionId: typeof fields.session_id === "string" ? fields.session_id : undefined,
-          workspaceId: typeof fields.workspace_id === "string" ? fields.workspace_id : undefined,
-          payload: (fields.payload as JsonObject | undefined) ?? undefined,
-          status: typeof fields.status === "string" ? fields.status : undefined,
-          priority: typeof fields.priority === "number" ? fields.priority : undefined,
-          availableAt: typeof fields.available_at === "string" ? fields.available_at : undefined,
-          attempt: typeof fields.attempt === "number" ? fields.attempt : undefined,
-          idempotencyKey:
-            typeof fields.idempotency_key === "string" ? fields.idempotency_key : fields.idempotency_key === null ? null : undefined,
-          claimedBy: typeof fields.claimed_by === "string" ? fields.claimed_by : fields.claimed_by === null ? null : undefined,
-          claimedUntil:
-            typeof fields.claimed_until === "string" ? fields.claimed_until : fields.claimed_until === null ? null : undefined
+        const record = store.updateInput({
+          workspaceId: String(envelope.workspace_id),
+          inputId: String(envelope.input_id),
+          fields: {
+            sessionId: typeof fields.session_id === "string" ? fields.session_id : undefined,
+            workspaceId: typeof fields.workspace_id === "string" ? fields.workspace_id : undefined,
+            payload: (fields.payload as JsonObject | undefined) ?? undefined,
+            status: typeof fields.status === "string" ? fields.status : undefined,
+            priority: typeof fields.priority === "number" ? fields.priority : undefined,
+            availableAt: typeof fields.available_at === "string" ? fields.available_at : undefined,
+            attempt: typeof fields.attempt === "number" ? fields.attempt : undefined,
+            idempotencyKey:
+              typeof fields.idempotency_key === "string" ? fields.idempotency_key : fields.idempotency_key === null ? null : undefined,
+            claimedBy: typeof fields.claimed_by === "string" ? fields.claimed_by : fields.claimed_by === null ? null : undefined,
+            claimedUntil:
+              typeof fields.claimed_until === "string" ? fields.claimed_until : fields.claimed_until === null ? null : undefined,
+          },
         });
         return record ? toInputRecord(record) : null;
       }
@@ -389,7 +399,7 @@ export function handleRequest(operation: string, envelope: RequestEnvelope): Jso
       case "has-available-inputs-for-session":
         return store.hasAvailableInputsForSession({
           sessionId: String(envelope.session_id),
-          workspaceId: typeof envelope.workspace_id === "string" ? envelope.workspace_id : undefined
+          workspaceId: String(envelope.workspace_id),
         });
       case "ensure-runtime-state":
         return toRuntimeStateRecord(

--- a/runtime/state-store/src/debug-cli.ts
+++ b/runtime/state-store/src/debug-cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * holaboss-runtime — debug CLI for runtime.db inside a sandbox.
+ * holaboss-runtime — debug CLI for host-state.db inside a sandbox.
  *
  * Use this instead of curling the api-server when you need to:
  *   - Inspect schema version / pending migrations
@@ -72,6 +72,10 @@ function openDb(dbPath: string): Database.Database {
   const db = new Database(dbPath, { readonly: true });
   db.pragma("query_only = ON");
   return db;
+}
+
+function workspaceRuntimeDbPathForWorkspacePath(workspacePath: string): string {
+  return path.join(workspacePath, ".holaboss", "state", "runtime.db");
 }
 
 function readUserVersion(db: Database.Database): number {
@@ -197,34 +201,52 @@ const commands: Record<string, (ctx: CommandContext) => Promise<number> | number
       out("usage: sessions <workspace-id>");
       return 2;
     }
-    const rows = db()
-      .prepare(
-        `SELECT s.session_id, s.kind, s.title, s.parent_session_id,
-                s.created_at, s.updated_at, s.archived_at,
-                rs.status AS runtime_status, rs.current_input_id,
-                rs.heartbeat_at, rs.last_error
-         FROM agent_sessions AS s
-         LEFT JOIN session_runtime_state AS rs
-           ON s.workspace_id = rs.workspace_id AND s.session_id = rs.session_id
-         WHERE s.workspace_id = ?
-         ORDER BY datetime(s.updated_at) DESC`,
+    const workspaceRow = db()
+      .prepare<[string], { workspace_path: string | null }>(
+        "SELECT workspace_path FROM workspaces WHERE id = ? LIMIT 1",
       )
-      .all(workspaceId);
+      .get(workspaceId);
+    const workspacePath = workspaceRow?.workspace_path?.trim() ?? "";
+    const workspaceDbPath = workspacePath
+      ? workspaceRuntimeDbPathForWorkspacePath(workspacePath)
+      : "";
+    const sessionSql = `SELECT s.session_id, s.kind, s.title, s.parent_session_id,
+            s.created_at, s.updated_at, s.archived_at,
+            rs.status AS runtime_status, rs.current_input_id,
+            rs.heartbeat_at, rs.last_error
+     FROM agent_sessions AS s
+     LEFT JOIN session_runtime_state AS rs
+       ON s.workspace_id = rs.workspace_id AND s.session_id = rs.session_id
+     WHERE s.workspace_id = ?
+     ORDER BY datetime(s.updated_at) DESC`;
+    let rows: unknown[] = [];
+    if (workspaceDbPath && existsSync(workspaceDbPath)) {
+      const workspaceDb = openDb(workspaceDbPath);
+      try {
+        rows = workspaceDb.prepare(sessionSql).all(workspaceId);
+      } finally {
+        workspaceDb.close();
+      }
+    } else {
+      const hasLegacySessionsTable = Boolean(
+        db()
+          .prepare<[string], { present: number }>(
+            "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+          )
+          .get("agent_sessions")?.present,
+      );
+      rows = hasLegacySessionsTable ? db().prepare(sessionSql).all(workspaceId) : [];
+    }
     out(JSON.stringify(rows, null, 2));
     return 0;
   },
 
   jobs: ({ db, out }) => {
-    const queueRows = safeAll(
-      db(),
-      `SELECT status, COUNT(*) AS count FROM agent_session_inputs GROUP BY status`,
-    );
-    const postRunRows = safeAll(
-      db(),
-      `SELECT status, COUNT(*) AS count FROM post_run_jobs GROUP BY status`,
-    );
+    const queueCounts = new Map<string, number>();
+    const postRunCounts = new Map<string, number>();
     const cronCounts = new Map<string, number>();
     const evolveCounts = new Map<string, number>();
+    let usedWorkspaceRuntimeDb = false;
     const workspaceRows = safeAll(
       db(),
       `SELECT id, workspace_path FROM workspaces WHERE deleted_at_utc IS NULL`,
@@ -238,17 +260,33 @@ const commands: Record<string, (ctx: CommandContext) => Promise<number> | number
         if (!workspacePath) {
           continue;
         }
-        const workspaceRuntimeDbPath = path.join(
-          workspacePath,
-          ".holaboss",
-          "state",
-          "runtime.db",
-        );
+        const workspaceRuntimeDbPath = workspaceRuntimeDbPathForWorkspacePath(workspacePath);
         if (!existsSync(workspaceRuntimeDbPath)) {
           continue;
         }
+        usedWorkspaceRuntimeDb = true;
         const workspaceDb = openDb(workspaceRuntimeDbPath);
         try {
+          const workspaceQueueRows = safeAll(
+            workspaceDb,
+            `SELECT status, COUNT(*) AS count FROM agent_session_inputs GROUP BY status`,
+          );
+          if (Array.isArray(workspaceQueueRows)) {
+            for (const row of workspaceQueueRows as Array<{ status?: string; count?: number }>) {
+              const key = typeof row.status === "string" ? row.status : "";
+              queueCounts.set(key, (queueCounts.get(key) ?? 0) + Number(row.count ?? 0));
+            }
+          }
+          const workspacePostRunRows = safeAll(
+            workspaceDb,
+            `SELECT status, COUNT(*) AS count FROM post_run_jobs GROUP BY status`,
+          );
+          if (Array.isArray(workspacePostRunRows)) {
+            for (const row of workspacePostRunRows as Array<{ status?: string; count?: number }>) {
+              const key = typeof row.status === "string" ? row.status : "";
+              postRunCounts.set(key, (postRunCounts.get(key) ?? 0) + Number(row.count ?? 0));
+            }
+          }
           const workspaceCronRows = safeAll(
             workspaceDb,
             `SELECT enabled, COUNT(*) AS count FROM cronjobs GROUP BY enabled`,
@@ -274,6 +312,18 @@ const commands: Record<string, (ctx: CommandContext) => Promise<number> | number
         }
       }
     }
+    const queueRows = usedWorkspaceRuntimeDb
+      ? Array.from(queueCounts.entries()).map(([status, count]) => ({ status, count }))
+      : safeAll(
+          db(),
+          `SELECT status, COUNT(*) AS count FROM agent_session_inputs GROUP BY status`,
+        );
+    const postRunRows = usedWorkspaceRuntimeDb
+      ? Array.from(postRunCounts.entries()).map(([status, count]) => ({ status, count }))
+      : safeAll(
+          db(),
+          `SELECT status, COUNT(*) AS count FROM post_run_jobs GROUP BY status`,
+        );
     const cronRows = Array.from(cronCounts.entries()).map(([enabled, count]) => ({
       enabled: Number(enabled),
       count,
@@ -336,7 +386,7 @@ function safeAll(
   }
 }
 
-const USAGE = `holaboss-runtime — debug CLI for runtime.db
+const USAGE = `holaboss-runtime — debug CLI for host-state.db
 
 Usage:
   holaboss-runtime [--db-path <path>] <command> [args]
@@ -352,7 +402,7 @@ Commands:
   help                    Show this message
 
 Flags:
-  --db-path <path>        Override runtime.db location (default: env-resolved)`;
+  --db-path <path>        Override host-state.db location (default: env-resolved)`;
 
 export interface RunCliOptions {
   argv?: ReadonlyArray<string>;

--- a/runtime/state-store/src/debug-cli.ts
+++ b/runtime/state-store/src/debug-cli.ts
@@ -28,6 +28,8 @@
  * Exit code: 0 on success, 1 on error, 2 on bad usage.
  */
 import Database from "better-sqlite3";
+import { existsSync } from "node:fs";
+import path from "node:path";
 
 import { LATEST_SEED_VERSION, RUNTIME_DB_MIGRATIONS } from "./migrations/index.js";
 import { runtimeDbPath } from "./store.js";
@@ -217,18 +219,69 @@ const commands: Record<string, (ctx: CommandContext) => Promise<number> | number
       db(),
       `SELECT status, COUNT(*) AS count FROM agent_session_inputs GROUP BY status`,
     );
-    const cronRows = safeAll(
-      db(),
-      `SELECT enabled, COUNT(*) AS count FROM cronjobs GROUP BY enabled`,
-    );
     const postRunRows = safeAll(
       db(),
       `SELECT status, COUNT(*) AS count FROM post_run_jobs GROUP BY status`,
     );
-    const evolveRows = safeAll(
+    const cronCounts = new Map<string, number>();
+    const evolveCounts = new Map<string, number>();
+    const workspaceRows = safeAll(
       db(),
-      `SELECT state, COUNT(*) AS count FROM evolve_skill_candidates GROUP BY state`,
+      `SELECT id, workspace_path FROM workspaces WHERE deleted_at_utc IS NULL`,
     );
+    if (Array.isArray(workspaceRows)) {
+      for (const workspaceRow of workspaceRows as Array<{ id?: string; workspace_path?: string }>) {
+        const workspacePath =
+          typeof workspaceRow.workspace_path === "string"
+            ? workspaceRow.workspace_path.trim()
+            : "";
+        if (!workspacePath) {
+          continue;
+        }
+        const workspaceRuntimeDbPath = path.join(
+          workspacePath,
+          ".holaboss",
+          "state",
+          "runtime.db",
+        );
+        if (!existsSync(workspaceRuntimeDbPath)) {
+          continue;
+        }
+        const workspaceDb = openDb(workspaceRuntimeDbPath);
+        try {
+          const workspaceCronRows = safeAll(
+            workspaceDb,
+            `SELECT enabled, COUNT(*) AS count FROM cronjobs GROUP BY enabled`,
+          );
+          if (Array.isArray(workspaceCronRows)) {
+            for (const row of workspaceCronRows as Array<{ enabled?: number; count?: number }>) {
+              const key = String(row.enabled ?? 0);
+              cronCounts.set(key, (cronCounts.get(key) ?? 0) + Number(row.count ?? 0));
+            }
+          }
+          const workspaceEvolveRows = safeAll(
+            workspaceDb,
+            `SELECT status AS state, COUNT(*) AS count FROM evolve_skill_candidates GROUP BY status`,
+          );
+          if (Array.isArray(workspaceEvolveRows)) {
+            for (const row of workspaceEvolveRows as Array<{ state?: string; count?: number }>) {
+              const key = typeof row.state === "string" ? row.state : "";
+              evolveCounts.set(key, (evolveCounts.get(key) ?? 0) + Number(row.count ?? 0));
+            }
+          }
+        } finally {
+          workspaceDb.close();
+        }
+      }
+    }
+    const cronRows = Array.from(cronCounts.entries()).map(([enabled, count]) => ({
+      enabled: Number(enabled),
+      count,
+    }));
+    const evolveRows = Array.from(evolveCounts.entries()).map(([state, count]) => ({
+      state,
+      count,
+    }));
     out(
       JSON.stringify(
         {

--- a/runtime/state-store/src/index.ts
+++ b/runtime/state-store/src/index.ts
@@ -9,6 +9,7 @@ export {
   type ConversationBindingRecord,
   RuntimeStateStore,
   controlPlaneDbPath,
+  hostStateDbPath,
   runtimeDbPath,
   sanitizeWorkspaceId,
   utcNowIso,

--- a/runtime/state-store/src/index.ts
+++ b/runtime/state-store/src/index.ts
@@ -8,6 +8,7 @@ export {
   type OAuthAppConfigRecord,
   type ConversationBindingRecord,
   RuntimeStateStore,
+  controlPlaneDbPath,
   runtimeDbPath,
   sanitizeWorkspaceId,
   utcNowIso,

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -36,7 +36,7 @@ test("workspace registry round trip uses hidden identity file", () => {
     status: "active"
   });
 
-  const identityPath = path.join(workspaceRoot, "workspace-1", ".holaboss", "workspace_id");
+  const identityPath = path.join(workspaceRoot, "workspace-1", ".holaboss", "state", "workspace_id");
   assert.equal(fs.readFileSync(identityPath, "utf-8").trim(), "workspace-1");
   assert.equal(created.id, "workspace-1");
   assert.deepEqual(store.getWorkspace("workspace-1"), created);
@@ -77,7 +77,7 @@ test("createWorkspace honors explicit workspacePath and registers it", () => {
 
   assert.equal(created.id, "ws-custom");
   assert.equal(fs.existsSync(customPath), true);
-  const identityPath = path.join(customPath, ".holaboss", "workspace_id");
+  const identityPath = path.join(customPath, ".holaboss", "state", "workspace_id");
   assert.equal(fs.readFileSync(identityPath, "utf-8").trim(), "ws-custom");
   assert.equal(path.resolve(store.workspaceDir("ws-custom")), path.resolve(customPath));
   // Default workspaceRoot was not touched.
@@ -307,7 +307,7 @@ test("relocateWorkspace accepts an empty directory and re-registers", () => {
   assert.equal(updated.id, "ws-r");
   assert.equal(path.resolve(store.workspaceDir("ws-r")), path.resolve(newPath));
   const identity = fs
-    .readFileSync(path.join(newPath, ".holaboss", "workspace_id"), "utf-8")
+    .readFileSync(path.join(newPath, ".holaboss", "state", "workspace_id"), "utf-8")
     .trim();
   assert.equal(identity, "ws-r");
   store.close();
@@ -434,7 +434,7 @@ test("runtime schema migrates workspace rows to registry and identity file", () 
   const rows = store.listWorkspaces();
 
   assert.deepEqual(rows.map((record) => record.id), ["workspace-legacy"]);
-  const identityPath = path.join(workspaceRoot, "workspace-legacy", ".holaboss", "workspace_id");
+  const identityPath = path.join(workspaceRoot, "workspace-legacy", ".holaboss", "state", "workspace_id");
   assert.equal(fs.readFileSync(identityPath, "utf-8").trim(), "workspace-legacy");
 
   const dbAfter = new Database(dbPath, { readonly: true });

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -852,8 +852,8 @@ test("transferring subagent ownership also moves pending queued main-session eve
   assert.ok(transferred);
   assert.equal(transferred?.ownerMainSessionId, "session-main-telegram");
   assert.equal(transferred?.ownerTransferredAt, "2026-04-24T12:21:00.000Z");
-  assert.equal(store.getMainSessionEvent({ eventId: pending.eventId })?.ownerMainSessionId, "session-main-telegram");
-  assert.equal(store.getMainSessionEvent({ eventId: delivered.eventId })?.ownerMainSessionId, "session-main-desktop");
+  assert.equal(store.getMainSessionEvent({ workspaceId: "workspace-1", eventId: pending.eventId })?.ownerMainSessionId, "session-main-telegram");
+  assert.equal(store.getMainSessionEvent({ workspaceId: "workspace-1", eventId: delivered.eventId })?.ownerMainSessionId, "session-main-desktop");
 
   store.close();
 });
@@ -882,16 +882,19 @@ test("main session event queue supports materialize deliver supersede lifecycle"
     payload: { question: "Create a new GCP project?" }
   });
 
-  const pending = store.listPendingMainSessionEvents({ ownerMainSessionId: "session-main" });
+  const pending = store.listPendingMainSessionEvents({ workspaceId: "workspace-1", ownerMainSessionId: "session-main" });
   const materialized = store.markMainSessionEventsMaterialized({
+    workspaceId: "workspace-1",
     eventIds: [first.eventId],
     materializedInputId: "main-input-1"
   });
   const delivered = store.markMainSessionEventsDelivered({
+    workspaceId: "workspace-1",
     eventIds: [first.eventId],
     deliveredAt: "2026-04-24T12:30:00.000Z"
   });
   const superseded = store.markMainSessionEventsSuperseded({
+    workspaceId: "workspace-1",
     eventIds: [second.eventId],
     supersededAt: "2026-04-24T12:31:00.000Z"
   });
@@ -903,7 +906,7 @@ test("main session event queue supports materialize deliver supersede lifecycle"
   assert.equal(delivered[0]?.deliveredAt, "2026-04-24T12:30:00.000Z");
   assert.equal(superseded[0]?.status, "superseded");
   assert.equal(superseded[0]?.supersededAt, "2026-04-24T12:31:00.000Z");
-  assert.equal(store.listPendingMainSessionEvents({ ownerMainSessionId: "session-main" }).length, 0);
+  assert.equal(store.listPendingMainSessionEvents({ workspaceId: "workspace-1", ownerMainSessionId: "session-main" }).length, 0);
 
   store.close();
 });
@@ -933,13 +936,14 @@ test("main session pending selectors exclude materialized events", () => {
   });
 
   store.markMainSessionEventsMaterialized({
+    workspaceId: "workspace-1",
     eventIds: [materialized.eventId],
     materializedInputId: "main-input-1"
   });
 
   assert.deepEqual(
     store
-      .listPendingMainSessionEvents({ ownerMainSessionId: "session-main" })
+      .listPendingMainSessionEvents({ workspaceId: "workspace-1", ownerMainSessionId: "session-main" })
       .map((event) => event.eventId),
     [pending.eventId]
   );
@@ -1489,10 +1493,14 @@ test("input queue supports idempotent enqueue, update, and claiming by priority"
   assert.equal(deduped.inputId, first.inputId);
   assert.equal(store.hasAvailableInputsForSession({ sessionId: "session-main", workspaceId: "workspace-1" }), true);
 
-  const updated = store.updateInput(first.inputId, {
-    status: "QUEUED",
-    claimedBy: "worker-old",
-    payload: { text: "hello-updated" }
+  const updated = store.updateInput({
+    workspaceId: "workspace-1",
+    inputId: first.inputId,
+    fields: {
+      status: "QUEUED",
+      claimedBy: "worker-old",
+      payload: { text: "hello-updated" }
+    }
   });
   assert.ok(updated);
   assert.deepEqual(updated.payload, { text: "hello-updated" });
@@ -1595,7 +1603,7 @@ test("claimInputs skips queued work for sessions that already have a live claime
     secondClaim.map((record) => record.inputId),
     [available.inputId]
   );
-  assert.equal(store.getInput(blocked.inputId)?.status, "QUEUED");
+  assert.equal(store.getInput({ workspaceId: "workspace-1", inputId: blocked.inputId })?.status, "QUEUED");
 
   store.close();
 });
@@ -1636,10 +1644,14 @@ test("post-run job queue supports idempotent enqueue, update, and claiming by pr
 
   assert.equal(deduped.jobId, first.jobId);
 
-  const updated = store.updatePostRunJob(first.jobId, {
-    status: "QUEUED",
-    claimedBy: "worker-old",
-    payload: { instruction: "hello-updated" }
+  const updated = store.updatePostRunJob({
+    workspaceId: "workspace-1",
+    jobId: first.jobId,
+    fields: {
+      status: "QUEUED",
+      claimedBy: "worker-old",
+      payload: { instruction: "hello-updated" }
+    }
   });
   assert.ok(updated);
   assert.deepEqual(updated.payload, { instruction: "hello-updated" });
@@ -1682,15 +1694,23 @@ test("state store lists expired claimed post-run jobs", () => {
     payload: {}
   });
 
-  store.updatePostRunJob(stale.jobId, {
-    status: "CLAIMED",
-    claimedBy: "worker-old",
-    claimedUntil: "2000-01-01T00:00:00.000Z"
+  store.updatePostRunJob({
+    workspaceId: "workspace-1",
+    jobId: stale.jobId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-old",
+      claimedUntil: "2000-01-01T00:00:00.000Z"
+    }
   });
-  store.updatePostRunJob(active.jobId, {
-    status: "CLAIMED",
-    claimedBy: "worker-new",
-    claimedUntil: "2999-01-01T00:00:00.000Z"
+  store.updatePostRunJob({
+    workspaceId: "workspace-1",
+    jobId: active.jobId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-new",
+      claimedUntil: "2999-01-01T00:00:00.000Z"
+    }
   });
 
   const expired = store.listExpiredClaimedPostRunJobs("2026-01-01T00:00:00.000Z");
@@ -1815,15 +1835,23 @@ test("state store lists expired claimed inputs", () => {
     payload: { text: "active" }
   });
 
-  store.updateInput(stale.inputId, {
-    status: "CLAIMED",
-    claimedBy: "worker-old",
-    claimedUntil: "2000-01-01T00:00:00.000Z"
+  store.updateInput({
+    workspaceId: "workspace-1",
+    inputId: stale.inputId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-old",
+      claimedUntil: "2000-01-01T00:00:00.000Z"
+    }
   });
-  store.updateInput(active.inputId, {
-    status: "CLAIMED",
-    claimedBy: "worker-new",
-    claimedUntil: "2999-01-01T00:00:00.000Z"
+  store.updateInput({
+    workspaceId: "workspace-1",
+    inputId: active.inputId,
+    fields: {
+      status: "CLAIMED",
+      claimedBy: "worker-new",
+      claimedUntil: "2999-01-01T00:00:00.000Z"
+    }
   });
 
   const expired = store.listExpiredClaimedInputs("2026-01-01T00:00:00.000Z");

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -1973,13 +1973,19 @@ test("output events support latest id, incremental listing, and tail mode", () =
     payload: { delta: "hi" }
   });
 
-  const latest = store.latestOutputEventId({ sessionId: "session-main", inputId: "input-1" });
+  const latest = store.latestOutputEventId({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    inputId: "input-1",
+  });
   const incremental = store.listOutputEvents({
+    workspaceId: "workspace-1",
     sessionId: "session-main",
     inputId: "input-1",
     afterEventId: 1
   });
   const tail = store.listOutputEvents({
+    workspaceId: "workspace-1",
     sessionId: "session-main",
     inputId: "input-1",
     includeHistory: false
@@ -2155,13 +2161,14 @@ test("turn results support upsert, lookup, count, and listing", () => {
   assert.deepEqual(updated.permissionDenials, [
     { tool_name: "deploy", tool_id: null, reason: "permission denied" }
   ]);
-  assert.deepEqual(store.getTurnResult({ inputId: "input-1" }), updated);
+  assert.deepEqual(store.getTurnResult({ workspaceId: "workspace-1", inputId: "input-1" }), updated);
   assert.equal(store.countTurnResults({ workspaceId: "workspace-1", sessionId: "session-main" }), 1);
   assert.equal(store.countTurnResults({ workspaceId: "workspace-1", sessionId: "session-main", status: "completed" }), 0);
   assert.equal(store.countTurnResults({ workspaceId: "workspace-1", sessionId: "session-main", status: "waiting_user" }), 1);
   assert.deepEqual(store.listTurnResults({ workspaceId: "workspace-1", sessionId: "session-main" }), [updated]);
   assert.deepEqual(store.listTurnResults({ workspaceId: "workspace-1", sessionId: "session-main", status: "waiting_user" }), [updated]);
   const telemetryOnlyUpdate = store.updateTurnResultContextBudgetDecisions({
+    workspaceId: "workspace-1",
     inputId: "input-1",
     contextBudgetDecisions: {
       mode: "observability_only",
@@ -2195,7 +2202,10 @@ test("turn request snapshots round trip", () => {
     },
   });
 
-  assert.deepEqual(store.getTurnRequestSnapshot({ inputId: "input-1" }), snapshot);
+  assert.deepEqual(
+    store.getTurnRequestSnapshot({ workspaceId: "workspace-1", inputId: "input-1" }),
+    snapshot
+  );
   assert.deepEqual(store.listTurnRequestSnapshots({ workspaceId: "workspace-1", sessionId: "session-main" }), [snapshot]);
   store.close();
 });

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -2317,8 +2317,21 @@ test("memory entries round trip and filter by workspace or scope", () => {
   ]);
   assert.deepEqual(
     store.listMemoryEntries({ status: "active" }).map((entry) => entry.memoryId),
-    [preference.memoryId, blocker.memoryId]
+    [blocker.memoryId, preference.memoryId]
   );
+
+  const controlPlaneDb = new Database(store.controlPlaneDbPath, { readonly: true });
+  const workspaceDb = new Database(workspaceRuntimeDbFile(store.workspaceRoot, "workspace-1"), { readonly: true });
+  assert.equal(
+    Number((controlPlaneDb.prepare("SELECT COUNT(*) AS count FROM memory_entries").get() as { count: number }).count),
+    1,
+  );
+  assert.equal(
+    Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM memory_entries").get() as { count: number }).count),
+    1,
+  );
+  controlPlaneDb.close();
+  workspaceDb.close();
   store.close();
 });
 
@@ -2387,7 +2400,7 @@ test("memory embedding index supports vector replacement, search, and delete", (
 
   store.deleteMemoryEmbeddingIndex("workspace-fact:workspace-1:deploy");
 
-  assert.equal(store.getMemoryEmbeddingIndexByMemoryId("workspace-fact:workspace-1:deploy"), null);
+  assert.equal(store.getMemoryEmbeddingIndexByMemoryId({ memoryId: "workspace-fact:workspace-1:deploy" }), null);
   assert.equal(
     store.searchWorkspaceMemoryRecallVectors({
       workspaceId: "workspace-1",

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -6,6 +6,7 @@ import { afterEach, test } from "node:test";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
 
 import { RuntimeStateStore } from "./store.js";
 
@@ -157,6 +158,232 @@ test("opening the store migrates legacy runtime.db files into host-state.db by d
     .get();
   migratedDb.close();
   assert.equal(row?.value, "migrated");
+});
+
+test("control-plane memory vector backfill migrates legacy user-scoped vec rows", () => {
+  const root = makeTempDir("hb-state-store-control-plane-vec-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const legacyDb = new Database(dbPath);
+  sqliteVec.load(legacyDb);
+  legacyDb.exec(`
+    CREATE TABLE memory_embedding_index (
+      vec_rowid INTEGER PRIMARY KEY,
+      memory_id TEXT NOT NULL UNIQUE,
+      path TEXT NOT NULL UNIQUE,
+      workspace_id TEXT,
+      scope_bucket TEXT NOT NULL,
+      memory_type TEXT NOT NULL,
+      content_fingerprint TEXT NOT NULL,
+      embedding_model TEXT NOT NULL,
+      embedding_dim INTEGER NOT NULL,
+      indexed_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE VIRTUAL TABLE memory_recall_vec USING vec0(
+      vec_rowid INTEGER PRIMARY KEY,
+      embedding float[1536],
+      scope_bucket TEXT,
+      workspace_id TEXT,
+      memory_type TEXT
+    );
+  `);
+  legacyDb
+    .prepare(`
+      INSERT INTO memory_embedding_index (
+        vec_rowid,
+        memory_id,
+        path,
+        workspace_id,
+        scope_bucket,
+        memory_type,
+        content_fingerprint,
+        embedding_model,
+        embedding_dim,
+        indexed_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      14,
+      "user-preference:style",
+      "preference/response-style.md",
+      null,
+      "preference",
+      "preference",
+      "b".repeat(64),
+      "text-embedding-3-small",
+      1536,
+      "2026-05-06T00:00:00.000Z",
+      "2026-05-06T00:00:00.000Z",
+    );
+  const embedding = new Float32Array(1536);
+  embedding[1] = 1;
+  legacyDb
+    .prepare(`
+      INSERT INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+    `)
+    .run(14, embedding, "preference", "", "preference");
+  legacyDb.close();
+
+  const store = new RuntimeStateStore({ dbPath, workspaceRoot });
+  assert.equal(store.supportsVectorIndex(), true);
+
+  const results = store.searchUserMemoryRecallVectors({
+    embedding,
+    limit: 5,
+  });
+
+  assert.equal(results[0]?.memoryId, "user-preference:style");
+  assert.equal(results[0]?.path, "preference/response-style.md");
+  store.close();
+});
+
+test("control-plane memory vector backfill is idempotent when a prior retry already inserted the vec row", () => {
+  const root = makeTempDir("hb-state-store-control-plane-vec-retry-");
+  const dbPath = path.join(root, "runtime.db");
+  const controlPlanePath = path.join(root, "control-plane.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const embedding = new Float32Array(1536);
+  embedding[1] = 1;
+
+  const legacyDb = new Database(dbPath);
+  sqliteVec.load(legacyDb);
+  legacyDb.exec(`
+    CREATE TABLE memory_embedding_index (
+      vec_rowid INTEGER PRIMARY KEY,
+      memory_id TEXT NOT NULL UNIQUE,
+      path TEXT NOT NULL UNIQUE,
+      workspace_id TEXT,
+      scope_bucket TEXT NOT NULL,
+      memory_type TEXT NOT NULL,
+      content_fingerprint TEXT NOT NULL,
+      embedding_model TEXT NOT NULL,
+      embedding_dim INTEGER NOT NULL,
+      indexed_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE VIRTUAL TABLE memory_recall_vec USING vec0(
+      vec_rowid INTEGER PRIMARY KEY,
+      embedding float[1536],
+      scope_bucket TEXT,
+      workspace_id TEXT,
+      memory_type TEXT
+    );
+  `);
+  legacyDb
+    .prepare(`
+      INSERT INTO memory_embedding_index (
+        vec_rowid,
+        memory_id,
+        path,
+        workspace_id,
+        scope_bucket,
+        memory_type,
+        content_fingerprint,
+        embedding_model,
+        embedding_dim,
+        indexed_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      14,
+      "user-preference:style",
+      "preference/response-style.md",
+      null,
+      "preference",
+      "preference",
+      "b".repeat(64),
+      "text-embedding-3-small",
+      1536,
+      "2026-05-06T00:00:00.000Z",
+      "2026-05-06T00:00:00.000Z",
+    );
+  legacyDb
+    .prepare(`
+      INSERT INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+    `)
+    .run(14, embedding, "preference", "", "preference");
+  legacyDb.close();
+
+  const controlPlaneDb = new Database(controlPlanePath);
+  sqliteVec.load(controlPlaneDb);
+  controlPlaneDb.exec(`
+    CREATE TABLE memory_embedding_index (
+      vec_rowid INTEGER PRIMARY KEY,
+      memory_id TEXT NOT NULL UNIQUE,
+      path TEXT NOT NULL UNIQUE,
+      workspace_id TEXT,
+      scope_bucket TEXT NOT NULL,
+      memory_type TEXT NOT NULL,
+      content_fingerprint TEXT NOT NULL,
+      embedding_model TEXT NOT NULL,
+      embedding_dim INTEGER NOT NULL,
+      indexed_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE VIRTUAL TABLE memory_recall_vec USING vec0(
+      vec_rowid INTEGER PRIMARY KEY,
+      embedding float[1536],
+      scope_bucket TEXT,
+      workspace_id TEXT,
+      memory_type TEXT
+    );
+  `);
+  controlPlaneDb
+    .prepare(`
+      INSERT INTO memory_embedding_index (
+        vec_rowid,
+        memory_id,
+        path,
+        workspace_id,
+        scope_bucket,
+        memory_type,
+        content_fingerprint,
+        embedding_model,
+        embedding_dim,
+        indexed_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      14,
+      "user-preference:style",
+      "preference/response-style.md",
+      null,
+      "preference",
+      "preference",
+      "b".repeat(64),
+      "text-embedding-3-small",
+      1536,
+      "2026-05-06T00:00:00.000Z",
+      "2026-05-06T00:00:00.000Z",
+    );
+  controlPlaneDb
+    .prepare(`
+      INSERT INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+    `)
+    .run(14, embedding, "preference", "", "preference");
+  controlPlaneDb.close();
+
+  const store = new RuntimeStateStore({ dbPath, controlPlaneDbPath: controlPlanePath, workspaceRoot });
+  store.listWorkspaces();
+  store.close();
+
+  const verifyDb = new Database(controlPlanePath, { readonly: true });
+  sqliteVec.load(verifyDb);
+  const countRow = verifyDb
+    .prepare<[], { total: number }>("SELECT COUNT(*) AS total FROM memory_recall_vec WHERE vec_rowid = 14")
+    .get();
+  verifyDb.close();
+
+  assert.equal(countRow?.total, 1);
 });
 
 test("createWorkspace honors explicit workspacePath and registers it", () => {
@@ -417,8 +644,8 @@ test("relocateWorkspace accepts a directory that already has a matching identity
   const customRoot = makeTempDir("hb-custom-ws-");
   const movedPath = path.join(customRoot, "moved");
   // Pre-seed the folder as if the user moved a workspace dir here.
-  fs.mkdirSync(path.join(movedPath, ".holaboss"), { recursive: true });
-  fs.writeFileSync(path.join(movedPath, ".holaboss", "workspace_id"), "ws-moved");
+  fs.mkdirSync(path.join(movedPath, ".holaboss", "state"), { recursive: true });
+  fs.writeFileSync(path.join(movedPath, ".holaboss", "state", "workspace_id"), "ws-moved");
   fs.writeFileSync(path.join(movedPath, "AGENTS.md"), "preserved");
 
   const store = new RuntimeStateStore({
@@ -432,6 +659,28 @@ test("relocateWorkspace accepts a directory that already has a matching identity
   // Pre-existing content is preserved (we don't wipe).
   assert.equal(fs.readFileSync(path.join(movedPath, "AGENTS.md"), "utf-8"), "preserved");
   assert.equal(path.resolve(store.workspaceDir("ws-moved")), path.resolve(movedPath));
+  store.close();
+});
+
+test("relocateWorkspace still accepts a directory with the legacy identity file path", () => {
+  const root = makeTempDir("hb-state-store-");
+  const customRoot = makeTempDir("hb-custom-ws-");
+  const movedPath = path.join(customRoot, "moved-legacy");
+  fs.mkdirSync(path.join(movedPath, ".holaboss"), { recursive: true });
+  fs.writeFileSync(path.join(movedPath, ".holaboss", "workspace_id"), "ws-moved");
+
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+  store.createWorkspace({ workspaceId: "ws-moved", name: "M", harness: "pi" });
+
+  store.relocateWorkspace("ws-moved", movedPath);
+
+  assert.equal(
+    fs.readFileSync(path.join(movedPath, ".holaboss", "state", "workspace_id"), "utf-8").trim(),
+    "ws-moved",
+  );
   store.close();
 });
 

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -2028,12 +2028,14 @@ test("terminal sessions support create update event append and list", () => {
   });
 
   const outputEvent = store.appendTerminalSessionEvent({
+    workspaceId: "workspace-1",
     terminalId: "term-1",
     eventType: "output",
     payload: { data: "ready\n" },
     status: "running",
   });
   const exitEvent = store.appendTerminalSessionEvent({
+    workspaceId: "workspace-1",
     terminalId: "term-1",
     eventType: "exit",
     payload: { exit_code: 0 },
@@ -2042,6 +2044,7 @@ test("terminal sessions support create update event append and list", () => {
     endedAt: "2026-01-01T00:00:10.000Z",
   });
   const updated = store.updateTerminalSession({
+    workspaceId: "workspace-1",
     terminalId: "term-1",
     title: "Dev Server Ready",
     metadata: { source: "test", ready: true },
@@ -2051,6 +2054,7 @@ test("terminal sessions support create update event append and list", () => {
     statuses: ["exited"],
   });
   const events = store.listTerminalSessionEvents({
+    workspaceId: "workspace-1",
     terminalId: "term-1",
   });
 
@@ -2066,7 +2070,12 @@ test("terminal sessions support create update event append and list", () => {
   assert.deepEqual(listed.map((record) => record.terminalId), ["term-1"]);
   assert.deepEqual(events.map((event) => event.eventType), ["output", "exit"]);
   assert.deepEqual(events[0]?.payload, { data: "ready\n" });
-  assert.deepEqual(store.listTerminalSessionEvents({ terminalId: "term-1", afterSequence: 1 }).map((event) => event.sequence), [2]);
+  assert.deepEqual(
+    store.listTerminalSessionEvents({ workspaceId: "workspace-1", terminalId: "term-1", afterSequence: 1 }).map(
+      (event) => event.sequence
+    ),
+    [2]
+  );
 
   store.close();
 });

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -618,6 +618,38 @@ test("createWorkspace allows reusing a soft-deleted workspace's former path", ()
   store.close();
 });
 
+test("createWorkspace revives a deleted workspace when the preserved folder still has its identity bundle", () => {
+  const root = makeTempDir("hb-state-store-");
+  const customRoot = makeTempDir("hb-custom-ws-");
+  const customPath = path.join(customRoot, "revive-folder");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace")
+  });
+
+  const created = store.createWorkspace({
+    workspaceId: "ws-revive",
+    name: "Revive Me",
+    harness: "pi",
+    workspacePath: customPath
+  });
+  fs.writeFileSync(path.join(customPath, "AGENTS.md"), "preserved\n");
+  store.deleteWorkspace(created.id);
+
+  const revived = store.createWorkspace({
+    name: "Ignored New Name",
+    harness: "pi",
+    workspacePath: customPath
+  });
+
+  assert.equal(revived.id, created.id);
+  assert.equal(revived.deletedAtUtc, null);
+  assert.equal(revived.name, "Revive Me");
+  assert.equal(path.resolve(store.workspaceDir(created.id)), path.resolve(customPath));
+  assert.equal(fs.readFileSync(path.join(customPath, "AGENTS.md"), "utf8"), "preserved\n");
+  store.close();
+});
+
 test("relocateWorkspace accepts an empty directory and re-registers", () => {
   const root = makeTempDir("hb-state-store-");
   const customRoot = makeTempDir("hb-custom-ws-");

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -762,6 +762,7 @@ test("subagent runs round trip and support waiting-user resume metadata", () => 
     status: "running"
   });
   const updated = store.updateSubagentRun({
+    workspaceId: "workspace-1",
     subagentId: created.subagentId,
     fields: {
       status: "waiting_on_user",
@@ -786,11 +787,15 @@ test("subagent runs round trip and support waiting-user resume metadata", () => 
     updated
   );
   assert.deepEqual(
-    store.listSubagentRunsByOwner({ ownerMainSessionId: "session-main" }).map((record) => record.subagentId),
+    store.listSubagentRunsByOwner({ workspaceId: "workspace-1", ownerMainSessionId: "session-main" }).map(
+      (record) => record.subagentId
+    ),
     [created.subagentId]
   );
   assert.deepEqual(
-    store.listWaitingSubagentRuns({ ownerMainSessionId: "session-main" }).map((record) => record.subagentId),
+    store.listWaitingSubagentRuns({ workspaceId: "workspace-1", ownerMainSessionId: "session-main" }).map(
+      (record) => record.subagentId
+    ),
     [created.subagentId]
   );
   assert.deepEqual(
@@ -838,6 +843,7 @@ test("transferring subagent ownership also moves pending queued main-session eve
   });
 
   const transferred = store.transferSubagentOwnership({
+    workspaceId: "workspace-1",
     subagentId: run.subagentId,
     ownerMainSessionId: "session-main-telegram",
     ownerTransferredAt: "2026-04-24T12:21:00.000Z"

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -134,6 +134,31 @@ test("control-plane metadata lives in control-plane.db while runtime.db keeps th
   assert.equal(appCatalogRow?.name, "Calendar");
 });
 
+test("opening the store migrates legacy runtime.db files into host-state.db by default", () => {
+  const root = makeTempDir("hb-state-store-");
+  const legacyPath = path.join(root, "state", "runtime.db");
+  const hostStatePath = path.join(root, "state", "host-state.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+  const legacyDb = new Database(legacyPath);
+  legacyDb.exec("CREATE TABLE legacy_marker (value TEXT NOT NULL);");
+  legacyDb.exec("INSERT INTO legacy_marker (value) VALUES ('migrated');");
+  legacyDb.close();
+
+  const store = new RuntimeStateStore({ workspaceRoot, sandboxRoot: root });
+  store.listWorkspaces();
+  store.close();
+
+  assert.equal(fs.existsSync(hostStatePath), true);
+  const migratedDb = new Database(hostStatePath, { readonly: true });
+  const row = migratedDb
+    .prepare<[], { value: string }>("SELECT value FROM legacy_marker LIMIT 1")
+    .get();
+  migratedDb.close();
+  assert.equal(row?.value, "migrated");
+});
+
 test("createWorkspace honors explicit workspacePath and registers it", () => {
   const root = makeTempDir("hb-state-store-");
   const dbPath = path.join(root, "runtime.db");
@@ -1771,7 +1796,8 @@ test("runtime state migration expands the status check constraint to include pau
   });
   store.close();
 
-  const db = new Database(dbPath);
+  const workspaceDbPath = workspaceRuntimeDbFile(workspaceRoot, "workspace-1");
+  const db = new Database(workspaceDbPath);
   db.exec(`
     ALTER TABLE session_runtime_state RENAME TO session_runtime_state_current;
 
@@ -2564,16 +2590,11 @@ test("workspace-scoped runtime tables persist inside the workspace bundle and mi
   workspaceDb.close();
 
   const runtimeDb = new Database(dbPath, { readonly: true });
-  const runtimeCounts = {
-    outputs: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM outputs").get() as { count: number }).count),
-    appBuilds: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM app_builds").get() as { count: number }).count),
-    appPorts: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM app_ports").get() as { count: number }).count),
-    cronjobs: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM cronjobs").get() as { count: number }).count),
-    notifications: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM runtime_notifications").get() as { count: number }).count),
-    taskProposals: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM task_proposals").get() as { count: number }).count),
-    evolveCandidates: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM evolve_skill_candidates").get() as { count: number }).count),
-    memoryUpdateProposals: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM memory_update_proposals").get() as { count: number }).count),
-  };
+  const runtimeTables = new Set<string>(
+    (runtimeDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+      (row) => row.name,
+    ),
+  );
   runtimeDb.close();
 
   assert.deepEqual(workspaceCounts, {
@@ -2586,16 +2607,14 @@ test("workspace-scoped runtime tables persist inside the workspace bundle and mi
     evolveCandidates: 1,
     memoryUpdateProposals: 1,
   });
-  assert.deepEqual(runtimeCounts, {
-    outputs: 0,
-    appBuilds: 0,
-    appPorts: 0,
-    cronjobs: 0,
-    notifications: 0,
-    taskProposals: 0,
-    evolveCandidates: 0,
-    memoryUpdateProposals: 0,
-  });
+  assert.equal(runtimeTables.has("outputs"), false);
+  assert.equal(runtimeTables.has("app_builds"), false);
+  assert.equal(runtimeTables.has("app_ports"), false);
+  assert.equal(runtimeTables.has("cronjobs"), false);
+  assert.equal(runtimeTables.has("runtime_notifications"), false);
+  assert.equal(runtimeTables.has("task_proposals"), false);
+  assert.equal(runtimeTables.has("evolve_skill_candidates"), false);
+  assert.equal(runtimeTables.has("memory_update_proposals"), false);
 });
 
 test("cronjobs round trip supports create, list, update, get, and delete", () => {
@@ -2710,6 +2729,27 @@ test("workspace-scoped runtime db backfills legacy cronjobs from runtime.db on f
   assert.equal(fs.existsSync(workspaceDbPath), false);
 
   const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE cronjobs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        initiated_by TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        cron TEXT NOT NULL,
+        description TEXT NOT NULL,
+        instruction TEXT NOT NULL DEFAULT '',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        delivery TEXT NOT NULL,
+        metadata TEXT NOT NULL DEFAULT '{}',
+        last_run_at TEXT,
+        next_run_at TEXT,
+        run_count INTEGER NOT NULL DEFAULT 0,
+        last_status TEXT,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+  `);
   db.prepare(`
     INSERT INTO cronjobs (
       id, workspace_id, initiated_by, name, cron, description, instruction, enabled, delivery, metadata,

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -23,6 +23,10 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
+function workspaceRuntimeDbFile(workspaceRoot: string, workspaceId: string): string {
+  return path.join(workspaceRoot, workspaceId, ".holaboss", "state", "runtime.db");
+}
+
 test("workspace registry round trip uses hidden identity file", () => {
   const root = makeTempDir("hb-state-store-");
   const dbPath = path.join(root, "runtime.db");
@@ -58,6 +62,76 @@ test("workspace registry round trip uses hidden identity file", () => {
   assert.equal(tables.has("workspaces"), true);
   assert.equal(path.resolve(row.workspace_path), path.join(workspaceRoot, "workspace-1"));
   store.close();
+});
+
+test("control-plane metadata lives in control-plane.db while runtime.db keeps the mirrored workspace registry", () => {
+  const root = makeTempDir("hb-state-store-");
+  const dbPath = path.join(root, "runtime.db");
+  const controlPlanePath = path.join(root, "control-plane.db");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({ dbPath, workspaceRoot });
+
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Acme",
+    harness: "pi",
+    status: "active"
+  });
+  store.upsertRuntimeUserProfile({
+    profileId: "default",
+    name: "Jeffrey",
+    nameSource: "manual"
+  });
+  store.upsertAppCatalogEntry({
+    appId: "calendar",
+    source: "marketplace",
+    name: "Calendar",
+    description: "Calendar app",
+    icon: null,
+    category: null,
+    tags: ["productivity"],
+    version: "1.0.0",
+    archiveUrl: null,
+    archivePath: null,
+    target: "apps/calendar",
+    cachedAt: "2026-05-06T00:00:00.000Z"
+  });
+  store.close();
+
+  const runtimeDb = new Database(dbPath, { readonly: true });
+  const runtimeTables = new Set<string>(
+    (runtimeDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+      (row) => row.name
+    )
+  );
+  const runtimeWorkspace = runtimeDb
+    .prepare<[string], { workspace_path: string }>("SELECT workspace_path FROM workspaces WHERE id = ? LIMIT 1")
+    .get("workspace-1");
+  runtimeDb.close();
+
+  const controlPlaneDb = new Database(controlPlanePath, { readonly: true });
+  const controlPlaneTables = new Set<string>(
+    (controlPlaneDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+      (row) => row.name
+    )
+  );
+  const profileRow = controlPlaneDb
+    .prepare<[string], { name: string | null }>("SELECT name FROM runtime_user_profiles WHERE profile_id = ? LIMIT 1")
+    .get("default");
+  const appCatalogRow = controlPlaneDb
+    .prepare<[string], { name: string }>("SELECT name FROM app_catalog WHERE app_id = ? LIMIT 1")
+    .get("calendar");
+  controlPlaneDb.close();
+
+  assert.ok(runtimeWorkspace);
+  assert.equal(runtimeTables.has("workspaces"), true);
+  assert.equal(runtimeTables.has("runtime_user_profiles"), false);
+  assert.equal(runtimeTables.has("app_catalog"), false);
+  assert.equal(controlPlaneTables.has("workspaces"), true);
+  assert.equal(controlPlaneTables.has("runtime_user_profiles"), true);
+  assert.equal(controlPlaneTables.has("app_catalog"), true);
+  assert.equal(profileRow?.name, "Jeffrey");
+  assert.equal(appCatalogRow?.name, "Calendar");
 });
 
 test("createWorkspace honors explicit workspacePath and registers it", () => {
@@ -484,6 +558,7 @@ test("workspaceDir recovers when folder is renamed", () => {
 test("getWorkspace recovers missing row from identity file", () => {
   const root = makeTempDir("hb-state-store-");
   const dbPath = path.join(root, "runtime.db");
+  const controlPlanePath = path.join(root, "control-plane.db");
   const workspaceRoot = path.join(root, "workspace");
   const store = new RuntimeStateStore({
     dbPath,
@@ -497,9 +572,12 @@ test("getWorkspace recovers missing row from identity file", () => {
     harness: "pi",
     status: "active"
   });
-  const db = new Database(dbPath);
-  db.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
-  db.close();
+  const controlPlaneDb = new Database(controlPlanePath);
+  controlPlaneDb.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
+  controlPlaneDb.close();
+  const runtimeDb = new Database(dbPath);
+  runtimeDb.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
+  runtimeDb.close();
 
   const recovered = store.getWorkspace("workspace-1");
 
@@ -2321,6 +2399,137 @@ test("app build status round trip supports upsert, lookup, and delete", () => {
   store.close();
 });
 
+test("workspace-scoped runtime tables persist inside the workspace bundle and mirror runtime.db", () => {
+  const root = makeTempDir("hb-state-store-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath,
+    workspaceRoot
+  });
+
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Acme",
+    harness: "pi",
+    status: "active"
+  });
+  store.ensureSession({
+    workspaceId: "workspace-1",
+    sessionId: "session-1"
+  });
+  store.createOutput({
+    workspaceId: "workspace-1",
+    outputType: "report",
+    title: "Daily note"
+  });
+  store.upsertAppBuild({
+    workspaceId: "workspace-1",
+    appId: "app-a",
+    status: "building"
+  });
+  store.allocateAppPort({
+    workspaceId: "workspace-1",
+    appId: "app-a"
+  });
+  const cronjob = store.createCronjob({
+    workspaceId: "workspace-1",
+    initiatedBy: "workspace_agent",
+    cron: "0 9 * * *",
+    description: "Daily check",
+    instruction: "Say hello",
+    delivery: { mode: "announce", channel: "session_run", to: null }
+  });
+  store.createRuntimeNotification({
+    workspaceId: "workspace-1",
+    cronjobId: cronjob.id,
+    sourceType: "cronjob",
+    title: "Hydrate",
+    message: "Drink water."
+  });
+  store.createTaskProposal({
+    proposalId: "proposal-1",
+    workspaceId: "workspace-1",
+    taskName: "Daily summary",
+    taskPrompt: "Summarize the day.",
+    taskGenerationRationale: "Keep the team aligned.",
+    createdAt: "2026-05-06T00:00:00.000Z"
+  });
+  store.createEvolveSkillCandidate({
+    candidateId: "candidate-1",
+    workspaceId: "workspace-1",
+    sessionId: "session-1",
+    inputId: "input-1",
+    kind: "skill_create",
+    title: "Daily summary helper",
+    summary: "Creates a short summary skill.",
+    slug: "daily-summary-helper",
+    skillPath: "skills/daily-summary-helper/SKILL.md",
+    contentFingerprint: "fp-1"
+  });
+  store.createMemoryUpdateProposal({
+    proposalId: "memory-proposal-1",
+    workspaceId: "workspace-1",
+    sessionId: "session-1",
+    inputId: "input-1",
+    proposalKind: "preference",
+    targetKey: "workspace/daily-summary",
+    title: "Remember summary preference",
+    summary: "Store that daily summaries should stay short.",
+  });
+  store.close();
+
+  const workspaceDbPath = workspaceRuntimeDbFile(workspaceRoot, "workspace-1");
+  assert.equal(fs.existsSync(workspaceDbPath), true);
+
+  const workspaceDb = new Database(workspaceDbPath, { readonly: true });
+  const workspaceCounts = {
+    outputs: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM outputs").get() as { count: number }).count),
+    appBuilds: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM app_builds").get() as { count: number }).count),
+    appPorts: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM app_ports").get() as { count: number }).count),
+    cronjobs: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM cronjobs").get() as { count: number }).count),
+    notifications: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM runtime_notifications").get() as { count: number }).count),
+    taskProposals: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM task_proposals").get() as { count: number }).count),
+    evolveCandidates: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM evolve_skill_candidates").get() as { count: number }).count),
+    memoryUpdateProposals: Number((workspaceDb.prepare("SELECT COUNT(*) AS count FROM memory_update_proposals").get() as { count: number }).count),
+  };
+  workspaceDb.close();
+
+  const runtimeDb = new Database(dbPath, { readonly: true });
+  const runtimeCounts = {
+    outputs: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM outputs").get() as { count: number }).count),
+    appBuilds: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM app_builds").get() as { count: number }).count),
+    appPorts: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM app_ports").get() as { count: number }).count),
+    cronjobs: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM cronjobs").get() as { count: number }).count),
+    notifications: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM runtime_notifications").get() as { count: number }).count),
+    taskProposals: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM task_proposals").get() as { count: number }).count),
+    evolveCandidates: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM evolve_skill_candidates").get() as { count: number }).count),
+    memoryUpdateProposals: Number((runtimeDb.prepare("SELECT COUNT(*) AS count FROM memory_update_proposals").get() as { count: number }).count),
+  };
+  runtimeDb.close();
+
+  assert.deepEqual(workspaceCounts, {
+    outputs: 1,
+    appBuilds: 1,
+    appPorts: 1,
+    cronjobs: 1,
+    notifications: 1,
+    taskProposals: 1,
+    evolveCandidates: 1,
+    memoryUpdateProposals: 1,
+  });
+  assert.deepEqual(runtimeCounts, {
+    outputs: 0,
+    appBuilds: 0,
+    appPorts: 0,
+    cronjobs: 0,
+    notifications: 0,
+    taskProposals: 0,
+    evolveCandidates: 0,
+    memoryUpdateProposals: 0,
+  });
+});
+
 test("cronjobs round trip supports create, list, update, get, and delete", () => {
   const root = makeTempDir("hb-state-store-");
   const store = new RuntimeStateStore({
@@ -2337,9 +2546,14 @@ test("cronjobs round trip supports create, list, update, get, and delete", () =>
     delivery: { mode: "announce", channel: "session_run", to: null }
   });
   const listed = store.listCronjobs({ workspaceId: "workspace-1" });
-  const fetched = store.getCronjob(job.id);
-  const updated = store.updateCronjob({ jobId: job.id, description: "Updated check", instruction: "Say hello loudly" });
-  const deleted = store.deleteCronjob(job.id);
+  const fetched = store.getCronjob({ workspaceId: "workspace-1", jobId: job.id });
+  const updated = store.updateCronjob({
+    workspaceId: "workspace-1",
+    jobId: job.id,
+    description: "Updated check",
+    instruction: "Say hello loudly"
+  });
+  const deleted = store.deleteCronjob({ workspaceId: "workspace-1", jobId: job.id });
 
   assert.equal(listed.length, 1);
   assert.ok(fetched);
@@ -2403,11 +2617,72 @@ test("cronjob schema migration backfills instruction from legacy description", (
   db.close();
 
   const store = new RuntimeStateStore({ dbPath, workspaceRoot });
-  const migrated = store.getCronjob("job-1");
+  const migrated = store.getCronjob({ workspaceId: "workspace-1", jobId: "job-1" });
 
   assert.ok(migrated);
   assert.equal(migrated.instruction, "Say hello every 5 minutes.");
   store.close();
+});
+
+test("workspace-scoped runtime db backfills legacy cronjobs from runtime.db on first access", () => {
+  const root = makeTempDir("hb-state-store-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+  const initialStore = new RuntimeStateStore({ dbPath, workspaceRoot });
+
+  initialStore.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Legacy",
+    harness: "pi",
+    status: "active"
+  });
+  initialStore.close();
+
+  const workspaceDbPath = workspaceRuntimeDbFile(workspaceRoot, "workspace-1");
+  assert.equal(fs.existsSync(workspaceDbPath), false);
+
+  const db = new Database(dbPath);
+  db.prepare(`
+    INSERT INTO cronjobs (
+      id, workspace_id, initiated_by, name, cron, description, instruction, enabled, delivery, metadata,
+      last_run_at, next_run_at, run_count, last_status, last_error, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "job-legacy",
+    "workspace-1",
+    "workspace_agent",
+    "Greeting",
+    "*/5 * * * *",
+    "Say hello every 5 minutes.",
+    "Say hello every 5 minutes.",
+    1,
+    JSON.stringify({ channel: "session_run" }),
+    "{}",
+    null,
+    null,
+    0,
+    null,
+    null,
+    "2026-01-01T00:00:00+00:00",
+    "2026-01-01T00:00:00+00:00"
+  );
+  db.close();
+
+  const store = new RuntimeStateStore({ dbPath, workspaceRoot });
+  const listed = store.listCronjobs({ workspaceId: "workspace-1" });
+  store.close();
+
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0]?.id, "job-legacy");
+  assert.equal(fs.existsSync(workspaceDbPath), true);
+
+  const workspaceDb = new Database(workspaceDbPath, { readonly: true });
+  const mirrored = workspaceDb
+    .prepare<[string], { id: string }>("SELECT id FROM cronjobs WHERE id = ? LIMIT 1")
+    .get("job-legacy");
+  workspaceDb.close();
+
+  assert.equal(mirrored?.id, "job-legacy");
 });
 
 test("runtime notifications round trip supports create, list, update, get, and dismiss", () => {
@@ -2428,12 +2703,14 @@ test("runtime notifications round trip supports create, list, update, get, and d
     priority: "high"
   });
   const listed = store.listRuntimeNotifications({ workspaceId: "workspace-1" });
-  const fetched = store.getRuntimeNotification(created.id);
+  const fetched = store.getRuntimeNotification({ workspaceId: "workspace-1", notificationId: created.id });
   const updated = store.updateRuntimeNotification({
+    workspaceId: "workspace-1",
     notificationId: created.id,
     state: "read"
   });
   const dismissed = store.updateRuntimeNotification({
+    workspaceId: "workspace-1",
     notificationId: created.id,
     state: "dismissed"
   });
@@ -2519,8 +2796,12 @@ test("task proposals round trip supports create, list, unreviewed, get, and stat
   });
   const listed = store.listTaskProposals({ workspaceId: "workspace-1" });
   const unreviewed = store.listUnreviewedTaskProposals({ workspaceId: "workspace-1" });
-  const fetched = store.getTaskProposal("proposal-1");
-  const updated = store.updateTaskProposalState({ proposalId: "proposal-1", state: "accepted" });
+  const fetched = store.getTaskProposal({ workspaceId: "workspace-1", proposalId: "proposal-1" });
+  const updated = store.updateTaskProposalState({
+    workspaceId: "workspace-1",
+    proposalId: "proposal-1",
+    state: "accepted"
+  });
 
   assert.equal(proposal.proposalId, "proposal-1");
   assert.equal(proposal.proposalSource, "proactive");
@@ -2561,6 +2842,7 @@ test("task proposal acceptance fields and child session metadata round trip", ()
 
   const sessions = store.listSessions({ workspaceId: "workspace-1" });
   const updated = store.updateTaskProposal({
+    workspaceId: "workspace-1",
     proposalId: "proposal-1",
     fields: {
       state: "accepted",
@@ -2627,7 +2909,10 @@ test("task proposal round trip preserves explicit evolve source", () => {
   });
 
   assert.equal(proposal.proposalSource, "evolve");
-  assert.equal(store.getTaskProposal("proposal-evolve-1")?.proposalSource, "evolve");
+  assert.equal(
+    store.getTaskProposal({ workspaceId: "workspace-1", proposalId: "proposal-evolve-1" })?.proposalSource,
+    "evolve"
+  );
   store.close();
 });
 
@@ -2677,9 +2962,10 @@ test("evolve skill candidates round trip supports create, list, lookup, and upda
     evaluationNotes: "Existing skill is stale.",
     sourceTurnInputIds: ["input-2"],
   });
-  const fetched = store.getEvolveSkillCandidate("candidate-1");
+  const fetched = store.getEvolveSkillCandidate({ workspaceId: "workspace-1", candidateId: "candidate-1" });
   const listed = store.listEvolveSkillCandidates({ workspaceId: "workspace-1" });
   const updated = store.updateEvolveSkillCandidate({
+    workspaceId: "workspace-1",
     candidateId: "candidate-1",
     fields: {
       taskProposalId: "proposal-1",
@@ -2697,7 +2983,13 @@ test("evolve skill candidates round trip supports create, list, lookup, and upda
   assert.equal(listed.length, 2);
   assert.equal(updated?.taskProposalId, "proposal-1");
   assert.equal(updated?.status, "proposed");
-  assert.equal(store.getEvolveSkillCandidateByTaskProposalId("proposal-1")?.candidateId, "candidate-1");
+  assert.equal(
+    store.getEvolveSkillCandidateByTaskProposalId({
+      workspaceId: "workspace-1",
+      proposalId: "proposal-1"
+    })?.candidateId,
+    "candidate-1"
+  );
   store.close();
 });
 
@@ -2740,8 +3032,12 @@ test("memory update proposals round trip supports create list filter get and acc
     limit: 10,
     offset: 0
   });
-  const fetched = store.getMemoryUpdateProposal("memory-proposal-1");
+  const fetched = store.getMemoryUpdateProposal({
+    workspaceId: "workspace-1",
+    proposalId: "memory-proposal-1"
+  });
   const accepted = store.updateMemoryUpdateProposal({
+    workspaceId: "workspace-1",
     proposalId: "memory-proposal-1",
     fields: {
       summary: "Prefer concise responses.",

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -701,10 +701,12 @@ test("conversation bindings round trip across channels and session ownership", (
     metadata: { chat_id: "chat-123" }
   });
   const touched = store.touchConversationBinding({
+    workspaceId: "workspace-1",
     bindingId: desktop.bindingId,
     lastActiveAt: "2026-04-24T12:00:00.000Z"
   });
   const inactive = store.setConversationBindingActive({
+    workspaceId: "workspace-1",
     bindingId: telegram.bindingId,
     isActive: false
   });

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -13,6 +13,7 @@ import {
 
 const RUNTIME_DB_PATH_ENV = "HOLABOSS_RUNTIME_DB_PATH";
 const WORKSPACE_RUNTIME_DIRNAME = ".holaboss";
+const WORKSPACE_STATE_DIRNAME = "state";
 const WORKSPACE_IDENTITY_FILENAME = "workspace_id";
 const LEGACY_WORKSPACE_METADATA_FILENAME = "workspace.json";
 
@@ -850,6 +851,36 @@ export function runtimeDbPath(options: RuntimeStateStoreOptions = {}): string {
   return path.join(sandboxRoot, "state", "runtime.db");
 }
 
+function workspaceRuntimeDir(workspacePath: string): string {
+  return path.join(workspacePath, WORKSPACE_RUNTIME_DIRNAME);
+}
+
+function workspaceStateDir(workspacePath: string): string {
+  return path.join(workspaceRuntimeDir(workspacePath), WORKSPACE_STATE_DIRNAME);
+}
+
+function currentWorkspaceIdentityPath(workspacePath: string): string {
+  return path.join(workspaceStateDir(workspacePath), WORKSPACE_IDENTITY_FILENAME);
+}
+
+function legacyWorkspaceIdentityPath(workspacePath: string): string {
+  return path.join(workspaceRuntimeDir(workspacePath), WORKSPACE_IDENTITY_FILENAME);
+}
+
+function ensureWorkspaceIdentityMigrated(workspacePath: string): string {
+  const currentPath = currentWorkspaceIdentityPath(workspacePath);
+  if (fs.existsSync(currentPath)) {
+    return currentPath;
+  }
+  const legacyPath = legacyWorkspaceIdentityPath(workspacePath);
+  if (fs.existsSync(legacyPath)) {
+    fs.mkdirSync(path.dirname(currentPath), { recursive: true });
+    fs.renameSync(legacyPath, currentPath);
+    return currentPath;
+  }
+  return currentPath;
+}
+
 export class RuntimeStateStore {
   readonly dbPath: string;
   readonly workspaceRoot: string;
@@ -887,7 +918,7 @@ export class RuntimeStateStore {
   }
 
   workspaceIdentityPath(workspaceId: string): string {
-    return path.join(this.workspaceDir(workspaceId), WORKSPACE_RUNTIME_DIRNAME, WORKSPACE_IDENTITY_FILENAME);
+    return ensureWorkspaceIdentityMigrated(this.workspaceDir(workspaceId));
   }
 
   /**
@@ -7973,9 +8004,8 @@ export class RuntimeStateStore {
   }
 
   private writeWorkspaceIdentityFile(workspacePath: string, workspaceId: string): void {
-    const runtimeDir = path.join(workspacePath, WORKSPACE_RUNTIME_DIRNAME);
-    fs.mkdirSync(runtimeDir, { recursive: true });
-    const identityPath = path.join(runtimeDir, WORKSPACE_IDENTITY_FILENAME);
+    const identityPath = currentWorkspaceIdentityPath(workspacePath);
+    fs.mkdirSync(path.dirname(identityPath), { recursive: true });
     const tempPath = `${identityPath}.tmp`;
     fs.writeFileSync(tempPath, `${workspaceId}\n`, "utf-8");
     fs.renameSync(tempPath, identityPath);
@@ -7991,13 +8021,15 @@ export class RuntimeStateStore {
       if (!fs.statSync(childPath).isDirectory()) {
         continue;
       }
-      const identityPath = path.join(childPath, WORKSPACE_RUNTIME_DIRNAME, WORKSPACE_IDENTITY_FILENAME);
-      if (!fs.existsSync(identityPath) || !fs.statSync(identityPath).isFile()) {
+      const identityPath = ensureWorkspaceIdentityMigrated(childPath);
+      const legacyPath = legacyWorkspaceIdentityPath(childPath);
+      const candidatePath = fs.existsSync(identityPath) ? identityPath : legacyPath;
+      if (!fs.existsSync(candidatePath) || !fs.statSync(candidatePath).isFile()) {
         continue;
       }
 
       try {
-        const raw = fs.readFileSync(identityPath, "utf-8").trim();
+        const raw = fs.readFileSync(candidatePath, "utf-8").trim();
         if (raw === workspaceId) {
           return childPath;
         }

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -1147,6 +1147,11 @@ export class RuntimeStateStore {
   createWorkspace(params: CreateWorkspaceParams): WorkspaceRecord {
     this.ensureWorkspaceMetadataReady();
 
+    const revived = this.tryReviveDeletedWorkspace(params);
+    if (revived) {
+      return revived;
+    }
+
     const workspaceId = params.workspaceId ?? randomUUID();
     if (this.getWorkspace(workspaceId, { includeDeleted: true })) {
       throw new Error(`workspace ${workspaceId} already exists`);
@@ -1175,6 +1180,58 @@ export class RuntimeStateStore {
     this.writeWorkspaceIdentityFile(workspacePath, workspaceId);
     this.upsertWorkspaceRow(record, workspacePath);
     return record;
+  }
+
+  private tryReviveDeletedWorkspace(params: CreateWorkspaceParams): WorkspaceRecord | null {
+    const requestedPath = params.workspacePath?.trim();
+    if (!requestedPath || !path.isAbsolute(requestedPath) || !fs.existsSync(requestedPath)) {
+      return null;
+    }
+    const stat = fs.statSync(requestedPath);
+    if (!stat.isDirectory()) {
+      return null;
+    }
+    const resolvedPath = path.resolve(requestedPath);
+    const identityPath = ensureWorkspaceIdentityMigrated(resolvedPath);
+    if (!fs.existsSync(identityPath)) {
+      return null;
+    }
+    let identityWorkspaceId: string;
+    try {
+      identityWorkspaceId = fs.readFileSync(identityPath, "utf-8").trim();
+    } catch {
+      return null;
+    }
+    if (!identityWorkspaceId) {
+      return null;
+    }
+    if (params.workspaceId && params.workspaceId !== identityWorkspaceId) {
+      throw new Error(
+        `workspacePath belongs to workspace ${identityWorkspaceId}, not requested workspace ${params.workspaceId}`,
+      );
+    }
+    const existing = this.getWorkspace(identityWorkspaceId, { includeDeleted: true });
+    if (!existing?.deletedAtUtc) {
+      return null;
+    }
+
+    const workspacePath = this.validateUserChosenWorkspacePath(resolvedPath, {
+      workspaceId: identityWorkspaceId,
+      allowMatchingIdentity: true,
+    });
+    const now = utcNowIso();
+    const revived: WorkspaceRecord = {
+      ...existing,
+      name: existing.name,
+      status: params.status ?? "provisioning",
+      harness: existing.harness ?? params.harness,
+      errorMessage: params.errorMessage ?? null,
+      updatedAt: now,
+      deletedAtUtc: null,
+    };
+    this.writeWorkspaceIdentityFile(workspacePath, identityWorkspaceId);
+    this.upsertWorkspaceRow(revived, workspacePath);
+    return revived;
   }
 
   private resolveCreateWorkspacePath(requested: string | undefined, workspaceId: string): string {

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -2478,16 +2478,17 @@ export class RuntimeStateStore {
       if (!updated) {
         return null;
       }
-      this.db()
+      this.workspaceRuntimeDb(params.workspaceId)
         .prepare(`
           UPDATE main_session_event_queue
           SET owner_main_session_id = ?,
               updated_at = ?
-          WHERE subagent_id = ?
+          WHERE workspace_id = ?
+            AND subagent_id = ?
             AND delivered_at IS NULL
             AND superseded_at IS NULL
         `)
-        .run(params.ownerMainSessionId, utcNowIso(), params.subagentId);
+        .run(params.ownerMainSessionId, utcNowIso(), params.workspaceId, params.subagentId);
       return this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
     });
     return transaction();
@@ -2546,7 +2547,7 @@ export class RuntimeStateStore {
     const eventId = params.eventId ?? randomUUID();
     const now = params.updatedAt ?? utcNowIso();
     const createdAt = params.createdAt ?? now;
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         INSERT INTO main_session_event_queue (
             event_id,
@@ -2589,7 +2590,10 @@ export class RuntimeStateStore {
         createdAt,
         now
       );
-    const record = this.getMainSessionEvent({ eventId });
+    const record = this.getMainSessionEvent({
+      workspaceId: params.workspaceId,
+      eventId,
+    });
     if (!record) {
       throw new Error("main session event row not found after insert");
     }
@@ -2597,14 +2601,21 @@ export class RuntimeStateStore {
   }
 
   updateMainSessionEvent(params: {
+    workspaceId: string;
     eventId: string;
     fields: MainSessionEventQueueUpdateFields;
   }): MainSessionEventQueueRecord | null {
     const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getMainSessionEvent({ eventId: params.eventId });
+      return this.getMainSessionEvent({
+        workspaceId: params.workspaceId,
+        eventId: params.eventId,
+      });
     }
-    const existing = this.getMainSessionEvent({ eventId: params.eventId });
+    const existing = this.getMainSessionEvent({
+      workspaceId: params.workspaceId,
+      eventId: params.eventId,
+    });
     if (!existing) {
       return null;
     }
@@ -2679,23 +2690,27 @@ export class RuntimeStateStore {
     }
     assignments.push("updated_at = ?");
     values.push(utcNowIso(), params.eventId);
-    const result = this.db()
+    const result = this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`UPDATE main_session_event_queue SET ${assignments.join(", ")} WHERE event_id = ?`)
       .run(...values);
     if (result.changes <= 0) {
       return null;
     }
-    return this.getMainSessionEvent({ eventId: params.eventId });
+    return this.getMainSessionEvent({
+      workspaceId: params.workspaceId,
+      eventId: params.eventId,
+    });
   }
 
-  getMainSessionEvent(params: { eventId: string }): MainSessionEventQueueRecord | null {
-    const row = this.db()
+  getMainSessionEvent(params: { workspaceId: string; eventId: string }): MainSessionEventQueueRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM main_session_event_queue WHERE event_id = ? LIMIT 1")
       .get(params.eventId);
     return row ? this.rowToMainSessionEventQueue(row) : null;
   }
 
   listPendingMainSessionEvents(params: {
+    workspaceId: string;
     ownerMainSessionId: string;
     deliveryBucket?: string | null;
     before?: string | null;
@@ -2725,7 +2740,7 @@ export class RuntimeStateStore {
       query += " LIMIT ?";
       values.push(Math.floor(params.limit));
     }
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToMainSessionEventQueue(row));
   }
 
@@ -2754,11 +2769,12 @@ export class RuntimeStateStore {
       query += " LIMIT ?";
       values.push(Math.floor(params.limit));
     }
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToMainSessionEventQueue(row));
   }
 
   markMainSessionEventsMaterialized(params: {
+    workspaceId: string;
     eventIds: string[];
     materializedInputId: string;
   }): MainSessionEventQueueRecord[] {
@@ -2766,7 +2782,7 @@ export class RuntimeStateStore {
       return [];
     }
     const now = utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE main_session_event_queue
         SET status = 'materialized',
@@ -2775,10 +2791,11 @@ export class RuntimeStateStore {
         WHERE event_id IN (${params.eventIds.map(() => "?").join(", ")})
       `)
       .run(params.materializedInputId, now, ...params.eventIds);
-    return this.listMainSessionEventsByIds(params.eventIds);
+    return this.listMainSessionEventsByIds(params.workspaceId, params.eventIds);
   }
 
   markMainSessionEventsDelivered(params: {
+    workspaceId: string;
     eventIds: string[];
     deliveredAt?: string;
   }): MainSessionEventQueueRecord[] {
@@ -2786,7 +2803,7 @@ export class RuntimeStateStore {
       return [];
     }
     const deliveredAt = params.deliveredAt ?? utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE main_session_event_queue
         SET status = 'delivered',
@@ -2795,10 +2812,11 @@ export class RuntimeStateStore {
         WHERE event_id IN (${params.eventIds.map(() => "?").join(", ")})
       `)
       .run(deliveredAt, deliveredAt, ...params.eventIds);
-    return this.listMainSessionEventsByIds(params.eventIds);
+    return this.listMainSessionEventsByIds(params.workspaceId, params.eventIds);
   }
 
   markMainSessionEventsSuperseded(params: {
+    workspaceId: string;
     eventIds: string[];
     supersededByEventId?: string | null;
     supersededAt?: string;
@@ -2807,7 +2825,7 @@ export class RuntimeStateStore {
       return [];
     }
     const supersededAt = params.supersededAt ?? utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE main_session_event_queue
         SET status = 'superseded',
@@ -2817,14 +2835,15 @@ export class RuntimeStateStore {
         WHERE event_id IN (${params.eventIds.map(() => "?").join(", ")})
       `)
       .run(this.normalizedNullableText(params.supersededByEventId), supersededAt, supersededAt, ...params.eventIds);
-    return this.listMainSessionEventsByIds(params.eventIds);
+    return this.listMainSessionEventsByIds(params.workspaceId, params.eventIds);
   }
 
   transferQueuedMainSessionEvents(params: {
+    workspaceId: string;
     subagentId: string;
     ownerMainSessionId: string;
   }): MainSessionEventQueueRecord[] {
-    const existing = this.db()
+    const existing = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], { workspace_id: string }>(`
         SELECT workspace_id
         FROM main_session_event_queue
@@ -2842,7 +2861,7 @@ export class RuntimeStateStore {
       );
     }
     const now = utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE main_session_event_queue
         SET owner_main_session_id = ?,
@@ -2852,7 +2871,7 @@ export class RuntimeStateStore {
           AND superseded_at IS NULL
       `)
       .run(params.ownerMainSessionId, now, params.subagentId);
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(`
         SELECT *
         FROM main_session_event_queue
@@ -2869,7 +2888,8 @@ export class RuntimeStateStore {
     workspaceId: string;
     nowIso?: string;
   }): MainSessionEventQueueRecord[] {
-    const rows = this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const rows = workspaceDb
       .prepare<[string], Record<string, unknown>>(
         `
           SELECT q.*
@@ -2890,7 +2910,7 @@ export class RuntimeStateStore {
       return [];
     }
     const now = params.nowIso ?? utcNowIso();
-    const resetEventStatement = this.db().prepare(`
+    const resetEventStatement = workspaceDb.prepare(`
       UPDATE main_session_event_queue
       SET status = 'pending',
           materialized_input_id = NULL,
@@ -2899,7 +2919,7 @@ export class RuntimeStateStore {
           updated_at = ?
       WHERE event_id = ?
     `);
-    const clearFailedInputIdempotencyStatement = this.db().prepare(`
+    const clearFailedInputIdempotencyStatement = workspaceDb.prepare(`
       UPDATE agent_session_inputs
       SET idempotency_key = NULL,
           updated_at = ?
@@ -2923,7 +2943,12 @@ export class RuntimeStateStore {
       }))
     );
     return events
-      .map((event) => this.getMainSessionEvent({ eventId: event.eventId }))
+      .map((event) =>
+        this.getMainSessionEvent({
+          workspaceId: params.workspaceId,
+          eventId: event.eventId,
+        })
+      )
       .filter((event): event is MainSessionEventQueueRecord => event !== null);
   }
 
@@ -3254,14 +3279,17 @@ export class RuntimeStateStore {
     idempotencyKey?: string | null;
   }): SessionInputRecord {
     if (params.idempotencyKey) {
-      const existing = this.getInputByIdempotencyKey(params.idempotencyKey);
+      const existing = this.getInputByIdempotencyKey({
+        workspaceId: params.workspaceId,
+        idempotencyKey: params.idempotencyKey,
+      });
       if (existing) {
         return existing;
       }
     }
     const inputId = randomUUID();
     const now = utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         INSERT INTO agent_session_inputs (
             input_id, session_id, workspace_id, payload, status, priority, available_at,
@@ -3280,26 +3308,29 @@ export class RuntimeStateStore {
         now,
         now
       );
-    const record = this.getInput(inputId);
+    const record = this.getInput({
+      workspaceId: params.workspaceId,
+      inputId,
+    });
     if (!record) {
       throw new Error("failed to load queued input");
     }
     return record;
   }
 
-  getInput(inputId: string): SessionInputRecord | null {
-    const row = this.db()
+  getInput(params: { workspaceId: string; inputId: string }): SessionInputRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM agent_session_inputs WHERE input_id = ? LIMIT 1")
-      .get(inputId);
+      .get(params.inputId);
     return this.rowToInput(row);
   }
 
-  getInputByIdempotencyKey(idempotencyKey: string): SessionInputRecord | null {
-    const row = this.db()
+  getInputByIdempotencyKey(params: { workspaceId: string; idempotencyKey: string }): SessionInputRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(
         "SELECT * FROM agent_session_inputs WHERE idempotency_key = ? LIMIT 1"
       )
-      .get(idempotencyKey);
+      .get(params.idempotencyKey);
     return this.rowToInput(row);
   }
 
@@ -3308,7 +3339,7 @@ export class RuntimeStateStore {
       typeof params.limit === "number" && Number.isFinite(params.limit) && params.limit > 0
         ? Math.floor(params.limit)
         : 200;
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string, number], Record<string, unknown>>(
         `
           SELECT *
@@ -3354,10 +3385,17 @@ export class RuntimeStateStore {
     return configured ?? filtered[0] ?? null;
   }
 
-  updateInput(inputId: string, fields: InputUpdateFields): SessionInputRecord | null {
-    const entries = Object.entries(fields);
+  updateInput(params: {
+    workspaceId: string;
+    inputId: string;
+    fields: InputUpdateFields;
+  }): SessionInputRecord | null {
+    const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getInput(inputId);
+      return this.getInput({
+        workspaceId: params.workspaceId,
+        inputId: params.inputId,
+      });
     }
 
     const columnMap: Record<keyof InputUpdateFields, string> = {
@@ -3385,15 +3423,19 @@ export class RuntimeStateStore {
     }
     assignments.push("updated_at = ?");
     values.push(utcNowIso());
-    values.push(inputId);
+    values.push(params.inputId);
 
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`UPDATE agent_session_inputs SET ${assignments.join(", ")} WHERE input_id = ?`)
       .run(...values);
-    return this.getInput(inputId);
+    return this.getInput({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
   }
 
   renewInputClaim(params: {
+    workspaceId: string;
     inputId: string;
     claimedBy: string;
     leaseSeconds: number;
@@ -3403,7 +3445,7 @@ export class RuntimeStateStore {
     const nowIso = params.nowIso ?? now.toISOString();
     const claimedUntilIso =
       params.leaseSeconds > 0 ? new Date(now.getTime() + params.leaseSeconds * 1000).toISOString() : nowIso;
-    const result = this.db()
+    const result = this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE agent_session_inputs
         SET claimed_until = ?,
@@ -3416,7 +3458,10 @@ export class RuntimeStateStore {
     if (result.changes === 0) {
       return null;
     }
-    return this.getInput(params.inputId);
+    return this.getInput({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
   }
 
   claimInputs(params: {
@@ -3431,102 +3476,138 @@ export class RuntimeStateStore {
     const claimedUntilIso =
       params.leaseSeconds > 0 ? new Date(now.getTime() + params.leaseSeconds * 1000).toISOString() : nowIso;
 
-    const rows = this.db()
-      .prepare<[string, string, string], { input_id: string; session_id: string }>(`
-        SELECT queued.input_id, queued.session_id
-        FROM agent_session_inputs AS queued
-        WHERE queued.status = 'QUEUED'
-          AND datetime(queued.available_at) <= datetime(?)
-          AND (queued.claimed_until IS NULL OR datetime(queued.claimed_until) <= datetime(?))
-          AND NOT EXISTS (
-            SELECT 1
-            FROM agent_session_inputs AS claimed
-            WHERE claimed.session_id = queued.session_id
-              AND claimed.input_id != queued.input_id
-              AND claimed.status = 'CLAIMED'
-              AND (claimed.claimed_until IS NULL OR datetime(claimed.claimed_until) > datetime(?))
-          )
-        ORDER BY priority DESC, datetime(created_at) ASC
-      `)
-      .all(nowIso, nowIso, nowIso);
+    const candidates = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db, workspaceId }) => {
+      const rows = db
+        .prepare<[string, string, string], { input_id: string; session_id: string; priority: number; created_at: string }>(`
+          SELECT queued.input_id, queued.session_id, queued.priority, queued.created_at
+          FROM agent_session_inputs AS queued
+          WHERE queued.status = 'QUEUED'
+            AND datetime(queued.available_at) <= datetime(?)
+            AND (queued.claimed_until IS NULL OR datetime(queued.claimed_until) <= datetime(?))
+            AND NOT EXISTS (
+              SELECT 1
+              FROM agent_session_inputs AS claimed
+              WHERE claimed.session_id = queued.session_id
+                AND claimed.input_id != queued.input_id
+                AND claimed.status = 'CLAIMED'
+                AND (claimed.claimed_until IS NULL OR datetime(claimed.claimed_until) > datetime(?))
+            )
+          ORDER BY priority DESC, datetime(created_at) ASC
+        `)
+        .all(nowIso, nowIso, nowIso);
+      return rows.map((row) => ({
+        workspaceId,
+        inputId: row.input_id,
+        sessionId: row.session_id,
+        priority: row.priority,
+        createdAt: row.created_at,
+      }));
+    });
+    candidates.sort((left, right) => {
+      const priorityCompare = Number(right.priority) - Number(left.priority);
+      if (priorityCompare !== 0) {
+        return priorityCompare;
+      }
+      const createdCompare = String(left.createdAt).localeCompare(String(right.createdAt));
+      if (createdCompare !== 0) {
+        return createdCompare;
+      }
+      return left.inputId.localeCompare(right.inputId);
+    });
 
-    const selectedInputIds: string[] = [];
+    const selectedInputs: Array<{ workspaceId: string; inputId: string }> = [];
     const seenSessionIds = new Set<string>();
     const excludedSessionIds = new Set(
       (params.excludeSessionIds ?? []).map((sessionId) => sessionId.trim()).filter((sessionId) => sessionId.length > 0),
     );
-    for (const row of rows) {
-      if (excludedSessionIds.has(row.session_id)) {
+    for (const row of candidates) {
+      if (excludedSessionIds.has(row.sessionId)) {
         continue;
       }
-      if (params.distinctSessions && seenSessionIds.has(row.session_id)) {
+      if (params.distinctSessions && seenSessionIds.has(row.sessionId)) {
         continue;
       }
-      selectedInputIds.push(row.input_id);
+      selectedInputs.push({
+        workspaceId: row.workspaceId,
+        inputId: row.inputId,
+      });
       if (params.distinctSessions) {
-        seenSessionIds.add(row.session_id);
+        seenSessionIds.add(row.sessionId);
       }
-      if (selectedInputIds.length >= Math.max(1, params.limit)) {
+      if (selectedInputs.length >= Math.max(1, params.limit)) {
         break;
       }
     }
-
-    const update = this.db().prepare(`
-      UPDATE agent_session_inputs
-      SET status = 'CLAIMED',
-          claimed_by = ?,
-          claimed_until = ?,
-          updated_at = ?
-      WHERE input_id = ?
-    `);
-
     const records: SessionInputRecord[] = [];
-    const transaction = this.db().transaction((inputIds: string[]) => {
-      for (const inputId of inputIds) {
-        update.run(params.claimedBy, claimedUntilIso, nowIso, inputId);
-        const record = this.getInput(inputId);
-        if (record) {
-          records.push(record);
-        }
+    for (const selected of selectedInputs) {
+      const result = this.workspaceRuntimeDb(selected.workspaceId)
+        .prepare(`
+          UPDATE agent_session_inputs
+          SET status = 'CLAIMED',
+              claimed_by = ?,
+              claimed_until = ?,
+              updated_at = ?
+          WHERE input_id = ?
+            AND status = 'QUEUED'
+        `)
+        .run(params.claimedBy, claimedUntilIso, nowIso, selected.inputId);
+      if (result.changes <= 0) {
+        continue;
       }
-    });
-    transaction(selectedInputIds);
+      const record = this.getInput(selected);
+      if (record) {
+        records.push(record);
+      }
+    }
     return records;
   }
 
-  hasAvailableInputsForSession(params: { sessionId: string; workspaceId?: string }): boolean {
+  hasAvailableInputsForSession(params: { workspaceId: string; sessionId: string }): boolean {
     const nowIso = utcNowIso();
-    let query = `
+    const query = `
       SELECT input_id FROM agent_session_inputs
       WHERE session_id = ?
+        AND workspace_id = ?
         AND status = 'QUEUED'
         AND datetime(available_at) <= datetime(?)
+      LIMIT 1
     `;
-    const values: Array<string> = [params.sessionId, nowIso];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
-    query += " LIMIT 1";
-
-    const row = this.db().prepare(query).get(...values);
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(
+      params.sessionId,
+      params.workspaceId,
+      nowIso,
+    );
     return Boolean(row);
   }
 
   listExpiredClaimedInputs(nowIso = utcNowIso()): SessionInputRecord[] {
-    const rows = this.db()
-      .prepare<[string], Record<string, unknown>>(`
-        SELECT *
-        FROM agent_session_inputs
-        WHERE status = 'CLAIMED'
-          AND claimed_until IS NOT NULL
-          AND datetime(claimed_until) <= datetime(?)
-        ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
-      `)
-      .all(nowIso);
-    return rows
-      .map((row) => this.rowToInput(row))
-      .filter((row): row is SessionInputRecord => row !== null);
+    const records = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+      const rows = db
+        .prepare<[string], Record<string, unknown>>(`
+          SELECT *
+          FROM agent_session_inputs
+          WHERE status = 'CLAIMED'
+            AND claimed_until IS NOT NULL
+            AND datetime(claimed_until) <= datetime(?)
+          ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
+        `)
+        .all(nowIso);
+      return rows
+        .map((row) => this.rowToInput(row))
+        .filter((row): row is SessionInputRecord => row !== null);
+    });
+    records.sort((left, right) => {
+      const claimedCompare = (left.claimedUntil ?? "").localeCompare(right.claimedUntil ?? "");
+      if (claimedCompare !== 0) {
+        return claimedCompare;
+      }
+      const updatedCompare = left.updatedAt.localeCompare(right.updatedAt);
+      if (updatedCompare !== 0) {
+        return updatedCompare;
+      }
+      return left.inputId.localeCompare(right.inputId);
+    });
+    return records;
   }
 
   static readonly #LIST_CLAIMED_INPUTS_SQL = `
@@ -3537,12 +3618,24 @@ export class RuntimeStateStore {
   `;
 
   listClaimedInputs(): SessionInputRecord[] {
-    const rows = this.#cachedPrepare(
-      RuntimeStateStore.#LIST_CLAIMED_INPUTS_SQL,
-    ).all() as Array<Record<string, unknown>>;
-    return rows
-      .map((row) => this.rowToInput(row))
-      .filter((row): row is SessionInputRecord => row !== null);
+    const records = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+      const rows = db.prepare(RuntimeStateStore.#LIST_CLAIMED_INPUTS_SQL).all() as Array<Record<string, unknown>>;
+      return rows
+        .map((row) => this.rowToInput(row))
+        .filter((row): row is SessionInputRecord => row !== null);
+    });
+    records.sort((left, right) => {
+      const claimedCompare = (left.claimedUntil ?? "").localeCompare(right.claimedUntil ?? "");
+      if (claimedCompare !== 0) {
+        return claimedCompare;
+      }
+      const updatedCompare = left.updatedAt.localeCompare(right.updatedAt);
+      if (updatedCompare !== 0) {
+        return updatedCompare;
+      }
+      return left.inputId.localeCompare(right.inputId);
+    });
+    return records;
   }
 
   enqueuePostRunJob(params: {
@@ -3555,14 +3648,17 @@ export class RuntimeStateStore {
     idempotencyKey?: string | null;
   }): PostRunJobRecord {
     if (params.idempotencyKey) {
-      const existing = this.getPostRunJobByIdempotencyKey(params.idempotencyKey);
+      const existing = this.getPostRunJobByIdempotencyKey({
+        workspaceId: params.workspaceId,
+        idempotencyKey: params.idempotencyKey,
+      });
       if (existing) {
         return existing;
       }
     }
     const jobId = randomUUID();
     const now = utcNowIso();
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         INSERT INTO post_run_jobs (
             job_id, job_type, input_id, session_id, workspace_id, payload, status, priority, available_at,
@@ -3583,24 +3679,27 @@ export class RuntimeStateStore {
         now,
         now
       );
-    const record = this.getPostRunJob(jobId);
+    const record = this.getPostRunJob({
+      workspaceId: params.workspaceId,
+      jobId,
+    });
     if (!record) {
       throw new Error("failed to load queued post-run job");
     }
     return record;
   }
 
-  getPostRunJob(jobId: string): PostRunJobRecord | null {
-    const row = this.db()
+  getPostRunJob(params: { workspaceId: string; jobId: string }): PostRunJobRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM post_run_jobs WHERE job_id = ? LIMIT 1")
-      .get(jobId);
+      .get(params.jobId);
     return this.rowToPostRunJob(row);
   }
 
-  getPostRunJobByIdempotencyKey(idempotencyKey: string): PostRunJobRecord | null {
-    const row = this.db()
+  getPostRunJobByIdempotencyKey(params: { workspaceId: string; idempotencyKey: string }): PostRunJobRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM post_run_jobs WHERE idempotency_key = ? LIMIT 1")
-      .get(idempotencyKey);
+      .get(params.idempotencyKey);
     return this.rowToPostRunJob(row);
   }
 
@@ -3613,6 +3712,46 @@ export class RuntimeStateStore {
     limit?: number;
     offset?: number;
   }): PostRunJobRecord[] {
+    if (!params.workspaceId) {
+      const jobs = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+        let query = "SELECT * FROM post_run_jobs WHERE 1 = 1";
+        const values: Array<string | number> = [];
+        if (params.sessionId) {
+          query += " AND session_id = ?";
+          values.push(params.sessionId);
+        }
+        if (params.inputId) {
+          query += " AND input_id = ?";
+          values.push(params.inputId);
+        }
+        if (params.jobType) {
+          query += " AND job_type = ?";
+          values.push(params.jobType);
+        }
+        if (params.statuses && params.statuses.length > 0) {
+          const placeholders = params.statuses.map(() => "?").join(", ");
+          query += ` AND status IN (${placeholders})`;
+          values.push(...params.statuses);
+        }
+        query += " ORDER BY priority DESC, datetime(created_at) ASC";
+        const rows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+        return rows
+          .map((row) => this.rowToPostRunJob(row))
+          .filter((row): row is PostRunJobRecord => row !== null);
+      });
+      jobs.sort((left, right) => {
+        const priorityCompare = right.priority - left.priority;
+        if (priorityCompare !== 0) {
+          return priorityCompare;
+        }
+        const createdCompare = left.createdAt.localeCompare(right.createdAt);
+        if (createdCompare !== 0) {
+          return createdCompare;
+        }
+        return left.jobId.localeCompare(right.jobId);
+      });
+      return jobs.slice(params.offset ?? 0, (params.offset ?? 0) + (params.limit ?? 100));
+    }
     let query = "SELECT * FROM post_run_jobs WHERE 1 = 1";
     const values: Array<string | number> = [];
     if (params.workspaceId) {
@@ -3638,16 +3777,23 @@ export class RuntimeStateStore {
     }
     query += " ORDER BY priority DESC, datetime(created_at) ASC LIMIT ? OFFSET ?";
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows
       .map((row) => this.rowToPostRunJob(row))
       .filter((row): row is PostRunJobRecord => row !== null);
   }
 
-  updatePostRunJob(jobId: string, fields: PostRunJobUpdateFields): PostRunJobRecord | null {
-    const entries = Object.entries(fields);
+  updatePostRunJob(params: {
+    workspaceId: string;
+    jobId: string;
+    fields: PostRunJobUpdateFields;
+  }): PostRunJobRecord | null {
+    const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getPostRunJob(jobId);
+      return this.getPostRunJob({
+        workspaceId: params.workspaceId,
+        jobId: params.jobId,
+      });
     }
 
     const columnMap: Record<keyof PostRunJobUpdateFields, string> = {
@@ -3684,12 +3830,15 @@ export class RuntimeStateStore {
     }
     assignments.push("updated_at = ?");
     values.push(utcNowIso());
-    values.push(jobId);
+    values.push(params.jobId);
 
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`UPDATE post_run_jobs SET ${assignments.join(", ")} WHERE job_id = ?`)
       .run(...values);
-    return this.getPostRunJob(jobId);
+    return this.getPostRunJob({
+      workspaceId: params.workspaceId,
+      jobId: params.jobId,
+    });
   }
 
   claimPostRunJobs(params: { limit: number; claimedBy: string; leaseSeconds: number; distinctSessions?: boolean }): PostRunJobRecord[] {
@@ -3698,52 +3847,75 @@ export class RuntimeStateStore {
     const claimedUntilIso =
       params.leaseSeconds > 0 ? new Date(now.getTime() + params.leaseSeconds * 1000).toISOString() : nowIso;
 
-    const rows = this.db()
-      .prepare<[string, string], { job_id: string; session_id: string }>(`
-        SELECT job_id, session_id
-        FROM post_run_jobs
-        WHERE status = 'QUEUED'
-          AND datetime(available_at) <= datetime(?)
-          AND (claimed_until IS NULL OR datetime(claimed_until) <= datetime(?))
-        ORDER BY priority DESC, datetime(created_at) ASC
-      `)
-      .all(nowIso, nowIso);
+    const candidates = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db, workspaceId }) => {
+      const rows = db
+        .prepare<[string, string], { job_id: string; session_id: string; priority: number; created_at: string }>(`
+          SELECT job_id, session_id, priority, created_at
+          FROM post_run_jobs
+          WHERE status = 'QUEUED'
+            AND datetime(available_at) <= datetime(?)
+            AND (claimed_until IS NULL OR datetime(claimed_until) <= datetime(?))
+          ORDER BY priority DESC, datetime(created_at) ASC
+        `)
+        .all(nowIso, nowIso);
+      return rows.map((row) => ({
+        workspaceId,
+        jobId: row.job_id,
+        sessionId: row.session_id,
+        priority: row.priority,
+        createdAt: row.created_at,
+      }));
+    });
+    candidates.sort((left, right) => {
+      const priorityCompare = Number(right.priority) - Number(left.priority);
+      if (priorityCompare !== 0) {
+        return priorityCompare;
+      }
+      const createdCompare = String(left.createdAt).localeCompare(String(right.createdAt));
+      if (createdCompare !== 0) {
+        return createdCompare;
+      }
+      return left.jobId.localeCompare(right.jobId);
+    });
 
-    const selectedJobIds: string[] = [];
+    const selectedJobs: Array<{ workspaceId: string; jobId: string }> = [];
     const seenSessionIds = new Set<string>();
-    for (const row of rows) {
-      if (params.distinctSessions && seenSessionIds.has(row.session_id)) {
+    for (const row of candidates) {
+      if (params.distinctSessions && seenSessionIds.has(row.sessionId)) {
         continue;
       }
-      selectedJobIds.push(row.job_id);
+      selectedJobs.push({
+        workspaceId: row.workspaceId,
+        jobId: row.jobId,
+      });
       if (params.distinctSessions) {
-        seenSessionIds.add(row.session_id);
+        seenSessionIds.add(row.sessionId);
       }
-      if (selectedJobIds.length >= Math.max(1, params.limit)) {
+      if (selectedJobs.length >= Math.max(1, params.limit)) {
         break;
       }
     }
-
-    const update = this.db().prepare(`
-      UPDATE post_run_jobs
-      SET status = 'CLAIMED',
-          claimed_by = ?,
-          claimed_until = ?,
-          updated_at = ?
-      WHERE job_id = ?
-    `);
-
     const records: PostRunJobRecord[] = [];
-    const transaction = this.db().transaction((jobIds: string[]) => {
-      for (const jobId of jobIds) {
-        update.run(params.claimedBy, claimedUntilIso, nowIso, jobId);
-        const record = this.getPostRunJob(jobId);
-        if (record) {
-          records.push(record);
-        }
+    for (const selected of selectedJobs) {
+      const result = this.workspaceRuntimeDb(selected.workspaceId)
+        .prepare(`
+          UPDATE post_run_jobs
+          SET status = 'CLAIMED',
+              claimed_by = ?,
+              claimed_until = ?,
+              updated_at = ?
+          WHERE job_id = ?
+            AND status = 'QUEUED'
+        `)
+        .run(params.claimedBy, claimedUntilIso, nowIso, selected.jobId);
+      if (result.changes <= 0) {
+        continue;
       }
-    });
-    transaction(selectedJobIds);
+      const record = this.getPostRunJob(selected);
+      if (record) {
+        records.push(record);
+      }
+    }
     return records;
   }
 
@@ -3757,12 +3929,24 @@ export class RuntimeStateStore {
   `;
 
   listExpiredClaimedPostRunJobs(nowIso = utcNowIso()): PostRunJobRecord[] {
-    const rows = this.#cachedPrepare(
-      RuntimeStateStore.#LIST_EXPIRED_CLAIMED_POST_RUN_JOBS_SQL,
-    ).all(nowIso) as Array<Record<string, unknown>>;
-    return rows
-      .map((row) => this.rowToPostRunJob(row))
-      .filter((row): row is PostRunJobRecord => row !== null);
+    const records = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+      const rows = db.prepare(RuntimeStateStore.#LIST_EXPIRED_CLAIMED_POST_RUN_JOBS_SQL).all(nowIso) as Array<Record<string, unknown>>;
+      return rows
+        .map((row) => this.rowToPostRunJob(row))
+        .filter((row): row is PostRunJobRecord => row !== null);
+    });
+    records.sort((left, right) => {
+      const claimedCompare = (left.claimedUntil ?? "").localeCompare(right.claimedUntil ?? "");
+      if (claimedCompare !== 0) {
+        return claimedCompare;
+      }
+      const updatedCompare = left.updatedAt.localeCompare(right.updatedAt);
+      if (updatedCompare !== 0) {
+        return updatedCompare;
+      }
+      return left.jobId.localeCompare(right.jobId);
+    });
+    return records;
   }
 
   ensureRuntimeState(params: {
@@ -6759,6 +6943,9 @@ export class RuntimeStateStore {
       "agent_sessions",
       "agent_runtime_sessions",
       "conversation_bindings",
+      "agent_session_inputs",
+      "post_run_jobs",
+      "main_session_event_queue",
       "session_runtime_state",
       "session_messages",
       "subagent_runs",
@@ -7029,6 +7216,86 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_conversation_bindings_channel_key_active
           ON conversation_bindings (channel, conversation_key, is_active);
+
+      CREATE TABLE IF NOT EXISTS agent_session_inputs (
+          input_id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          status TEXT NOT NULL,
+          priority INTEGER NOT NULL DEFAULT 0,
+          available_at TEXT NOT NULL,
+          attempt INTEGER NOT NULL DEFAULT 0,
+          idempotency_key TEXT,
+          claimed_by TEXT,
+          claimed_until TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_workspace_created
+          ON agent_session_inputs (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_session_status
+          ON agent_session_inputs (session_id, status, available_at);
+
+      CREATE TABLE IF NOT EXISTS post_run_jobs (
+          job_id TEXT PRIMARY KEY,
+          job_type TEXT NOT NULL,
+          input_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          status TEXT NOT NULL,
+          priority INTEGER NOT NULL DEFAULT 0,
+          available_at TEXT NOT NULL,
+          attempt INTEGER NOT NULL DEFAULT 0,
+          idempotency_key TEXT,
+          claimed_by TEXT,
+          claimed_until TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_post_run_jobs_workspace_created
+          ON post_run_jobs (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_post_run_jobs_session_status
+          ON post_run_jobs (session_id, status, available_at);
+
+      CREATE TABLE IF NOT EXISTS main_session_event_queue (
+          event_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          owner_main_session_id TEXT NOT NULL,
+          origin_main_session_id TEXT NOT NULL,
+          subagent_id TEXT,
+          event_type TEXT NOT NULL,
+          delivery_bucket TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          payload TEXT NOT NULL DEFAULT '{}',
+          coalesce_key TEXT,
+          earliest_deliver_at TEXT,
+          latest_deliver_at TEXT,
+          materialized_input_id TEXT,
+          superseded_by_event_id TEXT,
+          delivered_at TEXT,
+          superseded_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_owner_status_earliest
+          ON main_session_event_queue (owner_main_session_id, status, earliest_deliver_at, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_workspace_status_created
+          ON main_session_event_queue (workspace_id, status, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_subagent_created
+          ON main_session_event_queue (subagent_id, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_materialized_input
+          ON main_session_event_queue (materialized_input_id);
 
       CREATE TABLE IF NOT EXISTS session_runtime_state (
           workspace_id TEXT NOT NULL,
@@ -9894,11 +10161,11 @@ export class RuntimeStateStore {
     });
   }
 
-  private listMainSessionEventsByIds(eventIds: string[]): MainSessionEventQueueRecord[] {
+  private listMainSessionEventsByIds(workspaceId: string, eventIds: string[]): MainSessionEventQueueRecord[] {
     if (eventIds.length === 0) {
       return [];
     }
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(workspaceId)
       .prepare(`
         SELECT *
         FROM main_session_event_queue

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -6877,14 +6877,27 @@ export class RuntimeStateStore {
   }
 
   private workspaceRuntimeDb(workspaceId: string): Database.Database {
+    const cached = this.#workspaceRuntimeDbs.get(workspaceId);
     const workspaceRecord = this.getWorkspace(workspaceId, { includeDeleted: true });
     if (workspaceRecord?.deletedAtUtc) {
-      return this.db();
+      if (cached) {
+        return cached.db;
+      }
+      const db = new Database(":memory:");
+      db.pragma("journal_mode = MEMORY");
+      db.pragma("busy_timeout = 5000");
+      db.pragma("foreign_keys = ON");
+      this.#vectorIndexSupported = this.tryLoadVectorExtension(db) || this.#vectorIndexSupported;
+      this.ensureWorkspaceRuntimeDbSchema(db);
+      this.#workspaceRuntimeDbs.set(workspaceId, {
+        dbPath: `__deleted__/${workspaceId}`,
+        db,
+      });
+      return db;
     }
     const registeredPath = this.workspacePathFromRegistry(workspaceId);
     const workspacePath = registeredPath ? this.assertWorkspaceFolderHealthy(workspaceId) : this.workspaceDir(workspaceId);
     const dbPath = workspaceRuntimeDbPathForWorkspacePath(workspacePath);
-    const cached = this.#workspaceRuntimeDbs.get(workspaceId);
     if (cached && cached.dbPath === dbPath) {
       return cached.db;
     }

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -2059,7 +2059,8 @@ export class RuntimeStateStore {
     const latestChildInputId =
       this.normalizedNullableText(params.latestChildInputId) ?? currentChildInputId ?? initialChildInputId;
 
-    this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    workspaceDb
       .prepare(`
         INSERT INTO subagent_runs (
             subagent_id,
@@ -2135,7 +2136,7 @@ export class RuntimeStateStore {
         now
       );
 
-    const record = this.getSubagentRun({ subagentId });
+    const record = this.getSubagentRun({ workspaceId: params.workspaceId, subagentId });
     if (!record) {
       throw new Error("subagent run row not found after insert");
     }
@@ -2143,14 +2144,15 @@ export class RuntimeStateStore {
   }
 
   updateSubagentRun(params: {
+    workspaceId: string;
     subagentId: string;
     fields: SubagentRunUpdateFields;
   }): SubagentRunRecord | null {
     const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getSubagentRun({ subagentId: params.subagentId });
+      return this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
     }
-    const existing = this.getSubagentRun({ subagentId: params.subagentId });
+    const existing = this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
     if (!existing) {
       return null;
     }
@@ -2280,17 +2282,17 @@ export class RuntimeStateStore {
     assignments.push("updated_at = ?");
     values.push(utcNowIso(), params.subagentId);
 
-    const result = this.db()
+    const result = this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`UPDATE subagent_runs SET ${assignments.join(", ")} WHERE subagent_id = ?`)
       .run(...values);
     if (result.changes <= 0) {
       return null;
     }
-    return this.getSubagentRun({ subagentId: params.subagentId });
+    return this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
   }
 
-  getSubagentRun(params: { subagentId: string }): SubagentRunRecord | null {
-    const row = this.db()
+  getSubagentRun(params: { workspaceId: string; subagentId: string }): SubagentRunRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM subagent_runs WHERE subagent_id = ? LIMIT 1")
       .get(params.subagentId);
     return row ? this.rowToSubagentRun(row) : null;
@@ -2300,7 +2302,7 @@ export class RuntimeStateStore {
     workspaceId: string;
     childSessionId: string;
   }): SubagentRunRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string], Record<string, unknown>>(`
         SELECT *
         FROM subagent_runs
@@ -2338,11 +2340,12 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToSubagentRun(row));
   }
 
   listSubagentRunsByOwner(params: {
+    workspaceId: string;
     ownerMainSessionId: string;
     status?: string | null;
     limit?: number;
@@ -2363,11 +2366,12 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToSubagentRun(row));
   }
 
   listSubagentRunsByOrigin(params: {
+    workspaceId: string;
     originMainSessionId: string;
     status?: string | null;
     limit?: number;
@@ -2388,12 +2392,12 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToSubagentRun(row));
   }
 
   listWaitingSubagentRuns(params: {
-    workspaceId?: string | null;
+    workspaceId: string;
     ownerMainSessionId?: string | null;
     limit?: number;
     offset?: number;
@@ -2403,11 +2407,8 @@ export class RuntimeStateStore {
       FROM subagent_runs
       WHERE status = 'waiting_on_user'
     `;
-    const values: Array<string | number> = [];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    const values: Array<string | number> = [params.workspaceId];
+    query += " AND workspace_id = ?";
     if (params.ownerMainSessionId) {
       query += " AND owner_main_session_id = ?";
       values.push(params.ownerMainSessionId);
@@ -2417,12 +2418,12 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToSubagentRun(row));
   }
 
   listIncompleteSubagentRuns(params: {
-    workspaceId?: string | null;
+    workspaceId: string;
     ownerMainSessionId?: string | null;
     limit?: number;
     offset?: number;
@@ -2432,11 +2433,8 @@ export class RuntimeStateStore {
       FROM subagent_runs
       WHERE status NOT IN ('completed', 'failed', 'cancelled')
     `;
-    const values: Array<string | number> = [];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    const values: Array<string | number> = [params.workspaceId];
+    query += " AND workspace_id = ?";
     if (params.ownerMainSessionId) {
       query += " AND owner_main_session_id = ?";
       values.push(params.ownerMainSessionId);
@@ -2446,16 +2444,17 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToSubagentRun(row));
   }
 
   transferSubagentOwnership(params: {
+    workspaceId: string;
     subagentId: string;
     ownerMainSessionId: string;
     ownerTransferredAt?: string;
   }): SubagentRunRecord | null {
-    const existing = this.getSubagentRun({ subagentId: params.subagentId });
+    const existing = this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
     if (!existing) {
       return null;
     }
@@ -2469,6 +2468,7 @@ export class RuntimeStateStore {
     const ownerTransferredAt = params.ownerTransferredAt ?? utcNowIso();
     const transaction = this.db().transaction(() => {
       const updated = this.updateSubagentRun({
+        workspaceId: params.workspaceId,
         subagentId: params.subagentId,
         fields: {
           ownerMainSessionId: params.ownerMainSessionId,
@@ -2488,17 +2488,19 @@ export class RuntimeStateStore {
             AND superseded_at IS NULL
         `)
         .run(params.ownerMainSessionId, utcNowIso(), params.subagentId);
-      return this.getSubagentRun({ subagentId: params.subagentId });
+      return this.getSubagentRun({ workspaceId: params.workspaceId, subagentId: params.subagentId });
     });
     return transaction();
   }
 
   appendSubagentProgress(params: {
+    workspaceId: string;
     subagentId: string;
     latestProgressPayload: Record<string, unknown>;
     lastEventAt?: string | null;
   }): SubagentRunRecord | null {
     return this.updateSubagentRun({
+      workspaceId: params.workspaceId,
       subagentId: params.subagentId,
       fields: {
         latestProgressPayload: params.latestProgressPayload,
@@ -6731,6 +6733,7 @@ export class RuntimeStateStore {
       "conversation_bindings",
       "session_runtime_state",
       "session_messages",
+      "subagent_runs",
       "session_output_events",
       "turn_results",
       "turn_request_snapshots",
@@ -7073,6 +7076,56 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_turn_results_session_input
           ON turn_results (session_id, input_id);
 
+      CREATE TABLE IF NOT EXISTS subagent_runs (
+          subagent_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          parent_session_id TEXT,
+          parent_input_id TEXT,
+          origin_main_session_id TEXT NOT NULL,
+          owner_main_session_id TEXT NOT NULL,
+          child_session_id TEXT NOT NULL,
+          initial_child_input_id TEXT,
+          current_child_input_id TEXT,
+          latest_child_input_id TEXT,
+          title TEXT,
+          goal TEXT NOT NULL,
+          context TEXT,
+          source_type TEXT,
+          source_id TEXT,
+          proposal_id TEXT,
+          cronjob_id TEXT,
+          retry_of_subagent_id TEXT,
+          tool_profile TEXT NOT NULL DEFAULT '{}',
+          requested_model TEXT,
+          effective_model TEXT,
+          status TEXT NOT NULL,
+          summary TEXT,
+          latest_progress_payload TEXT,
+          blocking_payload TEXT,
+          result_payload TEXT,
+          error_payload TEXT,
+          last_event_at TEXT,
+          owner_transferred_at TEXT,
+          created_at TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          cancelled_at TEXT,
+          updated_at TEXT NOT NULL,
+          UNIQUE (workspace_id, child_session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_subagent_runs_workspace_status_updated
+          ON subagent_runs (workspace_id, status, updated_at DESC, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_subagent_runs_owner_status_updated
+          ON subagent_runs (owner_main_session_id, status, updated_at DESC, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_subagent_runs_origin_created
+          ON subagent_runs (origin_main_session_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_subagent_runs_retry_created
+          ON subagent_runs (retry_of_subagent_id, created_at DESC);
+
       CREATE TABLE IF NOT EXISTS task_proposals (
           proposal_id TEXT PRIMARY KEY,
           workspace_id TEXT NOT NULL,
@@ -7277,6 +7330,7 @@ export class RuntimeStateStore {
           ON runtime_notifications (state, created_at DESC);
     `);
     this.ensureConversationBindingsTableSchema(db);
+    this.ensureSubagentRunsTableSchema(db);
     this.ensureSessionRuntimeStateTableSchema(db);
     this.ensureTurnArtifactsSchema(db);
     this.ensureTaskProposalsTableSchema(db);

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -11,8 +11,11 @@ import {
   RUNTIME_DB_MIGRATIONS,
 } from "./migrations/index.js";
 
-const RUNTIME_DB_PATH_ENV = "HOLABOSS_RUNTIME_DB_PATH";
+const HOST_STATE_DB_PATH_ENV = "HOLABOSS_HOST_STATE_DB_PATH";
+const LEGACY_RUNTIME_DB_PATH_ENV = "HOLABOSS_RUNTIME_DB_PATH";
 const CONTROL_PLANE_DB_PATH_ENV = "HOLABOSS_CONTROL_PLANE_DB_PATH";
+const HOST_STATE_DB_FILENAME = "host-state.db";
+const LEGACY_RUNTIME_DB_FILENAME = "runtime.db";
 const WORKSPACE_RUNTIME_DIRNAME = ".holaboss";
 const WORKSPACE_STATE_DIRNAME = "state";
 const WORKSPACE_RUNTIME_DB_FILENAME = "runtime.db";
@@ -611,6 +614,7 @@ export interface CreateWorkspaceParams {
 }
 
 export interface RuntimeStateStoreOptions {
+  hostStateDbPath?: string;
   dbPath?: string;
   controlPlaneDbPath?: string;
   workspaceRoot?: string;
@@ -844,14 +848,45 @@ export function sanitizeWorkspaceId(workspaceId: string): string {
   return workspaceId.replace(/[^A-Za-z0-9._-]+/g, "-");
 }
 
-export function runtimeDbPath(options: RuntimeStateStoreOptions = {}): string {
-  const explicit = (options.dbPath ?? process.env[RUNTIME_DB_PATH_ENV] ?? "").trim();
+function hasExplicitHostStatePath(options: RuntimeStateStoreOptions = {}): boolean {
+  return Boolean(
+    (options.hostStateDbPath ?? "").trim()
+      || (process.env[HOST_STATE_DB_PATH_ENV] ?? "").trim()
+      || (options.dbPath ?? "").trim()
+      || (process.env[LEGACY_RUNTIME_DB_PATH_ENV] ?? "").trim(),
+  );
+}
+
+function defaultHostStateDbPath(options: RuntimeStateStoreOptions = {}): string {
+  const sandboxRoot = options.sandboxRoot ?? path.join(os.tmpdir(), "sandbox");
+  return path.join(sandboxRoot, "state", HOST_STATE_DB_FILENAME);
+}
+
+function legacyRuntimeDbPath(options: RuntimeStateStoreOptions = {}): string {
+  const explicit = (options.dbPath ?? process.env[LEGACY_RUNTIME_DB_PATH_ENV] ?? "").trim();
   if (explicit) {
     return path.resolve(explicit);
   }
-
   const sandboxRoot = options.sandboxRoot ?? path.join(os.tmpdir(), "sandbox");
-  return path.join(sandboxRoot, "state", "runtime.db");
+  return path.join(sandboxRoot, "state", LEGACY_RUNTIME_DB_FILENAME);
+}
+
+export function hostStateDbPath(options: RuntimeStateStoreOptions = {}): string {
+  const explicit = (
+    options.hostStateDbPath
+    ?? process.env[HOST_STATE_DB_PATH_ENV]
+    ?? options.dbPath
+    ?? process.env[LEGACY_RUNTIME_DB_PATH_ENV]
+    ?? ""
+  ).trim();
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+  return defaultHostStateDbPath(options);
+}
+
+export function runtimeDbPath(options: RuntimeStateStoreOptions = {}): string {
+  return hostStateDbPath(options);
 }
 
 export function controlPlaneDbPath(options: RuntimeStateStoreOptions = {}): string {
@@ -860,12 +895,11 @@ export function controlPlaneDbPath(options: RuntimeStateStoreOptions = {}): stri
     return path.resolve(explicit);
   }
 
-  if (options.dbPath) {
-    return path.join(path.dirname(path.resolve(options.dbPath)), "control-plane.db");
+  const resolvedHostStateDbPath = hostStateDbPath(options);
+  if (hasExplicitHostStatePath(options)) {
+    return path.join(path.dirname(resolvedHostStateDbPath), "control-plane.db");
   }
-
-  const sandboxRoot = options.sandboxRoot ?? path.join(os.tmpdir(), "sandbox");
-  return path.join(sandboxRoot, "state", "control-plane.db");
+  return path.join(path.dirname(resolvedHostStateDbPath), "control-plane.db");
 }
 
 function workspaceRuntimeDir(workspacePath: string): string {
@@ -904,6 +938,8 @@ function ensureWorkspaceIdentityMigrated(workspacePath: string): string {
 
 export class RuntimeStateStore {
   readonly dbPath: string;
+  readonly legacyDbPath: string;
+  readonly usesImplicitHostStatePath: boolean;
   readonly controlPlaneDbPath: string;
   readonly workspaceRoot: string;
   readonly sandboxAgentHarness: string | null;
@@ -915,7 +951,9 @@ export class RuntimeStateStore {
   #statementCache: Map<string, Database.Statement> = new Map();
 
   constructor(options: RuntimeStateStoreOptions = {}) {
-    this.dbPath = runtimeDbPath(options);
+    this.dbPath = hostStateDbPath(options);
+    this.legacyDbPath = legacyRuntimeDbPath(options);
+    this.usesImplicitHostStatePath = !hasExplicitHostStatePath(options);
     this.controlPlaneDbPath = controlPlaneDbPath(options);
     this.workspaceRoot = path.resolve(options.workspaceRoot ?? path.join(os.tmpdir(), "workspace-root"));
     this.#onMigrationEvent = options.onMigrationEvent;
@@ -2466,7 +2504,8 @@ export class RuntimeStateStore {
       { touchExisting: false }
     );
     const ownerTransferredAt = params.ownerTransferredAt ?? utcNowIso();
-    const transaction = this.db().transaction(() => {
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const transaction = workspaceDb.transaction(() => {
       const updated = this.updateSubagentRun({
         workspaceId: params.workspaceId,
         subagentId: params.subagentId,
@@ -2926,7 +2965,7 @@ export class RuntimeStateStore {
       WHERE input_id = ?
         AND status = 'FAILED'
     `);
-    const transaction = this.db().transaction(
+    const transaction = workspaceDb.transaction(
       (records: Array<{ eventId: string; materializedInputId: string | null }>) => {
         for (const record of records) {
           resetEventStatement.run(now, now, record.eventId);
@@ -5782,7 +5821,7 @@ export class RuntimeStateStore {
   // --- App Ports ---
 
   allocateAppPort(params: { workspaceId: string; appId: string }): AppPortRecord {
-    const allocate = this.db().transaction(() => {
+    const allocate = this.controlPlaneDb().transaction(() => {
       const existing = this.getAppPort({ workspaceId: params.workspaceId, appId: params.appId });
       if (existing) {
         return existing;
@@ -6743,6 +6782,7 @@ export class RuntimeStateStore {
       return this.#db;
     }
 
+    this.migrateLegacyHostStateDb();
     fs.mkdirSync(path.dirname(this.dbPath), { recursive: true });
     const db = new Database(this.dbPath);
     db.pragma("journal_mode = WAL");
@@ -6750,6 +6790,9 @@ export class RuntimeStateStore {
     db.pragma("foreign_keys = ON");
     this.#vectorIndexSupported = this.tryLoadVectorExtension(db);
     this.ensureRuntimeDbSchema(db);
+    if (this.controlPlaneDbPath === this.dbPath) {
+      this.ensureControlPlaneDbSchema(db);
+    }
     this.runPendingMigrations(db);
     this.#db = db;
     return db;
@@ -7156,27 +7199,36 @@ export class RuntimeStateStore {
       return;
     }
 
-    const columns = (
+    const targetColumns = (
       params.db.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>
     ).map((row) => row.name);
-    if (columns.length === 0) {
+    if (targetColumns.length === 0) {
+      return;
+    }
+    const legacyColumns = new Set<string>(
+      (params.legacy.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>).map(
+        (row) => row.name
+      )
+    );
+    const sharedColumns = targetColumns.filter((column) => legacyColumns.has(column));
+    if (sharedColumns.length === 0) {
       return;
     }
 
     const rows = params.legacy
-      .prepare(`SELECT ${columns.join(", ")} FROM ${params.tableName} WHERE workspace_id = ?`)
+      .prepare(`SELECT ${sharedColumns.join(", ")} FROM ${params.tableName} WHERE workspace_id = ?`)
       .all(params.workspaceId) as Array<Record<string, unknown>>;
     if (rows.length === 0) {
       return;
     }
 
     const insert = params.db.prepare(`
-      INSERT OR IGNORE INTO ${params.tableName} (${columns.join(", ")})
-      VALUES (${columns.map(() => "?").join(", ")})
+      INSERT OR IGNORE INTO ${params.tableName} (${sharedColumns.join(", ")})
+      VALUES (${sharedColumns.map(() => "?").join(", ")})
     `);
     const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
       for (const row of items) {
-        insert.run(...columns.map((column) => row[column] ?? null));
+        insert.run(...sharedColumns.map((column) => row[column] ?? null));
       }
     });
     insertMany(rows);
@@ -7191,25 +7243,34 @@ export class RuntimeStateStore {
     if (!this.tableExists(params.legacy, params.tableName) || !this.tableExists(params.db, params.tableName)) {
       return;
     }
-    const columns = (
+    const targetColumns = (
       params.db.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>
     ).map((row) => row.name);
-    if (columns.length === 0) {
+    if (targetColumns.length === 0) {
+      return;
+    }
+    const legacyColumns = new Set<string>(
+      (params.legacy.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>).map(
+        (row) => row.name
+      )
+    );
+    const sharedColumns = targetColumns.filter((column) => legacyColumns.has(column));
+    if (sharedColumns.length === 0) {
       return;
     }
     const rows = params.legacy
-      .prepare(`SELECT ${columns.join(", ")} FROM ${params.tableName} WHERE ${params.whereClause}`)
+      .prepare(`SELECT ${sharedColumns.join(", ")} FROM ${params.tableName} WHERE ${params.whereClause}`)
       .all() as Array<Record<string, unknown>>;
     if (rows.length === 0) {
       return;
     }
     const insert = params.db.prepare(`
-      INSERT OR IGNORE INTO ${params.tableName} (${columns.join(", ")})
-      VALUES (${columns.map(() => "?").join(", ")})
+      INSERT OR IGNORE INTO ${params.tableName} (${sharedColumns.join(", ")})
+      VALUES (${sharedColumns.map(() => "?").join(", ")})
     `);
     const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
       for (const row of items) {
-        insert.run(...columns.map((column) => row[column] ?? null));
+        insert.run(...sharedColumns.map((column) => row[column] ?? null));
       }
     });
     insertMany(rows);
@@ -7263,6 +7324,32 @@ export class RuntimeStateStore {
 
   private ensureWorkspaceMetadataReady(): void {
     void this.controlPlaneDb();
+  }
+
+  private migrateLegacyHostStateDb(): void {
+    if (!this.usesImplicitHostStatePath || this.dbPath === this.legacyDbPath) {
+      return;
+    }
+    if (fs.existsSync(this.dbPath) || !fs.existsSync(this.legacyDbPath)) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(this.dbPath), { recursive: true });
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const legacyPath = `${this.legacyDbPath}${suffix}`;
+      if (!fs.existsSync(legacyPath)) {
+        continue;
+      }
+      const nextPath = `${this.dbPath}${suffix}`;
+      if (fs.existsSync(nextPath)) {
+        continue;
+      }
+      try {
+        fs.renameSync(legacyPath, nextPath);
+      } catch {
+        fs.copyFileSync(legacyPath, nextPath);
+        fs.unlinkSync(legacyPath);
+      }
+    }
   }
 
   private tryLoadVectorExtension(db: Database.Database): boolean {
@@ -7963,13 +8050,8 @@ export class RuntimeStateStore {
 
   private ensureRuntimeDbSchema(db: Database.Database): void {
     this.ensureWorkspacesTableSchema(db);
-    this.ensureTaskProposalsTableSchema(db);
-    this.ensureEvolveSkillCandidatesTableSchema(db);
-    this.ensureMemoryUpdateProposalsTableSchema(db);
-    this.ensureMemoryEmbeddingIndexSchema(db);
-    this.ensureTurnArtifactsSchema(db);
-    this.ensureOutputsTableSchema(db);
-    this.migrateSandboxRunTokensTable(db);
+    this.migrateRevertIntegrationConnectionsWorkspace(db);
+    this.migrateIntegrationConnectionIdentityColumns(db);
     db.exec(`
       CREATE TABLE IF NOT EXISTS workspaces (
           id TEXT PRIMARY KEY,
@@ -7991,585 +8073,7 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_workspaces_updated
           ON workspaces (updated_at DESC, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS agent_sessions (
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          kind TEXT NOT NULL DEFAULT 'workspace_session',
-          title TEXT,
-          parent_session_id TEXT,
-          source_proposal_id TEXT,
-          created_by TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          archived_at TEXT,
-          PRIMARY KEY (workspace_id, session_id),
-          UNIQUE (workspace_id, source_proposal_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_agent_sessions_workspace_updated
-          ON agent_sessions (workspace_id, updated_at DESC, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS agent_runtime_sessions (
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          harness TEXT NOT NULL,
-          harness_session_id TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (workspace_id, session_id),
-          UNIQUE (workspace_id, harness, harness_session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_agent_runtime_sessions_workspace_updated
-          ON agent_runtime_sessions (workspace_id, updated_at DESC);
-
-      CREATE TABLE IF NOT EXISTS conversation_bindings (
-          binding_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          channel TEXT NOT NULL,
-          conversation_key TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          role TEXT NOT NULL DEFAULT 'main',
-          is_active INTEGER NOT NULL DEFAULT 1,
-          metadata TEXT NOT NULL DEFAULT '{}',
-          last_active_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          UNIQUE (workspace_id, channel, conversation_key, role),
-          UNIQUE (session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_conversation_bindings_workspace_role_active_updated
-          ON conversation_bindings (workspace_id, role, is_active, updated_at DESC, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_conversation_bindings_channel_key_active
-          ON conversation_bindings (channel, conversation_key, is_active);
-
-      CREATE TABLE IF NOT EXISTS agent_session_inputs (
-          input_id TEXT PRIMARY KEY,
-          session_id TEXT NOT NULL,
-          workspace_id TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          status TEXT NOT NULL,
-          priority INTEGER NOT NULL DEFAULT 0,
-          available_at TEXT NOT NULL,
-          attempt INTEGER NOT NULL DEFAULT 0,
-          idempotency_key TEXT,
-          claimed_by TEXT,
-          claimed_until TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_workspace_created
-          ON agent_session_inputs (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_agent_session_inputs_session_status
-          ON agent_session_inputs (session_id, status, available_at);
-
-      CREATE TABLE IF NOT EXISTS post_run_jobs (
-          job_id TEXT PRIMARY KEY,
-          job_type TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          workspace_id TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          status TEXT NOT NULL,
-          priority INTEGER NOT NULL DEFAULT 0,
-          available_at TEXT NOT NULL,
-          attempt INTEGER NOT NULL DEFAULT 0,
-          idempotency_key TEXT,
-          claimed_by TEXT,
-          claimed_until TEXT,
-          last_error TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_post_run_jobs_workspace_created
-          ON post_run_jobs (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_post_run_jobs_session_status
-          ON post_run_jobs (session_id, status, available_at);
-
-      CREATE TABLE IF NOT EXISTS main_session_event_queue (
-          event_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          owner_main_session_id TEXT NOT NULL,
-          origin_main_session_id TEXT NOT NULL,
-          subagent_id TEXT,
-          event_type TEXT NOT NULL,
-          delivery_bucket TEXT NOT NULL,
-          status TEXT NOT NULL DEFAULT 'pending',
-          payload TEXT NOT NULL DEFAULT '{}',
-          coalesce_key TEXT,
-          earliest_deliver_at TEXT,
-          latest_deliver_at TEXT,
-          materialized_input_id TEXT,
-          superseded_by_event_id TEXT,
-          delivered_at TEXT,
-          superseded_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_owner_status_earliest
-          ON main_session_event_queue (owner_main_session_id, status, earliest_deliver_at, created_at ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_workspace_status_created
-          ON main_session_event_queue (workspace_id, status, created_at ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_subagent_created
-          ON main_session_event_queue (subagent_id, created_at ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_main_session_event_queue_materialized_input
-          ON main_session_event_queue (materialized_input_id);
-
-      CREATE TABLE IF NOT EXISTS session_runtime_state (
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          status TEXT NOT NULL CHECK (status IN (${SESSION_RUNTIME_STATE_STATUS_SQL})),
-          current_input_id TEXT,
-          current_worker_id TEXT,
-          lease_until TEXT,
-          heartbeat_at TEXT,
-          last_error TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (workspace_id, session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS session_runtime_state_workspace_session_idx
-          ON session_runtime_state (workspace_id, session_id);
-
-      CREATE INDEX IF NOT EXISTS session_runtime_state_session_id_idx
-          ON session_runtime_state (session_id);
-
-      CREATE TABLE IF NOT EXISTS sandbox_run_tokens (
-          token TEXT PRIMARY KEY,
-          run_id TEXT NOT NULL UNIQUE,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          scopes TEXT NOT NULL DEFAULT '[]',
-          expires_at TEXT NOT NULL,
-          revoked_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS session_messages (
-          id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          role TEXT NOT NULL,
-          text TEXT NOT NULL,
-          created_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_session_messages_workspace_session_created
-          ON session_messages (workspace_id, session_id, created_at ASC);
-
-      CREATE TABLE IF NOT EXISTS session_output_events (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          sequence INTEGER NOT NULL,
-          event_type TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          created_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_session_output_events_session_input_sequence
-          ON session_output_events (session_id, input_id, sequence ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_session_output_events_workspace_session_created
-          ON session_output_events (workspace_id, session_id, created_at ASC);
-
-      CREATE TABLE IF NOT EXISTS terminal_sessions (
-          terminal_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT,
-          input_id TEXT,
-          title TEXT NOT NULL DEFAULT '',
-          backend TEXT NOT NULL,
-          owner TEXT NOT NULL,
-          status TEXT NOT NULL,
-          cwd TEXT NOT NULL,
-          shell TEXT,
-          command TEXT NOT NULL,
-          exit_code INTEGER,
-          last_event_seq INTEGER NOT NULL DEFAULT 0,
-          created_by TEXT,
-          created_at TEXT NOT NULL,
-          started_at TEXT NOT NULL,
-          last_activity_at TEXT NOT NULL,
-          ended_at TEXT,
-          metadata TEXT NOT NULL DEFAULT '{}'
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_workspace_status
-          ON terminal_sessions (workspace_id, status, last_activity_at DESC, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_session_created
-          ON terminal_sessions (session_id, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS terminal_session_events (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          terminal_id TEXT NOT NULL,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT,
-          sequence INTEGER NOT NULL,
-          event_type TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          created_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_terminal_session_events_terminal_sequence
-          ON terminal_session_events (terminal_id, sequence ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_terminal_session_events_workspace_created
-          ON terminal_session_events (workspace_id, created_at ASC);
-
-      CREATE TABLE IF NOT EXISTS turn_results (
-          input_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          started_at TEXT NOT NULL,
-          completed_at TEXT,
-          status TEXT NOT NULL,
-          stop_reason TEXT,
-          assistant_text TEXT NOT NULL DEFAULT '',
-          tool_usage_summary TEXT NOT NULL DEFAULT '{}',
-          permission_denials TEXT NOT NULL DEFAULT '[]',
-          prompt_section_ids TEXT NOT NULL DEFAULT '[]',
-          capability_manifest_fingerprint TEXT,
-          request_snapshot_fingerprint TEXT,
-          prompt_cache_profile TEXT,
-          context_budget_decisions TEXT,
-          token_usage TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_turn_results_workspace_session_completed
-          ON turn_results (workspace_id, session_id, completed_at DESC, started_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_turn_results_session_input
-          ON turn_results (session_id, input_id);
-
-      CREATE TABLE IF NOT EXISTS subagent_runs (
-          subagent_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          parent_session_id TEXT,
-          parent_input_id TEXT,
-          origin_main_session_id TEXT NOT NULL,
-          owner_main_session_id TEXT NOT NULL,
-          child_session_id TEXT NOT NULL,
-          initial_child_input_id TEXT,
-          current_child_input_id TEXT,
-          latest_child_input_id TEXT,
-          title TEXT,
-          goal TEXT NOT NULL,
-          context TEXT,
-          source_type TEXT,
-          source_id TEXT,
-          proposal_id TEXT,
-          cronjob_id TEXT,
-          retry_of_subagent_id TEXT,
-          tool_profile TEXT NOT NULL DEFAULT '{}',
-          requested_model TEXT,
-          effective_model TEXT,
-          status TEXT NOT NULL,
-          summary TEXT,
-          latest_progress_payload TEXT,
-          blocking_payload TEXT,
-          result_payload TEXT,
-          error_payload TEXT,
-          last_event_at TEXT,
-          owner_transferred_at TEXT,
-          created_at TEXT NOT NULL,
-          started_at TEXT,
-          completed_at TEXT,
-          cancelled_at TEXT,
-          updated_at TEXT NOT NULL,
-          UNIQUE (workspace_id, child_session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_subagent_runs_workspace_status_updated
-          ON subagent_runs (workspace_id, status, updated_at DESC, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_subagent_runs_owner_status_updated
-          ON subagent_runs (owner_main_session_id, status, updated_at DESC, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_subagent_runs_origin_created
-          ON subagent_runs (origin_main_session_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_subagent_runs_retry_created
-          ON subagent_runs (retry_of_subagent_id, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS turn_request_snapshots (
-          input_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          snapshot_kind TEXT NOT NULL,
-          fingerprint TEXT NOT NULL,
-          payload TEXT NOT NULL DEFAULT '{}',
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_turn_request_snapshots_workspace_session_updated
-          ON turn_request_snapshots (workspace_id, session_id, updated_at DESC, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS memory_entries (
-          memory_id TEXT PRIMARY KEY,
-          workspace_id TEXT,
-          session_id TEXT,
-          scope TEXT NOT NULL,
-          memory_type TEXT NOT NULL,
-          subject_key TEXT NOT NULL,
-          path TEXT NOT NULL,
-          title TEXT NOT NULL,
-          summary TEXT NOT NULL,
-          tags TEXT NOT NULL DEFAULT '[]',
-          verification_policy TEXT NOT NULL,
-          staleness_policy TEXT NOT NULL DEFAULT 'stable',
-          stale_after_seconds INTEGER,
-          source_turn_input_id TEXT,
-          source_message_id TEXT,
-          source_type TEXT,
-          observed_at TEXT,
-          last_verified_at TEXT,
-          confidence REAL,
-          fingerprint TEXT NOT NULL,
-          status TEXT NOT NULL DEFAULT 'active',
-          superseded_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_memory_entries_workspace_scope_updated
-          ON memory_entries (workspace_id, scope, status, updated_at DESC, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_memory_entries_scope_updated
-          ON memory_entries (scope, status, updated_at DESC, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS task_proposals (
-          proposal_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          task_name TEXT NOT NULL,
-          task_prompt TEXT NOT NULL,
-          task_generation_rationale TEXT NOT NULL,
-          proposal_source TEXT NOT NULL DEFAULT 'proactive',
-          source_event_ids TEXT NOT NULL DEFAULT '[]',
-          created_at TEXT NOT NULL,
-          state TEXT NOT NULL DEFAULT 'not_reviewed',
-          accepted_session_id TEXT,
-          accepted_input_id TEXT,
-          accepted_at TEXT
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_task_proposals_workspace_created
-          ON task_proposals (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_task_proposals_workspace_state_created
-          ON task_proposals (workspace_id, state, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS evolve_skill_candidates (
-          candidate_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          task_proposal_id TEXT,
-          kind TEXT NOT NULL,
-          status TEXT NOT NULL DEFAULT 'draft',
-          title TEXT NOT NULL,
-          summary TEXT NOT NULL,
-          slug TEXT NOT NULL,
-          skill_path TEXT NOT NULL,
-          content_fingerprint TEXT NOT NULL,
-          confidence REAL,
-          evaluation_notes TEXT,
-          source_turn_input_ids TEXT NOT NULL DEFAULT '[]',
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          proposed_at TEXT,
-          dismissed_at TEXT,
-          accepted_at TEXT,
-          promoted_at TEXT
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_workspace_created
-          ON evolve_skill_candidates (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_workspace_status_created
-          ON evolve_skill_candidates (workspace_id, status, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_task_proposal
-          ON evolve_skill_candidates (task_proposal_id);
-
-      CREATE TABLE IF NOT EXISTS memory_update_proposals (
-          proposal_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          proposal_kind TEXT NOT NULL,
-          target_key TEXT NOT NULL,
-          title TEXT NOT NULL,
-          summary TEXT NOT NULL,
-          payload TEXT NOT NULL DEFAULT '{}',
-          evidence TEXT,
-          confidence REAL,
-          source_message_id TEXT,
-          state TEXT NOT NULL DEFAULT 'pending',
-          persisted_memory_id TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          accepted_at TEXT,
-          dismissed_at TEXT
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_workspace_created
-          ON memory_update_proposals (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_session_input_created
-          ON memory_update_proposals (session_id, input_id, created_at ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_workspace_state_created
-          ON memory_update_proposals (workspace_id, state, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS output_folders (
-          id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          name TEXT NOT NULL,
-          position INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_output_folders_workspace_position
-          ON output_folders (workspace_id, position ASC, created_at ASC);
-
-      CREATE TABLE IF NOT EXISTS outputs (
-          id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          output_type TEXT NOT NULL,
-          title TEXT NOT NULL DEFAULT '',
-          status TEXT NOT NULL DEFAULT 'draft',
-          module_id TEXT,
-          module_resource_id TEXT,
-          file_path TEXT,
-          html_content TEXT,
-          session_id TEXT,
-          input_id TEXT,
-          artifact_id TEXT,
-          folder_id TEXT,
-          platform TEXT,
-          metadata TEXT NOT NULL DEFAULT '{}',
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_outputs_workspace_created
-          ON outputs (workspace_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_outputs_workspace_folder_created
-          ON outputs (workspace_id, folder_id, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_outputs_session_input_created
-          ON outputs (session_id, input_id, created_at DESC);
-
-      CREATE TABLE IF NOT EXISTS app_builds (
-          workspace_id TEXT NOT NULL,
-          app_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          started_at TEXT,
-          completed_at TEXT,
-          error TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (workspace_id, app_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_app_builds_workspace
-          ON app_builds (workspace_id);
-
-      CREATE TABLE IF NOT EXISTS app_ports (
-          workspace_id TEXT NOT NULL,
-          app_id TEXT NOT NULL,
-          port INTEGER NOT NULL UNIQUE,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          PRIMARY KEY (workspace_id, app_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_app_ports_workspace
-          ON app_ports (workspace_id);
-
-      CREATE TABLE IF NOT EXISTS cronjobs (
-          id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          initiated_by TEXT NOT NULL,
-          name TEXT NOT NULL DEFAULT '',
-          cron TEXT NOT NULL,
-          description TEXT NOT NULL,
-          instruction TEXT NOT NULL DEFAULT '',
-          enabled INTEGER NOT NULL DEFAULT 1,
-          delivery TEXT NOT NULL,
-          metadata TEXT NOT NULL DEFAULT '{}',
-          last_run_at TEXT,
-          next_run_at TEXT,
-          run_count INTEGER NOT NULL DEFAULT 0,
-          last_status TEXT,
-          last_error TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_cronjobs_workspace_created
-          ON cronjobs (workspace_id, created_at ASC);
-
-      CREATE INDEX IF NOT EXISTS idx_cronjobs_enabled_next_run
-          ON cronjobs (enabled, next_run_at);
-
-      CREATE TABLE IF NOT EXISTS runtime_notifications (
-          id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          cronjob_id TEXT,
-          source_type TEXT NOT NULL,
-          source_label TEXT,
-          title TEXT NOT NULL,
-          message TEXT NOT NULL,
-          level TEXT NOT NULL DEFAULT 'info',
-          priority TEXT NOT NULL DEFAULT 'normal',
-          state TEXT NOT NULL DEFAULT 'unread',
-          metadata TEXT NOT NULL DEFAULT '{}',
-          read_at TEXT,
-          dismissed_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_runtime_notifications_workspace_state_created
-          ON runtime_notifications (workspace_id, state, created_at DESC);
-
-      CREATE INDEX IF NOT EXISTS idx_runtime_notifications_state_created
-          ON runtime_notifications (state, created_at DESC);
-
     `);
-    this.ensureConversationBindingsTableSchema(db);
-    this.ensureSubagentRunsTableSchema(db);
-    this.ensureMainSessionEventQueueTableSchema(db);
-    this.ensureSessionRuntimeStateTableSchema(db);
-    this.migrateLegacySessionArtifactsToOutputs(db);
-    this.migrateRuntimeNotificationPriority(db);
-    this.migrateCronjobInstructions(db);
-    this.migrateAppBuildRestartAttempts(db);
-    this.migrateRevertIntegrationConnectionsWorkspace(db);
-    this.migrateIntegrationConnectionIdentityColumns(db);
   }
 
   private ensureConversationBindingsTableSchema(db: Database.Database): void {
@@ -8937,68 +8441,6 @@ export class RuntimeStateStore {
       )
       .get(tableName);
     return Boolean(row);
-  }
-
-  private migrateSandboxRunTokensTable(db: Database.Database): void {
-    const tables = new Set<string>(
-      (db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
-        (row) => row.name
-      )
-    );
-    if (!tables.has("sandbox_run_tokens")) {
-      return;
-    }
-
-    const columns = new Set<string>(
-      (db.prepare("PRAGMA table_info(sandbox_run_tokens)").all() as Array<{ name: string }>).map((row) => row.name)
-    );
-    if (!columns.has("holaboss_user_id")) {
-      return;
-    }
-
-    db.exec(`
-      ALTER TABLE sandbox_run_tokens RENAME TO sandbox_run_tokens_legacy_with_user;
-
-      CREATE TABLE sandbox_run_tokens (
-          token TEXT PRIMARY KEY,
-          run_id TEXT NOT NULL UNIQUE,
-          workspace_id TEXT NOT NULL,
-          session_id TEXT NOT NULL,
-          input_id TEXT NOT NULL,
-          scopes TEXT NOT NULL DEFAULT '[]',
-          expires_at TEXT NOT NULL,
-          revoked_at TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      INSERT INTO sandbox_run_tokens (
-          token,
-          run_id,
-          workspace_id,
-          session_id,
-          input_id,
-          scopes,
-          expires_at,
-          revoked_at,
-          created_at,
-          updated_at
-      )
-      SELECT
-          token,
-          run_id,
-          workspace_id,
-          session_id,
-          input_id,
-          scopes,
-          expires_at,
-          revoked_at,
-          created_at,
-          updated_at
-      FROM sandbox_run_tokens_legacy_with_user;
-
-      DROP TABLE sandbox_run_tokens_legacy_with_user;
-    `);
   }
 
   private ensureTaskProposalsTableSchema(db: Database.Database): void {

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -4087,7 +4087,8 @@ export class RuntimeStateStore {
     const startedAt = params.startedAt ?? createdAt;
     const lastActivityAt = params.lastActivityAt ?? startedAt;
 
-    this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    workspaceDb
       .prepare(`
         INSERT INTO terminal_sessions (
             terminal_id, workspace_id, session_id, input_id, title, backend, owner, status,
@@ -4117,7 +4118,7 @@ export class RuntimeStateStore {
         JSON.stringify(params.metadata ?? {})
       );
 
-    const row = this.db()
+    const row = workspaceDb
       .prepare<[string], Record<string, unknown>>("SELECT * FROM terminal_sessions WHERE terminal_id = ? LIMIT 1")
       .get(terminalId);
     if (!row) {
@@ -4126,19 +4127,10 @@ export class RuntimeStateStore {
     return this.rowToTerminalSession(row);
   }
 
-  getTerminalSession(params: { terminalId: string; workspaceId?: string }): TerminalSessionRecord | null {
-    let query = `
-      SELECT *
-      FROM terminal_sessions
-      WHERE terminal_id = ?
-    `;
-    const values: string[] = [params.terminalId];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
-    query += " LIMIT 1";
-    const row = this.db().prepare(query).get(...values) as Record<string, unknown> | undefined;
+  getTerminalSession(params: { workspaceId: string; terminalId: string }): TerminalSessionRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string], Record<string, unknown>>("SELECT * FROM terminal_sessions WHERE terminal_id = ? LIMIT 1")
+      .get(params.terminalId);
     return row ? this.rowToTerminalSession(row) : null;
   }
 
@@ -4147,31 +4139,63 @@ export class RuntimeStateStore {
     sessionId?: string;
     statuses?: TerminalSessionStatus[];
   } = {}): TerminalSessionRecord[] {
+    const statuses = (params.statuses ?? []).filter((value) => Boolean(value));
+    if (!params.workspaceId) {
+      const sessions = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+        let query = `
+          SELECT *
+          FROM terminal_sessions
+          WHERE 1 = 1
+        `;
+        const values: string[] = [];
+        if (params.sessionId) {
+          query += " AND session_id = ?";
+          values.push(params.sessionId);
+        }
+        if (statuses.length > 0) {
+          query += ` AND status IN (${statuses.map(() => "?").join(", ")})`;
+          values.push(...statuses);
+        }
+        query += " ORDER BY datetime(last_activity_at) DESC, datetime(created_at) DESC, terminal_id DESC";
+        const rows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+        return rows.map((row) => this.rowToTerminalSession(row));
+      });
+      sessions.sort((left, right) => {
+        const activityCompare = right.lastActivityAt.localeCompare(left.lastActivityAt);
+        if (activityCompare !== 0) {
+          return activityCompare;
+        }
+        const createdAtCompare = right.createdAt.localeCompare(left.createdAt);
+        if (createdAtCompare !== 0) {
+          return createdAtCompare;
+        }
+        return right.terminalId.localeCompare(left.terminalId);
+      });
+      return sessions;
+    }
     let query = `
       SELECT *
       FROM terminal_sessions
       WHERE 1 = 1
     `;
     const values: string[] = [];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    query += " AND workspace_id = ?";
+    values.push(params.workspaceId);
     if (params.sessionId) {
       query += " AND session_id = ?";
       values.push(params.sessionId);
     }
-    const statuses = (params.statuses ?? []).filter((value) => Boolean(value));
     if (statuses.length > 0) {
       query += ` AND status IN (${statuses.map(() => "?").join(", ")})`;
       values.push(...statuses);
     }
     query += " ORDER BY datetime(last_activity_at) DESC, datetime(created_at) DESC, terminal_id DESC";
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTerminalSession(row));
   }
 
   updateTerminalSession(params: {
+    workspaceId: string;
     terminalId: string;
     title?: string | null;
     status?: TerminalSessionStatus;
@@ -4180,7 +4204,7 @@ export class RuntimeStateStore {
     endedAt?: string | null;
     metadata?: Record<string, unknown> | null;
   }): TerminalSessionRecord {
-    const existing = this.getTerminalSession({ terminalId: params.terminalId });
+    const existing = this.getTerminalSession({ workspaceId: params.workspaceId, terminalId: params.terminalId });
     if (!existing) {
       throw new Error(`terminal session ${params.terminalId} not found`);
     }
@@ -4191,7 +4215,8 @@ export class RuntimeStateStore {
     const nextEndedAt = params.endedAt !== undefined ? params.endedAt : existing.endedAt;
     const nextMetadata = params.metadata !== undefined ? params.metadata ?? {} : existing.metadata;
 
-    this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    workspaceDb
       .prepare(`
         UPDATE terminal_sessions
         SET title = ?,
@@ -4212,7 +4237,7 @@ export class RuntimeStateStore {
         params.terminalId
       );
 
-    const row = this.db()
+    const row = workspaceDb
       .prepare<[string], Record<string, unknown>>("SELECT * FROM terminal_sessions WHERE terminal_id = ? LIMIT 1")
       .get(params.terminalId);
     if (!row) {
@@ -4222,6 +4247,7 @@ export class RuntimeStateStore {
   }
 
   appendTerminalSessionEvent(params: {
+    workspaceId: string;
     terminalId: string;
     eventType: string;
     payload: Record<string, unknown>;
@@ -4231,8 +4257,9 @@ export class RuntimeStateStore {
     endedAt?: string | null;
   }): TerminalSessionEventRecord {
     const createdAt = params.createdAt ?? utcNowIso();
-    const transaction = this.db().transaction(() => {
-      const row = this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const transaction = workspaceDb.transaction(() => {
+      const row = workspaceDb
         .prepare<[string], Record<string, unknown>>("SELECT * FROM terminal_sessions WHERE terminal_id = ? LIMIT 1")
         .get(params.terminalId);
       if (!row) {
@@ -4240,7 +4267,7 @@ export class RuntimeStateStore {
       }
       const session = this.rowToTerminalSession(row);
       const nextSequence = session.lastEventSeq + 1;
-      this.db()
+      workspaceDb
         .prepare(`
           INSERT INTO terminal_session_events (
               terminal_id, workspace_id, session_id, sequence, event_type, payload, created_at
@@ -4255,7 +4282,7 @@ export class RuntimeStateStore {
           JSON.stringify(params.payload),
           createdAt
         );
-      this.db()
+      workspaceDb
         .prepare(`
           UPDATE terminal_sessions
           SET last_event_seq = ?,
@@ -4273,7 +4300,7 @@ export class RuntimeStateStore {
           params.endedAt !== undefined ? params.endedAt : session.endedAt,
           session.terminalId
         );
-      const eventRow = this.db()
+      const eventRow = workspaceDb
         .prepare<[string, number], Record<string, unknown>>(
           "SELECT * FROM terminal_session_events WHERE terminal_id = ? AND sequence = ? LIMIT 1"
         )
@@ -4287,6 +4314,7 @@ export class RuntimeStateStore {
   }
 
   listTerminalSessionEvents(params: {
+    workspaceId: string;
     terminalId: string;
     afterSequence?: number;
     limit?: number;
@@ -4303,7 +4331,7 @@ export class RuntimeStateStore {
       query += " LIMIT ?";
       values.push(Math.trunc(params.limit));
     }
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTerminalSessionEvent(row));
   }
 
@@ -6735,6 +6763,8 @@ export class RuntimeStateStore {
       "session_messages",
       "subagent_runs",
       "session_output_events",
+      "terminal_sessions",
+      "terminal_session_events",
       "turn_results",
       "turn_request_snapshots",
       "task_proposals",
@@ -7048,6 +7078,51 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_session_output_events_workspace_session_created
           ON session_output_events (workspace_id, session_id, created_at ASC);
+
+      CREATE TABLE IF NOT EXISTS terminal_sessions (
+          terminal_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT,
+          input_id TEXT,
+          title TEXT NOT NULL DEFAULT '',
+          backend TEXT NOT NULL,
+          owner TEXT NOT NULL,
+          status TEXT NOT NULL,
+          cwd TEXT NOT NULL,
+          shell TEXT,
+          command TEXT NOT NULL,
+          exit_code INTEGER,
+          last_event_seq INTEGER NOT NULL DEFAULT 0,
+          created_by TEXT,
+          created_at TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          last_activity_at TEXT NOT NULL,
+          ended_at TEXT,
+          metadata TEXT NOT NULL DEFAULT '{}'
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_workspace_status
+          ON terminal_sessions (workspace_id, status, last_activity_at DESC, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_session_created
+          ON terminal_sessions (session_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS terminal_session_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          terminal_id TEXT NOT NULL,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT,
+          sequence INTEGER NOT NULL,
+          event_type TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_session_events_terminal_sequence
+          ON terminal_session_events (terminal_id, sequence ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_session_events_workspace_created
+          ON terminal_session_events (workspace_id, created_at ASC);
 
       CREATE TABLE IF NOT EXISTS turn_results (
           input_id TEXT PRIMARY KEY,

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -1245,7 +1245,7 @@ export class RuntimeStateStore {
       // Allow a folder that already contains this workspace's identity file
       // (relocate case — user moved the folder elsewhere on disk).
       if (options.allowMatchingIdentity) {
-        const identityPath = path.join(resolved, WORKSPACE_RUNTIME_DIRNAME, WORKSPACE_IDENTITY_FILENAME);
+        const identityPath = ensureWorkspaceIdentityMigrated(resolved);
         if (fs.existsSync(identityPath)) {
           try {
             const raw = fs.readFileSync(identityPath, "utf-8").trim();
@@ -7177,16 +7177,25 @@ export class RuntimeStateStore {
     if (rows.length === 0) {
       return;
     }
+    const existingRowIds = new Set<number>(
+      (db.prepare("SELECT vec_rowid FROM memory_recall_vec").all() as Array<{ vec_rowid: number }>).map((row) =>
+        Number(row.vec_rowid)
+      )
+    );
+    const pendingRows = rows.filter((row) => !existingRowIds.has(Number(row.vec_rowid)));
+    if (pendingRows.length === 0) {
+      return;
+    }
     const insert = db.prepare(`
       INSERT OR IGNORE INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
-      VALUES (?, ?, ?, ?, ?)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
     `);
     const insertMany = db.transaction((items: Array<Record<string, unknown>>) => {
       for (const row of items) {
         insert.run(row.vec_rowid, row.embedding, row.scope_bucket, row.workspace_id, row.memory_type);
       }
     });
-    insertMany(rows);
+    insertMany(pendingRows);
   }
 
   private backfillWorkspaceScopedTableRows(params: {
@@ -7295,16 +7304,25 @@ export class RuntimeStateStore {
     if (rows.length === 0) {
       return;
     }
+    const existingRowIds = new Set<number>(
+      (params.db.prepare("SELECT vec_rowid FROM memory_recall_vec").all() as Array<{ vec_rowid: number }>).map((row) =>
+        Number(row.vec_rowid)
+      )
+    );
+    const pendingRows = rows.filter((row) => !existingRowIds.has(Number(row.vec_rowid)));
+    if (pendingRows.length === 0) {
+      return;
+    }
     const insert = params.db.prepare(`
       INSERT OR IGNORE INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
-      VALUES (?, ?, ?, ?, ?)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
     `);
     const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
       for (const row of items) {
         insert.run(row.vec_rowid, row.embedding, row.scope_bucket, row.workspace_id, row.memory_type);
       }
     });
-    insertMany(rows);
+    insertMany(pendingRows);
   }
 
   private runPendingMigrations(db: Database.Database): void {

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -1348,6 +1348,7 @@ export class RuntimeStateStore {
     },
     options: { touchExisting?: boolean } = {}
   ): AgentSessionRecord {
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
     const existing = this.getSession({
       workspaceId: params.workspaceId,
       sessionId: params.sessionId
@@ -1355,7 +1356,7 @@ export class RuntimeStateStore {
     const now = utcNowIso();
 
     if (!existing) {
-      this.db()
+      workspaceDb
         .prepare(`
           INSERT INTO agent_sessions (
               workspace_id,
@@ -1420,7 +1421,7 @@ export class RuntimeStateStore {
       return existing;
     }
 
-    this.db()
+    workspaceDb
       .prepare("UPDATE agent_sessions SET updated_at = ? WHERE workspace_id = ? AND session_id = ?")
       .run(now, params.workspaceId, params.sessionId);
     return this.requireSession({
@@ -1430,7 +1431,7 @@ export class RuntimeStateStore {
   }
 
   getSession(params: { workspaceId: string; sessionId: string }): AgentSessionRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string], Record<string, unknown>>(`
         SELECT *
         FROM agent_sessions
@@ -1447,7 +1448,7 @@ export class RuntimeStateStore {
     limit?: number;
     offset?: number;
   }): AgentSessionRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, number, number, number], Record<string, unknown>>(`
         SELECT *
         FROM agent_sessions
@@ -1650,8 +1651,9 @@ export class RuntimeStateStore {
       existingHarnessBinding?.createdAt ??
       existingSessionBinding?.createdAt ??
       now;
-    const transaction = this.db().transaction(() => {
-      this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const transaction = workspaceDb.transaction(() => {
+      workspaceDb
         .prepare(
           `
             DELETE FROM agent_runtime_sessions
@@ -1659,7 +1661,7 @@ export class RuntimeStateStore {
           `,
         )
         .run(params.workspaceId, params.sessionId);
-      this.db()
+      workspaceDb
         .prepare(
           `
             DELETE FROM agent_runtime_sessions
@@ -1667,7 +1669,7 @@ export class RuntimeStateStore {
           `,
         )
         .run(params.workspaceId, params.harness, params.harnessSessionId);
-      this.db()
+      workspaceDb
         .prepare(`
           INSERT INTO agent_runtime_sessions (
               workspace_id, session_id, harness, harness_session_id, created_at, updated_at
@@ -1695,7 +1697,7 @@ export class RuntimeStateStore {
   }
 
   getBinding(params: { workspaceId: string; sessionId: string }): SessionBindingRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string], {
         workspace_id: string;
         session_id: string;
@@ -1728,7 +1730,7 @@ export class RuntimeStateStore {
     harness: string;
     harnessSessionId: string;
   }): SessionBindingRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<
         [string, string, string],
         {
@@ -1785,8 +1787,9 @@ export class RuntimeStateStore {
     const channel = this.requiredNormalizedText(params.channel, "channel");
     const conversationKey = this.requiredNormalizedText(params.conversationKey, "conversationKey");
     const bindingId = params.bindingId ?? randomUUID();
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
 
-    this.db()
+    workspaceDb
       .prepare(`
         INSERT INTO conversation_bindings (
             binding_id,
@@ -1834,8 +1837,8 @@ export class RuntimeStateStore {
     return record;
   }
 
-  getConversationBinding(params: { bindingId: string }): ConversationBindingRecord | null {
-    const row = this.db()
+  getConversationBinding(params: { workspaceId: string; bindingId: string }): ConversationBindingRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM conversation_bindings WHERE binding_id = ? LIMIT 1")
       .get(params.bindingId);
     return row ? this.rowToConversationBinding(row) : null;
@@ -1865,7 +1868,7 @@ export class RuntimeStateStore {
       values.push(role);
     }
     query += " ORDER BY is_active DESC, datetime(updated_at) DESC, created_at DESC LIMIT 1";
-    const row = this.db().prepare(query).get(...values) as Record<string, unknown> | undefined;
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(...values) as Record<string, unknown> | undefined;
     return row ? this.rowToConversationBinding(row) : null;
   }
 
@@ -1887,7 +1890,7 @@ export class RuntimeStateStore {
       values.push(role);
     }
     query += " ORDER BY is_active DESC, datetime(updated_at) DESC, created_at DESC LIMIT 1";
-    const row = this.db().prepare(query).get(...values) as Record<string, unknown> | undefined;
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(...values) as Record<string, unknown> | undefined;
     return row ? this.rowToConversationBinding(row) : null;
   }
 
@@ -1922,35 +1925,43 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToConversationBinding(row));
   }
 
   setConversationBindingActive(params: {
+    workspaceId: string;
     bindingId: string;
     isActive: boolean;
   }): ConversationBindingRecord | null {
     return this.updateConversationBinding({
+      workspaceId: params.workspaceId,
       bindingId: params.bindingId,
       fields: { isActive: params.isActive },
     });
   }
 
   touchConversationBinding(params: {
+    workspaceId: string;
     bindingId: string;
     lastActiveAt?: string | null;
   }): ConversationBindingRecord | null {
     return this.updateConversationBinding({
+      workspaceId: params.workspaceId,
       bindingId: params.bindingId,
       fields: { lastActiveAt: params.lastActiveAt ?? utcNowIso() },
     });
   }
 
   transferConversationBindingSession(params: {
+    workspaceId: string;
     bindingId: string;
     sessionId: string;
   }): ConversationBindingRecord | null {
-    const binding = this.getConversationBinding({ bindingId: params.bindingId });
+    const binding = this.getConversationBinding({
+      workspaceId: params.workspaceId,
+      bindingId: params.bindingId,
+    });
     if (!binding) {
       return null;
     }
@@ -1962,6 +1973,7 @@ export class RuntimeStateStore {
       { touchExisting: false }
     );
     return this.updateConversationBinding({
+      workspaceId: params.workspaceId,
       bindingId: params.bindingId,
       fields: { sessionId: params.sessionId },
     });
@@ -3757,6 +3769,7 @@ export class RuntimeStateStore {
     status?: string;
     currentInputId?: string | null;
   }): SessionRuntimeStateRecord {
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
     this.ensureSession(
       {
         workspaceId: params.workspaceId,
@@ -3765,7 +3778,7 @@ export class RuntimeStateStore {
       { touchExisting: false }
     );
     const now = utcNowIso();
-    this.db()
+    workspaceDb
       .prepare(`
         INSERT INTO session_runtime_state (
             workspace_id, session_id, status, current_input_id, current_worker_id,
@@ -3777,7 +3790,7 @@ export class RuntimeStateStore {
             updated_at = excluded.updated_at
       `)
       .run(params.workspaceId, params.sessionId, params.status ?? "QUEUED", params.currentInputId ?? null, now, now);
-    const row = this.db()
+    const row = workspaceDb
       .prepare<[string, string], Record<string, unknown>>(
         "SELECT * FROM session_runtime_state WHERE workspace_id = ? AND session_id = ? LIMIT 1"
       )
@@ -3795,6 +3808,7 @@ export class RuntimeStateStore {
     heartbeatAt?: string | null;
     lastError?: Record<string, unknown> | string | null;
   }): SessionRuntimeStateRecord {
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
     this.ensureSession(
       {
         workspaceId: params.workspaceId,
@@ -3810,7 +3824,7 @@ export class RuntimeStateStore {
         ? params.lastError
         : JSON.stringify(params.lastError);
 
-    this.db()
+    workspaceDb
       .prepare(`
         INSERT INTO session_runtime_state (
             workspace_id, session_id, status, current_input_id, current_worker_id,
@@ -3837,7 +3851,7 @@ export class RuntimeStateStore {
         heartbeatAt,
         heartbeatAt
       );
-    const row = this.db()
+    const row = workspaceDb
       .prepare<[string, string], Record<string, unknown>>(
         "SELECT * FROM session_runtime_state WHERE workspace_id = ? AND session_id = ? LIMIT 1"
       )
@@ -3846,7 +3860,7 @@ export class RuntimeStateStore {
   }
 
   listRuntimeStates(workspaceId: string): SessionRuntimeStateRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(workspaceId)
       .prepare<[string], Record<string, unknown>>(`
         SELECT * FROM session_runtime_state
         WHERE workspace_id = ?
@@ -3856,18 +3870,14 @@ export class RuntimeStateStore {
     return rows.map((row) => this.rowToRuntimeState(row));
   }
 
-  getRuntimeState(params: { sessionId: string; workspaceId?: string }): SessionRuntimeStateRecord | null {
-    let query = `
-      SELECT * FROM session_runtime_state
-      WHERE session_id = ?
-    `;
-    const values: string[] = [params.sessionId];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
-    query += " ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC LIMIT 1";
-    const row = this.db().prepare(query).get(...values) as Record<string, unknown> | undefined;
+  getRuntimeState(params: { workspaceId: string; sessionId: string }): SessionRuntimeStateRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string, string], Record<string, unknown>>(`
+        SELECT * FROM session_runtime_state
+        WHERE workspace_id = ? AND session_id = ?
+        ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC LIMIT 1
+      `)
+      .get(params.workspaceId, params.sessionId);
     return row ? this.rowToRuntimeState(row) : null;
   }
 
@@ -3879,7 +3889,7 @@ export class RuntimeStateStore {
     messageId?: string;
     createdAt?: string;
   }): void {
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         INSERT OR REPLACE INTO session_messages (
             id, workspace_id, session_id, role, text, created_at
@@ -3910,7 +3920,7 @@ export class RuntimeStateStore {
       query += " AND role = ?";
       values.push(params.role);
     }
-    const row = this.db().prepare(query).get(...values) as { total: number } | undefined;
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(...values) as { total: number } | undefined;
     return Number(row?.total ?? 0);
   }
 
@@ -3938,7 +3948,7 @@ export class RuntimeStateStore {
       query += " LIMIT ? OFFSET ?";
       values.push(params.limit ?? -1, params.offset ?? 0);
     }
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<typeof values, { id: string; role: string; text: string; created_at: string }>(query)
       .all(...values);
     return rows.map((row) => ({
@@ -6704,6 +6714,11 @@ export class RuntimeStateStore {
     workspaceId: string,
   ): void {
     const workspaceScopedTables = [
+      "agent_sessions",
+      "agent_runtime_sessions",
+      "conversation_bindings",
+      "session_runtime_state",
+      "session_messages",
       "task_proposals",
       "evolve_skill_candidates",
       "memory_update_proposals",
@@ -6913,6 +6928,92 @@ export class RuntimeStateStore {
 
   private ensureWorkspaceRuntimeDbSchema(db: Database.Database): void {
     db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_sessions (
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          kind TEXT NOT NULL DEFAULT 'workspace_session',
+          title TEXT,
+          parent_session_id TEXT,
+          source_proposal_id TEXT,
+          created_by TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          archived_at TEXT,
+          PRIMARY KEY (workspace_id, session_id),
+          UNIQUE (workspace_id, source_proposal_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_agent_sessions_workspace_updated
+          ON agent_sessions (workspace_id, updated_at DESC, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS agent_runtime_sessions (
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          harness TEXT NOT NULL,
+          harness_session_id TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (workspace_id, session_id),
+          UNIQUE (workspace_id, harness, harness_session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_agent_runtime_sessions_workspace_updated
+          ON agent_runtime_sessions (workspace_id, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS conversation_bindings (
+          binding_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          conversation_key TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          role TEXT NOT NULL DEFAULT 'main',
+          is_active INTEGER NOT NULL DEFAULT 1,
+          metadata TEXT NOT NULL DEFAULT '{}',
+          last_active_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          UNIQUE (workspace_id, channel, conversation_key, role),
+          UNIQUE (session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_conversation_bindings_workspace_role_active_updated
+          ON conversation_bindings (workspace_id, role, is_active, updated_at DESC, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_conversation_bindings_channel_key_active
+          ON conversation_bindings (channel, conversation_key, is_active);
+
+      CREATE TABLE IF NOT EXISTS session_runtime_state (
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN (${SESSION_RUNTIME_STATE_STATUS_SQL})),
+          current_input_id TEXT,
+          current_worker_id TEXT,
+          lease_until TEXT,
+          heartbeat_at TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (workspace_id, session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS session_runtime_state_workspace_session_idx
+          ON session_runtime_state (workspace_id, session_id);
+
+      CREATE INDEX IF NOT EXISTS session_runtime_state_session_id_idx
+          ON session_runtime_state (session_id);
+
+      CREATE TABLE IF NOT EXISTS session_messages (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          text TEXT NOT NULL,
+          created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_session_messages_workspace_session_created
+          ON session_messages (workspace_id, session_id, created_at ASC);
+
       CREATE TABLE IF NOT EXISTS task_proposals (
           proposal_id TEXT PRIMARY KEY,
           workspace_id TEXT NOT NULL,
@@ -7116,6 +7217,8 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_runtime_notifications_state_created
           ON runtime_notifications (state, created_at DESC);
     `);
+    this.ensureConversationBindingsTableSchema(db);
+    this.ensureSessionRuntimeStateTableSchema(db);
     this.ensureTaskProposalsTableSchema(db);
     this.ensureEvolveSkillCandidatesTableSchema(db);
     this.ensureMemoryUpdateProposalsTableSchema(db);
@@ -9546,10 +9649,14 @@ export class RuntimeStateStore {
   }
 
   private updateConversationBinding(params: {
+    workspaceId: string;
     bindingId: string;
     fields: ConversationBindingUpdateFields;
   }): ConversationBindingRecord | null {
-    const existing = this.getConversationBinding({ bindingId: params.bindingId });
+    const existing = this.getConversationBinding({
+      workspaceId: params.workspaceId,
+      bindingId: params.bindingId,
+    });
     if (!existing) {
       return null;
     }
@@ -9572,7 +9679,7 @@ export class RuntimeStateStore {
       updatedAt: utcNowIso(),
     };
 
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE conversation_bindings
         SET session_id = ?,
@@ -9592,7 +9699,10 @@ export class RuntimeStateStore {
         next.updatedAt,
         params.bindingId
       );
-    return this.getConversationBinding({ bindingId: params.bindingId });
+    return this.getConversationBinding({
+      workspaceId: params.workspaceId,
+      bindingId: params.bindingId,
+    });
   }
 
   private listMainSessionEventsByIds(eventIds: string[]): MainSessionEventQueueRecord[] {
@@ -9638,7 +9748,7 @@ export class RuntimeStateStore {
       updatedAt: utcNowIso()
     };
 
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         UPDATE agent_sessions
         SET kind = ?,

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -12,8 +12,10 @@ import {
 } from "./migrations/index.js";
 
 const RUNTIME_DB_PATH_ENV = "HOLABOSS_RUNTIME_DB_PATH";
+const CONTROL_PLANE_DB_PATH_ENV = "HOLABOSS_CONTROL_PLANE_DB_PATH";
 const WORKSPACE_RUNTIME_DIRNAME = ".holaboss";
 const WORKSPACE_STATE_DIRNAME = "state";
+const WORKSPACE_RUNTIME_DB_FILENAME = "runtime.db";
 const WORKSPACE_IDENTITY_FILENAME = "workspace_id";
 const LEGACY_WORKSPACE_METADATA_FILENAME = "workspace.json";
 
@@ -610,6 +612,7 @@ export interface CreateWorkspaceParams {
 
 export interface RuntimeStateStoreOptions {
   dbPath?: string;
+  controlPlaneDbPath?: string;
   workspaceRoot?: string;
   sandboxRoot?: string;
   sandboxAgentHarness?: string;
@@ -851,12 +854,30 @@ export function runtimeDbPath(options: RuntimeStateStoreOptions = {}): string {
   return path.join(sandboxRoot, "state", "runtime.db");
 }
 
+export function controlPlaneDbPath(options: RuntimeStateStoreOptions = {}): string {
+  const explicit = (options.controlPlaneDbPath ?? process.env[CONTROL_PLANE_DB_PATH_ENV] ?? "").trim();
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+
+  if (options.dbPath) {
+    return path.join(path.dirname(path.resolve(options.dbPath)), "control-plane.db");
+  }
+
+  const sandboxRoot = options.sandboxRoot ?? path.join(os.tmpdir(), "sandbox");
+  return path.join(sandboxRoot, "state", "control-plane.db");
+}
+
 function workspaceRuntimeDir(workspacePath: string): string {
   return path.join(workspacePath, WORKSPACE_RUNTIME_DIRNAME);
 }
 
 function workspaceStateDir(workspacePath: string): string {
   return path.join(workspaceRuntimeDir(workspacePath), WORKSPACE_STATE_DIRNAME);
+}
+
+function workspaceRuntimeDbPathForWorkspacePath(workspacePath: string): string {
+  return path.join(workspaceStateDir(workspacePath), WORKSPACE_RUNTIME_DB_FILENAME);
 }
 
 function currentWorkspaceIdentityPath(workspacePath: string): string {
@@ -883,15 +904,19 @@ function ensureWorkspaceIdentityMigrated(workspacePath: string): string {
 
 export class RuntimeStateStore {
   readonly dbPath: string;
+  readonly controlPlaneDbPath: string;
   readonly workspaceRoot: string;
   readonly sandboxAgentHarness: string | null;
   readonly #onMigrationEvent: ((event: MigrationLogEvent) => void) | undefined;
   #db: Database.Database | null = null;
+  #controlPlaneDb: Database.Database | null = null;
+  #workspaceRuntimeDbs: Map<string, { dbPath: string; db: Database.Database }> = new Map();
   #vectorIndexSupported = false;
   #statementCache: Map<string, Database.Statement> = new Map();
 
   constructor(options: RuntimeStateStoreOptions = {}) {
     this.dbPath = runtimeDbPath(options);
+    this.controlPlaneDbPath = controlPlaneDbPath(options);
     this.workspaceRoot = path.resolve(options.workspaceRoot ?? path.join(os.tmpdir(), "workspace-root"));
     this.#onMigrationEvent = options.onMigrationEvent;
     this.sandboxAgentHarness = (options.sandboxAgentHarness ?? process.env.SANDBOX_AGENT_HARNESS ?? "").trim() || null;
@@ -901,6 +926,14 @@ export class RuntimeStateStore {
     this.#statementCache.clear();
     this.#db?.close();
     this.#db = null;
+    if (this.controlPlaneDbPath !== this.dbPath) {
+      this.#controlPlaneDb?.close();
+    }
+    this.#controlPlaneDb = null;
+    for (const entry of this.#workspaceRuntimeDbs.values()) {
+      entry.db.close();
+    }
+    this.#workspaceRuntimeDbs.clear();
     this.#vectorIndexSupported = false;
   }
 
@@ -925,7 +958,7 @@ export class RuntimeStateStore {
    * connection merges atomic.
    */
   transaction<T>(fn: () => T): T {
-    return this.db().transaction(fn)();
+    return this.controlPlaneDb().transaction(fn)();
   }
 
   workspaceIdentityPath(workspaceId: string): string {
@@ -1031,7 +1064,7 @@ export class RuntimeStateStore {
 
   listWorkspaces(options: { includeDeleted?: boolean } = {}): WorkspaceRecord[] {
     this.ensureWorkspaceMetadataReady();
-    const rows = this.db()
+    const rows = this.controlPlaneDb()
       .prepare<[], WorkspaceRow>(`
         SELECT id, workspace_path, name, status, harness, error_message,
                onboarding_status, onboarding_session_id, onboarding_completed_at,
@@ -1051,7 +1084,7 @@ export class RuntimeStateStore {
 
   getWorkspace(workspaceId: string, options: { includeDeleted?: boolean } = {}): WorkspaceRecord | null {
     this.ensureWorkspaceMetadataReady();
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string], WorkspaceRow>(`
         SELECT id, workspace_path, name, status, harness, error_message,
                onboarding_status, onboarding_session_id, onboarding_completed_at,
@@ -1149,7 +1182,7 @@ export class RuntimeStateStore {
     // Soft-deleted rows are excluded: once a workspace is removed, its
     // former path is fair game for reuse (the metadata was already
     // stripped during DELETE).
-    const rows = this.db()
+    const rows = this.controlPlaneDb()
       .prepare<[], { id: string; workspace_path: string }>(
         "SELECT id, workspace_path FROM workspaces WHERE deleted_at_utc IS NULL"
       )
@@ -1295,7 +1328,10 @@ export class RuntimeStateStore {
     // reversible). Stamp a tombstone that is unique per workspace id and
     // identifiable in diagnostics.
     const tombstone = `__deleted__/${workspaceId}/${Date.now()}`;
-    this.db().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(tombstone, workspaceId);
+    this.controlPlaneDb().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(tombstone, workspaceId);
+    if (this.controlPlaneDbPath !== this.dbPath) {
+      this.db().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(tombstone, workspaceId);
+    }
     return result;
   }
 
@@ -1429,10 +1465,17 @@ export class RuntimeStateStore {
     return rows.map((row) => this.rowToAgentSession(row));
   }
 
-  updateTaskProposal(params: { proposalId: string; fields: TaskProposalUpdateFields }): TaskProposalRecord | null {
+  updateTaskProposal(params: { workspaceId: string; proposalId: string; fields: TaskProposalUpdateFields }): TaskProposalRecord | null {
+    const existing = this.getTaskProposal({
+      workspaceId: params.workspaceId,
+      proposalId: params.proposalId,
+    });
+    if (!existing) {
+      return null;
+    }
     const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getTaskProposal(params.proposalId);
+      return existing;
     }
 
     const columnMap: Record<keyof TaskProposalUpdateFields, string> = {
@@ -1457,22 +1500,30 @@ export class RuntimeStateStore {
     }
     values.push(params.proposalId);
 
-    const result = this.db()
-      .prepare(`UPDATE task_proposals SET ${assignments.join(", ")} WHERE proposal_id = ?`)
-      .run(...values);
-    if (result.changes <= 0) {
-      return null;
-    }
-    return this.getTaskProposal(params.proposalId);
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`UPDATE task_proposals SET ${assignments.join(", ")} WHERE proposal_id = ?`).run(...values);
+    });
+    return this.getTaskProposal({
+      workspaceId: params.workspaceId,
+      proposalId: params.proposalId,
+    });
   }
 
   updateMemoryUpdateProposal(params: {
+    workspaceId: string;
     proposalId: string;
     fields: MemoryUpdateProposalUpdateFields;
   }): MemoryUpdateProposalRecord | null {
+    const existing = this.getMemoryUpdateProposal({
+      workspaceId: params.workspaceId,
+      proposalId: params.proposalId,
+    });
+    if (!existing) {
+      return null;
+    }
     const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getMemoryUpdateProposal(params.proposalId);
+      return existing;
     }
 
     const columnMap: Record<keyof MemoryUpdateProposalUpdateFields, string> = {
@@ -1504,22 +1555,30 @@ export class RuntimeStateStore {
     assignments.push("updated_at = ?");
     values.push(utcNowIso(), params.proposalId);
 
-    const result = this.db()
-      .prepare(`UPDATE memory_update_proposals SET ${assignments.join(", ")} WHERE proposal_id = ?`)
-      .run(...values);
-    if (result.changes <= 0) {
-      return null;
-    }
-    return this.getMemoryUpdateProposal(params.proposalId);
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`UPDATE memory_update_proposals SET ${assignments.join(", ")} WHERE proposal_id = ?`).run(...values);
+    });
+    return this.getMemoryUpdateProposal({
+      workspaceId: params.workspaceId,
+      proposalId: params.proposalId,
+    });
   }
 
   updateEvolveSkillCandidate(params: {
+    workspaceId: string;
     candidateId: string;
     fields: EvolveSkillCandidateUpdateFields;
   }): EvolveSkillCandidateRecord | null {
+    const existing = this.getEvolveSkillCandidate({
+      workspaceId: params.workspaceId,
+      candidateId: params.candidateId,
+    });
+    if (!existing) {
+      return null;
+    }
     const entries = Object.entries(params.fields);
     if (entries.length === 0) {
-      return this.getEvolveSkillCandidate(params.candidateId);
+      return existing;
     }
 
     const columnMap: Record<keyof EvolveSkillCandidateUpdateFields, string> = {
@@ -1555,13 +1614,13 @@ export class RuntimeStateStore {
     assignments.push("updated_at = ?");
     values.push(utcNowIso(), params.candidateId);
 
-    const result = this.db()
-      .prepare(`UPDATE evolve_skill_candidates SET ${assignments.join(", ")} WHERE candidate_id = ?`)
-      .run(...values);
-    if (result.changes <= 0) {
-      return null;
-    }
-    return this.getEvolveSkillCandidate(params.candidateId);
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`UPDATE evolve_skill_candidates SET ${assignments.join(", ")} WHERE candidate_id = ?`).run(...values);
+    });
+    return this.getEvolveSkillCandidate({
+      workspaceId: params.workspaceId,
+      candidateId: params.candidateId,
+    });
   }
 
   upsertBinding(params: {
@@ -2868,7 +2927,7 @@ export class RuntimeStateStore {
     secretRef?: string | null;
   }): IntegrationConnectionRecord {
     const now = utcNowIso();
-    this.db()
+    this.controlPlaneDb()
       .prepare(`
         INSERT INTO integration_connections (
             connection_id, provider_id, owner_user_id, account_label, account_external_id,
@@ -2944,7 +3003,7 @@ export class RuntimeStateStore {
       values.push(email);
     }
     filters.push(`(${identityClauses.join(" OR ")})`);
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<typeof values, Record<string, unknown>>(
         `SELECT * FROM integration_connections WHERE ${filters.join(" AND ")} ORDER BY datetime(updated_at) DESC LIMIT 1`
       )
@@ -2953,7 +3012,7 @@ export class RuntimeStateStore {
   }
 
   getIntegrationConnection(connectionId: string): IntegrationConnectionRecord | null {
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string], Record<string, unknown>>(
         "SELECT * FROM integration_connections WHERE connection_id = ? LIMIT 1"
       )
@@ -2977,7 +3036,7 @@ export class RuntimeStateStore {
       query += ` WHERE ${filters.join(" AND ")}`;
     }
     query += " ORDER BY datetime(created_at) ASC, connection_id ASC";
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.controlPlaneDb().prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToIntegrationConnection(row));
   }
 
@@ -3004,7 +3063,7 @@ export class RuntimeStateStore {
     });
 
     if (existing) {
-      this.db()
+      this.controlPlaneDb()
         .prepare(`
           UPDATE integration_bindings
           SET binding_id = ?,
@@ -3024,7 +3083,7 @@ export class RuntimeStateStore {
           params.integrationKey
         );
     } else {
-      this.db()
+      this.controlPlaneDb()
         .prepare(`
           INSERT INTO integration_bindings (
               binding_id, workspace_id, target_type, target_id, integration_key,
@@ -3057,7 +3116,7 @@ export class RuntimeStateStore {
   }
 
   getIntegrationBinding(bindingId: string): IntegrationBindingRecord | null {
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string], Record<string, unknown>>("SELECT * FROM integration_bindings WHERE binding_id = ? LIMIT 1")
       .get(bindingId);
     return row ? this.rowToIntegrationBinding(row) : null;
@@ -3069,7 +3128,7 @@ export class RuntimeStateStore {
     targetId: string;
     integrationKey: string;
   }): IntegrationBindingRecord | null {
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string, string, string, string], Record<string, unknown>>(`
         SELECT * FROM integration_bindings
         WHERE workspace_id = ? AND target_type = ? AND target_id = ? AND integration_key = ?
@@ -3087,19 +3146,19 @@ export class RuntimeStateStore {
       values.push(params.workspaceId);
     }
     query += " ORDER BY is_default DESC, datetime(created_at) ASC, binding_id ASC";
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.controlPlaneDb().prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToIntegrationBinding(row));
   }
 
   deleteIntegrationConnection(connectionId: string): boolean {
-    const result = this.db()
+    const result = this.controlPlaneDb()
       .prepare("DELETE FROM integration_connections WHERE connection_id = ?")
       .run(connectionId);
     return result.changes > 0;
   }
 
   deleteIntegrationBinding(bindingId: string): boolean {
-    const result = this.db().prepare("DELETE FROM integration_bindings WHERE binding_id = ?").run(bindingId);
+    const result = this.controlPlaneDb().prepare("DELETE FROM integration_bindings WHERE binding_id = ?").run(bindingId);
     return result.changes > 0;
   }
 
@@ -3114,7 +3173,7 @@ export class RuntimeStateStore {
   }): OAuthAppConfigRecord {
     const now = utcNowIso();
     const redirectPort = params.redirectPort ?? 38765;
-    this.db().prepare(`
+    this.controlPlaneDb().prepare(`
       INSERT INTO oauth_app_configs (provider_id, client_id, client_secret, authorize_url, token_url, scopes, redirect_port, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT (provider_id) DO UPDATE SET
@@ -3138,7 +3197,7 @@ export class RuntimeStateStore {
   }
 
   getOAuthAppConfig(providerId: string): OAuthAppConfigRecord | null {
-    const row = this.db().prepare("SELECT * FROM oauth_app_configs WHERE provider_id = ?").get(providerId) as Record<string, unknown> | undefined;
+    const row = this.controlPlaneDb().prepare("SELECT * FROM oauth_app_configs WHERE provider_id = ?").get(providerId) as Record<string, unknown> | undefined;
     if (!row) return null;
     return {
       providerId: row.provider_id as string,
@@ -3154,7 +3213,7 @@ export class RuntimeStateStore {
   }
 
   listOAuthAppConfigs(): OAuthAppConfigRecord[] {
-    const rows = this.db().prepare("SELECT * FROM oauth_app_configs ORDER BY provider_id").all() as Record<string, unknown>[];
+    const rows = this.controlPlaneDb().prepare("SELECT * FROM oauth_app_configs ORDER BY provider_id").all() as Record<string, unknown>[];
     return rows.map((row) => ({
       providerId: row.provider_id as string,
       clientId: row.client_id as string,
@@ -3169,7 +3228,7 @@ export class RuntimeStateStore {
   }
 
   deleteOAuthAppConfig(providerId: string): boolean {
-    const result = this.db().prepare("DELETE FROM oauth_app_configs WHERE provider_id = ?").run(providerId);
+    const result = this.controlPlaneDb().prepare("DELETE FROM oauth_app_configs WHERE provider_id = ?").run(providerId);
     return result.changes > 0;
   }
 
@@ -4422,7 +4481,7 @@ export class RuntimeStateStore {
   }
 
   getRuntimeUserProfile(params: { profileId?: string } = {}): RuntimeUserProfileRecord | null {
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string], Record<string, unknown>>(
         "SELECT * FROM runtime_user_profiles WHERE profile_id = ? LIMIT 1"
       )
@@ -4447,7 +4506,7 @@ export class RuntimeStateStore {
       ? (params.nameSource ?? existing?.nameSource ?? "manual")
       : null;
 
-    this.db()
+    this.controlPlaneDb()
       .prepare(`
         INSERT INTO runtime_user_profiles (
             profile_id,
@@ -5023,18 +5082,19 @@ export class RuntimeStateStore {
   createOutputFolder(params: { workspaceId: string; name: string }): OutputFolderRecord {
     const resolvedId = randomUUID();
     const now = utcNowIso();
-    const countRow = this.db()
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const countRow = workspaceDb
       .prepare<[string], { count: number }>("SELECT COUNT(*) AS count FROM output_folders WHERE workspace_id = ?")
       .get(params.workspaceId);
     const position = countRow?.count ?? 0;
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO output_folders (
             id, workspace_id, name, position, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?)
-      `)
-      .run(resolvedId, params.workspaceId, params.name, position, now, now);
-    const row = this.db()
+      `).run(resolvedId, params.workspaceId, params.name, position, now, now);
+    });
+    const row = workspaceDb
       .prepare<[string], Record<string, unknown>>("SELECT * FROM output_folders WHERE id = ? LIMIT 1")
       .get(resolvedId);
     if (!row) {
@@ -5044,7 +5104,7 @@ export class RuntimeStateStore {
   }
 
   listOutputFolders(params: { workspaceId: string }): OutputFolderRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(`
         SELECT * FROM output_folders
         WHERE workspace_id = ?
@@ -5054,33 +5114,51 @@ export class RuntimeStateStore {
     return rows.map((row) => this.rowToOutputFolder(row));
   }
 
-  updateOutputFolder(params: { folderId: string; name?: string | null; position?: number | null }): OutputFolderRecord | null {
-    const existing = this.getOutputFolder(params.folderId);
+  updateOutputFolder(params: {
+    workspaceId: string;
+    folderId: string;
+    name?: string | null;
+    position?: number | null;
+  }): OutputFolderRecord | null {
+    const existing = this.getOutputFolder({
+      workspaceId: params.workspaceId,
+      folderId: params.folderId,
+    });
     if (!existing) {
       return null;
     }
     const updatedAt = utcNowIso();
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`
         UPDATE output_folders
         SET name = ?, position = ?, updated_at = ?
         WHERE id = ?
-      `)
-      .run(params.name ?? existing.name, params.position ?? existing.position, updatedAt, params.folderId);
-    return this.getOutputFolder(params.folderId);
+      `).run(params.name ?? existing.name, params.position ?? existing.position, updatedAt, params.folderId);
+    });
+    return this.getOutputFolder({
+      workspaceId: params.workspaceId,
+      folderId: params.folderId,
+    });
   }
 
-  getOutputFolder(folderId: string): OutputFolderRecord | null {
-    const row = this.db()
+  getOutputFolder(params: { workspaceId: string; folderId: string }): OutputFolderRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM output_folders WHERE id = ? LIMIT 1")
-      .get(folderId);
+      .get(params.folderId);
     return row ? this.rowToOutputFolder(row) : null;
   }
 
-  deleteOutputFolder(folderId: string): boolean {
-    this.db().prepare("UPDATE outputs SET folder_id = NULL, updated_at = ? WHERE folder_id = ?").run(utcNowIso(), folderId);
-    const result = this.db().prepare("DELETE FROM output_folders WHERE id = ?").run(folderId);
-    return result.changes > 0;
+  deleteOutputFolder(params: { workspaceId: string; folderId: string }): boolean {
+    const existing = this.getOutputFolder(params);
+    if (!existing) {
+      return false;
+    }
+    const updatedAt = utcNowIso();
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare("UPDATE outputs SET folder_id = NULL, updated_at = ? WHERE folder_id = ?").run(updatedAt, params.folderId);
+      db.prepare("DELETE FROM output_folders WHERE id = ?").run(params.folderId);
+    });
+    return this.getOutputFolder(params) === null;
   }
 
   createOutput(params: {
@@ -5102,14 +5180,14 @@ export class RuntimeStateStore {
   }): OutputRecord {
     const resolvedId = params.outputId ?? randomUUID();
     const now = utcNowIso();
-    this.db()
-      .prepare(`
+    const metadataJson = JSON.stringify(params.metadata ?? {});
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO outputs (
             id, workspace_id, output_type, title, status, module_id, module_resource_id, file_path,
             html_content, session_id, input_id, artifact_id, folder_id, platform, metadata, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      .run(
+      `).run(
         resolvedId,
         params.workspaceId,
         params.outputType,
@@ -5124,11 +5202,14 @@ export class RuntimeStateStore {
         params.artifactId ?? null,
         params.folderId ?? null,
         params.platform ?? null,
-        JSON.stringify(params.metadata ?? {}),
+        metadataJson,
         now,
         now
       );
-    const row = this.db().prepare<[string], Record<string, unknown>>("SELECT * FROM outputs WHERE id = ? LIMIT 1").get(resolvedId);
+    });
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string], Record<string, unknown>>("SELECT * FROM outputs WHERE id = ? LIMIT 1")
+      .get(resolvedId);
     if (!row) {
       throw new Error("output row not found after insert");
     }
@@ -5174,16 +5255,19 @@ export class RuntimeStateStore {
     }
     query += " ORDER BY datetime(created_at) DESC LIMIT ? OFFSET ?";
     values.push(params.limit ?? 50, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToOutput(row));
   }
 
-  getOutput(outputId: string): OutputRecord | null {
-    const row = this.db().prepare<[string], Record<string, unknown>>("SELECT * FROM outputs WHERE id = ? LIMIT 1").get(outputId);
+  getOutput(params: { workspaceId: string; outputId: string }): OutputRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string], Record<string, unknown>>("SELECT * FROM outputs WHERE id = ? LIMIT 1")
+      .get(params.outputId);
     return row ? this.rowToOutput(row) : null;
   }
 
   updateOutput(params: {
+    workspaceId: string;
     outputId: string;
     title?: string | null;
     status?: string | null;
@@ -5193,12 +5277,15 @@ export class RuntimeStateStore {
     metadata?: Record<string, unknown> | null;
     folderId?: string | null;
   }): OutputRecord | null {
-    const existing = this.getOutput(params.outputId);
+    const existing = this.getOutput({
+      workspaceId: params.workspaceId,
+      outputId: params.outputId,
+    });
     if (!existing) {
       return null;
     }
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`
         UPDATE outputs
         SET title = ?,
             status = ?,
@@ -5209,8 +5296,7 @@ export class RuntimeStateStore {
             folder_id = ?,
             updated_at = ?
         WHERE id = ?
-      `)
-      .run(
+      `).run(
         params.title ?? existing.title,
         params.status ?? existing.status,
         params.moduleResourceId ?? existing.moduleResourceId,
@@ -5221,16 +5307,26 @@ export class RuntimeStateStore {
         utcNowIso(),
         params.outputId
       );
-    return this.getOutput(params.outputId);
+    });
+    return this.getOutput({
+      workspaceId: params.workspaceId,
+      outputId: params.outputId,
+    });
   }
 
-  deleteOutput(outputId: string): boolean {
-    const result = this.db().prepare("DELETE FROM outputs WHERE id = ?").run(outputId);
-    return result.changes > 0;
+  deleteOutput(params: { workspaceId: string; outputId: string }): boolean {
+    const existing = this.getOutput(params);
+    if (!existing) {
+      return false;
+    }
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare("DELETE FROM outputs WHERE id = ?").run(params.outputId);
+    });
+    return this.getOutput(params) === null;
   }
 
   getOutputCounts(params: { workspaceId: string }): Record<string, unknown> {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT status, platform, folder_id FROM outputs WHERE workspace_id = ?")
       .all(params.workspaceId);
     const byStatus: Record<string, number> = {};
@@ -5259,6 +5355,7 @@ export class RuntimeStateStore {
     error?: string | null;
   }): AppBuildRecord {
     const now = utcNowIso();
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
     const existing = this.getAppBuild({
       workspaceId: params.workspaceId,
       appId: params.appId
@@ -5281,17 +5378,17 @@ export class RuntimeStateStore {
       const setClause = Object.keys(fields)
         .map((column) => `${column} = ?`)
         .join(", ");
-      this.db()
-        .prepare(`UPDATE app_builds SET ${setClause} WHERE workspace_id = ? AND app_id = ?`)
-        .run(...Object.values(fields), params.workspaceId, params.appId);
+      this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+        db.prepare(`UPDATE app_builds SET ${setClause} WHERE workspace_id = ? AND app_id = ?`)
+          .run(...Object.values(fields), params.workspaceId, params.appId);
+      });
     } else {
-      this.db()
-        .prepare(`
+      this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+        db.prepare(`
           INSERT INTO app_builds (
               workspace_id, app_id, status, started_at, completed_at, error, created_at, updated_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `)
-        .run(
+        `).run(
           params.workspaceId,
           params.appId,
           params.status,
@@ -5301,8 +5398,9 @@ export class RuntimeStateStore {
           now,
           now
         );
+      });
     }
-    const row = this.db()
+    const row = workspaceDb
       .prepare<[string, string], Record<string, unknown>>(
         "SELECT * FROM app_builds WHERE workspace_id = ? AND app_id = ? LIMIT 1"
       )
@@ -5314,7 +5412,7 @@ export class RuntimeStateStore {
   }
 
   getAppBuild(params: { workspaceId: string; appId: string }): AppBuildRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string], Record<string, unknown>>(
         "SELECT * FROM app_builds WHERE workspace_id = ? AND app_id = ? LIMIT 1"
       )
@@ -5323,10 +5421,10 @@ export class RuntimeStateStore {
   }
 
   deleteAppBuild(params: { workspaceId: string; appId: string }): boolean {
-    const result = this.db()
-      .prepare("DELETE FROM app_builds WHERE workspace_id = ? AND app_id = ?")
-      .run(params.workspaceId, params.appId);
-    return result.changes > 0;
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare("DELETE FROM app_builds WHERE workspace_id = ? AND app_id = ?").run(params.workspaceId, params.appId);
+    });
+    return this.getAppBuild(params) === null;
   }
 
   /** Set the persistent restart-attempts counter for an app build row.
@@ -5337,11 +5435,11 @@ export class RuntimeStateStore {
     attempts: number;
   }): void {
     const safeAttempts = Math.max(0, Math.floor(params.attempts) || 0);
-    this.db()
-      .prepare(
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(
         "UPDATE app_builds SET restart_attempts = ?, updated_at = ? WHERE workspace_id = ? AND app_id = ?",
-      )
-      .run(safeAttempts, utcNowIso(), params.workspaceId, params.appId);
+      ).run(safeAttempts, utcNowIso(), params.workspaceId, params.appId);
+    });
   }
 
   // --- App Ports ---
@@ -5356,10 +5454,12 @@ export class RuntimeStateStore {
       const port = this.findAvailablePort();
       const now = utcNowIso();
 
-      this.db().prepare(`
-        INSERT OR IGNORE INTO app_ports (workspace_id, app_id, port, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?)
-      `).run(params.workspaceId, params.appId, port, now, now);
+      this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+        db.prepare(`
+          INSERT OR IGNORE INTO app_ports (workspace_id, app_id, port, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)
+        `).run(params.workspaceId, params.appId, port, now, now);
+      });
 
       return this.getAppPort({ workspaceId: params.workspaceId, appId: params.appId })!;
     });
@@ -5367,7 +5467,7 @@ export class RuntimeStateStore {
   }
 
   getAppPort(params: { workspaceId: string; appId: string }): AppPortRecord | null {
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string, string], Record<string, unknown>>(
         "SELECT * FROM app_ports WHERE workspace_id = ? AND app_id = ? LIMIT 1"
       )
@@ -5376,7 +5476,7 @@ export class RuntimeStateStore {
   }
 
   listAppPorts(params: { workspaceId: string }): AppPortRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(
         "SELECT * FROM app_ports WHERE workspace_id = ?"
       )
@@ -5385,19 +5485,21 @@ export class RuntimeStateStore {
   }
 
   listAllAppPorts(): AppPortRecord[] {
-    const rows = this.db()
-      .prepare<[], Record<string, unknown>>(
-        "SELECT * FROM app_ports"
-      )
-      .all();
-    return rows.map((row) => this.rowToAppPort(row));
+    return this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+      const rows = db
+        .prepare<[], Record<string, unknown>>(
+          "SELECT * FROM app_ports"
+        )
+        .all();
+      return rows.map((row) => this.rowToAppPort(row));
+    });
   }
 
   deleteAppPort(params: { workspaceId: string; appId: string }): boolean {
-    const result = this.db()
-      .prepare("DELETE FROM app_ports WHERE workspace_id = ? AND app_id = ?")
-      .run(params.workspaceId, params.appId);
-    return result.changes > 0;
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare("DELETE FROM app_ports WHERE workspace_id = ? AND app_id = ?").run(params.workspaceId, params.appId);
+    });
+    return this.getAppPort(params) === null;
   }
 
   // --- App Catalog ---
@@ -5417,7 +5519,7 @@ export class RuntimeStateStore {
     cachedAt: string;
   }): AppCatalogEntryRecord {
     const tagsJson = JSON.stringify(params.tags ?? []);
-    this.db().prepare(`
+    this.controlPlaneDb().prepare(`
       INSERT INTO app_catalog (
         app_id, source, name, description, icon, category,
         tags_json, version, archive_url, archive_path, target, cached_at
@@ -5467,12 +5569,12 @@ export class RuntimeStateStore {
     params: { source?: "marketplace" | "local" } = {},
   ): AppCatalogEntryRecord[] {
     const rows = params.source
-      ? this.db()
+      ? this.controlPlaneDb()
           .prepare<[string], Record<string, unknown>>(
             "SELECT * FROM app_catalog WHERE source = ? ORDER BY app_id",
           )
           .all(params.source)
-      : this.db()
+      : this.controlPlaneDb()
           .prepare<[], Record<string, unknown>>(
             "SELECT * FROM app_catalog ORDER BY source, app_id",
           )
@@ -5481,14 +5583,14 @@ export class RuntimeStateStore {
   }
 
   clearAppCatalogSource(source: "marketplace" | "local"): number {
-    const result = this.db()
+    const result = this.controlPlaneDb()
       .prepare("DELETE FROM app_catalog WHERE source = ?")
       .run(source);
     return result.changes;
   }
 
   deleteAppCatalogEntry(params: { source: string; appId: string }): boolean {
-    const result = this.db()
+    const result = this.controlPlaneDb()
       .prepare("DELETE FROM app_catalog WHERE source = ? AND app_id = ?")
       .run(params.source, params.appId);
     return result.changes > 0;
@@ -5530,12 +5632,7 @@ export class RuntimeStateStore {
     const BASE_PORT = 38080;
     const MAX_PORT = 38979;
 
-    const allocated = new Set(
-      this.db()
-        .prepare<[], { port: number }>("SELECT port FROM app_ports")
-        .all()
-        .map((r) => r.port)
-    );
+    const allocated = new Set(this.listAllAppPorts().map((record) => record.port));
 
     for (let port = BASE_PORT; port <= MAX_PORT; port++) {
       if (!allocated.has(port)) {
@@ -5570,14 +5667,13 @@ export class RuntimeStateStore {
   }): CronjobRecord {
     const resolvedId = params.jobId ?? randomUUID();
     const now = utcNowIso();
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO cronjobs (
             id, workspace_id, initiated_by, name, cron, description, instruction, enabled, delivery, metadata,
             last_run_at, next_run_at, run_count, last_status, last_error, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, 0, NULL, NULL, ?, ?)
-      `)
-      .run(
+      `).run(
         resolvedId,
         params.workspaceId,
         params.initiatedBy,
@@ -5592,19 +5688,43 @@ export class RuntimeStateStore {
         now,
         now
       );
-    const row = this.db().prepare<[string], Record<string, unknown>>("SELECT * FROM cronjobs WHERE id = ? LIMIT 1").get(resolvedId);
+    });
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string], Record<string, unknown>>("SELECT * FROM cronjobs WHERE id = ? LIMIT 1")
+      .get(resolvedId);
     if (!row) {
       throw new Error("cronjob row not found after insert");
     }
     return this.rowToCronjob(row);
   }
 
-  getCronjob(jobId: string): CronjobRecord | null {
-    const row = this.db().prepare<[string], Record<string, unknown>>("SELECT * FROM cronjobs WHERE id = ? LIMIT 1").get(jobId);
+  getCronjob(params: { workspaceId: string; jobId: string }): CronjobRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<[string], Record<string, unknown>>("SELECT * FROM cronjobs WHERE id = ? LIMIT 1")
+      .get(params.jobId);
     return row ? this.rowToCronjob(row) : null;
   }
 
   listCronjobs(params: { workspaceId?: string | null; enabledOnly?: boolean }): CronjobRecord[] {
+    if (!params.workspaceId) {
+      const jobs = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+        let query = "SELECT * FROM cronjobs";
+        if (params.enabledOnly) {
+          query += " WHERE enabled = 1";
+        }
+        query += " ORDER BY datetime(created_at) ASC, id ASC";
+        const rows = db.prepare(query).all() as Array<Record<string, unknown>>;
+        return rows.map((row) => this.rowToCronjob(row));
+      });
+      jobs.sort((left, right) => {
+        const createdAtCompare = left.createdAt.localeCompare(right.createdAt);
+        if (createdAtCompare !== 0) {
+          return createdAtCompare;
+        }
+        return left.id.localeCompare(right.id);
+      });
+      return jobs;
+    }
     let query = "SELECT * FROM cronjobs";
     const filters: string[] = [];
     const values: string[] = [];
@@ -5619,11 +5739,12 @@ export class RuntimeStateStore {
       query += ` WHERE ${filters.join(" AND ")}`;
     }
     query += " ORDER BY datetime(created_at) ASC, id ASC";
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToCronjob(row));
   }
 
   updateCronjob(params: {
+    workspaceId: string;
     jobId: string;
     name?: string | null;
     cron?: string | null;
@@ -5638,12 +5759,15 @@ export class RuntimeStateStore {
     lastStatus?: string | null;
     lastError?: string | null;
   }): CronjobRecord | null {
-    const existing = this.getCronjob(params.jobId);
+    const existing = this.getCronjob({
+      workspaceId: params.workspaceId,
+      jobId: params.jobId,
+    });
     if (!existing) {
       return null;
     }
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`
         UPDATE cronjobs
         SET name = ?,
             cron = ?,
@@ -5659,8 +5783,7 @@ export class RuntimeStateStore {
             last_error = ?,
             updated_at = ?
         WHERE id = ?
-      `)
-      .run(
+      `).run(
         params.name ?? existing.name,
         params.cron ?? existing.cron,
         params.description ?? existing.description,
@@ -5676,12 +5799,22 @@ export class RuntimeStateStore {
         utcNowIso(),
         params.jobId
       );
-    return this.getCronjob(params.jobId);
+    });
+    return this.getCronjob({
+      workspaceId: params.workspaceId,
+      jobId: params.jobId,
+    });
   }
 
-  deleteCronjob(jobId: string): boolean {
-    const result = this.db().prepare("DELETE FROM cronjobs WHERE id = ?").run(jobId);
-    return result.changes > 0;
+  deleteCronjob(params: { workspaceId: string; jobId: string }): boolean {
+    const existing = this.getCronjob(params);
+    if (!existing) {
+      return false;
+    }
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare("DELETE FROM cronjobs WHERE id = ?").run(params.jobId);
+    });
+    return this.getCronjob(params) === null;
   }
 
   createRuntimeNotification(params: {
@@ -5714,14 +5847,13 @@ export class RuntimeStateStore {
     const dismissedAt =
       params.dismissedAt !== undefined ? params.dismissedAt : state === "dismissed" ? now : null;
 
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO runtime_notifications (
             id, workspace_id, cronjob_id, source_type, source_label, title, message, level, priority, state,
             metadata, read_at, dismissed_at, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      .run(
+      `).run(
         resolvedId,
         params.workspaceId,
         this.normalizedNullableText(params.cronjobId),
@@ -5738,8 +5870,9 @@ export class RuntimeStateStore {
         now,
         now
       );
+    });
 
-    const row = this.db()
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM runtime_notifications WHERE id = ? LIMIT 1")
       .get(resolvedId);
     if (!row) {
@@ -5748,10 +5881,10 @@ export class RuntimeStateStore {
     return this.rowToRuntimeNotification(row);
   }
 
-  getRuntimeNotification(notificationId: string): RuntimeNotificationRecord | null {
-    const row = this.db()
+  getRuntimeNotification(params: { workspaceId: string; notificationId: string }): RuntimeNotificationRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM runtime_notifications WHERE id = ? LIMIT 1")
-      .get(notificationId);
+      .get(params.notificationId);
     return row ? this.rowToRuntimeNotification(row) : null;
   }
 
@@ -5762,6 +5895,56 @@ export class RuntimeStateStore {
     sourceType?: string | null;
     excludeSourceTypes?: string[] | null;
   }): RuntimeNotificationRecord[] {
+    if (!params.workspaceId) {
+      const notifications = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db }) => {
+        let query = "SELECT * FROM runtime_notifications";
+        const filters: string[] = [];
+        const values: Array<string | number> = [];
+        const normalizedSourceType = this.normalizedNullableText(params.sourceType);
+        if (normalizedSourceType) {
+          filters.push("source_type = ?");
+          values.push(normalizedSourceType);
+        }
+        if (!params.includeDismissed) {
+          filters.push("state != 'dismissed'");
+        }
+        const excludedSourceTypes =
+          params.excludeSourceTypes
+            ?.map((value) => this.normalizedNullableText(value))
+            .filter((value): value is string => Boolean(value)) ?? [];
+        if (excludedSourceTypes.length > 0) {
+          filters.push(
+            `coalesce(source_type, '') NOT IN (${excludedSourceTypes
+              .map(() => "?")
+              .join(", ")})`,
+          );
+          values.push(...excludedSourceTypes);
+        }
+        if (filters.length > 0) {
+          query += ` WHERE ${filters.join(" AND ")}`;
+        }
+        query += " ORDER BY datetime(created_at) DESC, id DESC";
+        const rows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+        return rows.map((row) => this.rowToRuntimeNotification(row));
+      });
+      notifications.sort((left, right) => {
+        const priorityCompare =
+          this.notificationPriorityWeight(right.priority) -
+          this.notificationPriorityWeight(left.priority);
+        if (priorityCompare !== 0) {
+          return priorityCompare;
+        }
+        const createdAtCompare = right.createdAt.localeCompare(left.createdAt);
+        if (createdAtCompare !== 0) {
+          return createdAtCompare;
+        }
+        return right.id.localeCompare(left.id);
+      });
+      if (typeof params.limit === "number" && Number.isFinite(params.limit) && params.limit > 0) {
+        return notifications.slice(0, Math.floor(params.limit));
+      }
+      return notifications;
+    }
     let query = "SELECT * FROM runtime_notifications";
     const filters: string[] = [];
     const values: Array<string | number> = [];
@@ -5797,11 +5980,12 @@ export class RuntimeStateStore {
       query += " LIMIT ?";
       values.push(Math.floor(params.limit));
     }
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToRuntimeNotification(row));
   }
 
   updateRuntimeNotification(params: {
+    workspaceId: string;
     notificationId: string;
     title?: string | null;
     message?: string | null;
@@ -5813,7 +5997,10 @@ export class RuntimeStateStore {
     dismissedAt?: string | null;
     sourceLabel?: string | null;
   }): RuntimeNotificationRecord | null {
-    const existing = this.getRuntimeNotification(params.notificationId);
+    const existing = this.getRuntimeNotification({
+      workspaceId: params.workspaceId,
+      notificationId: params.notificationId,
+    });
     if (!existing) {
       return null;
     }
@@ -5833,8 +6020,8 @@ export class RuntimeStateStore {
           ? existing.dismissedAt ?? now
           : null;
 
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(existing.workspaceId, (db) => {
+      db.prepare(`
         UPDATE runtime_notifications
         SET source_label = ?,
             title = ?,
@@ -5847,8 +6034,7 @@ export class RuntimeStateStore {
             dismissed_at = ?,
             updated_at = ?
         WHERE id = ?
-      `)
-      .run(
+      `).run(
         params.sourceLabel === undefined ? existing.sourceLabel : this.normalizedNullableText(params.sourceLabel),
         params.title == null ? existing.title : params.title.trim(),
         params.message == null ? existing.message : params.message.trim(),
@@ -5861,8 +6047,12 @@ export class RuntimeStateStore {
         now,
         params.notificationId
       );
+    });
 
-    return this.getRuntimeNotification(params.notificationId);
+    return this.getRuntimeNotification({
+      workspaceId: params.workspaceId,
+      notificationId: params.notificationId,
+    });
   }
 
   createTaskProposal(params: {
@@ -5877,8 +6067,8 @@ export class RuntimeStateStore {
     state?: string;
   }): TaskProposalRecord {
     const proposalSource = normalizeTaskProposalSource(params.proposalSource);
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO task_proposals (
             proposal_id,
             workspace_id,
@@ -5893,8 +6083,7 @@ export class RuntimeStateStore {
             accepted_input_id,
             accepted_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
-      `)
-      .run(
+      `).run(
         params.proposalId,
         params.workspaceId,
         params.taskName,
@@ -5905,7 +6094,8 @@ export class RuntimeStateStore {
         params.createdAt,
         params.state ?? "not_reviewed"
       );
-    const row = this.db()
+    });
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM task_proposals WHERE proposal_id = ? LIMIT 1")
       .get(params.proposalId);
     if (!row) {
@@ -5914,15 +6104,15 @@ export class RuntimeStateStore {
     return this.rowToTaskProposal(row);
   }
 
-  getTaskProposal(proposalId: string): TaskProposalRecord | null {
-    const row = this.db()
+  getTaskProposal(params: { workspaceId: string; proposalId: string }): TaskProposalRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM task_proposals WHERE proposal_id = ? LIMIT 1")
-      .get(proposalId);
+      .get(params.proposalId);
     return row ? this.rowToTaskProposal(row) : null;
   }
 
   listTaskProposals(params: { workspaceId: string }): TaskProposalRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(`
         SELECT * FROM task_proposals
         WHERE workspace_id = ?
@@ -5933,7 +6123,7 @@ export class RuntimeStateStore {
   }
 
   listUnreviewedTaskProposals(params: { workspaceId: string }): TaskProposalRecord[] {
-    const rows = this.db()
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(`
         SELECT * FROM task_proposals
         WHERE workspace_id = ? AND state = 'not_reviewed'
@@ -5943,8 +6133,9 @@ export class RuntimeStateStore {
     return rows.map((row) => this.rowToTaskProposal(row));
   }
 
-  updateTaskProposalState(params: { proposalId: string; state: string }): TaskProposalRecord | null {
+  updateTaskProposalState(params: { workspaceId: string; proposalId: string; state: string }): TaskProposalRecord | null {
     return this.updateTaskProposal({
+      workspaceId: params.workspaceId,
       proposalId: params.proposalId,
       fields: {
         state: params.state
@@ -5984,8 +6175,8 @@ export class RuntimeStateStore {
     );
     const createdAt = params.createdAt ?? utcNowIso();
     const updatedAt = params.updatedAt ?? createdAt;
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO evolve_skill_candidates (
             candidate_id,
             workspace_id,
@@ -6009,8 +6200,7 @@ export class RuntimeStateStore {
             accepted_at,
             promoted_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      .run(
+      `).run(
         params.candidateId,
         params.workspaceId,
         params.sessionId,
@@ -6033,7 +6223,8 @@ export class RuntimeStateStore {
         this.normalizedNullableText(params.acceptedAt),
         this.normalizedNullableText(params.promotedAt)
       );
-    const row = this.db()
+    });
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM evolve_skill_candidates WHERE candidate_id = ? LIMIT 1")
       .get(params.candidateId);
     if (!row) {
@@ -6042,19 +6233,22 @@ export class RuntimeStateStore {
     return this.rowToEvolveSkillCandidate(row);
   }
 
-  getEvolveSkillCandidate(candidateId: string): EvolveSkillCandidateRecord | null {
-    const row = this.db()
+  getEvolveSkillCandidate(params: { workspaceId: string; candidateId: string }): EvolveSkillCandidateRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM evolve_skill_candidates WHERE candidate_id = ? LIMIT 1")
-      .get(candidateId);
+      .get(params.candidateId);
     return row ? this.rowToEvolveSkillCandidate(row) : null;
   }
 
-  getEvolveSkillCandidateByTaskProposalId(proposalId: string): EvolveSkillCandidateRecord | null {
-    const row = this.db()
+  getEvolveSkillCandidateByTaskProposalId(params: {
+    workspaceId: string;
+    proposalId: string;
+  }): EvolveSkillCandidateRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>(
         "SELECT * FROM evolve_skill_candidates WHERE task_proposal_id = ? ORDER BY datetime(created_at) DESC, candidate_id DESC LIMIT 1"
       )
-      .get(proposalId);
+      .get(params.proposalId);
     return row ? this.rowToEvolveSkillCandidate(row) : null;
   }
 
@@ -6087,7 +6281,7 @@ export class RuntimeStateStore {
     }
     query += " ORDER BY datetime(created_at) DESC, candidate_id DESC LIMIT ? OFFSET ?";
     values.push(params.limit ?? 200, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToEvolveSkillCandidate(row));
   }
 
@@ -6120,8 +6314,8 @@ export class RuntimeStateStore {
     );
     const createdAt = params.createdAt ?? utcNowIso();
     const updatedAt = params.updatedAt ?? createdAt;
-    this.db()
-      .prepare(`
+    this.mirrorWorkspaceRuntimeMutation(params.workspaceId, (db) => {
+      db.prepare(`
         INSERT INTO memory_update_proposals (
             proposal_id,
             workspace_id,
@@ -6142,8 +6336,7 @@ export class RuntimeStateStore {
             accepted_at,
             dismissed_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      .run(
+      `).run(
         params.proposalId,
         params.workspaceId,
         params.sessionId,
@@ -6163,7 +6356,8 @@ export class RuntimeStateStore {
         this.normalizedNullableText(params.acceptedAt),
         this.normalizedNullableText(params.dismissedAt)
       );
-    const row = this.db()
+    });
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_update_proposals WHERE proposal_id = ? LIMIT 1")
       .get(params.proposalId);
     if (!row) {
@@ -6172,10 +6366,10 @@ export class RuntimeStateStore {
     return this.rowToMemoryUpdateProposal(row);
   }
 
-  getMemoryUpdateProposal(proposalId: string): MemoryUpdateProposalRecord | null {
-    const row = this.db()
+  getMemoryUpdateProposal(params: { workspaceId: string; proposalId: string }): MemoryUpdateProposalRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_update_proposals WHERE proposal_id = ? LIMIT 1")
-      .get(proposalId);
+      .get(params.proposalId);
     return row ? this.rowToMemoryUpdateProposal(row) : null;
   }
 
@@ -6203,7 +6397,7 @@ export class RuntimeStateStore {
     }
     query += " ORDER BY datetime(created_at) ASC, proposal_id ASC LIMIT ? OFFSET ?";
     values.push(params.limit ?? 200, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToMemoryUpdateProposal(row));
   }
 
@@ -6224,6 +6418,348 @@ export class RuntimeStateStore {
     return db;
   }
 
+  private controlPlaneDb(): Database.Database {
+    if (this.controlPlaneDbPath === this.dbPath) {
+      return this.db();
+    }
+    if (this.#controlPlaneDb) {
+      return this.#controlPlaneDb;
+    }
+
+    const legacy = this.db();
+    fs.mkdirSync(path.dirname(this.controlPlaneDbPath), { recursive: true });
+    const db = new Database(this.controlPlaneDbPath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("busy_timeout = 5000");
+    db.pragma("foreign_keys = ON");
+    this.ensureControlPlaneDbSchema(db);
+    this.backfillControlPlaneDbFromLegacyRuntimeDb(db, legacy);
+    this.#controlPlaneDb = db;
+    return db;
+  }
+
+  private workspaceRuntimeDb(workspaceId: string): Database.Database {
+    const workspaceRecord = this.getWorkspace(workspaceId, { includeDeleted: true });
+    if (workspaceRecord?.deletedAtUtc) {
+      return this.db();
+    }
+    const registeredPath = this.workspacePathFromRegistry(workspaceId);
+    const workspacePath = registeredPath ? this.assertWorkspaceFolderHealthy(workspaceId) : this.workspaceDir(workspaceId);
+    const dbPath = workspaceRuntimeDbPathForWorkspacePath(workspacePath);
+    const cached = this.#workspaceRuntimeDbs.get(workspaceId);
+    if (cached && cached.dbPath === dbPath) {
+      return cached.db;
+    }
+    if (cached) {
+      cached.db.close();
+      this.#workspaceRuntimeDbs.delete(workspaceId);
+    }
+
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const db = new Database(dbPath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("busy_timeout = 5000");
+    db.pragma("foreign_keys = ON");
+    this.ensureWorkspaceRuntimeDbSchema(db);
+    this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(db, this.db(), workspaceId);
+    this.#workspaceRuntimeDbs.set(workspaceId, { dbPath, db });
+    return db;
+  }
+
+  private mirrorWorkspaceRuntimeMutation(workspaceId: string, mutate: (db: Database.Database) => void): void {
+    const workspaceDb = this.workspaceRuntimeDb(workspaceId);
+    mutate(workspaceDb);
+  }
+
+  private listReadableWorkspaceRuntimeDbs(): Array<{ workspaceId: string; db: Database.Database }> {
+    const databases = new Map<string, Database.Database>();
+    for (const [workspaceId, entry] of this.#workspaceRuntimeDbs.entries()) {
+      databases.set(workspaceId, entry.db);
+    }
+    for (const workspace of this.listWorkspaces({ includeDeleted: false })) {
+      if (databases.has(workspace.id)) {
+        continue;
+      }
+      try {
+        databases.set(workspace.id, this.workspaceRuntimeDb(workspace.id));
+      } catch {
+        // Skip unhealthy or missing workspace bundles during aggregate scans.
+      }
+    }
+    return Array.from(databases.entries()).map(([workspaceId, db]) => ({
+      workspaceId,
+      db,
+    }));
+  }
+
+  private backfillControlPlaneDbFromLegacyRuntimeDb(
+    db: Database.Database,
+    legacy: Database.Database,
+  ): void {
+    if (this.controlPlaneDbPath === this.dbPath) {
+      return;
+    }
+    const tableNames = new Set<string>(
+      (legacy.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+        (row) => row.name
+      )
+    );
+    if (tableNames.has("workspaces")) {
+      const rows = legacy.prepare("SELECT * FROM workspaces").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO workspaces (
+          id,
+          workspace_path,
+          name,
+          status,
+          harness,
+          error_message,
+          onboarding_status,
+          onboarding_session_id,
+          onboarding_completed_at,
+          onboarding_completion_summary,
+          onboarding_requested_at,
+          onboarding_requested_by,
+          created_at,
+          updated_at,
+          deleted_at_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.id,
+          row.workspace_path,
+          row.name,
+          row.status,
+          row.harness ?? null,
+          row.error_message ?? null,
+          row.onboarding_status,
+          row.onboarding_session_id ?? null,
+          row.onboarding_completed_at ?? null,
+          row.onboarding_completion_summary ?? null,
+          row.onboarding_requested_at ?? null,
+          row.onboarding_requested_by ?? null,
+          row.created_at ?? null,
+          row.updated_at ?? null,
+          row.deleted_at_utc ?? null
+        );
+      }
+    }
+    if (tableNames.has("runtime_user_profiles")) {
+      const rows = legacy.prepare("SELECT * FROM runtime_user_profiles").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO runtime_user_profiles (
+          profile_id,
+          name,
+          name_source,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.profile_id,
+          row.name ?? null,
+          row.name_source ?? null,
+          row.created_at,
+          row.updated_at
+        );
+      }
+    }
+    if (tableNames.has("integration_connections")) {
+      const rows = legacy.prepare("SELECT * FROM integration_connections").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO integration_connections (
+          connection_id,
+          provider_id,
+          owner_user_id,
+          account_label,
+          account_external_id,
+          account_handle,
+          account_email,
+          auth_mode,
+          granted_scopes,
+          status,
+          secret_ref,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.connection_id,
+          row.provider_id,
+          row.owner_user_id,
+          row.account_label,
+          row.account_external_id ?? null,
+          row.account_handle ?? null,
+          row.account_email ?? null,
+          row.auth_mode,
+          row.granted_scopes,
+          row.status,
+          row.secret_ref ?? null,
+          row.created_at,
+          row.updated_at
+        );
+      }
+    }
+    if (tableNames.has("integration_bindings")) {
+      const rows = legacy.prepare("SELECT * FROM integration_bindings").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO integration_bindings (
+          binding_id,
+          workspace_id,
+          target_type,
+          target_id,
+          integration_key,
+          connection_id,
+          is_default,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.binding_id,
+          row.workspace_id,
+          row.target_type,
+          row.target_id,
+          row.integration_key,
+          row.connection_id,
+          row.is_default,
+          row.created_at,
+          row.updated_at
+        );
+      }
+    }
+    if (tableNames.has("oauth_app_configs")) {
+      const rows = legacy.prepare("SELECT * FROM oauth_app_configs").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO oauth_app_configs (
+          provider_id,
+          client_id,
+          client_secret,
+          authorize_url,
+          token_url,
+          scopes,
+          redirect_port,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.provider_id,
+          row.client_id,
+          row.client_secret,
+          row.authorize_url,
+          row.token_url,
+          row.scopes,
+          row.redirect_port,
+          row.created_at,
+          row.updated_at
+        );
+      }
+    }
+    if (tableNames.has("app_catalog")) {
+      const rows = legacy.prepare("SELECT * FROM app_catalog").all() as Array<Record<string, unknown>>;
+      const statement = db.prepare(`
+        INSERT OR IGNORE INTO app_catalog (
+          app_id,
+          source,
+          name,
+          description,
+          icon,
+          category,
+          tags_json,
+          version,
+          archive_url,
+          archive_path,
+          target,
+          cached_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        statement.run(
+          row.app_id,
+          row.source,
+          row.name,
+          row.description ?? null,
+          row.icon ?? null,
+          row.category ?? null,
+          row.tags_json,
+          row.version ?? null,
+          row.archive_url ?? null,
+          row.archive_path ?? null,
+          row.target,
+          row.cached_at
+        );
+      }
+    }
+  }
+
+  private backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(
+    db: Database.Database,
+    legacy: Database.Database,
+    workspaceId: string,
+  ): void {
+    const workspaceScopedTables = [
+      "task_proposals",
+      "evolve_skill_candidates",
+      "memory_update_proposals",
+      "output_folders",
+      "outputs",
+      "app_builds",
+      "app_ports",
+      "cronjobs",
+      "runtime_notifications",
+    ] as const;
+    for (const tableName of workspaceScopedTables) {
+      this.backfillWorkspaceScopedTableRows({
+        db,
+        legacy,
+        workspaceId,
+        tableName,
+      });
+    }
+  }
+
+  private backfillWorkspaceScopedTableRows(params: {
+    db: Database.Database;
+    legacy: Database.Database;
+    workspaceId: string;
+    tableName: string;
+  }): void {
+    if (!this.tableExists(params.legacy, params.tableName) || !this.tableExists(params.db, params.tableName)) {
+      return;
+    }
+
+    const columns = (
+      params.db.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    if (columns.length === 0) {
+      return;
+    }
+
+    const rows = params.legacy
+      .prepare(`SELECT ${columns.join(", ")} FROM ${params.tableName} WHERE workspace_id = ?`)
+      .all(params.workspaceId) as Array<Record<string, unknown>>;
+    if (rows.length === 0) {
+      return;
+    }
+
+    const insert = params.db.prepare(`
+      INSERT OR IGNORE INTO ${params.tableName} (${columns.join(", ")})
+      VALUES (${columns.map(() => "?").join(", ")})
+    `);
+    const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        insert.run(...columns.map((column) => row[column] ?? null));
+      }
+    });
+    insertMany(rows);
+  }
+
   private runPendingMigrations(db: Database.Database): void {
     if (RUNTIME_DB_MIGRATIONS.length === 0 && LATEST_SEED_VERSION === 0) {
       // No migrations registered yet — skip the runner entirely so we don't
@@ -6240,7 +6776,7 @@ export class RuntimeStateStore {
   }
 
   private ensureWorkspaceMetadataReady(): void {
-    void this.db();
+    void this.controlPlaneDb();
   }
 
   private tryLoadVectorExtension(db: Database.Database): boolean {
@@ -6292,6 +6828,301 @@ export class RuntimeStateStore {
           memory_type TEXT
       );
     `);
+  }
+
+  private ensureControlPlaneDbSchema(db: Database.Database): void {
+    this.ensureWorkspacesTableSchema(db);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS runtime_user_profiles (
+          profile_id TEXT PRIMARY KEY,
+          name TEXT,
+          name_source TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS integration_connections (
+          connection_id TEXT PRIMARY KEY,
+          provider_id TEXT NOT NULL,
+          owner_user_id TEXT NOT NULL,
+          account_label TEXT NOT NULL,
+          account_external_id TEXT,
+          account_handle TEXT,
+          account_email TEXT,
+          auth_mode TEXT NOT NULL,
+          granted_scopes TEXT NOT NULL DEFAULT '[]',
+          status TEXT NOT NULL,
+          secret_ref TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_integration_connections_provider_owner_updated
+          ON integration_connections (provider_id, owner_user_id, updated_at DESC, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS integration_bindings (
+          binding_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          target_type TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          integration_key TEXT NOT NULL,
+          connection_id TEXT NOT NULL,
+          is_default INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          UNIQUE (workspace_id, target_type, target_id, integration_key),
+          FOREIGN KEY (connection_id) REFERENCES integration_connections(connection_id) ON DELETE RESTRICT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_integration_bindings_workspace_updated
+          ON integration_bindings (workspace_id, is_default DESC, updated_at DESC, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS app_catalog (
+          app_id TEXT NOT NULL,
+          source TEXT NOT NULL,
+          name TEXT NOT NULL,
+          description TEXT,
+          icon TEXT,
+          category TEXT,
+          tags_json TEXT NOT NULL DEFAULT '[]',
+          version TEXT,
+          archive_url TEXT,
+          archive_path TEXT,
+          target TEXT NOT NULL,
+          cached_at TEXT NOT NULL,
+          PRIMARY KEY (source, app_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_app_catalog_source
+          ON app_catalog (source);
+
+      CREATE TABLE IF NOT EXISTS oauth_app_configs (
+          provider_id TEXT PRIMARY KEY,
+          client_id TEXT NOT NULL,
+          client_secret TEXT NOT NULL,
+          authorize_url TEXT NOT NULL,
+          token_url TEXT NOT NULL,
+          scopes TEXT NOT NULL DEFAULT '[]',
+          redirect_port INTEGER NOT NULL DEFAULT 38765,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+    `);
+    this.migrateIntegrationConnectionIdentityColumns(db);
+  }
+
+  private ensureWorkspaceRuntimeDbSchema(db: Database.Database): void {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS task_proposals (
+          proposal_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          task_name TEXT NOT NULL,
+          task_prompt TEXT NOT NULL,
+          task_generation_rationale TEXT NOT NULL,
+          proposal_source TEXT NOT NULL DEFAULT 'proactive',
+          source_event_ids TEXT NOT NULL DEFAULT '[]',
+          created_at TEXT NOT NULL,
+          state TEXT NOT NULL DEFAULT 'not_reviewed',
+          accepted_session_id TEXT,
+          accepted_input_id TEXT,
+          accepted_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_task_proposals_workspace_created
+          ON task_proposals (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_task_proposals_workspace_state_created
+          ON task_proposals (workspace_id, state, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS evolve_skill_candidates (
+          candidate_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          input_id TEXT NOT NULL,
+          task_proposal_id TEXT,
+          kind TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'draft',
+          title TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          slug TEXT NOT NULL,
+          skill_path TEXT NOT NULL,
+          content_fingerprint TEXT NOT NULL,
+          confidence REAL,
+          evaluation_notes TEXT,
+          source_turn_input_ids TEXT NOT NULL DEFAULT '[]',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          proposed_at TEXT,
+          dismissed_at TEXT,
+          accepted_at TEXT,
+          promoted_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_workspace_created
+          ON evolve_skill_candidates (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_workspace_status_created
+          ON evolve_skill_candidates (workspace_id, status, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_evolve_skill_candidates_task_proposal
+          ON evolve_skill_candidates (task_proposal_id);
+
+      CREATE TABLE IF NOT EXISTS memory_update_proposals (
+          proposal_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          input_id TEXT NOT NULL,
+          proposal_kind TEXT NOT NULL,
+          target_key TEXT NOT NULL,
+          title TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          payload TEXT NOT NULL DEFAULT '{}',
+          evidence TEXT,
+          confidence REAL,
+          source_message_id TEXT,
+          state TEXT NOT NULL DEFAULT 'pending',
+          persisted_memory_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          accepted_at TEXT,
+          dismissed_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_workspace_created
+          ON memory_update_proposals (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_session_input_created
+          ON memory_update_proposals (session_id, input_id, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_memory_update_proposals_workspace_state_created
+          ON memory_update_proposals (workspace_id, state, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS output_folders (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          position INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_output_folders_workspace_position
+          ON output_folders (workspace_id, position ASC, created_at ASC);
+
+      CREATE TABLE IF NOT EXISTS outputs (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          output_type TEXT NOT NULL,
+          title TEXT NOT NULL DEFAULT '',
+          status TEXT NOT NULL DEFAULT 'draft',
+          module_id TEXT,
+          module_resource_id TEXT,
+          file_path TEXT,
+          html_content TEXT,
+          session_id TEXT,
+          input_id TEXT,
+          artifact_id TEXT,
+          folder_id TEXT,
+          platform TEXT,
+          metadata TEXT NOT NULL DEFAULT '{}',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_outputs_workspace_created
+          ON outputs (workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_outputs_workspace_folder_created
+          ON outputs (workspace_id, folder_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_outputs_session_input_created
+          ON outputs (session_id, input_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS app_builds (
+          workspace_id TEXT NOT NULL,
+          app_id TEXT NOT NULL,
+          status TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          restart_attempts INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (workspace_id, app_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_app_builds_workspace
+          ON app_builds (workspace_id);
+
+      CREATE TABLE IF NOT EXISTS app_ports (
+          workspace_id TEXT NOT NULL,
+          app_id TEXT NOT NULL,
+          port INTEGER NOT NULL UNIQUE,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (workspace_id, app_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_app_ports_workspace
+          ON app_ports (workspace_id);
+
+      CREATE TABLE IF NOT EXISTS cronjobs (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          initiated_by TEXT NOT NULL,
+          name TEXT NOT NULL DEFAULT '',
+          cron TEXT NOT NULL,
+          description TEXT NOT NULL,
+          instruction TEXT NOT NULL DEFAULT '',
+          enabled INTEGER NOT NULL DEFAULT 1,
+          delivery TEXT NOT NULL,
+          metadata TEXT NOT NULL DEFAULT '{}',
+          last_run_at TEXT,
+          next_run_at TEXT,
+          run_count INTEGER NOT NULL DEFAULT 0,
+          last_status TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_cronjobs_workspace_created
+          ON cronjobs (workspace_id, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_cronjobs_enabled_next_run
+          ON cronjobs (enabled, next_run_at);
+
+      CREATE TABLE IF NOT EXISTS runtime_notifications (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          cronjob_id TEXT,
+          source_type TEXT NOT NULL,
+          source_label TEXT,
+          title TEXT NOT NULL,
+          message TEXT NOT NULL,
+          level TEXT NOT NULL DEFAULT 'info',
+          priority TEXT NOT NULL DEFAULT 'normal',
+          state TEXT NOT NULL DEFAULT 'unread',
+          metadata TEXT NOT NULL DEFAULT '{}',
+          read_at TEXT,
+          dismissed_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_runtime_notifications_workspace_state_created
+          ON runtime_notifications (workspace_id, state, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_runtime_notifications_state_created
+          ON runtime_notifications (state, created_at DESC);
+    `);
+    this.ensureTaskProposalsTableSchema(db);
+    this.ensureEvolveSkillCandidatesTableSchema(db);
+    this.ensureMemoryUpdateProposalsTableSchema(db);
+    this.ensureOutputsTableSchema(db);
+    this.migrateRuntimeNotificationPriority(db);
+    this.migrateCronjobInstructions(db);
+    this.migrateAppBuildRestartAttempts(db);
   }
 
   private ensureRuntimeDbSchema(db: Database.Database): void {
@@ -6378,48 +7209,6 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_conversation_bindings_channel_key_active
           ON conversation_bindings (channel, conversation_key, is_active);
-
-      CREATE TABLE IF NOT EXISTS integration_connections (
-          connection_id TEXT PRIMARY KEY,
-          provider_id TEXT NOT NULL,
-          owner_user_id TEXT NOT NULL,
-          account_label TEXT NOT NULL,
-          account_external_id TEXT,
-          account_handle TEXT,
-          account_email TEXT,
-          auth_mode TEXT NOT NULL,
-          granted_scopes TEXT NOT NULL DEFAULT '[]',
-          status TEXT NOT NULL,
-          secret_ref TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_integration_connections_provider_owner_updated
-          ON integration_connections (provider_id, owner_user_id, updated_at DESC, created_at DESC);
-
-      -- Indexes for account_handle / account_email live in
-      -- migrateIntegrationConnectionIdentityColumns: on an upgrade path the
-      -- columns don't exist when the schema block runs, so creating those
-      -- indexes here would fail. The migration helper runs after the
-      -- ALTER TABLE statements and is idempotent (CREATE INDEX IF NOT EXISTS).
-
-      CREATE TABLE IF NOT EXISTS integration_bindings (
-          binding_id TEXT PRIMARY KEY,
-          workspace_id TEXT NOT NULL,
-          target_type TEXT NOT NULL,
-          target_id TEXT NOT NULL,
-          integration_key TEXT NOT NULL,
-          connection_id TEXT NOT NULL,
-          is_default INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          UNIQUE (workspace_id, target_type, target_id, integration_key),
-          FOREIGN KEY (connection_id) REFERENCES integration_connections(connection_id) ON DELETE RESTRICT
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_integration_bindings_workspace_updated
-          ON integration_bindings (workspace_id, is_default DESC, updated_at DESC, created_at DESC);
 
       CREATE TABLE IF NOT EXISTS agent_session_inputs (
           input_id TEXT PRIMARY KEY,
@@ -6699,14 +7488,6 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_turn_request_snapshots_workspace_session_updated
           ON turn_request_snapshots (workspace_id, session_id, updated_at DESC, created_at DESC);
 
-      CREATE TABLE IF NOT EXISTS runtime_user_profiles (
-          profile_id TEXT PRIMARY KEY,
-          name TEXT,
-          name_source TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
-
       CREATE TABLE IF NOT EXISTS memory_entries (
           memory_id TEXT PRIMARY KEY,
           workspace_id TEXT,
@@ -6892,25 +7673,6 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_app_ports_workspace
           ON app_ports (workspace_id);
 
-      CREATE TABLE IF NOT EXISTS app_catalog (
-          app_id        TEXT NOT NULL,
-          source        TEXT NOT NULL,
-          name          TEXT NOT NULL,
-          description   TEXT,
-          icon          TEXT,
-          category      TEXT,
-          tags_json     TEXT NOT NULL DEFAULT '[]',
-          version       TEXT,
-          archive_url   TEXT,
-          archive_path  TEXT,
-          target        TEXT NOT NULL,
-          cached_at     TEXT NOT NULL,
-          PRIMARY KEY (source, app_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_app_catalog_source
-          ON app_catalog (source);
-
       CREATE TABLE IF NOT EXISTS cronjobs (
           id TEXT PRIMARY KEY,
           workspace_id TEXT NOT NULL,
@@ -6961,17 +7723,6 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_runtime_notifications_state_created
           ON runtime_notifications (state, created_at DESC);
 
-      CREATE TABLE IF NOT EXISTS oauth_app_configs (
-          provider_id TEXT PRIMARY KEY,
-          client_id TEXT NOT NULL,
-          client_secret TEXT NOT NULL,
-          authorize_url TEXT NOT NULL,
-          token_url TEXT NOT NULL,
-          scopes TEXT NOT NULL DEFAULT '[]',
-          redirect_port INTEGER NOT NULL DEFAULT 38765,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL
-      );
     `);
     this.ensureConversationBindingsTableSchema(db);
     this.ensureSubagentRunsTableSchema(db);
@@ -7243,6 +7994,9 @@ export class RuntimeStateStore {
   // here. Both columns are nullable: legacy rows without whoami data
   // simply won't deduplicate until they next reconnect.
   private migrateIntegrationConnectionIdentityColumns(db: Database.Database): void {
+    if (!this.tableExists(db, "integration_connections")) {
+      return;
+    }
     const columns = new Set<string>(
       (db.prepare("PRAGMA table_info(integration_connections)").all() as Array<{ name: string }>).map((row) => row.name)
     );
@@ -7338,6 +8092,15 @@ export class RuntimeStateStore {
     });
 
     migrate();
+  }
+
+  private tableExists(db: Database.Database, tableName: string): boolean {
+    const row = db
+      .prepare<[string], { name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
+      )
+      .get(tableName);
+    return Boolean(row);
   }
 
   private migrateSandboxRunTokensTable(db: Database.Database): void {
@@ -7894,7 +8657,7 @@ export class RuntimeStateStore {
       const rows = db.prepare<[], Omit<WorkspaceRow, "workspace_path">>("SELECT * FROM workspaces_legacy_with_owner").all();
       for (const row of rows) {
         const record = this.workspaceRecordFromRowLike(row);
-        this.upsertWorkspaceRow(record, this.discoverWorkspacePath(record.id) ?? this.defaultWorkspaceDir(record.id), db);
+        this.upsertWorkspaceRowInDb(record, this.discoverWorkspacePath(record.id) ?? this.defaultWorkspaceDir(record.id), db);
       }
       db.exec("DROP TABLE workspaces_legacy_with_owner; DROP INDEX IF EXISTS idx_workspaces_user_updated;");
     }
@@ -7915,7 +8678,7 @@ export class RuntimeStateStore {
 
       const payload = JSON.parse(fs.readFileSync(legacyMetadataPath, "utf-8")) as Record<string, unknown>;
       const record = this.workspaceRecordFromLegacyPayload(payload);
-      this.upsertWorkspaceRow(record, childPath, db);
+      this.upsertWorkspaceRowInDb(record, childPath, db);
       this.writeWorkspaceIdentityFile(childPath, record.id);
       fs.rmSync(legacyMetadataPath, { force: true });
     }
@@ -7966,7 +8729,7 @@ export class RuntimeStateStore {
   }
 
   private workspacePathFromRegistry(workspaceId: string): string | null {
-    const row = this.db()
+    const row = this.controlPlaneDb()
       .prepare<[string], { workspace_path: string | null }>("SELECT workspace_path FROM workspaces WHERE id = ? LIMIT 1")
       .get(workspaceId);
     if (!row || row.workspace_path == null) {
@@ -7976,7 +8739,7 @@ export class RuntimeStateStore {
     return value || null;
   }
 
-  private upsertWorkspaceRow(record: WorkspaceRecord, workspacePath: string, db = this.db()): void {
+  private upsertWorkspaceRowInDb(record: WorkspaceRecord, workspacePath: string, db: Database.Database): void {
     db.prepare(`
       INSERT INTO workspaces (
           id, workspace_path, name, status, harness, error_message,
@@ -8018,6 +8781,13 @@ export class RuntimeStateStore {
     );
   }
 
+  private upsertWorkspaceRow(record: WorkspaceRecord, workspacePath: string): void {
+    this.upsertWorkspaceRowInDb(record, workspacePath, this.controlPlaneDb());
+    if (this.controlPlaneDbPath !== this.dbPath) {
+      this.upsertWorkspaceRowInDb(record, workspacePath, this.db());
+    }
+  }
+
   private writeWorkspaceIdentityFile(workspacePath: string, workspaceId: string): void {
     const identityPath = currentWorkspaceIdentityPath(workspacePath);
     fs.mkdirSync(path.dirname(identityPath), { recursive: true });
@@ -8057,7 +8827,10 @@ export class RuntimeStateStore {
   }
 
   private updateWorkspacePath(workspaceId: string, workspacePath: string): void {
-    this.db().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(workspacePath, workspaceId);
+    this.controlPlaneDb().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(workspacePath, workspaceId);
+    if (this.controlPlaneDbPath !== this.dbPath) {
+      this.db().prepare("UPDATE workspaces SET workspace_path = ? WHERE id = ?").run(workspacePath, workspaceId);
+    }
   }
 
   private recoverMissingWorkspaceRecord(workspaceId: string): WorkspaceRecord | null {
@@ -8741,6 +9514,19 @@ export class RuntimeStateStore {
   private notificationPrioritySortSql(tableAlias = ""): string {
     const prefix = tableAlias ? `${tableAlias}.` : "";
     return `CASE ${prefix}priority WHEN 'critical' THEN 3 WHEN 'high' THEN 2 WHEN 'normal' THEN 1 ELSE 0 END`;
+  }
+
+  private notificationPriorityWeight(priority: RuntimeNotificationPriority): number {
+    switch (priority) {
+      case "critical":
+        return 3;
+      case "high":
+        return 2;
+      case "normal":
+        return 1;
+      default:
+        return 0;
+    }
   }
 
   private normalizedNotificationState(value: string | null | undefined): RuntimeNotificationState {

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -3969,7 +3969,7 @@ export class RuntimeStateStore {
     payload: Record<string, unknown>;
     createdAt?: string;
   }): void {
-    this.db()
+    this.workspaceRuntimeDb(params.workspaceId)
       .prepare(`
         INSERT INTO session_output_events (
             workspace_id, session_id, input_id, sequence, event_type, payload, created_at
@@ -3986,13 +3986,14 @@ export class RuntimeStateStore {
       );
   }
 
-  latestOutputEventId(params: { sessionId: string; inputId?: string; excludedEventTypes?: string[] }): number {
+  latestOutputEventId(params: { workspaceId: string; sessionId: string; inputId?: string; excludedEventTypes?: string[] }): number {
     let query = `
       SELECT MAX(id) AS max_id
       FROM session_output_events
-      WHERE session_id = ?
+      WHERE workspace_id = ?
+        AND session_id = ?
     `;
-    const values: string[] = [params.sessionId];
+    const values: string[] = [params.workspaceId, params.sessionId];
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
@@ -4002,11 +4003,12 @@ export class RuntimeStateStore {
       query += ` AND event_type NOT IN (${excludedEventTypes.map(() => "?").join(", ")})`;
       values.push(...excludedEventTypes);
     }
-    const row = this.db().prepare(query).get(...values) as { max_id: number | null } | undefined;
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(...values) as { max_id: number | null } | undefined;
     return row?.max_id ?? 0;
   }
 
   listOutputEvents(params: {
+    workspaceId: string;
     sessionId: string;
     inputId?: string;
     includeHistory?: boolean;
@@ -4016,10 +4018,11 @@ export class RuntimeStateStore {
     let query = `
       SELECT id, workspace_id, session_id, input_id, sequence, event_type, payload, created_at
       FROM session_output_events
-      WHERE session_id = ?
+      WHERE workspace_id = ?
+        AND session_id = ?
         AND id > ?
     `;
-    const values: Array<string | number> = [params.sessionId, params.afterEventId ?? 0];
+    const values: Array<string | number> = [params.workspaceId, params.sessionId, params.afterEventId ?? 0];
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
@@ -4034,7 +4037,7 @@ export class RuntimeStateStore {
     }
     query += " ORDER BY id ASC";
 
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => ({
       id: Number(row.id),
       workspaceId: String(row.workspace_id),
@@ -4330,10 +4333,14 @@ export class RuntimeStateStore {
       { touchExisting: false }
     );
 
-    const existing = this.getTurnResult({ inputId: params.inputId });
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const existing = this.getTurnResult({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
     const now = params.updatedAt ?? utcNowIso();
     const createdAt = existing?.createdAt ?? params.createdAt ?? now;
-    this.db()
+    workspaceDb
       .prepare(`
         INSERT INTO turn_results (
             workspace_id,
@@ -4396,27 +4403,31 @@ export class RuntimeStateStore {
         now
       );
 
-    const record = this.getTurnResult({ inputId: params.inputId });
+    const record = this.getTurnResult({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
     if (!record) {
       throw new Error("turn result row not found after upsert");
     }
     return record;
   }
 
-  getTurnResult(params: { inputId: string }): TurnResultRecord | null {
-    const row = this.db()
+  getTurnResult(params: { workspaceId: string; inputId: string }): TurnResultRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM turn_results WHERE input_id = ? LIMIT 1")
       .get(params.inputId);
     return row ? this.rowToTurnResult(row) : null;
   }
 
   updateTurnResultContextBudgetDecisions(params: {
+    workspaceId: string;
     inputId: string;
     contextBudgetDecisions: Record<string, unknown> | null;
     updatedAt?: string;
   }): TurnResultRecord | null {
     const now = params.updatedAt ?? utcNowIso();
-    const result = this.db()
+    const result = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string | null, string, string]>(
         `
           UPDATE turn_results
@@ -4429,20 +4440,20 @@ export class RuntimeStateStore {
     if (result.changes === 0) {
       return null;
     }
-    return this.getTurnResult({ inputId: params.inputId });
+    return this.getTurnResult({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
   }
 
-  countTurnResults(params: { sessionId: string; workspaceId?: string; inputId?: string; status?: string }): number {
+  countTurnResults(params: { workspaceId: string; sessionId: string; inputId?: string; status?: string }): number {
     let query = `
       SELECT COUNT(*) AS total
       FROM turn_results
-      WHERE session_id = ?
+      WHERE workspace_id = ?
+        AND session_id = ?
     `;
-    const values: string[] = [params.sessionId];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    const values: string[] = [params.workspaceId, params.sessionId];
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
@@ -4451,13 +4462,13 @@ export class RuntimeStateStore {
       query += " AND status = ?";
       values.push(params.status);
     }
-    const row = this.db().prepare(query).get(...values) as { total: number } | undefined;
+    const row = this.workspaceRuntimeDb(params.workspaceId).prepare(query).get(...values) as { total: number } | undefined;
     return Number(row?.total ?? 0);
   }
 
   listTurnResults(params: {
+    workspaceId: string;
     sessionId: string;
-    workspaceId?: string;
     inputId?: string;
     status?: string;
     limit?: number;
@@ -4466,13 +4477,10 @@ export class RuntimeStateStore {
     let query = `
       SELECT *
       FROM turn_results
-      WHERE session_id = ?
+      WHERE workspace_id = ?
+        AND session_id = ?
     `;
-    const values: Array<string | number> = [params.sessionId];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    const values: Array<string | number> = [params.workspaceId, params.sessionId];
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
@@ -4486,7 +4494,7 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.#cachedPrepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTurnResult(row));
   }
 
@@ -5011,10 +5019,14 @@ export class RuntimeStateStore {
       { touchExisting: false }
     );
 
-    const existing = this.getTurnRequestSnapshot({ inputId: params.inputId });
+    const workspaceDb = this.workspaceRuntimeDb(params.workspaceId);
+    const existing = this.getTurnRequestSnapshot({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
     const now = params.updatedAt ?? utcNowIso();
     const createdAt = existing?.createdAt ?? params.createdAt ?? now;
-    this.db()
+    workspaceDb
       .prepare(`
         INSERT INTO turn_request_snapshots (
             workspace_id,
@@ -5045,23 +5057,26 @@ export class RuntimeStateStore {
         now
       );
 
-    const record = this.getTurnRequestSnapshot({ inputId: params.inputId });
+    const record = this.getTurnRequestSnapshot({
+      workspaceId: params.workspaceId,
+      inputId: params.inputId,
+    });
     if (!record) {
       throw new Error("turn request snapshot row not found after upsert");
     }
     return record;
   }
 
-  getTurnRequestSnapshot(params: { inputId: string }): TurnRequestSnapshotRecord | null {
-    const row = this.db()
+  getTurnRequestSnapshot(params: { workspaceId: string; inputId: string }): TurnRequestSnapshotRecord | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
       .prepare<[string], Record<string, unknown>>("SELECT * FROM turn_request_snapshots WHERE input_id = ? LIMIT 1")
       .get(params.inputId);
     return row ? this.rowToTurnRequestSnapshot(row) : null;
   }
 
   listTurnRequestSnapshots(params: {
+    workspaceId: string;
     sessionId: string;
-    workspaceId?: string;
     inputId?: string;
     limit?: number;
     offset?: number;
@@ -5069,13 +5084,10 @@ export class RuntimeStateStore {
     let query = `
       SELECT *
       FROM turn_request_snapshots
-      WHERE session_id = ?
+      WHERE workspace_id = ?
+        AND session_id = ?
     `;
-    const values: Array<string | number> = [params.sessionId];
-    if (params.workspaceId) {
-      query += " AND workspace_id = ?";
-      values.push(params.workspaceId);
-    }
+    const values: Array<string | number> = [params.workspaceId, params.sessionId];
     if (params.inputId) {
       query += " AND input_id = ?";
       values.push(params.inputId);
@@ -5085,7 +5097,7 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTurnRequestSnapshot(row));
   }
 
@@ -6719,6 +6731,9 @@ export class RuntimeStateStore {
       "conversation_bindings",
       "session_runtime_state",
       "session_messages",
+      "session_output_events",
+      "turn_results",
+      "turn_request_snapshots",
       "task_proposals",
       "evolve_skill_candidates",
       "memory_update_proposals",
@@ -7014,6 +7029,50 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_session_messages_workspace_session_created
           ON session_messages (workspace_id, session_id, created_at ASC);
 
+      CREATE TABLE IF NOT EXISTS session_output_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          input_id TEXT NOT NULL,
+          sequence INTEGER NOT NULL,
+          event_type TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_session_output_events_session_input_sequence
+          ON session_output_events (session_id, input_id, sequence ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_session_output_events_workspace_session_created
+          ON session_output_events (workspace_id, session_id, created_at ASC);
+
+      CREATE TABLE IF NOT EXISTS turn_results (
+          input_id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          completed_at TEXT,
+          status TEXT NOT NULL,
+          stop_reason TEXT,
+          assistant_text TEXT NOT NULL DEFAULT '',
+          tool_usage_summary TEXT NOT NULL DEFAULT '{}',
+          permission_denials TEXT NOT NULL DEFAULT '[]',
+          prompt_section_ids TEXT NOT NULL DEFAULT '[]',
+          capability_manifest_fingerprint TEXT,
+          request_snapshot_fingerprint TEXT,
+          prompt_cache_profile TEXT,
+          context_budget_decisions TEXT,
+          token_usage TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_turn_results_workspace_session_completed
+          ON turn_results (workspace_id, session_id, completed_at DESC, started_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_turn_results_session_input
+          ON turn_results (session_id, input_id);
+
       CREATE TABLE IF NOT EXISTS task_proposals (
           proposal_id TEXT PRIMARY KEY,
           workspace_id TEXT NOT NULL,
@@ -7219,6 +7278,7 @@ export class RuntimeStateStore {
     `);
     this.ensureConversationBindingsTableSchema(db);
     this.ensureSessionRuntimeStateTableSchema(db);
+    this.ensureTurnArtifactsSchema(db);
     this.ensureTaskProposalsTableSchema(db);
     this.ensureEvolveSkillCandidatesTableSchema(db);
     this.ensureMemoryUpdateProposalsTableSchema(db);

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -4809,10 +4809,14 @@ export class RuntimeStateStore {
     createdAt?: string;
     updatedAt?: string;
   }): MemoryEntryRecord {
-    const existing = this.getMemoryEntry({ memoryId: params.memoryId });
+    const existing = this.getMemoryEntry({
+      memoryId: params.memoryId,
+      workspaceId: params.workspaceId ?? null,
+    });
     const now = params.updatedAt ?? utcNowIso();
     const createdAt = existing?.createdAt ?? params.createdAt ?? now;
-    this.db()
+    const memoryDb = this.memoryDbForWorkspace(params.workspaceId ?? null);
+    memoryDb
       .prepare(`
         INSERT INTO memory_entries (
             memory_id,
@@ -4891,18 +4895,29 @@ export class RuntimeStateStore {
         now
       );
 
-    const record = this.getMemoryEntry({ memoryId: params.memoryId });
+    const record = this.getMemoryEntry({
+      memoryId: params.memoryId,
+      workspaceId: params.workspaceId ?? null,
+    });
     if (!record) {
       throw new Error("memory entry row not found after upsert");
     }
     return record;
   }
 
-  getMemoryEntry(params: { memoryId: string }): MemoryEntryRecord | null {
-    const row = this.db()
-      .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_entries WHERE memory_id = ? LIMIT 1")
-      .get(params.memoryId);
-    return row ? this.rowToMemoryEntry(row) : null;
+  getMemoryEntry(params: { memoryId: string; workspaceId?: string | null }): MemoryEntryRecord | null {
+    const databases = params.workspaceId === undefined
+      ? this.listReadableMemoryDbs()
+      : [{ workspaceId: params.workspaceId ?? null, db: this.memoryDbForWorkspace(params.workspaceId ?? null) }];
+    for (const { db } of databases) {
+      const row = db
+        .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_entries WHERE memory_id = ? LIMIT 1")
+        .get(params.memoryId);
+      if (row) {
+        return this.rowToMemoryEntry(row);
+      }
+    }
+    return null;
   }
 
   listMemoryEntries(params: {
@@ -4913,97 +4928,148 @@ export class RuntimeStateStore {
     limit?: number;
     offset?: number;
   } = {}): MemoryEntryRecord[] {
-    let query = `
-      SELECT *
-      FROM memory_entries
-      WHERE 1 = 1
-    `;
-    const values: Array<string | number> = [];
-    if (params.workspaceId !== undefined) {
+    const fetchLimit = (params.limit ?? 200) + (params.offset ?? 0);
+    const queryRows = (db: Database.Database, limit: number, offset: number): MemoryEntryRecord[] => {
+      let query = `
+        SELECT *
+        FROM memory_entries
+        WHERE 1 = 1
+      `;
+      const values: Array<string | number> = [];
+      if (params.workspaceId !== undefined) {
+        if (params.workspaceId === null) {
+          query += " AND workspace_id IS NULL";
+        } else {
+          query += " AND workspace_id = ?";
+          values.push(params.workspaceId);
+        }
+      }
+      if (params.scope !== undefined) {
+        if (params.scope === null) {
+          query += " AND scope IS NULL";
+        } else {
+          query += " AND scope = ?";
+          values.push(params.scope);
+        }
+      }
+      if (params.memoryType !== undefined) {
+        if (params.memoryType === null) {
+          query += " AND memory_type IS NULL";
+        } else {
+          query += " AND memory_type = ?";
+          values.push(params.memoryType);
+        }
+      }
+      if (params.status !== undefined) {
+        if (params.status === null) {
+          query += " AND status IS NULL";
+        } else {
+          query += " AND status = ?";
+          values.push(params.status);
+        }
+      }
+      query += `
+        ORDER BY updated_at DESC, created_at DESC, memory_id ASC
+        LIMIT ? OFFSET ?
+      `;
+      values.push(limit, offset);
+      const rows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+      return rows.map((row) => this.rowToMemoryEntry(row));
+    };
+    const databases = (() => {
       if (params.workspaceId === null) {
-        query += " AND workspace_id IS NULL";
-      } else {
-        query += " AND workspace_id = ?";
-        values.push(params.workspaceId);
+        return [{ workspaceId: null, db: this.controlPlaneDb() }];
       }
-    }
-    if (params.scope !== undefined) {
-      if (params.scope === null) {
-        query += " AND scope IS NULL";
-      } else {
-        query += " AND scope = ?";
-        values.push(params.scope);
+      if (typeof params.workspaceId === "string") {
+        return [{ workspaceId: params.workspaceId, db: this.workspaceRuntimeDb(params.workspaceId) }];
       }
-    }
-    if (params.memoryType !== undefined) {
-      if (params.memoryType === null) {
-        query += " AND memory_type IS NULL";
-      } else {
-        query += " AND memory_type = ?";
-        values.push(params.memoryType);
+      if (params.scope === "user") {
+        return [{ workspaceId: null, db: this.controlPlaneDb() }];
       }
-    }
-    if (params.status !== undefined) {
-      if (params.status === null) {
-        query += " AND status IS NULL";
-      } else {
-        query += " AND status = ?";
-        values.push(params.status);
+      if (params.scope && params.scope !== "user") {
+        return this.listReadableMemoryDbs({ includeControlPlane: false, includeWorkspace: true });
       }
+      return this.listReadableMemoryDbs();
+    })();
+    if (databases.length === 1) {
+      return queryRows(databases[0].db, params.limit ?? 200, params.offset ?? 0);
     }
-    query += `
-      ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC, memory_id ASC
-      LIMIT ? OFFSET ?
-    `;
-    values.push(params.limit ?? 200, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
-    return rows.map((row) => this.rowToMemoryEntry(row));
+    const records = databases.flatMap(({ db }) => queryRows(db, fetchLimit, 0));
+    records.sort((left, right) => {
+      const updatedCompare = right.updatedAt.localeCompare(left.updatedAt);
+      if (updatedCompare !== 0) {
+        return updatedCompare;
+      }
+      const createdCompare = right.createdAt.localeCompare(left.createdAt);
+      if (createdCompare !== 0) {
+        return createdCompare;
+      }
+      return left.memoryId.localeCompare(right.memoryId);
+    });
+    return records.slice(params.offset ?? 0, (params.offset ?? 0) + (params.limit ?? 200));
   }
 
   listWorkspaceMemoryEntryCounts(params: {
     status?: string | null;
   } = {}): Array<{ workspaceId: string; count: number }> {
-    let query = `
-      SELECT workspace_id, COUNT(*) AS total
-      FROM memory_entries
-      WHERE scope = 'workspace'
-        AND workspace_id IS NOT NULL
-    `;
-    const values: string[] = [];
-    if (params.status !== undefined) {
-      if (params.status === null) {
-        query += " AND status IS NULL";
-      } else {
-        query += " AND status = ?";
-        values.push(params.status);
+    const counts = this.listReadableWorkspaceRuntimeDbs().flatMap(({ db, workspaceId }) => {
+      let query = `
+        SELECT COUNT(*) AS total
+        FROM memory_entries
+        WHERE scope = 'workspace'
+          AND workspace_id = ?
+      `;
+      const values: Array<string | number> = [workspaceId];
+      if (params.status !== undefined) {
+        if (params.status === null) {
+          query += " AND status IS NULL";
+        } else {
+          query += " AND status = ?";
+          values.push(params.status);
+        }
+      }
+      const row = db.prepare(query).get(...values) as { total: number } | undefined;
+      const count = Number(row?.total ?? 0);
+      return count > 0 ? [{ workspaceId, count }] : [];
+    });
+    counts.sort((left, right) => left.workspaceId.localeCompare(right.workspaceId));
+    return counts;
+  }
+
+  getMemoryEmbeddingIndexByMemoryId(params: {
+    memoryId: string;
+    workspaceId?: string | null;
+  }): MemoryEmbeddingIndexRecord | null {
+    const databases = params.workspaceId === undefined
+      ? this.listReadableMemoryDbs()
+      : [{ workspaceId: params.workspaceId ?? null, db: this.memoryDbForWorkspace(params.workspaceId ?? null) }];
+    for (const { db } of databases) {
+      const row = db
+        .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_embedding_index WHERE memory_id = ? LIMIT 1")
+        .get(params.memoryId);
+      if (row) {
+        return this.rowToMemoryEmbeddingIndex(row);
       }
     }
-    query += `
-      GROUP BY workspace_id
-      ORDER BY workspace_id ASC
-    `;
-    const rows = this.db().prepare(query).all(...values) as Array<{
-      workspace_id: string;
-      total: number;
-    }>;
-    return rows.map((row) => ({
-      workspaceId: row.workspace_id,
-      count: Number(row.total),
-    }));
+    return null;
   }
 
-  getMemoryEmbeddingIndexByMemoryId(memoryId: string): MemoryEmbeddingIndexRecord | null {
-    const row = this.db()
-      .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_embedding_index WHERE memory_id = ? LIMIT 1")
-      .get(memoryId);
-    return row ? this.rowToMemoryEmbeddingIndex(row) : null;
-  }
-
-  getMemoryEmbeddingIndexByPath(pathValue: string): MemoryEmbeddingIndexRecord | null {
-    const row = this.db()
-      .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_embedding_index WHERE path = ? LIMIT 1")
-      .get(pathValue);
-    return row ? this.rowToMemoryEmbeddingIndex(row) : null;
+  getMemoryEmbeddingIndexByPath(params: {
+    path: string;
+    workspaceId?: string | null;
+  }): MemoryEmbeddingIndexRecord | null {
+    const databases = params.workspaceId === undefined
+      ? this.listReadableMemoryDbs()
+      : [{ workspaceId: params.workspaceId ?? null, db: this.memoryDbForWorkspace(params.workspaceId ?? null) }];
+    for (const { db } of databases) {
+      const row = db
+        .prepare<[string], Record<string, unknown>>("SELECT * FROM memory_embedding_index WHERE path = ? LIMIT 1")
+        .get(params.path);
+      if (row) {
+        return this.rowToMemoryEmbeddingIndex(row);
+      }
+    }
+    return null;
   }
 
   listMemoryEmbeddingIndexes(params: {
@@ -5014,47 +5080,68 @@ export class RuntimeStateStore {
     limit?: number;
     offset?: number;
   } = {}): MemoryEmbeddingIndexRecord[] {
-    let query = `
-      SELECT *
-      FROM memory_embedding_index
-      WHERE 1 = 1
-    `;
-    const values: Array<string | number> = [];
-    if (params.memoryIds && params.memoryIds.length > 0) {
-      query += ` AND memory_id IN (${params.memoryIds.map(() => "?").join(", ")})`;
-      values.push(...params.memoryIds);
-    }
-    if (params.workspaceId !== undefined) {
+    const fetchLimit = (params.limit ?? 5000) + (params.offset ?? 0);
+    const queryRows = (db: Database.Database): MemoryEmbeddingIndexRecord[] => {
+      let query = `
+        SELECT *
+        FROM memory_embedding_index
+        WHERE 1 = 1
+      `;
+      const values: Array<string | number> = [];
+      if (params.memoryIds && params.memoryIds.length > 0) {
+        query += ` AND memory_id IN (${params.memoryIds.map(() => "?").join(", ")})`;
+        values.push(...params.memoryIds);
+      }
+      if (params.workspaceId !== undefined) {
+        if (params.workspaceId === null) {
+          query += " AND workspace_id IS NULL";
+        } else {
+          query += " AND workspace_id = ?";
+          values.push(params.workspaceId);
+        }
+      }
+      if (params.scopeBucket !== undefined) {
+        if (params.scopeBucket === null) {
+          query += " AND scope_bucket IS NULL";
+        } else {
+          query += " AND scope_bucket = ?";
+          values.push(params.scopeBucket);
+        }
+      }
+      if (params.embeddingModel !== undefined) {
+        if (params.embeddingModel === null) {
+          query += " AND embedding_model IS NULL";
+        } else {
+          query += " AND embedding_model = ?";
+          values.push(params.embeddingModel);
+        }
+      }
+      query += `
+        ORDER BY vec_rowid ASC
+        LIMIT ? OFFSET 0
+      `;
+      values.push(fetchLimit);
+      const rows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+      return rows.map((row) => this.rowToMemoryEmbeddingIndex(row));
+    };
+    const databases = (() => {
       if (params.workspaceId === null) {
-        query += " AND workspace_id IS NULL";
-      } else {
-        query += " AND workspace_id = ?";
-        values.push(params.workspaceId);
+        return [{ workspaceId: null, db: this.controlPlaneDb() }];
       }
-    }
-    if (params.scopeBucket !== undefined) {
-      if (params.scopeBucket === null) {
-        query += " AND scope_bucket IS NULL";
-      } else {
-        query += " AND scope_bucket = ?";
-        values.push(params.scopeBucket);
+      if (typeof params.workspaceId === "string") {
+        return [{ workspaceId: params.workspaceId, db: this.workspaceRuntimeDb(params.workspaceId) }];
       }
-    }
-    if (params.embeddingModel !== undefined) {
-      if (params.embeddingModel === null) {
-        query += " AND embedding_model IS NULL";
-      } else {
-        query += " AND embedding_model = ?";
-        values.push(params.embeddingModel);
+      if (params.scopeBucket && params.scopeBucket !== "workspace") {
+        return [{ workspaceId: null, db: this.controlPlaneDb() }];
       }
-    }
-    query += `
-      ORDER BY vec_rowid ASC
-      LIMIT ? OFFSET ?
-    `;
-    values.push(params.limit ?? 5000, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
-    return rows.map((row) => this.rowToMemoryEmbeddingIndex(row));
+      if (params.scopeBucket === "workspace") {
+        return this.listReadableMemoryDbs({ includeControlPlane: false, includeWorkspace: true });
+      }
+      return this.listReadableMemoryDbs();
+    })();
+    const records = databases.flatMap(({ db }) => queryRows(db));
+    records.sort((left, right) => left.vecRowid - right.vecRowid);
+    return records.slice(params.offset ?? 0, (params.offset ?? 0) + (params.limit ?? 5000));
   }
 
   upsertMemoryEmbeddingIndex(params: {
@@ -5070,14 +5157,21 @@ export class RuntimeStateStore {
     updatedAt?: string;
   }): MemoryEmbeddingIndexRecord {
     const existing =
-      this.getMemoryEmbeddingIndexByMemoryId(params.memoryId) ??
-      this.getMemoryEmbeddingIndexByPath(params.path);
+      this.getMemoryEmbeddingIndexByMemoryId({
+        memoryId: params.memoryId,
+        workspaceId: params.workspaceId,
+      }) ??
+      this.getMemoryEmbeddingIndexByPath({
+        path: params.path,
+        workspaceId: params.workspaceId,
+      });
     const now = params.updatedAt ?? utcNowIso();
     const indexedAt = existing?.indexedAt ?? params.indexedAt ?? now;
     if (existing && existing.memoryId !== params.memoryId) {
       this.deleteMemoryEmbeddingIndex(existing.memoryId);
     }
-    this.db()
+    const memoryDb = this.memoryDbForWorkspace(params.workspaceId);
+    memoryDb
       .prepare(`
         INSERT INTO memory_embedding_index (
             vec_rowid,
@@ -5116,7 +5210,10 @@ export class RuntimeStateStore {
         indexedAt,
         now,
       );
-    const record = this.getMemoryEmbeddingIndexByMemoryId(params.memoryId);
+    const record = this.getMemoryEmbeddingIndexByMemoryId({
+      memoryId: params.memoryId,
+      workspaceId: params.workspaceId,
+    });
     if (!record) {
       throw new Error("memory embedding index row not found after upsert");
     }
@@ -5124,14 +5221,15 @@ export class RuntimeStateStore {
   }
 
   deleteMemoryEmbeddingIndex(memoryId: string): void {
-    const existing = this.getMemoryEmbeddingIndexByMemoryId(memoryId);
+    const existing = this.getMemoryEmbeddingIndexByMemoryId({ memoryId });
     if (!existing) {
       return;
     }
+    const memoryDb = this.memoryDbForWorkspace(existing.workspaceId);
     if (this.#vectorIndexSupported) {
-      this.db().prepare("DELETE FROM memory_recall_vec WHERE vec_rowid = ?").run(existing.vecRowid);
+      memoryDb.prepare("DELETE FROM memory_recall_vec WHERE vec_rowid = ?").run(existing.vecRowid);
     }
-    this.db().prepare("DELETE FROM memory_embedding_index WHERE memory_id = ?").run(memoryId);
+    memoryDb.prepare("DELETE FROM memory_embedding_index WHERE memory_id = ?").run(memoryId);
   }
 
   replaceMemoryRecallVector(params: {
@@ -5144,8 +5242,9 @@ export class RuntimeStateStore {
     if (!this.#vectorIndexSupported) {
       return;
     }
-    this.db().prepare("DELETE FROM memory_recall_vec WHERE vec_rowid = ?").run(params.vecRowid);
-    this.db()
+    const memoryDb = this.memoryDbForWorkspace(params.workspaceId);
+    memoryDb.prepare("DELETE FROM memory_recall_vec WHERE vec_rowid = ?").run(params.vecRowid);
+    memoryDb
       .prepare(`
         INSERT INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
         VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
@@ -5182,8 +5281,9 @@ export class RuntimeStateStore {
       query += ` AND memory_type IN (${params.memoryTypes.map(() => "?").join(", ")})`;
       values.push(...params.memoryTypes);
     }
-    const rows = this.db().prepare(query).all(...values) as Array<{ vec_rowid: number; distance: number }>;
-    return this.vectorResultsForRows(rows);
+    const memoryDb = this.memoryDbForWorkspace(params.workspaceId);
+    const rows = memoryDb.prepare(query).all(...values) as Array<{ vec_rowid: number; distance: number }>;
+    return this.vectorResultsForRows(memoryDb, rows);
   }
 
   searchUserMemoryRecallVectors(params: {
@@ -5211,8 +5311,9 @@ export class RuntimeStateStore {
       query += ` AND memory_type IN (${params.memoryTypes.map(() => "?").join(", ")})`;
       values.push(...params.memoryTypes);
     }
-    const rows = this.db().prepare(query).all(...values) as Array<{ vec_rowid: number; distance: number }>;
-    return this.vectorResultsForRows(rows);
+    const memoryDb = this.controlPlaneDb();
+    const rows = memoryDb.prepare(query).all(...values) as Array<{ vec_rowid: number; distance: number }>;
+    return this.vectorResultsForRows(memoryDb, rows);
   }
 
   upsertTurnRequestSnapshot(params: {
@@ -6668,6 +6769,7 @@ export class RuntimeStateStore {
     db.pragma("journal_mode = WAL");
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
+    this.#vectorIndexSupported = this.tryLoadVectorExtension(db) || this.#vectorIndexSupported;
     this.ensureControlPlaneDbSchema(db);
     this.backfillControlPlaneDbFromLegacyRuntimeDb(db, legacy);
     this.#controlPlaneDb = db;
@@ -6696,6 +6798,7 @@ export class RuntimeStateStore {
     db.pragma("journal_mode = WAL");
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
+    this.#vectorIndexSupported = this.tryLoadVectorExtension(db) || this.#vectorIndexSupported;
     this.ensureWorkspaceRuntimeDbSchema(db);
     this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(db, this.db(), workspaceId);
     this.#workspaceRuntimeDbs.set(workspaceId, { dbPath, db });
@@ -6726,6 +6829,29 @@ export class RuntimeStateStore {
       workspaceId,
       db,
     }));
+  }
+
+  private memoryDbForWorkspace(workspaceId?: string | null): Database.Database {
+    if (typeof workspaceId === "string" && workspaceId.trim().length > 0) {
+      return this.workspaceRuntimeDb(workspaceId);
+    }
+    return this.controlPlaneDb();
+  }
+
+  private listReadableMemoryDbs(params: {
+    includeControlPlane?: boolean;
+    includeWorkspace?: boolean;
+  } = {}): Array<{ workspaceId: string | null; db: Database.Database }> {
+    const includeControlPlane = params.includeControlPlane ?? true;
+    const includeWorkspace = params.includeWorkspace ?? true;
+    const databases: Array<{ workspaceId: string | null; db: Database.Database }> = [];
+    if (includeControlPlane) {
+      databases.push({ workspaceId: null, db: this.controlPlaneDb() });
+    }
+    if (includeWorkspace) {
+      databases.push(...this.listReadableWorkspaceRuntimeDbs());
+    }
+    return databases;
   }
 
   private backfillControlPlaneDbFromLegacyRuntimeDb(
@@ -6932,6 +7058,7 @@ export class RuntimeStateStore {
         );
       }
     }
+    this.backfillControlPlaneMemoryTables(db, legacy);
   }
 
   private backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(
@@ -6957,6 +7084,8 @@ export class RuntimeStateStore {
       "task_proposals",
       "evolve_skill_candidates",
       "memory_update_proposals",
+      "memory_entries",
+      "memory_embedding_index",
       "output_folders",
       "outputs",
       "app_builds",
@@ -6972,6 +7101,49 @@ export class RuntimeStateStore {
         tableName,
       });
     }
+    this.backfillWorkspaceScopedMemoryVectors({
+      db,
+      legacy,
+      workspaceId,
+    });
+  }
+
+  private backfillControlPlaneMemoryTables(db: Database.Database, legacy: Database.Database): void {
+    this.backfillControlPlaneMemoryTableRows({
+      db,
+      legacy,
+      tableName: "memory_entries",
+      whereClause: "workspace_id IS NULL",
+    });
+    this.backfillControlPlaneMemoryTableRows({
+      db,
+      legacy,
+      tableName: "memory_embedding_index",
+      whereClause: "workspace_id IS NULL",
+    });
+    if (!this.#vectorIndexSupported || !this.tableExists(legacy, "memory_recall_vec") || !this.tableExists(db, "memory_recall_vec")) {
+      return;
+    }
+    const rows = legacy
+      .prepare(`
+        SELECT vec_rowid, embedding, scope_bucket, workspace_id, memory_type
+        FROM memory_recall_vec
+        WHERE COALESCE(workspace_id, '') = ''
+      `)
+      .all() as Array<Record<string, unknown>>;
+    if (rows.length === 0) {
+      return;
+    }
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    const insertMany = db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        insert.run(row.vec_rowid, row.embedding, row.scope_bucket, row.workspace_id, row.memory_type);
+      }
+    });
+    insertMany(rows);
   }
 
   private backfillWorkspaceScopedTableRows(params: {
@@ -7005,6 +7177,70 @@ export class RuntimeStateStore {
     const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
       for (const row of items) {
         insert.run(...columns.map((column) => row[column] ?? null));
+      }
+    });
+    insertMany(rows);
+  }
+
+  private backfillControlPlaneMemoryTableRows(params: {
+    db: Database.Database;
+    legacy: Database.Database;
+    tableName: "memory_entries" | "memory_embedding_index";
+    whereClause: string;
+  }): void {
+    if (!this.tableExists(params.legacy, params.tableName) || !this.tableExists(params.db, params.tableName)) {
+      return;
+    }
+    const columns = (
+      params.db.prepare(`PRAGMA table_info(${params.tableName})`).all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    if (columns.length === 0) {
+      return;
+    }
+    const rows = params.legacy
+      .prepare(`SELECT ${columns.join(", ")} FROM ${params.tableName} WHERE ${params.whereClause}`)
+      .all() as Array<Record<string, unknown>>;
+    if (rows.length === 0) {
+      return;
+    }
+    const insert = params.db.prepare(`
+      INSERT OR IGNORE INTO ${params.tableName} (${columns.join(", ")})
+      VALUES (${columns.map(() => "?").join(", ")})
+    `);
+    const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        insert.run(...columns.map((column) => row[column] ?? null));
+      }
+    });
+    insertMany(rows);
+  }
+
+  private backfillWorkspaceScopedMemoryVectors(params: {
+    db: Database.Database;
+    legacy: Database.Database;
+    workspaceId: string;
+  }): void {
+    if (!this.#vectorIndexSupported || !this.tableExists(params.legacy, "memory_recall_vec") || !this.tableExists(params.db, "memory_recall_vec")) {
+      return;
+    }
+    const rows = params.legacy
+      .prepare(`
+        SELECT vec_rowid, embedding, scope_bucket, workspace_id, memory_type
+        FROM memory_recall_vec
+        WHERE scope_bucket = 'workspace'
+          AND workspace_id = ?
+      `)
+      .all(params.workspaceId) as Array<Record<string, unknown>>;
+    if (rows.length === 0) {
+      return;
+    }
+    const insert = params.db.prepare(`
+      INSERT OR IGNORE INTO memory_recall_vec (vec_rowid, embedding, scope_bucket, workspace_id, memory_type)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    const insertMany = params.db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        insert.run(row.vec_rowid, row.embedding, row.scope_bucket, row.workspace_id, row.memory_type);
       }
     });
     insertMany(rows);
@@ -7077,6 +7313,43 @@ export class RuntimeStateStore {
           workspace_id TEXT,
           memory_type TEXT
       );
+    `);
+  }
+
+  private ensureMemoryEntriesTableSchema(db: Database.Database): void {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_entries (
+          memory_id TEXT PRIMARY KEY,
+          workspace_id TEXT,
+          session_id TEXT,
+          scope TEXT NOT NULL,
+          memory_type TEXT NOT NULL,
+          subject_key TEXT NOT NULL,
+          path TEXT NOT NULL,
+          title TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          tags TEXT NOT NULL DEFAULT '[]',
+          verification_policy TEXT NOT NULL,
+          staleness_policy TEXT NOT NULL DEFAULT 'stable',
+          stale_after_seconds INTEGER,
+          source_turn_input_id TEXT,
+          source_message_id TEXT,
+          source_type TEXT,
+          observed_at TEXT,
+          last_verified_at TEXT,
+          confidence REAL,
+          fingerprint TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'active',
+          superseded_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memory_entries_workspace_scope_updated
+          ON memory_entries (workspace_id, scope, status, updated_at DESC, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_memory_entries_scope_updated
+          ON memory_entries (scope, status, updated_at DESC, created_at DESC);
     `);
   }
 
@@ -7158,6 +7431,8 @@ export class RuntimeStateStore {
           updated_at TEXT NOT NULL
       );
     `);
+    this.ensureMemoryEntriesTableSchema(db);
+    this.ensureMemoryEmbeddingIndexSchema(db);
     this.migrateIntegrationConnectionIdentityColumns(db);
   }
 
@@ -7671,6 +7946,8 @@ export class RuntimeStateStore {
       CREATE INDEX IF NOT EXISTS idx_runtime_notifications_state_created
           ON runtime_notifications (state, created_at DESC);
     `);
+    this.ensureMemoryEntriesTableSchema(db);
+    this.ensureMemoryEmbeddingIndexSchema(db);
     this.ensureConversationBindingsTableSchema(db);
     this.ensureSubagentRunsTableSchema(db);
     this.ensureSessionRuntimeStateTableSchema(db);
@@ -9645,7 +9922,10 @@ export class RuntimeStateStore {
     };
   }
 
-  private vectorResultsForRows(rows: Array<{ vec_rowid: number; distance: number }>): MemoryVectorSearchResult[] {
+  private vectorResultsForRows(
+    db: Database.Database,
+    rows: Array<{ vec_rowid: number; distance: number }>
+  ): MemoryVectorSearchResult[] {
     if (rows.length === 0) {
       return [];
     }
@@ -9653,7 +9933,7 @@ export class RuntimeStateStore {
     if (rowIds.length === 0) {
       return [];
     }
-    const mappingRows = this.db()
+    const mappingRows = db
       .prepare(`
         SELECT *
         FROM memory_embedding_index

--- a/sdk/runtime-client/src/methods/cronjobs.ts
+++ b/sdk/runtime-client/src/methods/cronjobs.ts
@@ -62,10 +62,14 @@ export type CronjobUpdatePayload = {
 
 export type CronjobsMethods = {
   list(workspaceId: string, enabledOnly?: boolean): Promise<CronjobListResponse>;
-  runNow(jobId: string): Promise<CronjobRunResponse>;
+  runNow(workspaceId: string, jobId: string): Promise<CronjobRunResponse>;
   create(payload: CronjobCreatePayload): Promise<CronjobRecord>;
-  update(jobId: string, payload: CronjobUpdatePayload): Promise<CronjobRecord>;
-  delete(jobId: string): Promise<{ success: boolean }>;
+  update(
+    workspaceId: string,
+    jobId: string,
+    payload: CronjobUpdatePayload
+  ): Promise<CronjobRecord>;
+  delete(workspaceId: string, jobId: string): Promise<{ success: boolean }>;
 };
 
 export function makeCronjobsMethods(request: RequestFn): CronjobsMethods {
@@ -80,10 +84,13 @@ export function makeCronjobsMethods(request: RequestFn): CronjobsMethods {
         },
       });
     },
-    runNow(jobId) {
+    runNow(workspaceId, jobId) {
       return request<CronjobRunResponse>({
         method: "POST",
         path: `/api/v1/cronjobs/${encodeURIComponent(jobId)}/run`,
+        params: {
+          workspace_id: workspaceId,
+        },
       });
     },
     create(payload) {
@@ -93,17 +100,23 @@ export function makeCronjobsMethods(request: RequestFn): CronjobsMethods {
         payload,
       });
     },
-    update(jobId, payload) {
+    update(workspaceId, jobId, payload) {
       return request<CronjobRecord>({
         method: "PATCH",
         path: `/api/v1/cronjobs/${encodeURIComponent(jobId)}`,
-        payload,
+        payload: {
+          workspace_id: workspaceId,
+          ...payload,
+        },
       });
     },
-    delete(jobId) {
+    delete(workspaceId, jobId) {
       return request<{ success: boolean }>({
         method: "DELETE",
         path: `/api/v1/cronjobs/${encodeURIComponent(jobId)}`,
+        params: {
+          workspace_id: workspaceId,
+        },
       });
     },
   };

--- a/sdk/runtime-client/src/methods/memory.ts
+++ b/sdk/runtime-client/src/methods/memory.ts
@@ -40,6 +40,7 @@ export type MemoryUpdateProposalListResponse = {
 
 export type MemoryUpdateProposalAcceptPayload = {
   proposalId: string;
+  workspaceId: string;
   summary?: string | null;
 };
 
@@ -59,6 +60,7 @@ export type MemoryMethods = {
     payload: MemoryUpdateProposalAcceptPayload
   ): Promise<MemoryUpdateProposalAcceptResponse>;
   dismissUpdateProposal(
+    workspaceId: string,
     proposalId: string
   ): Promise<MemoryUpdateProposalDismissResponse>;
 };
@@ -84,15 +86,18 @@ export function makeMemoryMethods(request: RequestFn): MemoryMethods {
         method: "POST",
         path: `/api/v1/memory-update-proposals/${encodeURIComponent(payload.proposalId)}/accept`,
         payload: {
+          workspace_id: payload.workspaceId,
           summary: payload.summary ?? undefined,
         },
       });
     },
-    dismissUpdateProposal(proposalId) {
+    dismissUpdateProposal(workspaceId, proposalId) {
       return request<MemoryUpdateProposalDismissResponse>({
         method: "POST",
         path: `/api/v1/memory-update-proposals/${encodeURIComponent(proposalId)}/dismiss`,
-        payload: {},
+        payload: {
+          workspace_id: workspaceId,
+        },
       });
     },
   };

--- a/sdk/runtime-client/src/methods/notifications.ts
+++ b/sdk/runtime-client/src/methods/notifications.ts
@@ -40,6 +40,7 @@ export type ListNotificationsParams = {
 export type NotificationsMethods = {
   list(params?: ListNotificationsParams): Promise<RuntimeNotificationListResponse>;
   update(
+    workspaceId: string,
     notificationId: string,
     payload: RuntimeNotificationUpdatePayload
   ): Promise<RuntimeNotificationRecord>;
@@ -60,11 +61,14 @@ export function makeNotificationsMethods(
         },
       });
     },
-    update(notificationId, payload) {
+    update(workspaceId, notificationId, payload) {
       return request<RuntimeNotificationRecord>({
         method: "PATCH",
         path: `/api/v1/notifications/${encodeURIComponent(notificationId)}`,
-        payload,
+        payload: {
+          workspace_id: workspaceId,
+          ...payload,
+        },
       });
     },
   };

--- a/sdk/runtime-client/src/methods/sessions.ts
+++ b/sdk/runtime-client/src/methods/sessions.ts
@@ -103,6 +103,7 @@ export type SessionOutputEventListResponse = {
 };
 
 export type GetSessionOutputEventsParams = {
+  workspaceId: string;
   sessionId: string;
   inputId?: string | null;
 };
@@ -234,6 +235,7 @@ export function makeSessionsMethods(request: RequestFn): SessionsMethods {
         method: "GET",
         path: `/api/v1/agent-sessions/${encodeURIComponent(params.sessionId)}/outputs/events`,
         params: {
+          workspace_id: params.workspaceId,
           input_id: params.inputId ?? undefined,
           include_history: true,
           after_event_id: 0,

--- a/sdk/runtime-client/src/methods/task-proposals.ts
+++ b/sdk/runtime-client/src/methods/task-proposals.ts
@@ -22,6 +22,7 @@ export type TaskProposalListResponse = {
 
 export type TaskProposalAcceptPayload = {
   proposal_id: string;
+  workspace_id: string;
   task_name?: string | null;
   task_prompt?: string | null;
   session_id?: string | null;
@@ -48,6 +49,7 @@ export type TaskProposalsMethods = {
   listUnreviewed(workspaceId: string): Promise<TaskProposalListResponse>;
   accept(payload: TaskProposalAcceptPayload): Promise<TaskProposalAcceptResponse>;
   updateState(
+    workspaceId: string,
     proposalId: string,
     state: string
   ): Promise<TaskProposalStateUpdateResponse>;
@@ -69,6 +71,7 @@ export function makeTaskProposalsMethods(
         method: "POST",
         path: `/api/v1/task-proposals/${encodeURIComponent(payload.proposal_id)}/accept`,
         payload: {
+          workspace_id: payload.workspace_id,
           task_name: payload.task_name,
           task_prompt: payload.task_prompt,
           session_id: payload.session_id,
@@ -79,11 +82,14 @@ export function makeTaskProposalsMethods(
         },
       });
     },
-    updateState(proposalId, state) {
+    updateState(workspaceId, proposalId, state) {
       return request<TaskProposalStateUpdateResponse>({
         method: "PATCH",
         path: `/api/v1/task-proposals/${encodeURIComponent(proposalId)}`,
-        payload: { state },
+        payload: {
+          workspace_id: workspaceId,
+          state,
+        },
       });
     },
   };

--- a/website/docs/content/docs/build/apps/troubleshooting.mdx
+++ b/website/docs/content/docs/build/apps/troubleshooting.mdx
@@ -34,7 +34,7 @@ In desktop dev, the embedded runtime is supposed to come up on `127.0.0.1:5160`,
 
 - Check `curl http://127.0.0.1:5160/healthz`.
 - Inspect `runtime.log` under the Electron `userData` directory.
-- Inspect the embedded sandbox root under `sandbox-host/`, especially `sandbox-host/state/runtime-config.json` and `sandbox-host/state/runtime.db`.
+- Inspect the embedded sandbox root under `sandbox-host/`, especially `sandbox-host/state/runtime-config.json`, `sandbox-host/state/host-state.db`, and `sandbox-host/state/control-plane.db`.
 - If you set a custom user-data path, make sure you are looking in `HOLABOSS_DESKTOP_USER_DATA_PATH`. Otherwise `desktop:dev` defaults to an Electron `userData` directory derived from `HOLABOSS_DESKTOP_USER_DATA_DIR=holaboss-local-dev`.
 - The desktop code pins `5160` because Node's fetch stack blocks `5060` as a bad port.
 
@@ -136,7 +136,9 @@ Check these files first:
 - `AGENTS.md`
 - `apps/<app-id>/app.runtime.yaml`
 - `.holaboss/`
-- `state/runtime.db`
+- `state/host-state.db`
+- `state/control-plane.db`
+- `.holaboss/state/runtime.db`
 
 If the workspace files are valid but the runtime still behaves unexpectedly, compare the current bundle against the source revision you used to stage it.
 

--- a/website/docs/content/docs/concepts/memory-and-continuity/durable-memory.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/durable-memory.mdx
@@ -12,9 +12,9 @@ The runtime memory model is intentionally split:
 | Layer | Purpose | Durable? |
 | --- | --- | --- |
 | `state/runtime.db` | execution truth, profile state, continuity boundaries | yes |
-| `memory/workspace/<workspace-id>/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
-| `memory/workspace/<workspace-id>/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
-| `memory/workspace/<workspace-id>/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
+| `<workspace-id>/.holaboss/memory/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
+| `<workspace-id>/.holaboss/memory/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
+| `<workspace-id>/.holaboss/memory/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
 | `memory/preference/` | user preferences | yes |
 | `memory/identity/` | user identity memory | yes |
 
@@ -62,9 +62,9 @@ That is why durable memory is intentionally smaller and more opinionated than se
 There are currently two durable write paths:
 
 - background evolve writeback
-  - writes workspace durable memory under `workspace/<workspace-id>/knowledge/`
+  - writes workspace durable memory under `.holaboss/memory/knowledge/`
   - updates the durable memory catalog in `state/runtime.db`
-  - refreshes `workspace/<workspace-id>/MEMORY.md` and the root `MEMORY.md` when indexed scopes change
+  - refreshes the workspace-local `MEMORY.md` plus the root `MEMORY.md` when indexed scopes change
 - accepted user-memory proposals
   - capture explicit user preferences from input
   - persist accepted preference memory into markdown under `memory/preference/`
@@ -77,7 +77,7 @@ Use these rules of thumb when reasoning about durable state:
 
 - `AGENTS.md`
   - human-authored workspace policy and operating instructions
-- `memory/workspace/<workspace-id>/knowledge/`
+- `<workspace-id>/.holaboss/memory/knowledge/`
   - durable workspace memory that may be recalled in later runs
 - `memory/preference/`
   - durable user preference memory

--- a/website/docs/content/docs/concepts/memory-and-continuity/durable-memory.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/durable-memory.mdx
@@ -11,7 +11,8 @@ The runtime memory model is intentionally split:
 
 | Layer | Purpose | Durable? |
 | --- | --- | --- |
-| `state/runtime.db` | execution truth, profile state, continuity boundaries | yes |
+| `state/control-plane.db` | canonical profile state and profile-global memory metadata | yes |
+| `<workspace-id>/.holaboss/state/runtime.db` | workspace execution truth, workspace-scoped memory metadata, pending proposals | yes |
 | `<workspace-id>/.holaboss/memory/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
 | `<workspace-id>/.holaboss/memory/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
 | `<workspace-id>/.holaboss/memory/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
@@ -63,12 +64,12 @@ There are currently two durable write paths:
 
 - background evolve writeback
   - writes workspace durable memory under `.holaboss/memory/knowledge/`
-  - updates the durable memory catalog in `state/runtime.db`
+  - updates the durable memory catalog in the workspace runtime DB or `state/control-plane.db`, depending on scope
   - refreshes the workspace-local `MEMORY.md` plus the root `MEMORY.md` when indexed scopes change
 - accepted user-memory proposals
   - capture explicit user preferences from input
   - persist accepted preference memory into markdown under `memory/preference/`
-  - update the canonical runtime profile for accepted profile proposals
+  - update the canonical runtime profile in `state/control-plane.db` for accepted profile proposals
   - refresh durable markdown indexes for accepted preference-memory writes
 
 ## What lives where
@@ -84,7 +85,7 @@ Use these rules of thumb when reasoning about durable state:
 - `memory/identity/`
   - durable user identity facts beyond the canonical runtime profile
 
-If it should be recalled later without replaying the full session, it belongs in durable memory. If it is a standing workspace rule, it belongs in `AGENTS.md`. If it is only a runtime profile field such as the canonical user name, it stays in `state/runtime.db` until a separate path promotes related durable identity memory.
+If it should be recalled later without replaying the full session, it belongs in durable memory. If it is a standing workspace rule, it belongs in `AGENTS.md`. If it is only a runtime profile field such as the canonical user name, it stays in `state/control-plane.db` until a separate path promotes related durable identity memory.
 
 ## Namespace boundaries
 

--- a/website/docs/content/docs/concepts/memory-and-continuity/index.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/index.mdx
@@ -17,9 +17,9 @@ Today the runtime stores those concerns on different surfaces:
 
 - standing workspace policy lives in authored workspace files such as `AGENTS.md`
 - session continuity lives in runtime-owned artifacts such as `turn_results`, request snapshots, persisted harness state, and session-memory projections
-- session-memory continuity projections live under `memory/workspace/<workspace-id>/runtime/session-memory/`
-- operational projections live under `memory/workspace/<workspace-id>/runtime/`, including the latest turn, session state, blockers, recent turns, and permission-blocker snapshots
-- durable recalled memory lives under `memory/workspace/<workspace-id>/knowledge/`, `memory/preference/`, and `memory/identity/`
+- session-memory continuity projections live under `<workspace-id>/.holaboss/memory/runtime/session-memory/`
+- operational projections live under `<workspace-id>/.holaboss/memory/runtime/`, including the latest turn, session state, blockers, recent turns, and permission-blocker snapshots
+- durable recalled memory lives under `<workspace-id>/.holaboss/memory/knowledge/`, `memory/preference/`, and `memory/identity/`
 
 The canonical operator profile also lives in `state/runtime.db`. That profile is runtime-owned identity state, not markdown memory. The runtime also keeps pending user-memory proposals in `state/runtime.db` so the current run can use them ephemerally without promoting them into durable memory yet.
 
@@ -30,9 +30,9 @@ The easiest way to think about the storage boundary is:
 | Layer | Purpose | Durable? |
 | --- | --- | --- |
 | `state/runtime.db` | execution truth, profile state, continuity records | yes |
-| `memory/workspace/<workspace-id>/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
-| `memory/workspace/<workspace-id>/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
-| `memory/workspace/<workspace-id>/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
+| `<workspace-id>/.holaboss/memory/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
+| `<workspace-id>/.holaboss/memory/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
+| `<workspace-id>/.holaboss/memory/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
 | `memory/preference/` | user preferences | yes |
 | `memory/identity/` | user identity memory | yes |
 
@@ -44,7 +44,7 @@ The source-of-truth split is deliberate:
 
 - runtime execution truth lives in `state/runtime.db`
 - canonical operator profile data lives in `state/runtime.db`
-- durable recalled memory lives in markdown under `memory/`
+- durable recalled memory lives in markdown under workspace-local `.holaboss/memory/` plus profile-global `memory/`
 - standing workspace policy lives in `AGENTS.md`
 
 That is what keeps continuity inspectable without turning workspace policy or durable memory into raw execution logs.

--- a/website/docs/content/docs/concepts/memory-and-continuity/index.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/index.mdx
@@ -21,15 +21,16 @@ Today the runtime stores those concerns on different surfaces:
 - operational projections live under `<workspace-id>/.holaboss/memory/runtime/`, including the latest turn, session state, blockers, recent turns, and permission-blocker snapshots
 - durable recalled memory lives under `<workspace-id>/.holaboss/memory/knowledge/`, `memory/preference/`, and `memory/identity/`
 
-The canonical operator profile also lives in `state/runtime.db`. That profile is runtime-owned identity state, not markdown memory. The runtime also keeps pending user-memory proposals in `state/runtime.db` so the current run can use them ephemerally without promoting them into durable memory yet.
+The canonical operator profile now lives in `state/control-plane.db`. That profile is runtime-owned identity state, not markdown memory. The runtime keeps pending user-memory proposals in `<workspace-id>/.holaboss/state/runtime.db` so the current run can use them ephemerally without promoting them into durable memory yet.
 
-Accepted user-memory proposals are the separate path that promotes user preference memory into `memory/preference/` or updates the runtime profile in `state/runtime.db`. The background evolve path does not create user preference or profile memory on its own.
+Accepted user-memory proposals are the separate path that promotes user preference memory into `memory/preference/` or updates the runtime profile in `state/control-plane.db`. The background evolve path does not create user preference or profile memory on its own.
 
 The easiest way to think about the storage boundary is:
 
 | Layer | Purpose | Durable? |
 | --- | --- | --- |
-| `state/runtime.db` | execution truth, profile state, continuity records | yes |
+| `state/control-plane.db` | canonical profile state and profile-global memory metadata | yes |
+| `<workspace-id>/.holaboss/state/runtime.db` | workspace execution truth, continuity records, workspace-scoped memory metadata, pending proposals | yes |
 | `<workspace-id>/.holaboss/memory/runtime/` | latest-turn projections, blockers, recent-turn snapshots | no |
 | `<workspace-id>/.holaboss/memory/runtime/session-memory/` | resume-friendly continuity snapshots | semi-volatile |
 | `<workspace-id>/.holaboss/memory/knowledge/` | workspace facts, procedures, blockers, reference memories | yes |
@@ -42,8 +43,8 @@ Runtime files under `runtime/` are meant for inspection and restoration. They ar
 
 The source-of-truth split is deliberate:
 
-- runtime execution truth lives in `state/runtime.db`
-- canonical operator profile data lives in `state/runtime.db`
+- runtime execution truth lives in `<workspace-id>/.holaboss/state/runtime.db`
+- canonical operator profile data lives in `state/control-plane.db`
 - durable recalled memory lives in markdown under workspace-local `.holaboss/memory/` plus profile-global `memory/`
 - standing workspace policy lives in `AGENTS.md`
 

--- a/website/docs/content/docs/concepts/memory-and-continuity/recall-and-evolve.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/recall-and-evolve.mdx
@@ -16,7 +16,7 @@ The current flow is:
 3. The current run may use pending proposals as ephemeral context without promoting them into durable memory yet.
 4. When the run finishes, the runtime persists `turn_results`.
 5. An immediate continuity writeback runs inline after the turn result is committed.
-6. That writeback updates volatile runtime projections under `memory/workspace/<workspace-id>/runtime/`, including `session-memory/`.
+6. That writeback updates volatile runtime projections under `.holaboss/memory/runtime/`, including `session-memory/`.
 7. The runtime then persists a queued evolve job for heavier durable-memory and skill-review work.
 8. The evolve worker reloads the finished turn, recent session state, and current memory catalog state.
 9. Deterministic and optional model-assisted extraction promote durable workspace facts, procedures, and repeated blockers into markdown memory plus catalog rows.
@@ -77,7 +77,7 @@ This boundary is intentional. The system can prepare candidates, summarize evide
 Reusable procedural patterns do not become live skills automatically. The current lifecycle is:
 
 1. queued evolve reviews a cadence turn
-2. if it finds a reusable pattern, it writes a draft under `memory/workspace/<workspace-id>/evolve/skills/<candidate-id>/SKILL.md`
+2. if it finds a reusable pattern, it writes a draft under `workspace/<workspace-id>/evolve/skills/<candidate-id>/SKILL.md`
 3. the runtime stores candidate metadata in `state/runtime.db`
 4. candidate skills that merit attention are raised through proposal surfaces rather than silently activated
 5. an accepted proposal opens a tightly scoped review session

--- a/website/docs/content/docs/concepts/memory-and-continuity/recall-and-evolve.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/recall-and-evolve.mdx
@@ -11,7 +11,7 @@ That separation is what keeps the next run cheap to restore while still allowing
 
 The current flow is:
 
-1. User input is queued, and strong-signal user-scoped proposals may be captured in `state/runtime.db`.
+1. User input is queued, and strong-signal user-scoped proposals may be captured in `<workspace-id>/.holaboss/state/runtime.db`.
 2. The runtime compiles the workspace, projects capabilities, computes the prompt package, and persists a sanitized request snapshot before the harness starts.
 3. The current run may use pending proposals as ephemeral context without promoting them into durable memory yet.
 4. When the run finishes, the runtime persists `turn_results`.
@@ -23,11 +23,11 @@ The current flow is:
 10. `MEMORY.md` indexes are refreshed only for the durable scopes that changed.
 11. Later runs restore from persisted harness session state, `session-memory`, and scratchpad context.
 
-User-memory proposals remain staged in `state/runtime.db` until they are accepted. That acceptance path is what creates durable preference memory or updates the canonical runtime profile; queued evolve does not create user preference or profile memory automatically. Repeated runtime blockers can also graduate into durable `knowledge/blockers/` during queued evolve when they stop looking like a one-off run artifact and start looking like stable workspace knowledge.
+User-memory proposals remain staged in `<workspace-id>/.holaboss/state/runtime.db` until they are accepted. That acceptance path is what creates durable preference memory or updates the canonical runtime profile in `state/control-plane.db`; queued evolve does not create user preference or profile memory automatically. Repeated runtime blockers can also graduate into durable `knowledge/blockers/` during queued evolve when they stop looking like a one-off run artifact and start looking like stable workspace knowledge.
 
 ## Recall behavior
 
-Runtime recall is manifest-based and model-mediated. It starts from active durable memory catalog entries in `state/runtime.db`, opens the scoped `MEMORY.md` indexes plus candidate leaf files under the memory root, and selects a bounded set of durable memories to inject as context.
+Runtime recall is manifest-based and model-mediated. It starts from active durable memory catalog entries in the workspace runtime DB and `state/control-plane.db`, opens the scoped `MEMORY.md` indexes plus candidate leaf files under the memory root, and selects a bounded set of durable memories to inject as context.
 
 Important characteristics:
 
@@ -49,7 +49,7 @@ When embeddings are configured and the state store has vector support, recall ca
    - keeps next-run continuity fresh without waiting on heavier extraction work
    - refreshes runtime projections and `session-memory` immediately
 2. queued `evolve` jobs
-   - persist as post-run jobs in `state/runtime.db`
+   - persist as post-run jobs in `<workspace-id>/.holaboss/state/runtime.db`
    - drain through the dedicated evolve worker
    - handles durable-memory promotion, index refresh, and background skill review
 
@@ -78,7 +78,7 @@ Reusable procedural patterns do not become live skills automatically. The curren
 
 1. queued evolve reviews a cadence turn
 2. if it finds a reusable pattern, it writes a draft under `workspace/<workspace-id>/evolve/skills/<candidate-id>/SKILL.md`
-3. the runtime stores candidate metadata in `state/runtime.db`
+3. the runtime stores candidate metadata in `<workspace-id>/.holaboss/state/runtime.db`
 4. candidate skills that merit attention are raised through proposal surfaces rather than silently activated
 5. an accepted proposal opens a tightly scoped review session
 6. after successful review, the candidate can be promoted into the live workspace `skills/` namespace

--- a/website/docs/content/docs/concepts/memory-and-continuity/runtime-continuity.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/runtime-continuity.mdx
@@ -21,9 +21,9 @@ The most important continuity artifacts are:
   - the runtime split between cacheable and volatile prompt sections for a run
 - capability manifest
   - the reduced visible and callable surface passed to the harness for that run
-- runtime projections under `memory/workspace/<workspace-id>/runtime/`
+- runtime projections under `<workspace-id>/.holaboss/memory/runtime/`
   - latest-turn summaries, session snapshots, blocker snapshots, recent-turn history, and permission-blocker artifacts
-- session-memory snapshots under `memory/workspace/<workspace-id>/runtime/session-memory/`
+- session-memory snapshots under `<workspace-id>/.holaboss/memory/runtime/session-memory/`
   - compact continuity views used to restore the next run without replaying the full transcript
 - user-memory proposals in `state/runtime.db`
   - staged strong-signal user-memory candidates that the current run can use ephemerally before acceptance
@@ -34,7 +34,7 @@ The continuity path after a run is:
 
 1. The runtime persists `turn_results`.
 2. An immediate continuity writeback runs in the same post-turn flow.
-3. That writeback refreshes runtime projections under `memory/workspace/<workspace-id>/runtime/`, including `session-memory/`.
+3. That writeback refreshes runtime projections under `.holaboss/memory/runtime/`, including `session-memory/`.
 4. The same flow then queues a background evolve job for heavier durable-memory and skill-review work.
 
 The point of this split is to keep the next run cheap to restore without waiting for heavier background extraction.
@@ -65,9 +65,9 @@ Use these rules of thumb when reasoning about resume state:
 
 - `state/runtime.db`
   - execution truth, session continuity, canonical runtime profile, user-memory proposals, and memory catalog metadata
-- `memory/workspace/<workspace-id>/runtime/`
+- `<workspace-id>/.holaboss/memory/runtime/`
   - volatile runtime projections for inspection and debugging
-- `memory/workspace/<workspace-id>/runtime/session-memory/`
+- `<workspace-id>/.holaboss/memory/runtime/session-memory/`
   - session-scoped continuity snapshots used during resume restoration
 
 At restore time, the runtime uses persisted harness session state plus the latest `session-memory` excerpt if it exists. It no longer restores from a separate compaction-boundary artifact. If a piece of information is only needed to resume the latest session, it belongs in runtime continuity rather than durable memory. Repeated blockers can begin in runtime projections first and only later be promoted into durable `knowledge/blockers/` during queued evolve.

--- a/website/docs/content/docs/concepts/memory-and-continuity/runtime-continuity.mdx
+++ b/website/docs/content/docs/concepts/memory-and-continuity/runtime-continuity.mdx
@@ -25,7 +25,7 @@ The most important continuity artifacts are:
   - latest-turn summaries, session snapshots, blocker snapshots, recent-turn history, and permission-blocker artifacts
 - session-memory snapshots under `<workspace-id>/.holaboss/memory/runtime/session-memory/`
   - compact continuity views used to restore the next run without replaying the full transcript
-- user-memory proposals in `state/runtime.db`
+- user-memory proposals in `<workspace-id>/.holaboss/state/runtime.db`
   - staged strong-signal user-memory candidates that the current run can use ephemerally before acceptance
 
 ## Continuity writeback
@@ -63,8 +63,10 @@ That is the point of runtime continuity: resume the important state cheaply, not
 
 Use these rules of thumb when reasoning about resume state:
 
-- `state/runtime.db`
-  - execution truth, session continuity, canonical runtime profile, user-memory proposals, and memory catalog metadata
+- `<workspace-id>/.holaboss/state/runtime.db`
+  - execution truth, session continuity, user-memory proposals, and workspace-scoped memory catalog metadata
+- `state/control-plane.db`
+  - canonical runtime profile plus profile-global memory metadata
 - `<workspace-id>/.holaboss/memory/runtime/`
   - volatile runtime projections for inspection and debugging
 - `<workspace-id>/.holaboss/memory/runtime/session-memory/`

--- a/website/docs/content/docs/concepts/workspace-model.mdx
+++ b/website/docs/content/docs/concepts/workspace-model.mdx
@@ -26,24 +26,6 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
         accent: "engine",
         children: [
           {
-            name: ".holaboss/",
-            meta: "Shared MCP sidecar state",
-            children: [
-              {
-                name: "workspace-mcp-sidecar-state.json",
-                meta: "Sidecar registry",
-              },
-              {
-                name: "<server>.workspace-mcp-sidecar.stdout.log",
-                meta: "Sidecar stdout",
-              },
-              {
-                name: "<server>.workspace-mcp-sidecar.stderr.log",
-                meta: "Sidecar stderr",
-              },
-            ],
-          },
-          {
             name: "<workspace-id>/",
             accent: "engine",
             children: [
@@ -83,12 +65,47 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
               },
               {
                 name: ".holaboss/",
-                meta: "Workspace runtime state",
+                meta: "Workspace-owned runtime state and memory",
                 children: [
-                  { name: "workspace_id", meta: "Identity marker" },
                   {
-                    name: "harness-session-state.json",
-                    meta: "Harness session mapping",
+                    name: "state/",
+                    meta: "Workspace runtime state",
+                    children: [
+                      { name: "workspace_id", meta: "Identity marker" },
+                      {
+                        name: "harness-session-state.json",
+                        meta: "Harness session mapping",
+                      },
+                      { name: "data.db", meta: "Shared workspace SQLite" },
+                      {
+                        name: "workspace-mcp-sidecar-state.json",
+                        meta: "Sidecar registry",
+                      },
+                      {
+                        name: "<server>.workspace-mcp-sidecar.stdout.log",
+                        meta: "Sidecar stdout",
+                      },
+                      {
+                        name: "<server>.workspace-mcp-sidecar.stderr.log",
+                        meta: "Sidecar stderr",
+                      },
+                      {
+                        name: "todos/",
+                        meta: "Session todo state",
+                      },
+                      {
+                        name: "scratchpads/",
+                        meta: "Session scratchpads",
+                      },
+                      {
+                        name: "legacy-session-histories/",
+                        meta: "Archived front-session exports",
+                      },
+                      {
+                        name: "tool-results/",
+                        meta: "Preview spillover artifacts",
+                      },
+                    ],
                   },
                   {
                     name: "input-attachments/",
@@ -98,14 +115,46 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
                     ],
                   },
                   {
-                    name: "pi-agent/",
-                    meta: "Pi harness config",
+                    name: "memory/",
+                    meta: "Workspace-scoped markdown memory",
                     children: [
-                      { name: "auth.json", meta: "Harness auth state" },
-                      { name: "models.json", meta: "Harness model config" },
+                      { name: "MEMORY.md", meta: "Workspace memory index" },
+                      {
+                        name: "runtime/",
+                        meta: "Resume-only continuity",
+                        children: [
+                          { name: "latest-turn.md", meta: "Last-turn projection" },
+                          {
+                            name: "session-state/",
+                            meta: "Session state projections",
+                          },
+                          {
+                            name: "session-memory/",
+                            meta: "Resume-friendly snapshots",
+                          },
+                          {
+                            name: "recent-turns/",
+                            meta: "Recent turn snapshots",
+                          },
+                          { name: "blockers/", meta: "Operational blockers" },
+                          {
+                            name: "permission-blockers/",
+                            meta: "Permission-gated blockers",
+                          },
+                        ],
+                      },
+                      {
+                        name: "knowledge/",
+                        meta: "Durable recalled memory",
+                        children: [
+                          { name: "facts/", meta: "Stable workspace facts" },
+                          { name: "procedures/", meta: "Reusable workflows" },
+                          { name: "blockers/", meta: "Longer-lived blockers" },
+                          { name: "reference/", meta: "Reference material" },
+                        ],
+                      },
                     ],
                   },
-                  { name: "pi-sessions/...", meta: "Persisted Pi session state" },
                 ],
               },
             ],
@@ -117,53 +166,6 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
         accent: "context",
         children: [
           { name: "MEMORY.md", meta: "Memory system root" },
-          {
-            name: "workspace/",
-            meta: "Workspace-scoped memory",
-            children: [
-              {
-                name: "<workspace-id>/",
-                accent: "context",
-                children: [
-                  { name: "MEMORY.md", meta: "Workspace memory index" },
-                  {
-                    name: "runtime/",
-                    meta: "Resume-only continuity",
-                    children: [
-                      { name: "latest-turn.md", meta: "Last-turn projection" },
-                      {
-                        name: "session-state/",
-                        meta: "Session state projections",
-                      },
-                      {
-                        name: "session-memory/",
-                        meta: "Resume-friendly snapshots",
-                      },
-                      {
-                        name: "recent-turns/",
-                        meta: "Recent turn snapshots",
-                      },
-                      { name: "blockers/", meta: "Operational blockers" },
-                      {
-                        name: "permission-blockers/",
-                        meta: "Permission-gated blockers",
-                      },
-                    ],
-                  },
-                  {
-                    name: "knowledge/",
-                    meta: "Durable recalled memory",
-                    children: [
-                      { name: "facts/", meta: "Stable workspace facts" },
-                      { name: "procedures/", meta: "Reusable workflows" },
-                      { name: "blockers/", meta: "Longer-lived blockers" },
-                      { name: "reference/", meta: "Reference material" },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
           {
             name: "preference/",
             meta: "Durable user preferences",
@@ -260,17 +262,31 @@ If you are changing app behavior, continue into [App Anatomy](/docs/build/apps/a
 
 ### `.holaboss/`
 
-`<workspace-id>/.holaboss/` stores runtime-managed workspace state such as the identity marker, persisted harness session mapping, staged input attachments, and Pi harness state.
+`<workspace-id>/.holaboss/` now holds the workspace bundle's runtime-owned surfaces:
 
-`workspace/.holaboss/` is separate from the per-workspace `.holaboss/` directory. It stores shared workspace-root state for MCP sidecars and their logs.
+- `.holaboss/state/`
+  - workspace identity marker, persisted harness-session mapping, shared workspace SQLite, MCP sidecar state, todos, scratchpads, and archived session exports
+- `.holaboss/memory/`
+  - workspace-scoped runtime projections plus durable workspace knowledge
+- `.holaboss/input-attachments/`
+  - staged attachment batches referenced by in-flight runs
 
 ### `state/runtime.db`
 
-`state/runtime.db` is the durable runtime registry for workspaces, onboarding status/session state, sessions, bindings, queue state, turn results, request snapshots, durable memory catalog metadata, integration connections, integration bindings, output folders, app port allocation, runtime notifications, task proposals, evolve skill candidates, and memory update proposals. The `workspace_id` file exists mainly as an on-disk identity marker for workspace discovery and migration.
+`state/runtime.db` is the durable runtime registry for workspaces, onboarding status/session state, sessions, bindings, queue state, turn results, request snapshots, durable memory catalog metadata, integration connections, integration bindings, output folders, app port allocation, runtime notifications, task proposals, evolve skill candidates, and memory update proposals. The workspace identity file now lives at `<workspace-id>/.holaboss/state/workspace_id` as the on-disk marker for workspace discovery and migration.
 
 ### `memory/`
 
-`memory/` is OS-global, not part of a single workspace directory. It holds the markdown memory surfaces used by the runtime memory service.
+`memory/` is still OS-global, but it is now profile-global rather than workspace-global. It holds:
+
+- `MEMORY.md`
+  - the global memory index
+- `preference/`
+  - durable user preference memory
+- `identity/`
+  - durable user identity memory
+
+Workspace-scoped markdown memory now lives inside each workspace at `<workspace-id>/.holaboss/memory/`.
 
 ## What the runtime compiles per run
 

--- a/website/docs/content/docs/concepts/workspace-model.mdx
+++ b/website/docs/content/docs/concepts/workspace-model.mdx
@@ -16,8 +16,12 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
         children: [
           { name: "runtime-config.json", meta: "Model providers" },
           {
-            name: "runtime.db",
-            meta: "Sessions · turns · integrations · notifications",
+            name: "host-state.db",
+            meta: "Host bootstrap · diagnostics · compatibility",
+          },
+          {
+            name: "control-plane.db",
+            meta: "Workspaces · profiles · integrations · catalog",
           },
         ],
       },
@@ -72,6 +76,10 @@ Workspaces live under the runtime OS root. In desktop mode that root comes from 
                     meta: "Workspace runtime state",
                     children: [
                       { name: "workspace_id", meta: "Identity marker" },
+                      {
+                        name: "runtime.db",
+                        meta: "Sessions · turns · queues · outputs · notifications",
+                      },
                       {
                         name: "harness-session-state.json",
                         meta: "Harness session mapping",
@@ -271,9 +279,17 @@ If you are changing app behavior, continue into [App Anatomy](/docs/build/apps/a
 - `.holaboss/input-attachments/`
   - staged attachment batches referenced by in-flight runs
 
-### `state/runtime.db`
+### `state/host-state.db`
 
-`state/runtime.db` is the durable runtime registry for workspaces, onboarding status/session state, sessions, bindings, queue state, turn results, request snapshots, durable memory catalog metadata, integration connections, integration bindings, output folders, app port allocation, runtime notifications, task proposals, evolve skill candidates, and memory update proposals. The workspace identity file now lives at `<workspace-id>/.holaboss/state/workspace_id` as the on-disk marker for workspace discovery and migration.
+`state/host-state.db` is the sandbox-global host database. It keeps local host/bootstrap state, embedded-runtime diagnostics, and compatibility metadata used while older local installs migrate forward. It is no longer the canonical home for workspace execution truth.
+
+### `state/control-plane.db`
+
+`state/control-plane.db` is the sandbox-global control-plane database. It keeps workspace registry metadata, runtime user profiles, integration connections and bindings, OAuth app config, and app catalog metadata.
+
+### `<workspace-id>/.holaboss/state/runtime.db`
+
+`<workspace-id>/.holaboss/state/runtime.db` is the durable runtime execution database for one workspace. It keeps sessions, bindings, queue state, turn results, request snapshots, output folders, app runtime state, cronjobs, runtime notifications, task proposals, evolve skill candidates, memory update proposals, and workspace-scoped memory catalog metadata. The workspace identity file still lives alongside it at `<workspace-id>/.holaboss/state/workspace_id` as the on-disk marker for workspace discovery and migration.
 
 ### `memory/`
 

--- a/website/docs/content/docs/contribute/desktop/internals.mdx
+++ b/website/docs/content/docs/contribute/desktop/internals.mdx
@@ -39,7 +39,7 @@ The desktop does not talk to the runtime through a vague helper. `desktop/electr
 
 1. Resolve the staged runtime bundle under `desktop/out/runtime-<platform>` or an override such as `HOLABOSS_RUNTIME_ROOT`.
 2. Validate that the bundle includes the executable, packaged Node runtime, packaged Python runtime, `package-metadata.json`, and `runtime/api-server/dist/index.mjs`.
-3. Spawn `bin/sandbox-runtime` with desktop-owned env such as `HB_SANDBOX_ROOT`, `SANDBOX_AGENT_BIND_HOST=127.0.0.1`, `SANDBOX_AGENT_BIND_PORT=5160`, `SANDBOX_AGENT_HARNESS`, `HOLABOSS_RUNTIME_DB_PATH`, and the bridge settings.
+3. Spawn `bin/sandbox-runtime` with desktop-owned env such as `HB_SANDBOX_ROOT`, `SANDBOX_AGENT_BIND_HOST=127.0.0.1`, `SANDBOX_AGENT_BIND_PORT=5160`, `SANDBOX_AGENT_HARNESS`, `HOLABOSS_HOST_STATE_DB_PATH`, `HOLABOSS_CONTROL_PLANE_DB_PATH`, the legacy `HOLABOSS_RUNTIME_DB_PATH` alias, and the bridge settings.
 4. Wait for the embedded runtime health check to pass.
 5. Stream stdout and stderr into `runtime.log` under the Electron `userData` directory.
 6. On app quit, block final Electron exit until desktop-owned cleanup tears down the embedded runtime and browser service.
@@ -58,6 +58,8 @@ const child = spawn(launchSpec.command, launchSpec.args, {
     SANDBOX_AGENT_BIND_PORT: String(RUNTIME_API_PORT),
     HOLABOSS_EMBEDDED_RUNTIME: "1",
     SANDBOX_AGENT_HARNESS: harness,
+    HOLABOSS_HOST_STATE_DB_PATH: runtimeDatabasePath(),
+    HOLABOSS_CONTROL_PLANE_DB_PATH: controlPlaneDatabasePath(),
     HOLABOSS_RUNTIME_DB_PATH: runtimeDatabasePath(),
     PROACTIVE_ENABLE_REMOTE_BRIDGE: "1",
     HOLABOSS_AUTH_COOKIE: authCookieHeader() ?? "",

--- a/website/docs/content/docs/contribute/runtime/independent-deploy.mdx
+++ b/website/docs/content/docs/contribute/runtime/independent-deploy.mdx
@@ -76,7 +76,14 @@ By default, the runtime owns this directory shape under `HB_SANDBOX_ROOT`:
 ```text
 $HB_SANDBOX_ROOT/
   workspace/
+    <workspace-id>/
+      .holaboss/
+        memory/
+        state/
   memory/
+    MEMORY.md
+    preference/
+    identity/
   state/
     runtime.db
     runtime-config.json
@@ -88,7 +95,7 @@ $HB_SANDBOX_ROOT/
 
 | Variable | Why you set it |
 | --- | --- |
-| `HB_SANDBOX_ROOT` | Choose where the runtime keeps workspace, memory, and state data |
+| `HB_SANDBOX_ROOT` | Choose where the runtime keeps workspace bundles, profile-global memory, and runtime state |
 | `HOLABOSS_RUNTIME_CONFIG_PATH` | Override the default `state/runtime-config.json` location |
 | `SANDBOX_AGENT_BIND_HOST` | Bind the runtime to a specific host |
 | `SANDBOX_AGENT_BIND_PORT` | Bind the runtime to a specific port |
@@ -204,7 +211,7 @@ Independent deploy does not change the runtime contract:
 - workspace layout is still the same
 - `AGENTS.md` is still the instruction surface
 - `state/runtime.db` is still the durable runtime registry
-- `memory/` is still the durable memory store
+- `memory/` still holds the profile-global memory surfaces, while workspace-scoped memory lives under each workspace's `.holaboss/memory/`
 - app manifests still drive app lifecycle
 
 The main difference is deployment responsibility. Instead of being launched by the desktop app, the runtime is started directly on the machine that will host workspaces.

--- a/website/docs/content/docs/contribute/runtime/independent-deploy.mdx
+++ b/website/docs/content/docs/contribute/runtime/independent-deploy.mdx
@@ -80,12 +80,14 @@ $HB_SANDBOX_ROOT/
       .holaboss/
         memory/
         state/
+          runtime.db
   memory/
     MEMORY.md
     preference/
     identity/
   state/
-    runtime.db
+    host-state.db
+    control-plane.db
     runtime-config.json
 ```
 
@@ -100,7 +102,9 @@ $HB_SANDBOX_ROOT/
 | `SANDBOX_AGENT_BIND_HOST` | Bind the runtime to a specific host |
 | `SANDBOX_AGENT_BIND_PORT` | Bind the runtime to a specific port |
 | `SANDBOX_AGENT_HARNESS` | Select the harness path, currently `pi` in OSS |
-| `HOLABOSS_RUNTIME_DB_PATH` | Override the SQLite runtime DB path used by `runtime/state-store` |
+| `HOLABOSS_HOST_STATE_DB_PATH` | Override the sandbox-global host-state DB path used for host/bootstrap state |
+| `HOLABOSS_CONTROL_PLANE_DB_PATH` | Override the control-plane DB path used for workspace registry, profiles, and integrations |
+| `HOLABOSS_RUNTIME_DB_PATH` | Legacy alias for `HOLABOSS_HOST_STATE_DB_PATH` |
 | `HOLABOSS_SANDBOX_AUTH_TOKEN` | Provide product auth when you are running against the holaOS-backed model proxy path |
 | `HOLABOSS_USER_ID` | Provide the runtime user identity for auth-backed flows |
 | `HOLABOSS_MODEL_PROXY_BASE_URL` | Override the model-proxy base URL instead of relying on the default |
@@ -149,7 +153,8 @@ SANDBOX_AGENT_BIND_HOST=127.0.0.1 \
 SANDBOX_AGENT_BIND_PORT=8080 \
 SANDBOX_AGENT_HARNESS=pi \
 HOLABOSS_RUNTIME_WORKFLOW_BACKEND=remote_api \
-HOLABOSS_RUNTIME_DB_PATH=/var/lib/holaboss/state/runtime.db \
+HOLABOSS_HOST_STATE_DB_PATH=/var/lib/holaboss/state/host-state.db \
+HOLABOSS_CONTROL_PLANE_DB_PATH=/var/lib/holaboss/state/control-plane.db \
 PROACTIVE_ENABLE_REMOTE_BRIDGE=1 \
 PROACTIVE_BRIDGE_BASE_URL=https://your-bridge.example \
 holaboss-runtime
@@ -168,7 +173,8 @@ SANDBOX_AGENT_BIND_HOST=127.0.0.1 \
 SANDBOX_AGENT_BIND_PORT=8080 \
 SANDBOX_AGENT_HARNESS=pi \
 HOLABOSS_RUNTIME_WORKFLOW_BACKEND=remote_api \
-HOLABOSS_RUNTIME_DB_PATH="$HOME/Library/Application Support/HolabossRuntime/state/runtime.db" \
+HOLABOSS_HOST_STATE_DB_PATH="$HOME/Library/Application Support/HolabossRuntime/state/host-state.db" \
+HOLABOSS_CONTROL_PLANE_DB_PATH="$HOME/Library/Application Support/HolabossRuntime/state/control-plane.db" \
 PROACTIVE_ENABLE_REMOTE_BRIDGE=1 \
 PROACTIVE_BRIDGE_BASE_URL=https://your-bridge.example \
 holaboss-runtime
@@ -185,7 +191,8 @@ $env:SANDBOX_AGENT_BIND_HOST="127.0.0.1"
 $env:SANDBOX_AGENT_BIND_PORT="8080"
 $env:SANDBOX_AGENT_HARNESS="pi"
 $env:HOLABOSS_RUNTIME_WORKFLOW_BACKEND="remote_api"
-$env:HOLABOSS_RUNTIME_DB_PATH="$env:LOCALAPPDATA\holaboss\state\runtime.db"
+$env:HOLABOSS_HOST_STATE_DB_PATH="$env:LOCALAPPDATA\holaboss\state\host-state.db"
+$env:HOLABOSS_CONTROL_PLANE_DB_PATH="$env:LOCALAPPDATA\holaboss\state\control-plane.db"
 $env:PROACTIVE_ENABLE_REMOTE_BRIDGE="1"
 $env:PROACTIVE_BRIDGE_BASE_URL="https://your-bridge.example"
 
@@ -210,7 +217,9 @@ Independent deploy does not change the runtime contract:
 
 - workspace layout is still the same
 - `AGENTS.md` is still the instruction surface
-- `state/runtime.db` is still the durable runtime registry
+- each workspace still keeps execution truth in `<workspace-id>/.holaboss/state/runtime.db`
+- `state/host-state.db` now keeps sandbox-global host/bootstrap state
+- `state/control-plane.db` keeps workspace registry, runtime profiles, and integration metadata
 - `memory/` still holds the profile-global memory surfaces, while workspace-scoped memory lives under each workspace's `.holaboss/memory/`
 - app manifests still drive app lifecycle
 

--- a/website/docs/content/docs/contribute/runtime/run-compilation.mdx
+++ b/website/docs/content/docs/contribute/runtime/run-compilation.mdx
@@ -167,7 +167,7 @@ The runner then loads the context that is specific to this run:
 - operator surface context from the desktop browser capability base URL when desktop browser tooling is active
 - pending user-memory proposals for the current input
 
-Those inputs come from both filesystem state and `runtime.db`. They are runtime-owned context, not authored workspace config.
+Those inputs come from filesystem state plus the runtime-owned SQLite layers, primarily the workspace runtime DB and control-plane DB. They are runtime-owned context, not authored workspace config.
 
 ## Stage 5: Project Agent Runtime Config
 
@@ -235,7 +235,7 @@ After runtime config projection, the harness adapter builds the host request.
 
 - computes a request fingerprint
 - measures the `persist_turn_request_snapshot` bootstrap stage and calls `persistTurnRequestSnapshot()`
-- persists a sanitized `turn_request_snapshot` in `runtime.db`
+- persists a sanitized `turn_request_snapshot` in the workspace runtime DB
 - carries request-scoped execution metadata such as `thinking_value` into the reduced host request alongside the resolved model client
 - includes MCP server mapping metadata and bootstrap timing details in the run-started payload
 - launches the harness host with the reduced request payload

--- a/website/docs/content/docs/contribute/runtime/state-store.mdx
+++ b/website/docs/content/docs/contribute/runtime/state-store.mdx
@@ -36,7 +36,7 @@ If the runtime needs durable state that is not just a file in the workspace, it 
 The store also resolves workspace paths from:
 
 - the workspace registry row
-- the workspace identity file under `.holaboss/workspace_id`
+- the workspace identity file under `.holaboss/state/workspace_id`
 - fallback discovery under the runtime workspace root
 
 That means the runtime uses both the database and filesystem markers to keep workspace discovery stable.
@@ -96,7 +96,8 @@ The package also loads `sqlite-vec` when available so memory recall can use vect
 
 Important distinction:
 
-- the markdown memory documents still live on disk under `memory/`
+- workspace-scoped markdown memory lives on disk under each workspace's `.holaboss/memory/`
+- profile-global markdown memory still lives under `memory/preference/`, `memory/identity/`, and the root `MEMORY.md`
 - the runtime-state-store keeps the searchable registry and embedding index around those documents
 
 ### Workspace-visible product state
@@ -171,8 +172,9 @@ The runtime currently uses:
 
 - `runtime.db` for registry, queue, and durable runtime metadata
 - workspace files for authored config and app/template state
-- `memory/` markdown files for durable memory content
-- `.holaboss/` under each workspace for workspace-local runtime state such as the identity marker and harness session mapping
+- `.holaboss/memory/` under each workspace for workspace-scoped markdown memory
+- global `memory/` for profile-global memory
+- `.holaboss/state/` under each workspace for workspace-local runtime state such as the identity marker and harness session mapping
 
 That split is deliberate. The database tracks runtime truth around the workspace; it does not become the workspace.
 

--- a/website/docs/content/docs/contribute/runtime/state-store.mdx
+++ b/website/docs/content/docs/contribute/runtime/state-store.mdx
@@ -1,9 +1,9 @@
 ---
 title: Runtime State Store
-description: SQLite-backed state store for sessions, inputs, and artifacts.
+description: SQLite-backed state store for host, control-plane, and workspace execution data.
 ---
 
-Use this page when you are changing `runtime.db`, queue behavior, continuity records, or any runtime-owned persistent state.
+Use this page when you are changing `host-state.db`, `control-plane.db`, workspace runtime DBs, queue behavior, continuity records, or any runtime-owned persistent state.
 
 The source of truth is:
 
@@ -13,25 +13,33 @@ The source of truth is:
 
 ## What This Package Owns
 
-`@holaboss/runtime-state-store` is the durable SQLite registry for the runtime.
+`@holaboss/runtime-state-store` owns the runtime's durable SQLite surfaces.
 
 It does not replace the workspace filesystem or the markdown memory tree. It stores the runtime-owned metadata around them:
 
-- workspace registry and discovery
-- session and harness binding state
-- input and post-run job queues
-- turn results and request snapshots
-- memory registry metadata and vector index entries
-- outputs, app build state, cronjobs, notifications, and proposals
+- host/bootstrap state for the local embedded runtime
+- control-plane metadata such as workspace registry, runtime profiles, and integrations
+- workspace execution state such as sessions, queues, outputs, turns, and notifications
+- durable memory registry metadata and vector index entries
 
 If the runtime needs durable state that is not just a file in the workspace, it usually lands here.
 
-## Where `runtime.db` Lives
+## Where the SQLite surfaces live
 
-`runtimeDbPath()` resolves the database path this way:
+`hostStateDbPath()` resolves the sandbox-global host-state path this way:
 
-- `HOLABOSS_RUNTIME_DB_PATH` if set
-- else `<sandboxRoot>/state/runtime.db`
+- `HOLABOSS_HOST_STATE_DB_PATH` if set
+- else `HOLABOSS_RUNTIME_DB_PATH` as a legacy alias
+- else `<sandboxRoot>/state/host-state.db`
+
+`controlPlaneDbPath()` defaults to:
+
+- `HOLABOSS_CONTROL_PLANE_DB_PATH` if set
+- else `<sandboxRoot>/state/control-plane.db`
+
+Workspace execution state lives at:
+
+- `<workspaceRoot>/<workspace-id>/.holaboss/state/runtime.db`
 
 The store also resolves workspace paths from:
 
@@ -43,16 +51,41 @@ That means the runtime uses both the database and filesystem markers to keep wor
 
 ## Major Record Families
 
-### Workspace and session registry
+### Control-plane metadata
 
-The store owns:
+`control-plane.db` owns:
 
 - `workspaces`
+- `runtime_user_profiles`
+- `integration_connections`
+- `integration_bindings`
+- `oauth_app_configs`
+- `app_catalog`
+
+This is the durable product/control metadata that exists above one workspace run.
+
+### Workspace execution state
+
+Each workspace runtime DB owns:
+
 - `agent_sessions`
 - session-to-harness bindings
 - session runtime state
+- queue records and leases
+- continuity artifacts such as turn results, request snapshots, and output events
+- outputs, app build/runtime state, cronjobs, notifications, and proposals
 
-This is the durable registry that tells the runtime which workspaces and sessions exist, which harness path they use, and whether a session is idle, busy, waiting on user input, or errored.
+This is the durable execution truth for one workspace: which sessions exist, what the runtime is currently doing, and which artifacts must survive a restart.
+
+### Host/bootstrap state
+
+`host-state.db` keeps only sandbox-global host concerns such as:
+
+- local embedded-runtime bootstrap state
+- desktop/runtime process diagnostics
+- compatibility mirrors needed during migration from older local layouts
+
+This is deliberately not the home for workspace execution state anymore.
 
 ### Queues and leases
 
@@ -71,11 +104,11 @@ Both support:
 - optional `distinctSessions` claiming so one worker does not take multiple queued items from the same session in one batch
 - input claiming can also exclude specific session ids so queue workers do not claim a second active run for a session that is already executing
 
-This is the runtime’s queue and lease model. If job pickup or replay behavior is wrong, inspect these records before you patch workers.
+This is the runtime's queue and lease model. If job pickup or replay behavior is wrong, inspect the workspace runtime DB records before you patch workers.
 
 ### Continuity and replay state
 
-The store persists:
+The workspace runtime DB persists:
 
 - session messages
 - output events
@@ -86,7 +119,7 @@ This is part of the persistent continuity seam between runs. It is how the runti
 
 ### Memory registry and vector index
 
-The store tracks memory metadata with:
+The state store tracks memory metadata with:
 
 - runtime user profile rows
 - memory entries
@@ -98,18 +131,17 @@ Important distinction:
 
 - workspace-scoped markdown memory lives on disk under each workspace's `.holaboss/memory/`
 - profile-global markdown memory still lives under `memory/preference/`, `memory/identity/`, and the root `MEMORY.md`
-- the runtime-state-store keeps the searchable registry and embedding index around those documents
+- workspace-scoped memory metadata lives in the corresponding workspace runtime DB
+- profile-global memory metadata and canonical runtime profiles live in `control-plane.db`
 
 ### Workspace-visible product state
 
-The same database also stores:
+Workspace runtime DBs also store:
 
 - output folders and outputs
 - app builds, app restart-attempt counters, and app port allocation
-- app catalog metadata
 - cronjobs
 - runtime notifications
-- OAuth app config
 - task proposals
 - evolve skill candidates
 - memory update proposals
@@ -170,7 +202,9 @@ Do not collapse the persistence model into one place.
 
 The runtime currently uses:
 
-- `runtime.db` for registry, queue, and durable runtime metadata
+- `state/host-state.db` for sandbox-global host/bootstrap state
+- `state/control-plane.db` for registry, profiles, and integrations
+- `<workspace-id>/.holaboss/state/runtime.db` for workspace execution truth and workspace-scoped runtime metadata
 - workspace files for authored config and app/template state
 - `.holaboss/memory/` under each workspace for workspace-scoped markdown memory
 - global `memory/` for profile-global memory
@@ -186,9 +220,9 @@ Current migration seams in `store.ts` include:
 
 - workspace-table migration and workspace-path recovery
 - legacy session-artifact migration into outputs
+- legacy `state/runtime.db` rename/migration into `state/host-state.db`
 - runtime-notification priority normalization
 - cronjob instruction migration
-- sandbox run-token table migration
 - queue/runtime-state lease-column migrations
 - app-build `restart_attempts` persistence migration
 
@@ -216,7 +250,7 @@ For development, the tests are usually the better executable reference than manu
 The CLI expects `cli <operation> --request-base64 <base64-json>`. A representative claim flow looks like this:
 
 ```bash
-REQ='{"options":{"dbPath":"/tmp/runtime.db","workspaceRoot":"/tmp/workspace"},"claimed_by":"worker-1","limit":2,"lease_seconds":60,"distinct_sessions":true}'
+REQ='{"options":{"dbPath":"/tmp/host-state.db","workspaceRoot":"/tmp/workspace"},"claimed_by":"worker-1","limit":2,"lease_seconds":60,"distinct_sessions":true}'
 holaboss-state-store claim-inputs --request-base64 "$(printf '%s' "$REQ" | base64 | tr -d '\n')"
 ```
 

--- a/website/docs/content/docs/reference/environment-variables.mdx
+++ b/website/docs/content/docs/reference/environment-variables.mdx
@@ -22,7 +22,9 @@ The tables below focus on the names that are already used in the current repo an
 | `SANDBOX_AGENT_BIND_PORT` | Runtime API port. |
 | `SANDBOX_AGENT_HARNESS` | Harness selector, typically `pi`. |
 | `HOLABOSS_RUNTIME_WORKFLOW_BACKEND` | Workflow backend selector used by the runtime. |
-| `HOLABOSS_RUNTIME_DB_PATH` | Path to the SQLite runtime database. |
+| `HOLABOSS_HOST_STATE_DB_PATH` | Preferred override for the sandbox-global host-state SQLite path. |
+| `HOLABOSS_CONTROL_PLANE_DB_PATH` | Optional override for the control-plane SQLite path. |
+| `HOLABOSS_RUNTIME_DB_PATH` | Legacy alias for `HOLABOSS_HOST_STATE_DB_PATH`. |
 | `HOLABOSS_RUNTIME_CONFIG_PATH` | Optional override for `runtime-config.json`. |
 | `HOLABOSS_DEFAULT_MODEL` | Default model id used when one is not selected explicitly. |
 | `HOLABOSS_MODEL_PROXY_BASE_URL` | Proxy base URL for model routing. |


### PR DESCRIPTION
## Context
- refactor local workspace storage toward a self-contained workspace bundle so workspace-scoped state can move with the workspace
- align the local runtime layout with the cloud-workspace direction without changing the remaining profile-global surfaces
- preserve compatibility with existing workspaces by migrating legacy paths forward on access

## What Changed
- move workspace-scoped markdown memory into `<workspace>/.holaboss/memory`
- move workspace-scoped runtime state into `<workspace>/.holaboss/state`
- keep profile-global preference and identity memory, plus runtime config, under the sandbox root
- add compatibility helpers that migrate legacy workspace memory, identity files, harness session state, todos, scratchpads, MCP sidecar state, and legacy session exports into the bundled workspace layout
- update runtime, desktop, harness, and tests to resolve workspace-scoped paths through the new bundle helpers
- refresh workspace and memory docs to describe the bundled local model and the remaining global state

## Validation
- `node --import tsx --test src/store.test.ts`
- `node --import tsx --test src/memory.test.ts src/memory-recall-manifest.test.ts src/session-todo.test.ts src/ts-runner-session-state.test.ts src/runtime-agent-tools.test.ts src/tool-result-preview.test.ts src/agent-runtime-prompt.test.ts src/ts-runner.test.ts src/app.test.ts`
- `npm run typecheck` in `runtime/state-store`
- `npm run typecheck` in `runtime/api-server`
- `node --test desktop/electron/workspace-git.test.mjs`
