### PR TITLE
perf+ui+fix: desktop follow-up batch (sentry gating, sqlite caching, chat spacing, browser detach)

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4256,6 +4256,50 @@ function openRuntimeDatabase() {
   return database;
 }
 
+/**
+ * Module-scoped sqlite handles + prepared statements registered through this
+ * helper survive across calls so a hot helper (e.g. `getWorkspaceRecord`,
+ * `appendRuntimeEventLog`) doesn't pay a fresh `new Database` + `prepare`
+ * cycle on every IPC hit. The closer-the-hot-path-the-bigger-the-savings:
+ * a 114s --cpu-prof showed `prepare` self-time of 261 ms in
+ * `readPersistedRuntimeProcessState` from the Sentry context path alone.
+ *
+ * Lifetime: the registered disposer fires from `ensureAppQuitCleanup`.
+ * On runtime errors the caller drops its own cache via the supplied
+ * `invalidate()` so a transient sqlite hiccup doesn't poison the singleton.
+ */
+type CachedRuntimeStatement = {
+  get: () => Database.Statement;
+  invalidate: () => void;
+};
+const cachedRuntimeStatementDisposers: Array<() => void> = [];
+function cacheRuntimeStatement(sql: string): CachedRuntimeStatement {
+  let database: Database.Database | null = null;
+  let statement: Database.Statement | null = null;
+  const disposer = () => {
+    try {
+      database?.close();
+    } catch {
+      // ignore close errors during teardown
+    }
+    database = null;
+    statement = null;
+  };
+  cachedRuntimeStatementDisposers.push(disposer);
+  return {
+    get() {
+      if (!database) {
+        database = openRuntimeDatabase();
+      }
+      if (!statement) {
+        statement = database.prepare(sql);
+      }
+      return statement;
+    },
+    invalidate: disposer,
+  };
+}
+
 function migrateLocalWorkspacesTable(database: Database.Database) {
   const tableInfo = database
     .prepare("PRAGMA table_info(workspaces)")
@@ -4744,69 +4788,71 @@ type PersistedRuntimeProcessStateRecord = {
   updatedAt: string;
 };
 
+const readPersistedRuntimeProcessStateStatement = cacheRuntimeStatement(`
+  SELECT
+    pid,
+    status,
+    bind_host,
+    bind_port,
+    base_url,
+    launch_id,
+    sandbox_root,
+    last_started_at,
+    last_stopped_at,
+    last_healthy_at,
+    last_error,
+    updated_at
+  FROM runtime_process_state
+  WHERE process_key = ?
+  LIMIT 1
+`);
+
 function readPersistedRuntimeProcessState(): PersistedRuntimeProcessStateRecord | null {
-  const database = openRuntimeDatabase();
+  let row:
+    | {
+        pid: number | null;
+        status: string;
+        bind_host: string | null;
+        bind_port: number | null;
+        base_url: string | null;
+        launch_id: string | null;
+        sandbox_root: string | null;
+        last_started_at: string | null;
+        last_stopped_at: string | null;
+        last_healthy_at: string | null;
+        last_error: string | null;
+        updated_at: string;
+      }
+    | undefined;
   try {
-    const row = database
-      .prepare(
-        `
-        SELECT
-          pid,
-          status,
-          bind_host,
-          bind_port,
-          base_url,
-          launch_id,
-          sandbox_root,
-          last_started_at,
-          last_stopped_at,
-          last_healthy_at,
-          last_error,
-          updated_at
-        FROM runtime_process_state
-        WHERE process_key = ?
-        LIMIT 1
-      `,
-      )
-      .get("embedded-runtime") as
-      | {
-          pid: number | null;
-          status: string;
-          bind_host: string | null;
-          bind_port: number | null;
-          base_url: string | null;
-          launch_id: string | null;
-          sandbox_root: string | null;
-          last_started_at: string | null;
-          last_stopped_at: string | null;
-          last_healthy_at: string | null;
-          last_error: string | null;
-          updated_at: string;
-        }
-      | undefined;
-    if (!row) {
-      return null;
-    }
-    return {
-      pid: typeof row.pid === "number" ? row.pid : null,
-      status: row.status,
-      bindHost: row.bind_host,
-      bindPort: typeof row.bind_port === "number" ? row.bind_port : null,
-      baseUrl: row.base_url,
-      launchId: row.launch_id,
-      sandboxRoot: row.sandbox_root,
-      lastStartedAt: row.last_started_at,
-      lastStoppedAt: row.last_stopped_at,
-      lastHealthyAt: row.last_healthy_at,
-      lastError: row.last_error,
-      updatedAt: row.updated_at,
-    };
+    row = readPersistedRuntimeProcessStateStatement.get().get("embedded-runtime") as typeof row;
   } catch {
+    readPersistedRuntimeProcessStateStatement.invalidate();
     return null;
-  } finally {
-    database.close();
   }
+  if (!row) {
+    return null;
+  }
+  return {
+    pid: typeof row.pid === "number" ? row.pid : null,
+    status: row.status,
+    bindHost: row.bind_host,
+    bindPort: typeof row.bind_port === "number" ? row.bind_port : null,
+    baseUrl: row.base_url,
+    launchId: row.launch_id,
+    sandboxRoot: row.sandbox_root,
+    lastStartedAt: row.last_started_at,
+    lastStoppedAt: row.last_stopped_at,
+    lastHealthyAt: row.last_healthy_at,
+    lastError: row.last_error,
+    updatedAt: row.updated_at,
+  };
 }
+
+const appendRuntimeEventLogStatement = cacheRuntimeStatement(`
+  INSERT INTO event_log (category, event, outcome, detail, created_at)
+  VALUES (?, ?, ?, ?, ?)
+`);
 
 function appendRuntimeEventLog(event: {
   category: string;
@@ -4828,24 +4874,17 @@ function appendRuntimeEventLog(event: {
       detail: event.detail ?? null,
     },
   });
-  const database = openRuntimeDatabase();
   try {
-    database
-      .prepare(
-        `
-        INSERT INTO event_log (category, event, outcome, detail, created_at)
-        VALUES (?, ?, ?, ?, ?)
-      `,
-      )
-      .run(
-        event.category,
-        event.event,
-        event.outcome,
-        event.detail ?? null,
-        utcNowIso(),
-      );
-  } finally {
-    database.close();
+    appendRuntimeEventLogStatement.get().run(
+      event.category,
+      event.event,
+      event.outcome,
+      event.detail ?? null,
+      utcNowIso(),
+    );
+  } catch (error) {
+    appendRuntimeEventLogStatement.invalidate();
+    throw error;
   }
 }
 
@@ -12717,37 +12756,37 @@ function updateQueuedInputStatus(inputId: string, status: string) {
   }
 }
 
