### PR TITLE
perf(desktop): disable Sentry attachScreenshot, root cause of idle 100% CPU

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -9,7 +9,16 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: !!process.env.SENTRY_DSN,
   enableLogs: !!process.env.SENTRY_DSN,
-  attachScreenshot: !!process.env.SENTRY_DSN,
+  // attachScreenshot was the dominant idle-CPU culprit on desktop: when true,
+  // the @sentry/electron screenshots integration calls
+  // `BrowserWindow.capturePage()` + `toPNG()` inside `processEvent` for every
+  // non-transaction event the SDK ships — and `enableLogs` + the console
+  // logging integration below funnel info/warn/error console writes through
+  // that same path. CPU profile on a fresh idle launch attributed >70% of
+  // process time to a single `processEvent` frame in screenshots.js.
+  // If we ever want screenshots in crash reports, capture them manually
+  // inside `beforeSend` and gate on `event.level === "fatal"`.
+  attachScreenshot: false,
   maxBreadcrumbs: 200,
   integrations: [
     Sentry.consoleLoggingIntegration({


### PR DESCRIPTION
## TL;DR
Idle desktop runs (both \`npm run dev\` and packaged builds) sat at 70–110% CPU on the Electron main process while the user did nothing. Root cause: \`@sentry/electron\`'s screenshots integration was capturing the entire window via \`webContents.capturePage()\` + PNG-encoding it for **every** Sentry event the SDK fired — and the existing config was generating a lot of events.

This PR turns the screenshot attachment off. One-line behavior change.

## How we found it

Captured a \`--cpu-prof\` of the Electron main process on a fresh idle launch (no user interaction):

\`\`\`bash
NODE_OPTIONS=\"--cpu-prof --cpu-prof-dir=/tmp/holaos-cpuprof --cpu-prof-interval=500\" \\
  npm run dev
# wait ~150s, SIGTERM electron, parse the .cpuprofile
\`\`\`

Top-1 self-time frame in a 153s capture:

| self ms | incl ms | function | location |
| ---: | ---: | --- | --- |
| **110009** | **110009** | \`processEvent\` | \`@sentry/electron/main/integrations/screenshots.js:10\` |
| 34126 | 34126 | (idle) | — |
| 3034 | 3034 | (gc) | — |
| 575 | 576 | \`getAppMemory\` | \`@sentry/electron/main/integrations/electron-context.js:6\` |
| ... | ... | (everything else is sub-1%) | ... |

That single \`processEvent\` frame is **71.6%** of the process CPU time — for as long as the app was open. Every other hot frame in the profile was a downstream effect (sentry context-gather, persistRuntimeProcessState, sqlite \`prepare\` calls all sit at <1%).

## Why this fired so hard

\`@sentry/electron\`'s screenshots integration looks like this (\`screenshots.js\`):

\`\`\`js
async processEvent(event, hint, client) {
  const attachScreenshot = !!client.getOptions().attachScreenshot;
  if (!attachScreenshot) return event;
  if (!event.transaction && event.platform !== 'native') {
    for (const window of electron.BrowserWindow.getAllWindows()) {
      if (!window.isDestroyed() && window.isVisible()) {
        const image = await window.capturePage();           // GPU compositor read
        hint.attachments.push({ data: image.toPNG(), ... }); // CPU PNG encode
      }
    }
  }
  return event;
}
\`\`\`

It runs on **every non-transaction event** the SDK is about to send.

The previous \`Sentry.init\` had:
- \`enableLogs: !!process.env.SENTRY_DSN\` — turn console writes into Sentry log events
- \`Sentry.consoleLoggingIntegration({ levels: [\"info\", \"warn\", \"error\"] })\` — and those console writes are info/warn/error
- \`attachScreenshot: !!process.env.SENTRY_DSN\` — and screenshot every one of them

So every \`console.info\` / \`console.warn\` / \`console.error\` from anywhere in the main process fed an event into the screenshots integration → \`capturePage\` → \`toPNG\`. The desktop logs liberally during normal operation; the steady stream was enough to keep the GPU compositor and PNG encoder busy continuously.

## The fix

\`\`\`diff
- attachScreenshot: !!process.env.SENTRY_DSN,
+ // attachScreenshot was the dominant idle-CPU culprit on desktop... [comment]
+ attachScreenshot: false,
\`\`\`

Sentry's other context-attachment paths (errors, breadcrumbs, scopes, tags) are unaffected — only the per-event window capture is turned off.

## If we ever want screenshots back

The right place is \`beforeSend(event, hint)\` — it already exists in the same config. Capture once per real crash:

\`\`\`ts
beforeSend(event, hint) {
  if (event.level === \"fatal\") {
    // capturePage one window, push to hint.attachments here
  }
  return enrichDesktopSentryEvent(event, hint);
}
\`\`\`

That's one capture per actual error report, not one per log line. Out of scope for this PR.

## Test plan

- [ ] \`npm run dev\` → wait 30s idle → Activity Monitor shows main electron at <5% CPU (was 70–110%)
- [ ] Sentry breadcrumbs / errors still attach context (process metadata, breadcrumbs, scopes) when checked against the Sentry dashboard for an injected test error
- [ ] Packaged build via \`desktop:dist:mac:local\` shows the same drop
- [ ] No regressions to existing \`beforeSend\` / \`enrichDesktopSentryEvent\` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)