### PR TITLE
refactor(desktop): make marketplace.json the single source of truth for app→provider mapping

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -12944,6 +12944,8 @@ async function syncAppCatalog(params: {
         version: tmpl.version ?? null,
         archive_url: matching.url,
         archive_path: null,
+        provider_id: tmpl.provider_id ?? null,
+        credential_source: tmpl.credential_source ?? null,
       });
     }
     return runtimeClient.apps.syncCatalog({
@@ -12966,6 +12968,8 @@ async function syncAppCatalog(params: {
       version: null,
       archive_url: null,
       archive_path: row.filePath,
+      provider_id: null,
+      credential_source: null,
     };
   });
   return runtimeClient.apps.syncCatalog({

--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ExternalLink, FileUp, LoaderCircle } from "lucide-react";
-import { getProviderForApp, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import { getProviderForCatalogEntry, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -275,7 +275,7 @@ export function AppsGallery() {
               : isInstalling
                 ? "installing"
                 : "available";
-            const provider = getProviderForApp(entry.app_id);
+            const provider = getProviderForCatalogEntry(entry);
             const candidates = provider
               ? accountsByProvider[provider.toLowerCase()] ?? []
               : [];

--- a/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/desktop/src/components/panes/IntegrationsPane.tsx
@@ -73,35 +73,7 @@ function uniqueStrings(values: string[]): string[] {
 }
 
 function providerIdForToolkit(slug: string): string {
-  const normalizedSlug = slug.trim().toLowerCase();
-  return (TOOLKIT_SLUG_TO_PROVIDER[normalizedSlug] || normalizedSlug)
-    .trim()
-    .toLowerCase();
-}
-
-function providerCategories(providerId: string): string[] {
-  return PROVIDER_CATEGORY_GROUPS[providerId] || ["other"];
-}
-
-function toolkitPreferenceRank(providerId: string, slug: string): number {
-  const normalizedSlug = slug.trim().toLowerCase();
-  const preferredSlugs = PROVIDER_TOOLKIT_PREFERENCE[providerId] || [];
-  const index = preferredSlugs.indexOf(normalizedSlug);
-  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
-}
-
-function preferredToolkitForProvider(
-  providerId: string,
-  current: ComposioToolkit | undefined,
-  candidate: ComposioToolkit,
-): ComposioToolkit {
-  if (!current) {
-    return candidate;
-  }
-  return toolkitPreferenceRank(providerId, candidate.slug) <
-    toolkitPreferenceRank(providerId, current.slug)
-    ? candidate
-    : current;
+  return slug.trim().toLowerCase();
 }
 
 // Composio publishes a stable logo CDN keyed by toolkit slug — usable as
@@ -124,14 +96,9 @@ function mergeIntegrationCards(
   const toolkitByProvider = new Map<string, ComposioToolkit>();
   for (const toolkit of toolkits) {
     const providerId = providerIdForToolkit(toolkit.slug);
-    toolkitByProvider.set(
-      providerId,
-      preferredToolkitForProvider(
-        providerId,
-        toolkitByProvider.get(providerId),
-        toolkit,
-      ),
-    );
+    if (!toolkitByProvider.has(providerId)) {
+      toolkitByProvider.set(providerId, toolkit);
+    }
   }
 
   const cards: IntegrationCard[] = [];
@@ -163,10 +130,7 @@ function mergeIntegrationCards(
         ...(toolkit?.auth_schemes || []),
         ...(provider.auth_modes || []),
       ]),
-      categories:
-        toolkitCategories.length > 0
-          ? toolkitCategories
-          : providerCategories(providerId),
+      categories: toolkitCategories.length > 0 ? toolkitCategories : ["other"],
       supportsManaged: provider.supports_managed !== false,
     });
   }
@@ -175,6 +139,7 @@ function mergeIntegrationCards(
     if (seenProviderIds.has(providerId)) {
       continue;
     }
+    const toolkitCategories = uniqueStrings(toolkit.categories || []);
     cards.push({
       slug: providerId,
       providerId,
@@ -182,10 +147,7 @@ function mergeIntegrationCards(
       description: normalizedText(toolkit.description) || providerId,
       logo: toolkit.logo,
       authSchemes: uniqueStrings(toolkit.auth_schemes || []),
-      categories:
-        uniqueStrings(toolkit.categories || []).length > 0
-          ? uniqueStrings(toolkit.categories || [])
-          : providerCategories(providerId),
+      categories: toolkitCategories.length > 0 ? toolkitCategories : ["other"],
       supportsManaged: true,
     });
   }
@@ -1409,37 +1371,3 @@ function ConnectedProviderCard({
   );
 }
 
-const PROVIDER_CATEGORY_GROUPS: Record<string, string[]> = {
-  google: ["productivity"],
-  github: ["developer"],
-  reddit: ["community"],
-  twitter: ["social"],
-  linkedin: ["social"],
-  hubspot: ["crm"],
-  attio: ["crm"],
-  cal: ["productivity"],
-  apollo: ["sales"],
-  instantly: ["sales"],
-  zoominfo: ["sales"],
-};
-
-const PROVIDER_TOOLKIT_PREFERENCE: Record<string, string[]> = {
-  google: ["gmail", "googledrive", "googlecalendar", "googlesheets"],
-  github: ["github"],
-  reddit: ["reddit"],
-  twitter: ["twitter"],
-  linkedin: ["linkedin"],
-  hubspot: ["hubspot"],
-  attio: ["attio"],
-  cal: ["cal"],
-  apollo: ["apollo"],
-  instantly: ["instantly"],
-  zoominfo: ["zoominfo"],
-};
-
-const TOOLKIT_SLUG_TO_PROVIDER: Record<string, string> = {
-  gmail: "google",
-  googlesheets: "google",
-  googlecalendar: "google",
-  googledrive: "google",
-};

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -14,31 +14,16 @@ import { hydrateInstalledWorkspaceApps, type WorkspaceInstalledAppDefinition } f
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
 /**
- * Maps an app id (e.g. `twitter`, `sheets`) to the integration provider id
- * the runtime expects in `integration_bindings.integration_key`. Apps with
- * no integration are absent from the table — callers should treat
- * `undefined` as "no provider needed".
- *
- * Exported so renderer-side components (AppsGallery, install cards) can
- * derive the same provider without each reimplementing the mapping.
+ * Each app self-declares its integration provider in `app.runtime.yaml`,
+ * which the marketplace catalog API surfaces as `provider_id`. Callers
+ * should look up the catalog entry for the app id and read
+ * `entry.provider_id` directly — `null` means "no integration needed".
  */
-export const APP_TO_PROVIDER_MAP: Record<string, string> = {
-  twitter: "twitter",
-  linkedin: "linkedin",
-  reddit: "reddit",
-  gmail: "gmail",
-  sheets: "googlesheets",
-  github: "github",
-  hubspot: "hubspot",
-  attio: "attio",
-  calcom: "calcom",
-  apollo: "apollo",
-  instantly: "instantly",
-  zoominfo: "zoominfo",
-};
-
-export function getProviderForApp(appId: string): string | undefined {
-  return APP_TO_PROVIDER_MAP[appId.toLowerCase()];
+export function getProviderForCatalogEntry(
+  entry: AppCatalogEntryPayload | undefined,
+): string | undefined {
+  const value = entry?.provider_id?.trim();
+  return value ? value : undefined;
 }
 
 const ONBOARDING_ACTIVE_STATUSES = new Set(["pending", "awaiting_confirmation", "in_progress"]);
@@ -820,9 +805,10 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     }
   }
 
-  // (Same map exported above as APP_TO_PROVIDER_MAP for renderer-side reuse.)
-  // Local alias keeps the rest of the hook readable.
-  const APP_TO_PROVIDER = APP_TO_PROVIDER_MAP;
+  function providerForApp(appId: string): string | undefined {
+    const entry = appCatalog.find((e) => e.app_id === appId);
+    return getProviderForCatalogEntry(entry);
+  }
 
   async function installAppFromCatalog(
     appId: string,
@@ -838,7 +824,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     setAppCatalogError("");
 
     // Check if this app requires an integration that isn't connected yet
-    const provider = APP_TO_PROVIDER[appId.toLowerCase()];
+    const provider = providerForApp(appId);
     if (provider) {
       try {
         const { connections } = await window.electronAPI.workspace.listIntegrationConnections();
@@ -876,7 +862,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       //      connection on the expected provider. This is the silent
       //      single-account happy path; with the dedupe work in place
       //      "first match" is now stable.
-      const provider = APP_TO_PROVIDER[appId.toLowerCase()];
+      const provider = providerForApp(appId);
       if (provider && selectedWorkspaceId) {
         try {
           const { connections } = await window.electronAPI.workspace.listIntegrationConnections();

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -1108,6 +1108,8 @@ interface RuntimeNotificationListOptionsPayload {
     archive_path: string | null;
     target: string;
     cached_at: string;
+    provider_id: string | null;
+    credential_source: string | null;
   }
 
   interface AppCatalogListResponse {
@@ -1161,6 +1163,8 @@ interface RuntimeNotificationListOptionsPayload {
     tags: string[];
     version?: string | null;
     archives?: AppTemplateArchivePayload[];
+    provider_id?: string | null;
+    credential_source?: string | null;
   }
 
   interface WorkspaceLifecycleBlockingAppPayload {

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -7266,6 +7266,8 @@ test("GET /api/v1/apps/catalog returns entries filtered by source", async () => 
     archivePath: null,
     target: "darwin-arm64",
     cachedAt: "2026-04-09T00:00:00Z",
+    providerId: "twitter",
+    credentialSource: "platform",
   });
   store.upsertAppCatalogEntry({
     appId: "linkedin",
@@ -7280,6 +7282,8 @@ test("GET /api/v1/apps/catalog returns entries filtered by source", async () => 
     archivePath: "/tmp/linkedin-module-darwin-arm64.tar.gz",
     target: "darwin-arm64",
     cachedAt: "2026-04-09T00:00:00Z",
+    providerId: "linkedin",
+    credentialSource: "platform",
   });
 
   const res = await app.inject({ method: "GET", url: "/api/v1/apps/catalog?source=marketplace" });
@@ -7315,6 +7319,8 @@ test("POST /api/v1/apps/catalog/sync replaces all entries for a source", async (
     archivePath: null,
     target: "darwin-arm64",
     cachedAt: "2026-04-08T00:00:00Z",
+    providerId: null,
+    credentialSource: null,
   });
 
   const res = await app.inject({

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -1974,6 +1974,8 @@ function appCatalogEntryToWire(record: AppCatalogEntryRecord): Record<string, un
     archive_path: record.archivePath,
     target: record.target,
     cached_at: record.cachedAt,
+    provider_id: record.providerId,
+    credential_source: record.credentialSource,
   };
 }
 
@@ -6373,6 +6375,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         archivePath: typeof raw.archive_path === "string" ? raw.archive_path : null,
         target,
         cachedAt: now,
+        providerId: typeof raw.provider_id === "string" && raw.provider_id.trim().length > 0
+          ? raw.provider_id.trim()
+          : null,
+        credentialSource: typeof raw.credential_source === "string" && raw.credential_source.trim().length > 0
+          ? raw.credential_source.trim()
+          : null,
       });
       synced += 1;
     }

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -95,7 +95,9 @@ test("control-plane metadata lives in control-plane.db while runtime.db keeps th
     archiveUrl: null,
     archivePath: null,
     target: "apps/calendar",
-    cachedAt: "2026-05-06T00:00:00.000Z"
+    cachedAt: "2026-05-06T00:00:00.000Z",
+    providerId: null,
+    credentialSource: null
   });
   store.close();
 
@@ -3553,6 +3555,8 @@ test("app_catalog upserts and lists entries for a given source", () => {
     archivePath: null,
     target: "darwin-arm64",
     cachedAt: "2026-04-09T00:00:00Z",
+    providerId: "twitter",
+    credentialSource: "platform",
   });
 
   const entries = store.listAppCatalogEntries({ source: "marketplace" });
@@ -3581,6 +3585,8 @@ test("app_catalog clearAppCatalogSource wipes only the given source", () => {
     version: null,
     target: "darwin-arm64",
     cachedAt: "2026-04-09T00:00:00Z",
+    providerId: null,
+    credentialSource: null,
   };
   store.upsertAppCatalogEntry({
     ...base, appId: "twitter", source: "marketplace",
@@ -3612,6 +3618,7 @@ test("app_catalog deleteAppCatalogEntry removes a single row", () => {
     description: null, icon: null, category: null, tags: [],
     version: "v0.1.0", archiveUrl: "https://a.test", archivePath: null,
     target: "darwin-arm64", cachedAt: "2026-04-09T00:00:00Z",
+    providerId: null, credentialSource: null,
   });
   const deleted = store.deleteAppCatalogEntry({ source: "marketplace", appId: "twitter" });
   assert.equal(deleted, true);
@@ -3637,6 +3644,8 @@ test("app_catalog composite PK allows same appId in both sources", () => {
     version: null,
     target: "darwin-arm64",
     cachedAt: "2026-04-09T00:00:00Z",
+    providerId: null,
+    credentialSource: null,
   };
   store.upsertAppCatalogEntry({
     ...base, source: "marketplace",

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -471,6 +471,8 @@ export interface AppCatalogEntryRecord {
   archivePath: string | null;
   target: string;
   cachedAt: string;
+  providerId: string | null;
+  credentialSource: string | null;
 }
 
 export interface CronjobRecord {
@@ -5950,13 +5952,16 @@ export class RuntimeStateStore {
     archivePath: string | null;
     target: string;
     cachedAt: string;
+    providerId: string | null;
+    credentialSource: string | null;
   }): AppCatalogEntryRecord {
     const tagsJson = JSON.stringify(params.tags ?? []);
     this.controlPlaneDb().prepare(`
       INSERT INTO app_catalog (
         app_id, source, name, description, icon, category,
-        tags_json, version, archive_url, archive_path, target, cached_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        tags_json, version, archive_url, archive_path, target, cached_at,
+        provider_id, credential_source
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(source, app_id) DO UPDATE SET
         name = excluded.name,
         description = excluded.description,
@@ -5967,7 +5972,9 @@ export class RuntimeStateStore {
         archive_url = excluded.archive_url,
         archive_path = excluded.archive_path,
         target = excluded.target,
-        cached_at = excluded.cached_at
+        cached_at = excluded.cached_at,
+        provider_id = excluded.provider_id,
+        credential_source = excluded.credential_source
     `).run(
       params.appId,
       params.source,
@@ -5981,6 +5988,8 @@ export class RuntimeStateStore {
       params.archivePath,
       params.target,
       params.cachedAt,
+      params.providerId,
+      params.credentialSource,
     );
     return {
       appId: params.appId,
@@ -5995,6 +6004,8 @@ export class RuntimeStateStore {
       archivePath: params.archivePath,
       target: params.target,
       cachedAt: params.cachedAt,
+      providerId: params.providerId,
+      credentialSource: params.credentialSource,
     };
   }
 
@@ -6058,6 +6069,9 @@ export class RuntimeStateStore {
       archivePath: row.archive_path == null ? null : String(row.archive_path),
       target: String(row.target ?? ""),
       cachedAt: String(row.cached_at ?? ""),
+      providerId: row.provider_id == null ? null : String(row.provider_id),
+      credentialSource:
+        row.credential_source == null ? null : String(row.credential_source),
     };
   }
 
@@ -7151,8 +7165,10 @@ export class RuntimeStateStore {
           archive_url,
           archive_path,
           target,
-          cached_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          cached_at,
+          provider_id,
+          credential_source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       for (const row of rows) {
         statement.run(
@@ -7167,7 +7183,9 @@ export class RuntimeStateStore {
           row.archive_url ?? null,
           row.archive_path ?? null,
           row.target,
-          row.cached_at
+          row.cached_at,
+          row.provider_id ?? null,
+          row.credential_source ?? null
         );
       }
     }
@@ -7588,6 +7606,8 @@ export class RuntimeStateStore {
           archive_path TEXT,
           target TEXT NOT NULL,
           cached_at TEXT NOT NULL,
+          provider_id TEXT,
+          credential_source TEXT,
           PRIMARY KEY (source, app_id)
       );
 
@@ -7609,6 +7629,27 @@ export class RuntimeStateStore {
     this.ensureMemoryEntriesTableSchema(db);
     this.ensureMemoryEmbeddingIndexSchema(db);
     this.migrateIntegrationConnectionIdentityColumns(db);
+    this.migrateAppCatalogProviderColumns(db);
+  }
+
+  private migrateAppCatalogProviderColumns(db: Database.Database): void {
+    const tableNames = new Set<string>(
+      (db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+        (row) => row.name,
+      ),
+    );
+    if (!tableNames.has("app_catalog")) {
+      return;
+    }
+    const columns = new Set<string>(
+      (db.prepare("PRAGMA table_info(app_catalog)").all() as Array<{ name: string }>).map((row) => row.name),
+    );
+    if (!columns.has("provider_id")) {
+      db.exec("ALTER TABLE app_catalog ADD COLUMN provider_id TEXT;");
+    }
+    if (!columns.has("credential_source")) {
+      db.exec("ALTER TABLE app_catalog ADD COLUMN credential_source TEXT;");
+    }
   }
 
   private ensureWorkspaceRuntimeDbSchema(db: Database.Database): void {

--- a/sdk/runtime-client/src/methods/apps.ts
+++ b/sdk/runtime-client/src/methods/apps.ts
@@ -27,6 +27,8 @@ export type AppCatalogEntry = {
   archive_path: string | null;
   target: string;
   cached_at: string;
+  provider_id: string | null;
+  credential_source: string | null;
 };
 
 export type AppCatalogListResponse = {


### PR DESCRIPTION
## Summary

- Apps self-declare `provider_id` + `credential_source` in `app.runtime.yaml`; the control plane already surfaces them on the templates API. The desktop was ignoring those fields and keeping **four parallel hardcoded tables**, so adding a new module to `marketplace.json` silently broke install-time integration binding writes.
- Plumb `provider_id` + `credential_source` end-to-end (state-store → api-server → runtime-client SDK → desktop main → renderer) so **adding a module to `marketplace.json` is now sufficient** — no desktop code change required.
- Net: -12 lines, four hardcoded maps deleted (`APP_TO_PROVIDER_MAP`, `PROVIDER_CATEGORY_GROUPS`, `PROVIDER_TOOLKIT_PREFERENCE`, `TOOLKIT_SLUG_TO_PROVIDER`).

## Behaviour notes

- Google sub-toolkits (gmail, googledrive, googlecalendar, googlesheets) now appear as **separate cards** in the Integrations pane instead of being collapsed under a single "google" provider. Each is its own Composio toolkit anyway, and this matches how every other module is treated.
- Integration card categories now come from Composio's toolkit response (`toolkit.categories`), falling back to `["other"]` instead of the deleted `PROVIDER_CATEGORY_GROUPS`.
- `app_catalog` SQLite migration is additive (`ALTER TABLE … ADD COLUMN`) — existing installations get `provider_id`/`credential_source` as `NULL` until the next desktop catalog sync repopulates them from the control-plane templates response.

## Files

| Layer | Files |
|---|---|
| state-store | `runtime/state-store/src/store.{ts,test.ts}` |
| api-server | `runtime/api-server/src/app.{ts,test.ts}` |
| SDK | `sdk/runtime-client/src/methods/apps.ts` |
| desktop | `desktop/electron/main.ts`, `desktop/src/types/electron.d.ts`, `desktop/src/lib/workspaceDesktop.tsx`, `desktop/src/components/marketplace/AppsGallery.tsx`, `desktop/src/components/panes/IntegrationsPane.tsx` |

## Test plan

- [x] `npm run runtime:state-store:test` — 110/110 pass
- [x] `npm run runtime:api-server:test` — 639/639 pass
- [x] `npm run desktop:typecheck` — clean
- [x] `npm run runtime:state-store:typecheck` / `runtime:api-server:typecheck` — clean
- [x] `npm --prefix desktop run build:electron` + `build:renderer` — clean
- [ ] Manual: install a fresh module from marketplace, verify install-time integration binding is written without any desktop edit
- [ ] Manual: open Integrations pane, confirm gmail / googledrive / googlecalendar / googlesheets render as separate cards with correct categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)