### PR TITLE
fix(desktop): hide system-level workspace files in explorer

### DIFF
--- a/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
+++ b/desktop/electron/file-explorer-spreadsheet-preview.test.mjs
@@ -165,6 +165,11 @@ test("desktop file explorer enforces the selected workspace root as a filesystem
     source,
     /if \(\s*hideWorkspaceManagedRootEntries &&\s*dirEntry\.isDirectory\(\) &&\s*dirEntry\.name === "apps"\s*\) \{\s*continue;\s*\}/,
   );
+  assert.match(source, /const absolutePath = path\.join\(resolvedPath, dirEntry\.name\);/);
+  assert.match(
+    source,
+    /if \(\s*hideWorkspaceManagedRootEntries &&\s*describeProtectedWorkspaceExplorerPath\(workspaceRoot, absolutePath\)\s*\) \{\s*continue;\s*\}/,
+  );
   assert.doesNotMatch(
     source,
     /!dirEntry\.isDirectory\(\) && dirEntry\.name === "workspace\.yaml"/,

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -18947,6 +18947,7 @@ async function listDirectory(
     if (dirEntry.name.startsWith(".")) {
       continue;
     }
+    const absolutePath = path.join(resolvedPath, dirEntry.name);
     if (
       hideWorkspaceManagedRootEntries &&
       dirEntry.isDirectory() &&
@@ -18954,7 +18955,12 @@ async function listDirectory(
     ) {
       continue;
     }
-    const absolutePath = path.join(resolvedPath, dirEntry.name);
+    if (
+      hideWorkspaceManagedRootEntries &&
+      describeProtectedWorkspaceExplorerPath(workspaceRoot, absolutePath)
+    ) {
+      continue;
+    }
     try {
       const meta = await fs.stat(absolutePath);
       entries.push({

--- a/desktop/src/components/panes/FileExplorerPane.test.mjs
+++ b/desktop/src/components/panes/FileExplorerPane.test.mjs
@@ -209,32 +209,27 @@ test("file explorer attaches folders through @ and drag payloads while preservin
   assert.match(source, /use @ or drag to attach in chat/);
 });
 
-test("file explorer groups protected workspace system entries into a dedicated root section", async () => {
+test("file explorer hides protected workspace system entries from the root tree", async () => {
   const source = await readFile(sourcePath, "utf8");
 
   assert.match(source, /type FileExplorerVisibleSection = \{/);
-  assert.match(source, /id: "protected" \| "workspace";/);
+  assert.match(source, /id: "workspace";/);
   assert.match(source, /rows: FileExplorerVisibleRow\[];/);
   assert.match(source, /function isWorkspaceRootExplorerView\(/);
   assert.match(
     source,
-    /if \(!isWorkspaceRootExplorerView\(currentPath, workspaceRootPath\)\) \{\s*return \[\s*\{\s*id: "workspace" as const,\s*rows: buildRows\(entries\),\s*\},\s*\];\s*\}/,
+    /const visibleRootEntries = isWorkspaceRootExplorerView\(\s*currentPath,\s*workspaceRootPath,\s*\)\s*\?\s*entries\.filter\(\s*\(entry\) =>\s*!isProtectedWorkspacePath\(workspaceRootPath, entry\.absolutePath\),\s*\)\s*:\s*entries;/,
   );
   assert.match(
     source,
-    /const protectedRootEntries = entries\.filter\(\(entry\) =>\s*isProtectedWorkspacePath\(workspaceRootPath, entry\.absolutePath\),\s*\);/,
-  );
-  assert.match(
-    source,
-    /sections\.push\(\{\s*id: "protected",\s*rows: protectedRows,\s*\}\);/,
+    /return \[\s*\{\s*id: "workspace" as const,\s*rows: buildRows\(visibleRootEntries\),\s*\},\s*\];/,
   );
   assert.match(
     source,
     /const visibleRows = useMemo\(\s*\(\) => filteredEntries\.flatMap\(\(section\) => section\.rows\),\s*\[filteredEntries\],\s*\);/,
   );
-  assert.doesNotMatch(source, /label: "System"/);
-  assert.doesNotMatch(source, /badgeLabel: "Protected"/);
-  assert.doesNotMatch(source, /No rename, move, or delete\./);
+  assert.doesNotMatch(source, /id: "protected"/);
+  assert.doesNotMatch(source, /Protected workspace files/);
 });
 
 test("file explorer keeps a minimal tree header without showing the workspace root row", async () => {

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -220,7 +220,7 @@ type FileExplorerVisibleRow =
     };
 
 type FileExplorerVisibleSection = {
-  id: "protected" | "workspace";
+  id: "workspace";
   rows: FileExplorerVisibleRow[];
 };
 
@@ -1672,40 +1672,22 @@ export function FileExplorerPane({
         normalizedQuery,
       );
 
-    if (!isWorkspaceRootExplorerView(currentPath, workspaceRootPath)) {
-      return [
-        {
-          id: "workspace" as const,
-          rows: buildRows(entries),
-        },
-      ];
-    }
+    const visibleRootEntries = isWorkspaceRootExplorerView(
+      currentPath,
+      workspaceRootPath,
+    )
+      ? entries.filter(
+          (entry) =>
+            !isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
+        )
+      : entries;
 
-    const protectedRootEntries = entries.filter((entry) =>
-      isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
-    );
-    const workspaceEntries = entries.filter(
-      (entry) =>
-        !isProtectedWorkspacePath(workspaceRootPath, entry.absolutePath),
-    );
-    const protectedRows = buildRows(protectedRootEntries);
-    const workspaceRows = buildRows(workspaceEntries);
-    const sections: FileExplorerVisibleSection[] = [];
-
-    if (protectedRows.length > 0) {
-      sections.push({
-        id: "protected",
-        rows: protectedRows,
-      });
-    }
-    if (workspaceRows.length > 0) {
-      sections.push({
-        id: "workspace",
-        rows: workspaceRows,
-      });
-    }
-
-    return sections;
+    return [
+      {
+        id: "workspace" as const,
+        rows: buildRows(visibleRootEntries),
+      },
+    ];
   }, [
     currentPath,
     directoryEntriesByPath,
@@ -3864,16 +3846,11 @@ export function FileExplorerPane({
           ) : null}
 
           {!loading && !error
-            ? filteredEntries.map((section, sectionIndex) => (
+            ? filteredEntries.map((section) => (
                 <div
                   key={section.id}
                   role="group"
-                  aria-label={
-                    section.id === "protected"
-                      ? "Protected workspace files"
-                      : "Workspace files"
-                  }
-                  className={sectionIndex > 0 ? "mt-1.5 pt-1.5" : ""}
+                  aria-label="Workspace files"
                 >
                   {section.rows.map((row) => {
                     if (row.type === "feedback") {


### PR DESCRIPTION
## Summary
- hide workspace-managed root entries like `skills/`, `AGENTS.md`, and `workspace.yaml` from the desktop file explorer
- remove the dedicated protected root section so the explorer tree only renders user-visible workspace entries
- keep protected-path mutation guards intact and update source assertions for the new behavior

## Validation
- `npm --prefix desktop run typecheck`
- `node --test --test-name-pattern "file explorer hides protected workspace system entries from the root tree" desktop/src/components/panes/FileExplorerPane.test.mjs`

## Screenshots
- Not included; this UI change removes hidden system entries from the workspace root tree.