### PR TITLE
ui(desktop): file explorer shortcuts, auto-reveal, and export

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -58,6 +58,7 @@ import {
   shell,
   type IpcMainInvokeEvent,
   type OpenDialogOptions,
+  type SaveDialogOptions,
   type Session,
   type WebContents,
 } from "electron";
@@ -18359,6 +18360,61 @@ async function deleteExplorerPath(
   return { deleted: true };
 }
 
+async function revealExplorerPath(
+  targetPath: string,
+  workspaceId?: string | null,
+): Promise<{ revealed: boolean }> {
+  const { absolutePath } = await resolveWorkspaceScopedExplorerPath(
+    targetPath,
+    workspaceId,
+  );
+  if (!(await fileExists(absolutePath))) {
+    throw new Error("Target path no longer exists.");
+  }
+  shell.showItemInFolder(absolutePath);
+  return { revealed: true };
+}
+
+async function exportExplorerPathToFile(
+  targetPath: string,
+  workspaceId: string | null | undefined,
+  payload?: { content?: string; suggestedName?: string },
+): Promise<{ path: string | null; canceled: boolean }> {
+  const { absolutePath } = await resolveWorkspaceScopedExplorerPath(
+    targetPath,
+    workspaceId,
+  );
+  const stat = await fs.stat(absolutePath);
+  if (!stat.isFile()) {
+    throw new Error("Only files can be exported.");
+  }
+
+  const sourceBaseName = path.basename(absolutePath);
+  const suggestedName = payload?.suggestedName?.trim() || sourceBaseName;
+  const downloadsDir = app.getPath("downloads");
+  const ownerWindow = BrowserWindow.getFocusedWindow() ?? mainWindow ?? null;
+  const options: SaveDialogOptions = {
+    title: "Export file",
+    defaultPath: path.join(downloadsDir, suggestedName),
+    buttonLabel: "Export",
+  };
+  const result = ownerWindow
+    ? await dialog.showSaveDialog(ownerWindow, options)
+    : await dialog.showSaveDialog(options);
+  if (result.canceled || !result.filePath) {
+    return { path: null, canceled: true };
+  }
+
+  const destination = path.resolve(result.filePath);
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  if (typeof payload?.content === "string") {
+    await fs.writeFile(destination, payload.content, "utf-8");
+  } else {
+    await fs.copyFile(absolutePath, destination);
+  }
+  return { path: destination, canceled: false };
+}
+
 async function listDirectory(
   targetPath?: string | null,
   workspaceId?: string | null,
@@ -20415,6 +20471,22 @@ app.whenReady().then(async () => {
     ["main"],
     async (_event, targetPath: string, workspaceId?: string | null) =>
       deleteExplorerPath(targetPath, workspaceId),
+  );
+  handleTrustedIpc(
+    "fs:revealInFolder",
+    ["main"],
+    async (_event, targetPath: string, workspaceId?: string | null) =>
+      revealExplorerPath(targetPath, workspaceId),
+  );
+  handleTrustedIpc(
+    "fs:exportFileTo",
+    ["main"],
+    async (
+      _event,
+      targetPath: string,
+      workspaceId?: string | null,
+      payload?: { content?: string; suggestedName?: string },
+    ) => exportExplorerPathToFile(targetPath, workspaceId, payload),
   );
   handleTrustedIpc("fs:getBookmarks", ["main"], () => fileBookmarks);
   handleTrustedIpc(

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1155,6 +1155,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("fs:movePath", sourcePath, destinationDirectoryPath, workspaceId) as Promise<FileSystemMutationPayload>,
     deletePath: (targetPath: string, workspaceId?: string | null) =>
       ipcRenderer.invoke("fs:deletePath", targetPath, workspaceId) as Promise<{ deleted: boolean }>,
+    revealInFolder: (targetPath: string, workspaceId?: string | null) =>
+      ipcRenderer.invoke("fs:revealInFolder", targetPath, workspaceId) as Promise<{ revealed: boolean }>,
+    exportFileTo: (
+      targetPath: string,
+      workspaceId?: string | null,
+      payload?: { content?: string; suggestedName?: string },
+    ) =>
+      ipcRenderer.invoke(
+        "fs:exportFileTo",
+        targetPath,
+        workspaceId,
+        payload,
+      ) as Promise<{ path: string | null; canceled: boolean }>,
     getBookmarks: (workspaceId?: string | null) =>
       ipcRenderer.invoke("fs:getBookmarks", workspaceId) as Promise<FileBookmarkPayload[]>,
     addBookmark: (targetPath: string, label?: string, workspaceId?: string | null) =>

--- a/desktop/src/components/auth/AuthPanel.tsx
+++ b/desktop/src/components/auth/AuthPanel.tsx
@@ -12,7 +12,6 @@ import {
   Plug,
   Plus,
   RefreshCw,
-  Search,
   ShieldCheck,
   Terminal,
   Unplug,
@@ -3653,7 +3652,6 @@ export function AuthPanel({ view = "full" }: AuthPanelProps) {
                 ? "Holaboss Search requires an active Holaboss runtime binding. Sign in or refresh the session to re-enable it."
                 : selectedWebSearchTemplate.description
             }
-            leading={<Search className="size-4 text-muted-foreground" />}
             value={webSearchDraft.providerId}
             onValueChange={(value) =>
               applyWebSearchProviderSelection(webSearchProviderDraftId(value))

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -3246,24 +3246,11 @@ export function FileExplorerPane({
       }
 
       const primaryModifier = event.metaKey || event.ctrlKey;
-      if (!primaryModifier) {
+      if (!primaryModifier || event.altKey) {
         return;
       }
 
       const normalizedKey = event.key.trim().toLowerCase();
-      if (event.shiftKey && !event.altKey && normalizedKey === "r") {
-        if (!selectedEntry) {
-          return;
-        }
-        event.preventDefault();
-        void revealEntryInFolder(selectedEntry);
-        return;
-      }
-
-      if (event.altKey) {
-        return;
-      }
-
       if (normalizedKey === "c") {
         if (!selectedEntry) {
           return;
@@ -3304,7 +3291,6 @@ export function FileExplorerPane({
     creationTargetDirectoryPath,
     pasteExplorerClipboardIntoDirectory,
     renamingPath,
-    revealEntryInFolder,
     selectedEntry,
   ]);
 
@@ -4311,8 +4297,6 @@ export function FileExplorerPane({
       : desktopPlatform === "win32"
         ? "Show in Explorer"
         : "Show in File Manager";
-  const revealShortcutHint =
-    desktopPlatform === "darwin" ? "⇧⌘R" : "Ctrl+Shift+R";
 
   return (
     <>
@@ -4431,12 +4415,9 @@ export function FileExplorerPane({
                 onClick={() => {
                   void revealEntryFromContextMenu(contextMenu.entry);
                 }}
-                className="w-full justify-start gap-3 font-normal"
+                className="w-full justify-start font-normal"
               >
-                <span className="flex-1 text-left">{revealInFolderLabel}</span>
-                <span className="text-[11px] text-muted-foreground">
-                  {revealShortcutHint}
-                </span>
+                {revealInFolderLabel}
               </Button>
               <Button
                 type="button"

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -1169,6 +1169,9 @@ export function FileExplorerPane({
   const currentPathRef = useRef("");
   const isDirtyRef = useRef(false);
   const isSavingRef = useRef(false);
+  const deleteEntryRef = useRef<
+    ((entry: LocalFileEntry) => Promise<void>) | null
+  >(null);
   const [currentPath, setCurrentPath] = useState<string>("");
   const [entries, setEntries] = useState<LocalFileEntry[]>([]);
   const [directoryEntriesByPath, setDirectoryEntriesByPath] = useState<
@@ -1760,6 +1763,13 @@ export function FileExplorerPane({
     resetPreviewState();
   }, [error, hasVisibleEntryRows, loading, resetPreviewState]);
 
+  useEffect(() => {
+    if (!selectedPath) return;
+    const rowElement = document.getElementById(getExplorerRowId(selectedPath));
+    if (!rowElement) return;
+    rowElement.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [selectedPath, expandedDirectoryPaths, visibleRows]);
+
   const openPreviewLink = useCallback(
     (url: string) => {
       if (onOpenLinkInBrowser) {
@@ -2260,7 +2270,7 @@ export function FileExplorerPane({
 
   const openFilePreview = async (
     targetPath: string,
-    options?: { skipConfirm?: boolean; syncDirectory?: boolean },
+    options?: { skipConfirm?: boolean },
   ) => {
     const workspaceSessionKey = workspaceSessionKeyRef.current;
     const requestKey = ++previewRequestKeyRef.current;
@@ -2289,9 +2299,7 @@ export function FileExplorerPane({
       return;
     }
 
-    if (options?.syncDirectory) {
-      await revealPathInTree(validatedTargetPath);
-    }
+    await revealPathInTree(validatedTargetPath);
 
     setSelectedPath(validatedTargetPath);
     setPreviewLoading(true);
@@ -2341,7 +2349,7 @@ export function FileExplorerPane({
   const openFileTarget = useCallback(
     async (
       targetPath: string,
-      options?: { skipConfirm?: boolean; syncDirectory?: boolean },
+      options?: { skipConfirm?: boolean },
     ) => {
       if (previewInPane || !onFileOpen) {
         await openFilePreview(targetPath, options);
@@ -2359,9 +2367,7 @@ export function FileExplorerPane({
         return;
       }
 
-      if (options?.syncDirectory) {
-        await revealPathInTree(validatedTargetPath);
-      }
+      await revealPathInTree(validatedTargetPath);
 
       setSelectedPath(validatedTargetPath);
       resetPreviewState();
@@ -2461,6 +2467,19 @@ export function FileExplorerPane({
           }
           return;
         }
+        case "F2": {
+          if (currentIndex < 0) return;
+          event.preventDefault();
+          startRenamingEntry(entryRows[currentIndex].entry);
+          return;
+        }
+        case "Delete":
+        case "Backspace": {
+          if (currentIndex < 0) return;
+          event.preventDefault();
+          void deleteEntryRef.current?.(entryRows[currentIndex].entry);
+          return;
+        }
         default:
           return;
       }
@@ -2471,6 +2490,7 @@ export function FileExplorerPane({
       previewInPane,
       renamingPath,
       selectedPath,
+      startRenamingEntry,
       toggleDirectoryExpansion,
       visibleRows,
     ],
@@ -2609,10 +2629,7 @@ export function FileExplorerPane({
       return;
     }
 
-    await openFileTarget(bookmark.targetPath, {
-      skipConfirm: false,
-      syncDirectory: true,
-    });
+    await openFileTarget(bookmark.targetPath, { skipConfirm: false });
   };
 
   useEffect(() => {
@@ -2649,7 +2666,7 @@ export function FileExplorerPane({
       }
 
       try {
-        await openFileTarget(targetPath, { syncDirectory: true });
+        await openFileTarget(targetPath);
       } finally {
         if (!cancelled) {
           onFocusRequestConsumed?.(request.requestKey);
@@ -3142,6 +3159,33 @@ export function FileExplorerPane({
     ],
   );
 
+  const revealEntryInFolder = useCallback(
+    async (entry: LocalFileEntry) => {
+      setError("");
+      try {
+        await window.electronAPI.fs.revealInFolder(
+          entry.absolutePath,
+          selectedWorkspaceId ?? null,
+        );
+      } catch (cause) {
+        const message =
+          cause instanceof Error
+            ? cause.message
+            : "Failed to reveal in file manager.";
+        setError(message);
+      }
+    },
+    [selectedWorkspaceId],
+  );
+
+  const revealEntryFromContextMenu = useCallback(
+    async (entry: LocalFileEntry) => {
+      closeContextMenu();
+      await revealEntryInFolder(entry);
+    },
+    [closeContextMenu, revealEntryInFolder],
+  );
+
   useEffect(() => {
     const isExplorerShortcutTarget = (target: EventTarget | null) => {
       if (renamingPath) {
@@ -3202,11 +3246,24 @@ export function FileExplorerPane({
       }
 
       const primaryModifier = event.metaKey || event.ctrlKey;
-      if (!primaryModifier || event.altKey) {
+      if (!primaryModifier) {
         return;
       }
 
       const normalizedKey = event.key.trim().toLowerCase();
+      if (event.shiftKey && !event.altKey && normalizedKey === "r") {
+        if (!selectedEntry) {
+          return;
+        }
+        event.preventDefault();
+        void revealEntryInFolder(selectedEntry);
+        return;
+      }
+
+      if (event.altKey) {
+        return;
+      }
+
       if (normalizedKey === "c") {
         if (!selectedEntry) {
           return;
@@ -3247,6 +3304,7 @@ export function FileExplorerPane({
     creationTargetDirectoryPath,
     pasteExplorerClipboardIntoDirectory,
     renamingPath,
+    revealEntryInFolder,
     selectedEntry,
   ]);
 
@@ -3445,6 +3503,10 @@ export function FileExplorerPane({
       workspaceRootPath,
     ],
   );
+
+  useEffect(() => {
+    deleteEntryRef.current = deleteEntryFromContextMenu;
+  }, [deleteEntryFromContextMenu]);
 
   const contextMenuPosition = useMemo(() => {
     if (!contextMenu) {
@@ -4242,6 +4304,15 @@ export function FileExplorerPane({
     Boolean(explorerClipboardEntry) &&
     Boolean(contextMenuTargetDirectoryPath) &&
     !contextMenuTargetDirectoryIsProtected;
+  const desktopPlatform = window.electronAPI?.platform ?? "";
+  const revealInFolderLabel =
+    desktopPlatform === "darwin"
+      ? "Show in Finder"
+      : desktopPlatform === "win32"
+        ? "Show in Explorer"
+        : "Show in File Manager";
+  const revealShortcutHint =
+    desktopPlatform === "darwin" ? "⇧⌘R" : "Ctrl+Shift+R";
 
   return (
     <>
@@ -4351,6 +4422,21 @@ export function FileExplorerPane({
                 className="w-full justify-start font-normal"
               >
                 Paste
+              </Button>
+              <Button
+                type="button"
+                role="menuitem"
+                variant="ghost"
+                size="default"
+                onClick={() => {
+                  void revealEntryFromContextMenu(contextMenu.entry);
+                }}
+                className="w-full justify-start gap-3 font-normal"
+              >
+                <span className="flex-1 text-left">{revealInFolderLabel}</span>
+                <span className="text-[11px] text-muted-foreground">
+                  {revealShortcutHint}
+                </span>
               </Button>
               <Button
                 type="button"

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronsLeftRight,
   ChevronsRightLeft,
+  Download,
   Eye,
   FileText,
   FileWarning,
@@ -15,6 +16,11 @@ import {
   SpreadsheetEditor,
 } from "@/components/panes/SpreadsheetEditor";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { DashboardRenderer } from "@/components/dashboard/DashboardRenderer";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { PresentationPreview } from "@/components/panes/PresentationPreview";
@@ -460,6 +466,28 @@ export function InternalSurfacePane({
     });
   }, [isDirty, isSaving, loadPreviewFromDisk]);
 
+  const exportPreview = useCallback(async () => {
+    if (!preview) {
+      return;
+    }
+    setErrorMessage("");
+    try {
+      const useDraftContent = preview.kind === "text";
+      await window.electronAPI.fs.exportFileTo(
+        preview.absolutePath,
+        selectedWorkspaceId ?? null,
+        {
+          suggestedName: preview.name,
+          content: useDraftContent ? previewDraft : undefined,
+        },
+      );
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to export file.",
+      );
+    }
+  }, [preview, previewDraft, selectedWorkspaceId]);
+
   const savePreview = useCallback(async () => {
     if (!preview || !preview.isEditable) {
       return;
@@ -660,6 +688,24 @@ export function InternalSurfacePane({
                   {isSaving ? "Saving" : "Save"}
                 </Button>
               ) : null}
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => void exportPreview()}
+                      aria-label="Export"
+                    />
+                  }
+                >
+                  <Download className="size-3.5" />
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="py-1">
+                  Export
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
 
@@ -785,8 +831,8 @@ export function InternalSurfacePane({
                   {isDirty ? " · Unsaved changes" : ""}
                 </div>
               </div>
-              {preview.isEditable ? (
-                <div className="flex shrink-0 items-center gap-2">
+              <div className="flex shrink-0 items-center gap-2">
+                {preview.isEditable ? (
                   <Button
                     type="button"
                     variant="outline"
@@ -797,8 +843,26 @@ export function InternalSurfacePane({
                     <Save size={12} />
                     {isSaving ? "Saving" : "Save"}
                   </Button>
-                </div>
-              ) : null}
+                ) : null}
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => void exportPreview()}
+                        aria-label="Export"
+                      />
+                    }
+                  >
+                    <Download className="size-3.5" />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="py-1">
+                    Export
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden p-3">

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -1594,6 +1594,12 @@ interface RuntimeNotificationListOptionsPayload {
         workspaceId?: string | null,
       ) => Promise<FileSystemMutationPayload>;
       deletePath: (targetPath: string, workspaceId?: string | null) => Promise<{ deleted: boolean }>;
+      revealInFolder: (targetPath: string, workspaceId?: string | null) => Promise<{ revealed: boolean }>;
+      exportFileTo: (
+        targetPath: string,
+        workspaceId?: string | null,
+        payload?: { content?: string; suggestedName?: string },
+      ) => Promise<{ path: string | null; canceled: boolean }>;
       getBookmarks: (workspaceId?: string | null) => Promise<FileBookmarkPayload[]>;
       addBookmark: (targetPath: string, label?: string, workspaceId?: string | null) => Promise<FileBookmarkPayload[]>;
       removeBookmark: (bookmarkId: string) => Promise<FileBookmarkPayload[]>;


### PR DESCRIPTION
## Summary
- File tree: keyboard shortcuts — **⌘⇧R / Ctrl+Shift+R** reveals selection in OS file manager; **F2** renames; **Delete / Backspace** deletes (existing confirm + protected-path checks still apply). Right-click menu picks up a matching "Show in Finder / Explorer / File Manager" entry.
- File tree: opening any file (tree click, bookmark, or external focus request) now always expands the ancestor folders and scrolls the row into view, so the left tree always lines up with the right preview.
- File editor toolbar: new **Export** icon button next to Save opens a native save dialog and writes the file to the chosen destination — writes the in-memory draft for text/markdown/html, otherwise a byte-perfect copy from disk. Tooltip is rendered via the existing \`Tooltip\` component.
- AuthPanel: drop the redundant \`Search\` icon from the "Search provider" row.
- New IPC: \`fs:revealInFolder\`, \`fs:exportFileTo\`, with matching preload exposure and TypeScript types.

## Test plan
- [ ] Cmd+Shift+R on a selected entry opens that path in Finder (macOS); Ctrl+Shift+R on Windows opens Explorer.
- [ ] Right-click → Show in Finder works on file and folder entries.
- [ ] F2 starts inline rename; Delete prompts the confirm dialog and deletes on confirm.
- [ ] Click a file in chat → left tree expands ancestors and scrolls the row into view.
- [ ] Open a deeply nested file via a focus request (chat artifact / agent operation) → left tree still expands and scrolls.
- [ ] Export button on a text file: dialog defaults to \`~/Downloads/<basename>\`, picking a target writes utf-8 of the current draft.
- [ ] Export button on a binary file (image / PDF): same dialog, byte-perfect copy of the on-disk file.
- [ ] Web search settings: "Search provider" row no longer shows a leading magnifier icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)