### PR TITLE
ui(desktop): topbar + CreditsPill style cleanup — variants, tokens, icon swap

### DIFF
--- a/desktop/src/components/billing/CreditsPill.tsx
+++ b/desktop/src/components/billing/CreditsPill.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { AlertTriangle, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface CreditsPillProps {
@@ -19,14 +19,13 @@ export function CreditsPill({
       <Button
         type="button"
         size="sm"
-        variant="outline"
+        variant="bordered"
         role="status"
         aria-busy="true"
         aria-label="Loading credits balance"
-        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border/55 bg-foreground/6 px-2"
       >
-        <span className="size-3.5 animate-pulse rounded-full bg-muted-foreground/20" />
-        <span className="h-3 w-10 animate-pulse rounded bg-muted-foreground/20" />
+        <span className="size-3.5 animate-pulse rounded-full bg-muted" />
+        <span className="h-3 w-10 animate-pulse rounded bg-muted" />
       </Button>
     );
   }
@@ -35,17 +34,16 @@ export function CreditsPill({
     <Button
       type="button"
       size="sm"
-      variant="outline"
+      variant="bordered"
       onClick={onClick}
-      className={`inline-flex h-7 shrink-0 tracking-tight items-center gap-1.5 rounded-md border px-2 text-xs transition ${
+      aria-label={
         isLowBalance
-          ? "border-warning/40 bg-warning/10 text-warning hover:bg-warning/14"
-          : "border-border/55 bg-foreground/6"
-      }`}
-      aria-label="Open credits and billing details"
+          ? "Credits balance low — open billing"
+          : "Open credits and billing details"
+      }
     >
-      <Sparkles className="size-3.5 opacity-60" />
-      <span className="font-medium tabular-nums">
+      {isLowBalance ? <AlertTriangle className="text-warning" /> : <Sparkles />}
+      <span className="tabular-nums">
         {(balance ?? 0).toLocaleString()}
       </span>
     </Button>

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -291,10 +291,9 @@ export function TopTabsBar({
     : undefined;
 
   const windowControlButtonClassName =
-    "window-no-drag flex h-6 w-6 items-center justify-center rounded-[7px] border border-transparent text-muted-foreground transition-colors duration-150 hover:bg-foreground/6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+    "window-no-drag flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors duration-150 hover:bg-fg-6 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
   const workspaceSwitcherContainerClassName = `${integratedTitleBar ? "window-no-drag " : ""}relative w-40 shrink-0`;
-  const workspaceSwitcherButtonClassName =
-    "h-7 w-full shrink-0 justify-start gap-1.5 rounded-md border border-border/55 bg-foreground/6 px-2 text-xs";
+  const workspaceSwitcherButtonClassName = "w-full justify-start";
 
   return (
     <header
@@ -333,7 +332,7 @@ export function TopTabsBar({
             >
               <Button
                 ref={workspaceSwitcherButtonRef}
-                variant="outline"
+                variant="bordered"
                 size="sm"
                 aria-expanded={workspaceSwitcherOpen}
                 onClick={() => {
@@ -351,12 +350,12 @@ export function TopTabsBar({
                 }}
                 className={workspaceSwitcherButtonClassName}
               >
-                <FolderKanban className="size-3.5 shrink-0 text-primary" />
-                <span className="min-w-0 truncate text-left font-medium">
+                <FolderKanban />
+                <span className="min-w-0 truncate text-left">
                   {selectedWorkspace?.name || "Select workspace"}
                 </span>
                 <ChevronDown
-                  className={`ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
+                  className={`ml-auto transition-transform ${workspaceSwitcherOpen ? "rotate-180" : ""}`}
                 />
               </Button>
             </div>
@@ -370,7 +369,7 @@ export function TopTabsBar({
                   variant="outline"
                   size="icon-sm"
                   aria-label="Open account menu"
-                  className="size-7 shrink-0 overflow-hidden rounded-full border border-border/55 bg-foreground/6 p-0"
+                  className="size-7 shrink-0 overflow-hidden rounded-full border border-border bg-fg-6 p-0"
                 />
               }
             >
@@ -453,7 +452,7 @@ export function TopTabsBar({
 
       {workspaceErrorMessage ? (
         <div
-          className={`${integratedTitleBar ? "window-no-drag " : ""}theme-chat-system-bubble mt-2 rounded-[14px] border px-3 py-2 text-xs leading-6`}
+          className={`${integratedTitleBar ? "window-no-drag " : ""}theme-chat-system-bubble mt-2 rounded-2xl border px-3 py-2 text-xs leading-6`}
         >
           {workspaceErrorMessage}
         </div>


### PR DESCRIPTION
## Summary

Pure presentational refactor of the top toolbar. **No behavior changes** — all callbacks, props, and conditional rendering paths are preserved.

This is a subset of an internal branch's UI cleanup, narrowed to changes that only adjust how existing surfaces look.

## TopTabsBar

- Workspace switcher Button: \`outline\` → \`bordered\` variant; drop manual \`h-7\` / \`border-border/55\` / \`bg-foreground/6\` / \`px-2\` / \`text-xs\` override in favor of the canonical Button variant.
- FolderKanban / ChevronDown inside the switcher: drop hand-tuned \`size-3.5\` / \`text-primary\` / \`text-muted-foreground\` / \`shrink-0\` / \`font-medium\` in favor of the Button's default icon sizing + foreground color.
- \`windowControlButtonClassName\`: \`rounded-[7px]\` → \`rounded-md\`; hover token \`bg-foreground/6\` → \`bg-fg-6\`.
- Avatar trigger: \`border-border/55\` → \`border-border\`; \`bg-foreground/6\` → \`bg-fg-6\`.
- \`workspaceErrorMessage\`: \`rounded-[14px]\` → \`rounded-2xl\`.

## CreditsPill

- Drop manual \`h-7\` / \`border-border/55\` / \`bg-foreground/6\` wrappers; use \`bordered\` variant directly.
- Low-balance signal moves from border/text color override to icon swap (Sparkles → AlertTriangle with \`text-warning\`); \`aria-label\` updates to reflect the warning state.
- Skeleton bg switches from \`bg-muted-foreground/20\` to \`bg-muted\` token.

## Test plan

- [x] \`npm run desktop:typecheck\` — clean
- [x] \`npm --prefix desktop run build:renderer\` — clean
- [ ] Manual: open a workspace, confirm workspace switcher / window controls / avatar / error bubble all render correctly under both light and dark themes
- [ ] Manual: low-balance state on CreditsPill shows the AlertTriangle icon with warning color

🤖 Generated with [Claude Code](https://claude.com/claude-code)