### PR TITLE
fix(desktop): unify Composio toolkit display across marketplace + sidebar

### DIFF
--- a/desktop/src/components/marketplace/AppCatalogCard.tsx
+++ b/desktop/src/components/marketplace/AppCatalogCard.tsx
@@ -24,6 +24,15 @@ interface AppCatalogCardProps {
   disabled: boolean;
   onInstall: () => void;
   /**
+   * Display name override sourced from the Composio toolkit by
+   * `entry.provider_id`. Used when the marketplace manifest's `name` is
+   * just the slug (e.g. "gcalendar") and Composio knows the proper name
+   * ("Google Calendar"). Falls back to `entry.name` when null.
+   */
+  displayName?: string | null;
+  /** Logo URL from the Composio toolkit; takes precedence over `entry.icon`. */
+  logoUrl?: string | null;
+  /**
    * Active connections matching the app's expected provider. When the
    * caller has computed this list, the install footer renders an inline
    * account picker so the user binds at install time instead of
@@ -45,11 +54,14 @@ export function AppCatalogCard({
   state,
   disabled,
   onInstall,
+  displayName,
+  logoUrl,
   availableAccounts,
   selectedConnectionId,
   onSelectAccount,
 }: AppCatalogCardProps) {
-  const label = entry.name || entry.app_id;
+  const label =
+    displayName?.trim() || entry.name?.trim() || entry.app_id;
   const description = entry.description ?? "";
   const showAccountPicker =
     state === "available" &&
@@ -94,8 +106,9 @@ export function AppCatalogCard({
       <CardHeader>
         <div className="flex items-center gap-3">
           <AppIcon
-            iconUrl={entry.icon}
+            iconUrl={logoUrl ?? entry.icon}
             appId={entry.app_id}
+            providerId={entry.provider_id}
             label={label}
             size="card"
           />

--- a/desktop/src/components/marketplace/AppIcon.tsx
+++ b/desktop/src/components/marketplace/AppIcon.tsx
@@ -8,6 +8,14 @@ interface AppIconProps {
   iconUrl?: string | null;
   /** Toolkit slug / app id used for CDN lookup and local SVG match. */
   appId: string;
+  /**
+   * Composio toolkit slug (e.g. `googlecalendar`, `googledrive`) when the
+   * app's `app_id` differs from it (e.g. `gcalendar`, `gdrive`). Preferred
+   * over `appId` for the CDN lookup since the Composio logo CDN is keyed
+   * by toolkit slug — using `appId` 404s for any app whose internal id
+   * isn't also a Composio slug.
+   */
+  providerId?: string | null;
   /** Human label, used to compute the letter-fallback character(s). */
   label: string;
   /**
@@ -37,6 +45,7 @@ interface AppIconProps {
 export function AppIcon({
   iconUrl,
   appId,
+  providerId,
   label,
   size = "card",
 }: AppIconProps) {
@@ -80,11 +89,11 @@ export function AppIcon({
   }
 
   if (stage === "cdn") {
-    const slug = appId.trim().toLowerCase();
+    const cdnSlug = (providerId?.trim() || appId.trim()).toLowerCase();
     return (
       <span className={containerClass}>
         <img
-          src={`https://logos.composio.dev/api/${slug}`}
+          src={`https://logos.composio.dev/api/${cdnSlug}`}
           alt=""
           className={imgClass}
           onError={() => setStage(localSvg ? "local" : "letter")}

--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ExternalLink, FileUp, LoaderCircle } from "lucide-react";
-import { getProviderForCatalogEntry, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import {
+  getProviderForCatalogEntry,
+  resolveAppDisplay,
+  useWorkspaceDesktop,
+} from "@/lib/workspaceDesktop";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -34,15 +38,6 @@ function AppCatalogCardSkeleton() {
   );
 }
 
-interface ComposioToolkit {
-  slug: string;
-  name: string;
-  description: string;
-  logo: string | null;
-  auth_schemes: string[];
-  categories: string[];
-}
-
 export function AppsGallery() {
   const {
     appCatalog,
@@ -50,6 +45,7 @@ export function AppsGallery() {
     appCatalogError,
     appCatalogSource,
     refreshAppCatalog,
+    composioToolkitsByProvider,
     installingAppId,
     installAppFromCatalog,
     installedApps,
@@ -99,44 +95,6 @@ export function AppsGallery() {
   );
   const workspaceGated = !selectedWorkspace;
   const anyInstalling = Boolean(installingAppId);
-
-  // Composio toolkit metadata (name + logo) keyed by toolkit slug, used
-  // to enrich each card so display name + icon match what users see in
-  // Integrations and what Composio publishes — without us re-maintaining
-  // a local app→display table. Lookup is by `entry.provider_id` (the
-  // toolkit slug self-declared in app.runtime.yaml). Fetched once when
-  // the gallery first mounts; failures degrade silently to entry.name +
-  // CDN-by-app_id.
-  const [toolkitsByProvider, setToolkitsByProvider] = useState<
-    Record<string, ComposioToolkit>
-  >({});
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const { toolkits } =
-          await window.electronAPI.workspace.composioListToolkits();
-        if (cancelled) return;
-        const indexed: Record<string, ComposioToolkit> = {};
-        for (const toolkit of toolkits) {
-          const slug = toolkit.slug?.trim().toLowerCase();
-          if (slug) indexed[slug] = toolkit;
-        }
-        setToolkitsByProvider(indexed);
-      } catch {
-        // Non-fatal — cards fall back to manifest name + CDN-by-app_id.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  function lookupToolkit(entry: AppCatalogEntryPayload): ComposioToolkit | null {
-    const slug = entry.provider_id?.trim().toLowerCase();
-    if (!slug) return null;
-    return toolkitsByProvider[slug] ?? null;
-  }
 
   // Active integration connections, indexed by provider id, used to
   // surface the multi-account picker on cards that have ≥2 accounts for
@@ -245,12 +203,12 @@ export function AppsGallery() {
           >
             <p className="text-base font-semibold text-foreground">
               Connect{" "}
-              {toolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
+              {composioToolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
                 ?.name ?? pendingAppInstall.provider}
             </p>
             <p className="mt-1.5 text-xs text-muted-foreground">
               {pendingAppInstall.appId} requires a connected{" "}
-              {toolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
+              {composioToolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
                 ?.name ?? pendingAppInstall.provider}{" "}
               account to work. Connect it first, then the app will be installed
               automatically.
@@ -319,7 +277,10 @@ export function AppsGallery() {
             const selected =
               selectedAccountByApp[entry.app_id] ??
               sortedCandidates[0]?.connection_id;
-            const toolkit = lookupToolkit(entry);
+            const display = resolveAppDisplay(
+              entry.provider_id,
+              composioToolkitsByProvider,
+            );
             return (
               <AppCatalogCard
                 key={`${entry.source}:${entry.app_id}`}
@@ -330,8 +291,8 @@ export function AppsGallery() {
                   (anyInstalling && !isInstalling) ||
                   Boolean(pendingAppInstall)
                 }
-                displayName={toolkit?.name ?? null}
-                logoUrl={toolkit?.logo ?? null}
+                displayName={display.name}
+                logoUrl={display.logo}
                 availableAccounts={sortedCandidates}
                 selectedConnectionId={selected ?? null}
                 onSelectAccount={(connectionId) =>

--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -34,20 +34,14 @@ function AppCatalogCardSkeleton() {
   );
 }
 
-const PROVIDER_DISPLAY: Record<string, string> = {
-  twitter: "Twitter / X",
-  linkedin: "LinkedIn",
-  reddit: "Reddit",
-  gmail: "Google (Gmail)",
-  googlesheets: "Google (Sheets)",
-  github: "GitHub",
-  hubspot: "HubSpot",
-  attio: "Attio",
-  calcom: "Cal.com",
-  apollo: "Apollo.io",
-  instantly: "Instantly",
-  zoominfo: "ZoomInfo",
-};
+interface ComposioToolkit {
+  slug: string;
+  name: string;
+  description: string;
+  logo: string | null;
+  auth_schemes: string[];
+  categories: string[];
+}
 
 export function AppsGallery() {
   const {
@@ -105,6 +99,44 @@ export function AppsGallery() {
   );
   const workspaceGated = !selectedWorkspace;
   const anyInstalling = Boolean(installingAppId);
+
+  // Composio toolkit metadata (name + logo) keyed by toolkit slug, used
+  // to enrich each card so display name + icon match what users see in
+  // Integrations and what Composio publishes — without us re-maintaining
+  // a local app→display table. Lookup is by `entry.provider_id` (the
+  // toolkit slug self-declared in app.runtime.yaml). Fetched once when
+  // the gallery first mounts; failures degrade silently to entry.name +
+  // CDN-by-app_id.
+  const [toolkitsByProvider, setToolkitsByProvider] = useState<
+    Record<string, ComposioToolkit>
+  >({});
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { toolkits } =
+          await window.electronAPI.workspace.composioListToolkits();
+        if (cancelled) return;
+        const indexed: Record<string, ComposioToolkit> = {};
+        for (const toolkit of toolkits) {
+          const slug = toolkit.slug?.trim().toLowerCase();
+          if (slug) indexed[slug] = toolkit;
+        }
+        setToolkitsByProvider(indexed);
+      } catch {
+        // Non-fatal — cards fall back to manifest name + CDN-by-app_id.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function lookupToolkit(entry: AppCatalogEntryPayload): ComposioToolkit | null {
+    const slug = entry.provider_id?.trim().toLowerCase();
+    if (!slug) return null;
+    return toolkitsByProvider[slug] ?? null;
+  }
 
   // Active integration connections, indexed by provider id, used to
   // surface the multi-account picker on cards that have ≥2 accounts for
@@ -213,13 +245,13 @@ export function AppsGallery() {
           >
             <p className="text-base font-semibold text-foreground">
               Connect{" "}
-              {PROVIDER_DISPLAY[pendingAppInstall.provider] ??
-                pendingAppInstall.provider}
+              {toolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
+                ?.name ?? pendingAppInstall.provider}
             </p>
             <p className="mt-1.5 text-xs text-muted-foreground">
               {pendingAppInstall.appId} requires a connected{" "}
-              {PROVIDER_DISPLAY[pendingAppInstall.provider] ??
-                pendingAppInstall.provider}{" "}
+              {toolkitsByProvider[pendingAppInstall.provider.toLowerCase()]
+                ?.name ?? pendingAppInstall.provider}{" "}
               account to work. Connect it first, then the app will be installed
               automatically.
             </p>
@@ -287,6 +319,7 @@ export function AppsGallery() {
             const selected =
               selectedAccountByApp[entry.app_id] ??
               sortedCandidates[0]?.connection_id;
+            const toolkit = lookupToolkit(entry);
             return (
               <AppCatalogCard
                 key={`${entry.source}:${entry.app_id}`}
@@ -297,6 +330,8 @@ export function AppsGallery() {
                   (anyInstalling && !isInstalling) ||
                   Boolean(pendingAppInstall)
                 }
+                displayName={toolkit?.name ?? null}
+                logoUrl={toolkit?.logo ?? null}
                 availableAccounts={sortedCandidates}
                 selectedConnectionId={selected ?? null}
                 onSelectAccount={(connectionId) =>

--- a/desktop/src/components/panes/AppSurfacePane.tsx
+++ b/desktop/src/components/panes/AppSurfacePane.tsx
@@ -35,7 +35,7 @@ import {
   accountDisplayLabel,
   useEnrichedConnections,
 } from "@/lib/integrationDisplay";
-import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import { resolveAppDisplay, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import {
   getWorkspaceAppDefinition,
@@ -96,7 +96,12 @@ export function AppSurfacePane({
   resourceId,
   view,
 }: AppSurfacePaneProps) {
-  const { refreshInstalledApps, removeInstalledApp } = useWorkspaceDesktop();
+  const {
+    refreshInstalledApps,
+    removeInstalledApp,
+    appCatalog,
+    composioToolkitsByProvider,
+  } = useWorkspaceDesktop();
   const { selectedWorkspaceId } = useWorkspaceSelection();
   const app = providedApp || getWorkspaceAppDefinition(appId);
   const [isRemoving, setIsRemoving] = useState(false);
@@ -127,7 +132,10 @@ export function AppSurfacePane({
     return () => observer.disconnect();
   }, []);
 
-  const label = app?.label ?? appId;
+  const catalogEntry = appCatalog.find((entry) => entry.app_id === appId);
+  const providerId = catalogEntry?.provider_id ?? null;
+  const display = resolveAppDisplay(providerId, composioToolkitsByProvider);
+  const label = display.name ?? app?.label ?? appId;
   const ready = app && "ready" in app ? app.ready : false;
   const error =
     app && "error" in app && typeof app.error === "string" ? app.error : null;
@@ -381,7 +389,13 @@ export function AppSurfacePane({
           destructive overflow trigger. */}
       <div className="shrink-0 border-b border-border px-3 py-2">
         <div className="flex items-center gap-2.5">