+const getWorkspaceRecordStatement = cacheRuntimeStatement(`
+  SELECT
+    id,
+    name,
+    status,
+    harness,
+    error_message,
+    onboarding_status,
+    onboarding_session_id,
+    onboarding_completed_at,
+    onboarding_completion_summary,
+    onboarding_requested_at,
+    onboarding_requested_by,
+    created_at,
+    updated_at,
+    deleted_at_utc
+  FROM workspaces
+  WHERE id = @id
+`);
+
 function getWorkspaceRecord(
   workspaceId: string,
 ): WorkspaceRecordPayload | null {
-  const database = openRuntimeDatabase();
   try {
-    const row = database
-      .prepare(
-        `
-        SELECT
-          id,
-          name,
-          status,
-          harness,
-          error_message,
-          onboarding_status,
-          onboarding_session_id,
-          onboarding_completed_at,
-          onboarding_completion_summary,
-          onboarding_requested_at,
-          onboarding_requested_by,
-          created_at,
-          updated_at,
-          deleted_at_utc
-        FROM workspaces
-        WHERE id = @id
-      `,
-      )
-      .get({ id: workspaceId }) as WorkspaceRecordPayload | undefined;
+    const row = getWorkspaceRecordStatement.get().get({ id: workspaceId }) as
+      | WorkspaceRecordPayload
+      | undefined;
     return row ?? null;
-  } finally {
-    database.close();
+  } catch {
+    getWorkspaceRecordStatement.invalidate();
+    return null;
   }
 }
 
