### PR TITLE
perf(chat): bump history page size 10→50 to cut load-earlier churn

### DIFF
--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -362,7 +362,14 @@ const STREAM_ATTACH_PENDING = "__stream_attach_pending__";
 const STREAM_TELEMETRY_LIMIT = 240;
 const TOOL_TRACE_TERMINAL_PHASES = new Set(["completed", "failed", "error"]);
 const CHAT_AUTO_SCROLL_THRESHOLD_PX = 72;
-const CHAT_HISTORY_PAGE_SIZE = 10;
+// Drives both the initial session-open fetch and each "load earlier" pull.
+// Was 10 originally — small enough that scroll-restoration after a prepend
+// often left the user still inside the 96px top threshold, immediately
+// triggering the next load. The runtime caps `limit` at 1000 (default 200);
+// 50 keeps the per-call work bounded while making any single load earn
+// enough vertical content (~25 turns) to push the user well past the
+// re-trigger threshold.
+const CHAT_HISTORY_PAGE_SIZE = 50;
 const CHAT_HISTORY_TOP_LOAD_THRESHOLD_PX = 96;
 const COMPOSER_FOOTER_GAP_PX = 8;
 const COMPOSER_FULL_MODEL_CONTROL_WIDTH_PX = 240;


### PR DESCRIPTION
## Problem
\"Loading earlier messages...\" in ChatPane fires too often. On a long session with many short messages (user prompts, small tool calls), scrolling near the top kicks off back-to-back fetches — chip flickers, scroll position keeps jumping.

## Root cause
\`ChatPane.tsx:7720-7724\`:

\`\`\`ts
onScroll={(event) => {
  // ...
  if (currentTarget.scrollTop <= CHAT_HISTORY_TOP_LOAD_THRESHOLD_PX) {
    void loadOlderSessionHistory();
  }
}}
\`\`\`

That threshold is 96 px. \`loadOlderSessionHistory\` itself is properly serialized (\`isLoadingOlderHistoryRef.current\` guard short-circuits concurrent calls), but each successful pull only added **10 messages** — \`CHAT_HISTORY_PAGE_SIZE = 10\`. After the prepend the scroll handler re-anchors against \`scrollHeight\` so the user stays at the same logical position relative to the new content; with only 10 short messages the new content above is often less than 96 px, so the user is still inside the trigger zone the moment the load completes. Next scroll event → fires again. Loop visible to the user.

## Fix
Bump \`CHAT_HISTORY_PAGE_SIZE\` from 10 to 50. The runtime endpoint already accepts \`limit\` up to 1000 with a default of 200 — 50 is the conservative middle ground that earns ~25 turns of content per pull, enough to push the post-prepend scroll position well below the 96 px threshold.

\`\`\`diff
-const CHAT_HISTORY_PAGE_SIZE = 10;
+const CHAT_HISTORY_PAGE_SIZE = 50;
\`\`\`

No other behavior changes. The existing reentry guard, scroll-restoration math, and total/loaded counters all carry through unchanged.

## Test plan
- [ ] Open a session with > 100 messages, scroll to top — \"Loading earlier messages...\" appears once per scroll-to-top, not in rapid succession
- [ ] Initial session open still snappy (50 messages × first paint is fine; runtime returns ~ms)
- [ ] Existing pagination tests still pass: \`ChatPane.history-pagination.test.mjs\`, \`ChatPaneHistoryLoading.test.mjs\`, \`session-history-pagination.test.mjs\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)