### PR TITLE
fix: route always-on workspace rules to AGENTS.md

### DIFF
--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -158,11 +158,19 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   );
   assert.match(
     prompt.systemPrompt,
-    /Create or update a workspace-local skill when the user describes a reusable workflow/
+    /Create or update a workspace-local skill for reusable workflows/
   );
   assert.match(
     prompt.systemPrompt,
-    /do not create skills for one-off state\./i
+    /do not use skills for unconditional policy or one-off state\./i
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /Put always-on workspace rules in `AGENTS\.md`/i
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /use skills for reusable workflows that load when relevant/i
   );
   assert.match(prompt.systemPrompt, /Session policy:/);
   assert.match(prompt.systemPrompt, /front-of-house workspace session/i);

--- a/runtime/api-server/src/agent-runtime-prompt.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.ts
@@ -674,7 +674,8 @@ export function buildBaseAgentPromptSections(
     "Use coordination tools instead of hidden state. The newest user message is primary.",
     "Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.",
     "Ask for missing identity details instead of guessing.",
-    "Create or update a workspace-local skill when the user describes a reusable workflow; do not create skills for one-off state."
+    "Put always-on workspace rules in `AGENTS.md`; use skills for reusable workflows that load when relevant.",
+    "Create or update a workspace-local skill for reusable workflows; do not use skills for unconditional policy or one-off state."
   ];
   if (capabilityManifest?.browser_tools.length) {
     executionLines.push(
@@ -917,7 +918,8 @@ export function buildMainSessionPromptSections(
     "Use coordination tools instead of hidden state. The newest user message is primary.",
     "Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.",
     "Ask for missing identity details instead of guessing.",
-    "Create or update a workspace-local skill when the user describes a reusable workflow; do not create skills for one-off state."
+    "Put always-on workspace rules in `AGENTS.md`; use skills for reusable workflows that load when relevant.",
+    "Create or update a workspace-local skill for reusable workflows; do not use skills for unconditional policy or one-off state."
   ];
   if (normalizedSessionKind === "onboarding") {
     conversationLines.splice(4, 0,


### PR DESCRIPTION
## Context
The runtime prompt doctrine previously pushed reusable user instructions toward workspace-local skills, but it did not distinguish unconditional workspace policy from conditional workflows. That caused requests like always use this report format to become a skill instead of a standing AGENTS.md rule.

## Changes
- teach the base and main-session prompt doctrine to put always-on workspace rules in AGENTS.md
- keep skills scoped to reusable workflows that should load when relevant
- update prompt tests to cover the standing-policy versus skill distinction

## Validation
- node --import tsx --test src/agent-runtime-prompt.test.ts

## Notes
- left unrelated existing worktree changes outside this PR