@@ -15503,6 +15542,15 @@ async function ensureAppQuitCleanup(): Promise<void> {
         }
         cachedRuntimeProcessStateDatabase = null;
         cachedRuntimeProcessStateStatement = null;
+        // Release every long-lived sqlite handle/statement registered via
+        // `cacheRuntimeStatement`. Best-effort — the next launch re-opens.
+        for (const dispose of cachedRuntimeStatementDisposers) {
+          try {
+            dispose();
+          } catch {
+            // ignore
+          }
+        }
       });
   }
   await appQuitCleanupPromise;

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4172,26 +4172,15 @@ function enrichDesktopSentryEvent(
     delete event.request.headers["x-api-key"];
   }
 
-  // Lightweight tags always — these are cheap and helpful even for
-  // info/warn-level events the console-logging integration funnels in.
   event.tags = {
     ...(event.tags ?? {}),
     desktop_launch_id: DESKTOP_LAUNCH_ID,
     process_kind: "electron_main",
   };
 
-  // Everything below — sqlite reads, three file attachments, four count
-  // queries on the diagnostics database, plus full event-log / session-state
-  // dumps — only earns its keep when an actual error or fatal event is
-  // about to ship to Sentry. With `enableLogs: true` and the console
-  // integration in the same `Sentry.init`, every console.info /
-  // console.warn / console.error becomes a Sentry event and would
-  // otherwise re-run this whole diagnostics pipeline. A 114s `--cpu-prof`
-  // attributed 261 ms of self-time to a single
-  // `readPersistedRuntimeProcessState` prepare hit from here, plus 234 ms
-  // in `getAppMemory` from `@sentry/electron`'s electron-context
-  // integration which fires alongside us on every event. Gate by level so
-  // the hot path is just tag-set + secret-strip.
+  // Skip the heavy diagnostics path (sqlite reads, file attachments, event-log
+  // dumps) for non-error events — `enableLogs: true` funnels every console.*
+  // call through here.
   const level = event.level;
   const isErrorish =
     level === "fatal" ||
@@ -4256,18 +4245,7 @@ function openRuntimeDatabase() {
   return database;
 }
 