-          <AppIcon appId={appId} label={label} size="toolbar" />
+          <AppIcon
+            iconUrl={display.logo}
+            appId={appId}
+            providerId={providerId}
+            label={label}
+            size="toolbar"
+          />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <span className="truncate text-xs font-semibold tracking-wide text-foreground">
               {label}

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.test.mjs
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.test.mjs
@@ -30,8 +30,10 @@ test("app list rows stay single-line with tooltip descriptions", async () => {
   // Row no longer renders a two-line name + truncated summary stack.
   assert.doesNotMatch(source, /line-clamp-1/);
   assert.doesNotMatch(source, />\{app\.summary\}</);
-  // Hover tooltip surfaces summary instead.
-  assert.match(source, /title=\{app\.summary \|\| app\.label\}/);
+  // Hover tooltip surfaces summary instead. `label` is the resolved
+  // display name (Composio toolkit when available, falling back to the
+  // manifest's app.label) — summary still wins when set.
+  assert.match(source, /title=\{app\.summary \|\| label\}/);
 });
 
 test("status dot is suppressed for ready apps, visible for non-ready", async () => {

--- a/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx
@@ -2,6 +2,7 @@ import { AppWindow, Plus } from "lucide-react";
 import { AppIcon } from "@/components/marketplace/AppIcon";
 import { Button } from "@/components/ui/button";
 import type { WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
+import { resolveAppDisplay, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 interface SpaceApplicationsExplorerPaneProps {
   installedApps: WorkspaceInstalledAppDefinition[];
@@ -45,7 +46,13 @@ export function SpaceApplicationsExplorerPane({
   onSelectApp,
   onAddApp,
 }: SpaceApplicationsExplorerPaneProps) {
+  const { appCatalog, composioToolkitsByProvider } = useWorkspaceDesktop();
   const isEmpty = installedApps.length === 0;
+
+  function lookupProviderId(appId: string): string | null {
+    const entry = appCatalog.find((candidate) => candidate.app_id === appId);
+    return entry?.provider_id ?? null;
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
@@ -70,6 +77,12 @@ export function SpaceApplicationsExplorerPane({
               const isActive = activeAppId === app.id;
               const tone = appStatusTone(app);
               const showStatus = tone !== "ready";
+              const providerId = lookupProviderId(app.id);
+              const display = resolveAppDisplay(
+                providerId,
+                composioToolkitsByProvider,
+              );
+              const label = display.name ?? app.label;
               return (
                 <Button
                   key={app.id}
@@ -78,17 +91,23 @@ export function SpaceApplicationsExplorerPane({
                   size="sm"
                   onClick={() => onSelectApp(app.id)}
                   aria-current={isActive ? "page" : undefined}
-                  aria-label={`${app.label} — ${statusPipLabel(tone)}`}
-                  title={app.summary || app.label}
+                  aria-label={`${label} — ${statusPipLabel(tone)}`}
+                  title={app.summary || label}
                   className={`h-auto w-full justify-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors ${
                     isActive
                       ? "bg-accent text-foreground"
                       : "text-foreground hover:bg-accent"
                   }`}
                 >
-                  <AppIcon appId={app.id} label={app.label} size="row" />
+                  <AppIcon
+                    iconUrl={display.logo}
+                    appId={app.id}
+                    providerId={providerId}
+                    label={label}
+                    size="row"
+                  />
                   <span className="min-w-0 flex-1 truncate text-sm">
-                    {app.label}
+                    {label}
                   </span>
                   {showStatus ? (
                     <span

--- a/desktop/src/components/publish/LivePreviewPanel.tsx
+++ b/desktop/src/components/publish/LivePreviewPanel.tsx
@@ -11,6 +11,7 @@ import { AppIcon } from "@/components/marketplace/AppIcon";
 import { Badge } from "@/components/ui/badge";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { cn } from "@/lib/utils";
+import { resolveAppDisplay, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 const CATEGORY_LABELS: Record<string, string> = {
   marketing: "Marketing",
@@ -223,6 +224,7 @@ function BundleIllustration({
   forceExcludePaths: string[];
 }) {
   const [bundle, setBundle] = useState<BundleSummary | null>(null);
+  const { appCatalog, composioToolkitsByProvider } = useWorkspaceDesktop();
 
   useEffect(() => {
     let cancelled = false;
@@ -320,21 +322,34 @@ function BundleIllustration({
               Apps
             </p>
             <ul>
-              {data.apps.map((app) => (
-                <li
-                  className="flex items-center gap-2.5 rounded-md px-2 py-1.5"
-                  key={app.id}
-                >
-                  <AppIcon
-                    appId={app.id}
-                    label={app.label || app.id}
-                    size="row"
-                  />
-                  <span className="min-w-0 flex-1 truncate text-sm">
-                    {app.label || app.id}
-                  </span>
-                </li>
-              ))}
+              {data.apps.map((app) => {
+                const catalogEntry = appCatalog.find(
+                  (e) => e.app_id === app.id,
+                );
+                const providerId = catalogEntry?.provider_id ?? null;
+                const display = resolveAppDisplay(
+                  providerId,
+                  composioToolkitsByProvider,
+                );
+                const resolvedLabel = display.name ?? app.label ?? app.id;
+                return (
+                  <li
+                    className="flex items-center gap-2.5 rounded-md px-2 py-1.5"
+                    key={app.id}
+                  >
+                    <AppIcon
+                      iconUrl={display.logo}
+                      appId={app.id}
+                      providerId={providerId}
+                      label={resolvedLabel}
+                      size="row"
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm">
+                      {resolvedLabel}
+                    </span>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}

--- a/desktop/src/components/publish/PublishScreen.tsx
+++ b/desktop/src/components/publish/PublishScreen.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { cn } from "@/lib/utils";
-import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import { resolveAppDisplay, useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 import { BundleFileTree } from "./BundleFileTree";
 import { LivePreviewPanel } from "./LivePreviewPanel";
@@ -902,6 +902,7 @@ function BundleForm({
   selectedApps,
   onSelectedAppsChange,
 }: BundleFormProps) {
+  const { appCatalog, composioToolkitsByProvider } = useWorkspaceDesktop();
   const allSelected = apps.length > 0 && selectedApps.length === apps.length;
   return (
     <div className="space-y-5">
@@ -969,21 +970,39 @@ function BundleForm({
                       >
                         {checked && <Check className="size-3" />}
                       </span>
-                      <AppIcon
-                        appId={app.id}
-                        label={app.label || app.id}
-                        size="row"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium">
-                          {app.label || app.id}
-                        </span>
-                        {app.summary && (
-                          <span className="mt-0.5 line-clamp-1 block text-xs text-muted-foreground">
-                            {app.summary}
-                          </span>
-                        )}
-                      </span>
+                      {(() => {
+                        const catalogEntry = appCatalog.find(
+                          (e) => e.app_id === app.id,
+                        );
+                        const providerId = catalogEntry?.provider_id ?? null;
+                        const display = resolveAppDisplay(
+                          providerId,
+                          composioToolkitsByProvider,
+                        );
+                        const resolvedLabel =
+                          display.name ?? app.label ?? app.id;
+                        return (
+                          <>
+                            <AppIcon
+                              iconUrl={display.logo}
+                              appId={app.id}
+                              providerId={providerId}
+                              label={resolvedLabel}
+                              size="row"
+                            />
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate text-sm font-medium">
+                                {resolvedLabel}
+                              </span>
+                              {app.summary && (
+                                <span className="mt-0.5 line-clamp-1 block text-xs text-muted-foreground">
+                                  {app.summary}
+                                </span>
+                              )}
+                            </span>
+                          </>
+                        );
+                      })()}
                     </button>
                   </li>
                 );

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -24,6 +25,39 @@ export function getProviderForCatalogEntry(
 ): string | undefined {
   const value = entry?.provider_id?.trim();
   return value ? value : undefined;
+}
+
+/**
+ * Subset of the Composio toolkit shape we need across the desktop shell —
+ * display name + logo + categories. The full payload comes from
+ * `composioListToolkits()`; we keep the locally-typed alias narrow on
+ * purpose so app surfaces don't accidentally couple to fields we may
+ * later choose not to expose globally.
+ */
+export interface ComposioToolkitMetadata {
+  slug: string;
+  name: string;
+  description: string;
+  logo: string | null;
+  categories: string[];
+}
+
+/**
+ * Resolves the display name + logo for an app by combining the catalog
+ * entry's `provider_id` (self-declared in app.runtime.yaml) with the
+ * shared Composio toolkit map. Returns `null` fields when no toolkit
+ * data is available, so callers can fall back to their own defaults.
+ */
+export function resolveAppDisplay(
+  providerId: string | null | undefined,
+  toolkitsByProvider: Record<string, ComposioToolkitMetadata>,
+): { name: string | null; logo: string | null } {
+  const slug = providerId?.trim().toLowerCase();
+  const toolkit = slug ? toolkitsByProvider[slug] : undefined;
+  return {
+    name: toolkit?.name?.trim() || null,
+    logo: toolkit?.logo ?? null,
+  };
 }
 
 const ONBOARDING_ACTIVE_STATUSES = new Set(["pending", "awaiting_confirmation", "in_progress"]);
@@ -82,6 +116,7 @@ interface WorkspaceDesktopContextValue {
   appCatalogSource: "marketplace" | "local";
   setAppCatalogSource: (source: "marketplace" | "local") => void;
   refreshAppCatalog: () => Promise<void>;
+  composioToolkitsByProvider: Record<string, ComposioToolkitMetadata>;
   installingAppId: string | null;
   installAppFromCatalog: (
     appId: string,
@@ -284,6 +319,15 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
   const [isResolvingIntegrations, setIsResolvingIntegrations] = useState(false);
   const [pendingAppInstall, setPendingAppInstall] = useState<{ appId: string; provider: string } | null>(null);
   const [isConnectingAppIntegration, setIsConnectingAppIntegration] = useState(false);
+  // Composio toolkit metadata (name + logo + categories) keyed by toolkit
+  // slug. Single source of truth for app display name + icon across the
+  // shell — both the marketplace gallery and the workspace sidebar look
+  // up by `provider_id` (declared in app.runtime.yaml). Fetched once when
+  // the provider mounts; failures degrade silently to manifest names +
+  // CDN-by-app_id.
+  const [composioToolkitsByProvider, setComposioToolkitsByProvider] = useState<
+    Record<string, ComposioToolkitMetadata>
+  >({});
 
   const signedInUserId = sessionUserId(session);
   const isSignedIn = Boolean(signedInUserId);
@@ -314,6 +358,59 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
   useEffect(() => {
     setBrowserImportProfileDirState("");
   }, [browserImportSource]);
+
+  // Auto-load the marketplace app catalog once the runtime is running,
+  // even if the user hasn't opened the marketplace pane yet. The
+  // workspace sidebar uses `appCatalog[].provider_id` to map an installed
+  // app id (e.g. "gcalendar") to its Composio toolkit slug
+  // ("googlecalendar") for display name + logo lookup; without this
+  // eager load the sidebar would render the bare slug for any app
+  // surface entered before marketplace is visited.
+  const appCatalogAutoLoadAttemptedRef = useRef(false);
+  useEffect(() => {
+    if (runtimeStatus?.status !== "running") return;
+    if (appCatalogAutoLoadAttemptedRef.current) return;
+    appCatalogAutoLoadAttemptedRef.current = true;
+    void refreshAppCatalog();
+    // refreshAppCatalog is stable enough for this one-shot use; we
+    // intentionally don't list it as a dep to avoid re-firing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runtimeStatus?.status]);
+
+  // One-shot fetch of the Composio toolkit catalog. The shape lives in the
+  // shared context so app surfaces (marketplace gallery + workspace
+  // sidebar + onboarding) all derive display name + logo from the same
+  // source of truth and we never need a local app→display table.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { toolkits } =
+          await window.electronAPI.workspace.composioListToolkits();
+        if (cancelled) return;
+        const indexed: Record<string, ComposioToolkitMetadata> = {};
+        for (const toolkit of toolkits) {
+          const slug = toolkit.slug?.trim().toLowerCase();
+          if (!slug) continue;
+          indexed[slug] = {
+            slug,
+            name: toolkit.name ?? "",
+            description: toolkit.description ?? "",
+            logo: toolkit.logo ?? null,
+            categories: Array.isArray(toolkit.categories)
+              ? toolkit.categories
+              : [],
+          };
+        }
+        setComposioToolkitsByProvider(indexed);
+      } catch {
+        // Non-fatal — surfaces fall back to manifest names + CDN-by-app_id.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const onboardingModeActive = useMemo(() => isOnboardingMode(selectedWorkspace), [selectedWorkspace]);
   const sessionModeLabel = onboardingModeActive ? "onboarding" : "session";
@@ -1466,6 +1563,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       appCatalogSource,
       setAppCatalogSource,
       refreshAppCatalog,
+      composioToolkitsByProvider,
       installingAppId,
       installAppFromCatalog,
       pendingAppInstall,
@@ -1545,6 +1643,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       appCatalogSource,
       setAppCatalogSource,
       refreshAppCatalog,
+      composioToolkitsByProvider,
       installingAppId,
       installAppFromCatalog,
       pendingAppInstall,


### PR DESCRIPTION
## Problem

Multiple surfaces rendered installed apps with broken display:

- **Marketplace cards** (`gcalendar`, `gdrive`, …) showed the raw slug as the display name with a colored letter chip instead of the toolkit logo.
- **Workspace sidebar** showed the same problem (`Gcalendar` capitalized via `labelFromAppId`, generic `G` icon).
- **App surface toolbar** (the header of an opened app pane) showed `Gcalendar` + `G` chip — even though the app's own embedded UI rendered `Google Calendar` correctly.
- **Publish wizard** (BundleForm checklist + LivePreviewPanel bundle illustration) had the same issue.

Each surface was deriving display name + icon from its own local table or the manifest's `name` field. AppIcon's CDN call also used the app id as the toolkit slug — fine for `twitter`/`linkedin`, broken for any app whose internal id differs (`gcalendar`→`googlecalendar`, `gdrive`→`googledrive`).

## Fix — single source of truth in the shell

Each app already self-declares its Composio toolkit via `provider_id` in `app.runtime.yaml` (now plumbed end-to-end after #274). The Composio toolkit endpoint returns the authoritative display name + logo. Resolve them once in the shell and reuse everywhere.

### Shared layer (`workspaceDesktop.tsx`)

- One-shot Composio toolkit fetch on provider mount; expose `composioToolkitsByProvider` (slug-keyed) via context.
- `resolveAppDisplay(provider_id, toolkitsByProvider)` helper returns `{ name, logo }`.
- Auto-trigger `refreshAppCatalog()` once the runtime is running so any surface can map an installed app id to its `provider_id` without depending on the user opening marketplace.

### Per-surface

- **`AppIcon`**: accept a `providerId` prop; CDN slug now uses the toolkit slug when present, falling back to `appId`.
- **`AppCatalogCard`**: accept `displayName` + `logoUrl` props that override `entry.name` / `entry.icon` when provided.
- **`AppsGallery`**: drop the locally-fetched toolkit map and the local `PROVIDER_DISPLAY` table (12 hardcoded entries used by the connect-account dialog); pull both from the shared context.
- **`SpaceApplicationsExplorerPane`** (sidebar): read `provider_id` from the catalog, resolve display via the shared helper, pass `providerId` + `toolkit.logo` down to AppIcon. Tooltip + aria-label use the resolved name.
- **`AppSurfacePane`** (in-shell app toolbar): same resolution — header now reads "Google Calendar" with the proper logo instead of "Gcalendar"/G.
- **`PublishScreen` / `BundleForm`** (publish wizard checklist): same resolution.
- **`LivePreviewPanel` / `BundleIllustration`** (publish wizard preview): same resolution.

After this, adding a new module to `marketplace.json` requires zero desktop edits — every surface (marketplace card, sidebar row, app toolbar, publish flow) renders correct name + icon as long as the toolkit exists in Composio's catalog.

## Files

| Layer | File |
|---|---|
| Shared | `desktop/src/lib/workspaceDesktop.tsx` |
| Icons | `desktop/src/components/marketplace/AppIcon.tsx` |
| Marketplace | `desktop/src/components/marketplace/AppCatalogCard.tsx`, `AppsGallery.tsx` |
| Sidebar | `desktop/src/components/panes/SpaceApplicationsExplorerPane.tsx` (+ `.test.mjs`) |
| App surface | `desktop/src/components/panes/AppSurfacePane.tsx` |
| Publish | `desktop/src/components/publish/PublishScreen.tsx`, `LivePreviewPanel.tsx` |

## Test plan

- [x] `npm run desktop:typecheck` — clean
- [x] `npm --prefix desktop run build:renderer` — clean
- [x] `SpaceApplicationsExplorerPane.test.mjs` — 4/4 pass (`AppShell.test.mjs` had a pre-existing failure unrelated to this PR)
- [ ] Manual: open the marketplace, verify gcalendar / gdrive / slack / youtube / mailchimp / notion / instagram all render with toolkit-authentic name + logo (not the bare slug + letter chip).
- [ ] Manual: open a workspace with installed apps including gcalendar / gdrive — confirm the sidebar list shows "Google Calendar" / "Google Drive" with proper icons. Hover tooltip shows the marketplace summary.
- [ ] Manual: open the gcalendar app — toolbar header shows "Google Calendar" + Google Calendar logo (not "Gcalendar" + G chip).
- [ ] Manual: open the publish wizard, navigate to the Bundle step — installed-apps checklist + bundle preview both show the correct names + icons.
- [ ] Manual: trigger the connect-account dialog (install an app with no connected integration); verify the provider name in the dialog matches what the toolkit publishes.
- [ ] Manual: existing apps (twitter / linkedin / etc.) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)