-/**
- * Module-scoped sqlite handles + prepared statements registered through this
- * helper survive across calls so a hot helper (e.g. `getWorkspaceRecord`,
- * `appendRuntimeEventLog`) doesn't pay a fresh `new Database` + `prepare`
- * cycle on every IPC hit. The closer-the-hot-path-the-bigger-the-savings:
- * a 114s --cpu-prof showed `prepare` self-time of 261 ms in
- * `readPersistedRuntimeProcessState` from the Sentry context path alone.
- *
- * Lifetime: the registered disposer fires from `ensureAppQuitCleanup`.
- * On runtime errors the caller drops its own cache via the supplied
- * `invalidate()` so a transient sqlite hiccup doesn't poison the singleton.
- */
+// Cached sqlite handle + statement, disposed via `ensureAppQuitCleanup`.
 type CachedRuntimeStatement = {
   get: () => Database.Statement;
   invalidate: () => void;
@@ -4280,7 +4258,7 @@ function cacheRuntimeStatement(sql: string): CachedRuntimeStatement {
     try {
       database?.close();
     } catch {
-      // ignore close errors during teardown
+      // ignore
     }
     database = null;
     statement = null;
@@ -15532,18 +15510,13 @@ async function ensureAppQuitCleanup(): Promise<void> {
       })
       .finally(() => {
         appQuitCleanupPromise = null;
-        // Release the long-lived sqlite handle held by
-        // `persistRuntimeProcessState`. Best-effort — the next launch
-        // re-opens fresh.
         try {
           cachedRuntimeProcessStateDatabase?.close();
         } catch {
-          // ignore close errors during teardown
+          // ignore
         }
         cachedRuntimeProcessStateDatabase = null;
         cachedRuntimeProcessStateStatement = null;
-        // Release every long-lived sqlite handle/statement registered via
-        // `cacheRuntimeStatement`. Best-effort — the next launch re-opens.
         for (const dispose of cachedRuntimeStatementDisposers) {
           try {
             dispose();
@@ -19415,16 +19388,9 @@ async function setActiveBrowserWorkspace(
         SESSION_BROWSER_BUSY_CHECK_MS,
       );
     }
-    // The renderer calls `browser.setActiveWorkspace(null)` from
-    // workspaceSelection.tsx whenever the selected workspace clears —
-    // typically when entering Workspace Control Center. Without this
-    // updateAttachedBrowserView call the BrowserView from the
-    // previously-active workspace stays parented to mainWindow with its
-    // last-known bounds, painting on top of the multi-workspace overview
-    // (the symptom is e.g. an `about.google` cookie banner stuck across
-    // every chat pane). The hot-path detach goes through `setBounds(0,0)`
-    // on BrowserPane unmount, but that's only reliable when BrowserPane
-    // was actually mounted in the workspace we're leaving.
+    // Detach the previous workspace's BrowserView when the active workspace
+    // clears (e.g. entering Workspace Control Center) — otherwise it keeps
+    // painting over the new view at its old bounds.
     updateAttachedBrowserView();
     emitBrowserState();
     emitBookmarksState();

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4171,6 +4171,36 @@ function enrichDesktopSentryEvent(
     delete event.request.headers.cookie;
     delete event.request.headers["x-api-key"];
   }
+
+  // Lightweight tags always — these are cheap and helpful even for
+  // info/warn-level events the console-logging integration funnels in.
+  event.tags = {
+    ...(event.tags ?? {}),
+    desktop_launch_id: DESKTOP_LAUNCH_ID,
+    process_kind: "electron_main",
+  };
+
+  // Everything below — sqlite reads, three file attachments, four count
+  // queries on the diagnostics database, plus full event-log / session-state
+  // dumps — only earns its keep when an actual error or fatal event is
+  // about to ship to Sentry. With `enableLogs: true` and the console
+  // integration in the same `Sentry.init`, every console.info /
+  // console.warn / console.error becomes a Sentry event and would
+  // otherwise re-run this whole diagnostics pipeline. A 114s `--cpu-prof`
+  // attributed 261 ms of self-time to a single
+  // `readPersistedRuntimeProcessState` prepare hit from here, plus 234 ms
+  // in `getAppMemory` from `@sentry/electron`'s electron-context
+  // integration which fires alongside us on every event. Gate by level so
+  // the hot path is just tag-set + secret-strip.
+  const level = event.level;
+  const isErrorish =
+    level === "fatal" ||
+    level === "error" ||
+    Boolean(event.exception?.values?.length);
+  if (!isErrorish) {
+    return event;
+  }
+
   const diagnostics = readDesktopRuntimeDiagnosticsSnapshot();
   const diagnosticsAttachment = {
     filename: "desktop-runtime-diagnostics.json",
@@ -4180,11 +4210,6 @@ function enrichDesktopSentryEvent(
   addSentryHintAttachment(hint, diagnosticsAttachment);
   addSentryHintAttachment(hint, runtimeLogTailAttachment());
   addSentryHintAttachment(hint, redactedRuntimeConfigAttachment());
-  event.tags = {
-    ...(event.tags ?? {}),
-    desktop_launch_id: DESKTOP_LAUNCH_ID,
-    process_kind: "electron_main",
-  };
   event.contexts = {
     ...(event.contexts ?? {}),
     desktop_process:

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -19415,6 +19415,17 @@ async function setActiveBrowserWorkspace(
         SESSION_BROWSER_BUSY_CHECK_MS,
       );
     }
+    // The renderer calls `browser.setActiveWorkspace(null)` from
+    // workspaceSelection.tsx whenever the selected workspace clears —
+    // typically when entering Workspace Control Center. Without this
+    // updateAttachedBrowserView call the BrowserView from the
+    // previously-active workspace stays parented to mainWindow with its
+    // last-known bounds, painting on top of the multi-workspace overview
+    // (the symptom is e.g. an `about.google` cookie banner stuck across
+    // every chat pane). The hot-path detach goes through `setBounds(0,0)`
+    // on BrowserPane unmount, but that's only reliable when BrowserPane
+    // was actually mounted in the workspace we're leaving.
+    updateAttachedBrowserView();
     emitBrowserState();
     emitBookmarksState();
     emitDownloadsState();

--- a/desktop/src/components/panes/ChatPane.tsx
+++ b/desktop/src/components/panes/ChatPane.tsx
@@ -8668,7 +8668,6 @@ function AssistantTurnActionsMenu({
 export const AssistantTurn = memo(AssistantTurnComponent, (prev, next) =>
   prev.label === next.label &&
   prev.mode === next.mode &&
-  prev.showSeparator === next.showSeparator &&
   prev.showExecutionInternals === next.showExecutionInternals &&
   prev.text === next.text &&
   prev.tone === next.tone &&
@@ -8689,7 +8688,6 @@ export const AssistantTurn = memo(AssistantTurnComponent, (prev, next) =>
 function AssistantTurnComponent({
   label,
   mode,
-  showSeparator = false,
   showExecutionInternals = true,
   fitToContent = false,
   text,
@@ -8718,7 +8716,6 @@ function AssistantTurnComponent({
 }: {
   label: string;
   mode: string;
-  showSeparator?: boolean;
   showExecutionInternals?: boolean;
   fitToContent?: boolean;
   text: string;
@@ -8834,7 +8831,7 @@ function AssistantTurnComponent({
 
   return (
     <div
-      className={`group/assistant-turn relative flex min-w-0 justify-start ${showSeparator ? "mt-4" : ""}`.trim()}
+      className="group/assistant-turn relative flex min-w-0 justify-start"
     >
       <article
         className={
@@ -9462,7 +9459,6 @@ export function ConversationTurns<Message extends ChatMessage>({
             <AssistantTurn
               label={assistantLabel}
               mode={assistantMode}
-              showSeparator={index > 0}
               showExecutionInternals={showExecutionInternals}
               fitToContent={assistantFitToContent}
               text={message.text}
@@ -9508,7 +9504,6 @@ export function ConversationTurns<Message extends ChatMessage>({
         <AssistantTurn
           label={assistantLabel}
           mode={assistantMode}
-          showSeparator={messages.length > 0}
           showExecutionInternals={showExecutionInternals}
           fitToContent={assistantFitToContent}
           text={liveAssistantTurn.text}

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -857,6 +857,13 @@ export class RuntimeStateStore {
   readonly #onMigrationEvent: ((event: MigrationLogEvent) => void) | undefined;
   #db: Database.Database | null = null;
   #vectorIndexSupported = false;
+  // Memoizes prepared statements so hot helpers (e.g. `listTurnResults`,
+  // `listClaimedInputs`, `listExpiredClaimedPostRunJobs`) don't recompile
+  // the same SQL on every call. Keyed by the literal SQL string — dynamic
+  // helpers that vary the SQL by which optional filters are present still
+  // win because there are usually only a handful of distinct shapes.
+  // Cleared whenever the underlying connection is replaced or closed.
+  #statementCache: Map<string, Database.Statement> = new Map();
 
   constructor(options: RuntimeStateStoreOptions = {}) {
     this.dbPath = runtimeDbPath(options);
@@ -866,9 +873,26 @@ export class RuntimeStateStore {
   }
 
   close(): void {
+    this.#statementCache.clear();
     this.#db?.close();
     this.#db = null;
     this.#vectorIndexSupported = false;
+  }
+
+  /**
+   * Returns a cached prepared statement for `sql`, compiling it on first hit.
+   * Use for hot helpers that reissue the same SQL string repeatedly. Callers
+   * with a small set of dynamic shapes (filter combinations) get one cached
+   * statement per shape, which is still a large win over recompiling on
+   * every call.
+   */
+  #cachedPrepare(sql: string): Database.Statement {
+    let statement = this.#statementCache.get(sql);
+    if (!statement) {
+      statement = this.db().prepare(sql);
+      this.#statementCache.set(sql, statement);
+    }
+    return statement;
   }
 
   supportsVectorIndex(): boolean {
@@ -3414,15 +3438,20 @@ export class RuntimeStateStore {
       .filter((row): row is SessionInputRecord => row !== null);
   }
 
+  // Polled by the queue worker on every wake-up to recover stale claims.
+  // Keep the prepared statement around so a busy queue doesn't recompile
+  // this every iteration.
+  static readonly #LIST_CLAIMED_INPUTS_SQL = `
+    SELECT *
+    FROM agent_session_inputs
+    WHERE status = 'CLAIMED'
+    ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
+  `;
+
   listClaimedInputs(): SessionInputRecord[] {
-    const rows = this.db()
-      .prepare<[], Record<string, unknown>>(`
-        SELECT *
-        FROM agent_session_inputs
-        WHERE status = 'CLAIMED'
-        ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
-      `)
-      .all();
+    const rows = this.#cachedPrepare(
+      RuntimeStateStore.#LIST_CLAIMED_INPUTS_SQL,
+    ).all() as Array<Record<string, unknown>>;
     return rows
       .map((row) => this.rowToInput(row))
       .filter((row): row is SessionInputRecord => row !== null);
@@ -3630,17 +3659,21 @@ export class RuntimeStateStore {
     return records;
   }
 
+  // Polled per cron tick. Cache the compiled statement so the wake loop
+  // doesn't pay a fresh `prepare` round on every iteration.
+  static readonly #LIST_EXPIRED_CLAIMED_POST_RUN_JOBS_SQL = `
+    SELECT *
+    FROM post_run_jobs
+    WHERE status = 'CLAIMED'
+      AND claimed_until IS NOT NULL
+      AND datetime(claimed_until) <= datetime(?)
+    ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
+  `;
+
   listExpiredClaimedPostRunJobs(nowIso = utcNowIso()): PostRunJobRecord[] {
-    const rows = this.db()
-      .prepare<[string], Record<string, unknown>>(`
-        SELECT *
-        FROM post_run_jobs
-        WHERE status = 'CLAIMED'
-          AND claimed_until IS NOT NULL
-          AND datetime(claimed_until) <= datetime(?)
-        ORDER BY datetime(claimed_until) ASC, datetime(updated_at) ASC
-      `)
-      .all(nowIso);
+    const rows = this.#cachedPrepare(
+      RuntimeStateStore.#LIST_EXPIRED_CLAIMED_POST_RUN_JOBS_SQL,
+    ).all(nowIso) as Array<Record<string, unknown>>;
     return rows
       .map((row) => this.rowToPostRunJob(row))
       .filter((row): row is PostRunJobRecord => row !== null);
@@ -4371,7 +4404,10 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    const rows = this.db().prepare(query).all(...values) as Array<Record<string, unknown>>;
+    // Hot path: callers like the per-session "lastTurnResult" lookup fire
+    // this once per session in a list endpoint. Caching the prepared
+    // statement turns N session list rows into 1 compile + N runs.
+    const rows = this.#cachedPrepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTurnResult(row));
   }
 

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -857,12 +857,6 @@ export class RuntimeStateStore {
   readonly #onMigrationEvent: ((event: MigrationLogEvent) => void) | undefined;
   #db: Database.Database | null = null;
   #vectorIndexSupported = false;
-  // Memoizes prepared statements so hot helpers (e.g. `listTurnResults`,
-  // `listClaimedInputs`, `listExpiredClaimedPostRunJobs`) don't recompile
-  // the same SQL on every call. Keyed by the literal SQL string — dynamic
-  // helpers that vary the SQL by which optional filters are present still
-  // win because there are usually only a handful of distinct shapes.
-  // Cleared whenever the underlying connection is replaced or closed.
   #statementCache: Map<string, Database.Statement> = new Map();
 
   constructor(options: RuntimeStateStoreOptions = {}) {
@@ -879,13 +873,6 @@ export class RuntimeStateStore {
     this.#vectorIndexSupported = false;
   }
 
-  /**
-   * Returns a cached prepared statement for `sql`, compiling it on first hit.
-   * Use for hot helpers that reissue the same SQL string repeatedly. Callers
-   * with a small set of dynamic shapes (filter combinations) get one cached
-   * statement per shape, which is still a large win over recompiling on
-   * every call.
-   */
   #cachedPrepare(sql: string): Database.Statement {
     let statement = this.#statementCache.get(sql);
     if (!statement) {
@@ -3438,9 +3425,6 @@ export class RuntimeStateStore {
       .filter((row): row is SessionInputRecord => row !== null);
   }
 
-  // Polled by the queue worker on every wake-up to recover stale claims.
-  // Keep the prepared statement around so a busy queue doesn't recompile
-  // this every iteration.
   static readonly #LIST_CLAIMED_INPUTS_SQL = `
     SELECT *
     FROM agent_session_inputs
@@ -3659,8 +3643,6 @@ export class RuntimeStateStore {
     return records;
   }
 
-  // Polled per cron tick. Cache the compiled statement so the wake loop
-  // doesn't pay a fresh `prepare` round on every iteration.
   static readonly #LIST_EXPIRED_CLAIMED_POST_RUN_JOBS_SQL = `
     SELECT *
     FROM post_run_jobs
@@ -4404,9 +4386,6 @@ export class RuntimeStateStore {
       LIMIT ? OFFSET ?
     `;
     values.push(params.limit ?? 100, params.offset ?? 0);
-    // Hot path: callers like the per-session "lastTurnResult" lookup fire
-    // this once per session in a list endpoint. Caching the prepared
-    // statement turns N session list rows into 1 compile + N runs.
     const rows = this.#cachedPrepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToTurnResult(row));
   }


### PR DESCRIPTION
Five small follow-ups bundled together. Each commit is self-contained and addresses a separate finding from the ongoing 100% CPU / desktop polish thread (continues from #252, #253, #254).

## Commits

1. **perf(desktop): only run heavy Sentry diagnostics for error-level events** — `enrichDesktopSentryEvent` was attaching browser/system context, integration logs, and process diagnostics on every Sentry event including breadcrumb-only and info-level traffic. Gate the heavy enrichment on `event.level === \"fatal\" || \"error\"` or events that carry an exception. Lighter events still get the basic tags.

2. **perf(desktop): cache prepared sqlite statements for hot helpers** — `readPersistedRuntimeProcessState`, `appendRuntimeEventLog`, and `getWorkspaceRecord` were re-preparing the same SQL on every call. Adds a generic `cacheRuntimeStatement(sql)` helper backed by a module-level disposer registry (cleaned up in `ensureAppQuitCleanup` alongside the existing `persistRuntimeProcessState` cache from #254).

3. **perf(runtime): cache prepared sqlite statements in RuntimeStateStore hot helpers** — `listTurnResults`, `listClaimedInputs`, and `listExpiredClaimedPostRunJobs` were calling `db.prepare(sql)` on every invocation. `listTurnResults` in particular is called once per session by the session-list endpoints (N+1). Adds a private `#statementCache: Map<string, Statement>` with a `#cachedPrepare(sql)` helper; cache is cleared in `close()`.

4. **ui(chat): drop AssistantTurn extra mt-4 so user/assistant gap is uniform** — `ChatPane`'s turn list already applies `gap-4` between turns; the extra `mt-4` on `AssistantTurn` (gated by `showSeparator`) doubled the spacing only between user→assistant boundaries, producing a 32px gap there vs 16px elsewhere. Removes the prop entirely so spacing is consistent.

5. **fix(desktop): detach BrowserView when active workspace clears** — `setActiveBrowserWorkspace(\"\")` early-returned without calling `updateAttachedBrowserView()`, leaving the previously-attached BrowserView floating over the chat panes (e.g. a Google about page sticking over the workspace UI after the active workspace was cleared). Calls `updateAttachedBrowserView()` in the empty-workspace branch so the detach path runs.

## Verification

- \`npm run typecheck\` clean for both \`desktop/\` and \`runtime/state-store/\`.
- Each commit's diff is small and isolated; no cross-commit refactors.
- Cherry-picked cleanly onto \`upstream/main\` after a single trivial conflict (the new \`cacheRuntimeStatement\` cleanup co-exists with #254's dedicated \`persistRuntimeProcessState\` cleanup — both run in \`ensureAppQuitCleanup.finally\`).