### PR TITLE
fix(desktop): preserve imported bookmark folders

### DIFF
--- a/desktop/electron/browser-import-chrome.test.mjs
+++ b/desktop/electron/browser-import-chrome.test.mjs
@@ -73,6 +73,10 @@ test("desktop browser import flow discovers a Chrome profile and imports bookmar
     chromiumSource,
     /export async function readChromeBookmarks\(\s*profileDir: string,\s*\): Promise<BrowserBookmarkPayload\[]> \{/,
   );
+  assert.match(chromiumSource, /const CHROME_BOOKMARK_ROOT_LABELS: Record<string, string> = \{/);
+  assert.match(chromiumSource, /chromeBookmarkRootFolderPath\(/);
+  assert.match(chromiumSource, /collectChromeBookmarkEntries\(\s*child,\s*bookmarks,\s*rootFolderPath\s*\)/);
+  assert.match(chromiumSource, /folderPath: \[\.\.\.folderPath\]/);
   assert.match(
     chromiumSource,
     /export async function readChromeHistory\(\s*profileDir: string,\s*\): Promise<BrowserHistoryEntryPayload\[]> \{/,
@@ -188,6 +192,13 @@ test("desktop browser import flow discovers a Chrome profile and imports bookmar
     browsersSource,
     /cookieSummary\.importedCount === 0 &&\s*\(bookmarkCount > 0 \|\| historyCount > 0\)/,
   );
+  assert.match(browsersSource, /const tokenPattern =/);
+  assert.match(browsersSource, /<\\\/\?dl\\b\[\^>\]\*>\/gi/);
+  assert.match(browsersSource, /normalizeImportedBookmarkFolderPath\(/);
+  assert.match(browsersSource, /folderPath\.push\(pendingFolderName\);/);
+  assert.match(browsersSource, /export function cloneBrowserBookmarkPayload\(/);
+  assert.match(browsersSource, /nextFolderPath\.length > 0/);
+  assert.match(browsersSource, /folderPath: nextFolderPath/);
   assert.match(
     browsersSource,
     /Skipped \$\{expiredCount\} expired workspace cookies\./,

--- a/desktop/electron/browser-pane/handlers.ts
+++ b/desktop/electron/browser-pane/handlers.ts
@@ -41,6 +41,7 @@ export interface BrowserBookmarkPayload {
   url: string;
   title: string;
   faviconUrl?: string;
+  folderPath?: string[];
   createdAt: string;
 }
 export interface BrowserDownloadPayload {

--- a/desktop/electron/browser-pane/import-browsers.ts
+++ b/desktop/electron/browser-pane/import-browsers.ts
@@ -80,6 +80,29 @@ function stripHtmlTags(value: string) {
   return value.replace(/<[^>]*>/g, " ");
 }
 
+function normalizeImportedBookmarkFolderPath(
+  folderPath: readonly unknown[] | undefined,
+) {
+  if (!Array.isArray(folderPath)) {
+    return [];
+  }
+  return folderPath
+    .map((segment) => (typeof segment === "string" ? segment.trim() : ""))
+    .filter(Boolean);
+}
+
+function sameBookmarkFolderPath(
+  left: readonly unknown[] | undefined,
+  right: readonly unknown[] | undefined,
+) {
+  const leftNormalized = normalizeImportedBookmarkFolderPath(left);
+  const rightNormalized = normalizeImportedBookmarkFolderPath(right);
+  if (leftNormalized.length !== rightNormalized.length) {
+    return false;
+  }
+  return leftNormalized.every((segment, index) => segment === rightNormalized[index]);
+}
+
 export function parseImportedVisitTimestamp(value: unknown): string | null {
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -126,24 +149,63 @@ export function parseSafariBookmarksFromHtml(
   html: string,
 ): BrowserBookmarkPayload[] {
   const bookmarks: BrowserBookmarkPayload[] = [];
-  const anchorPattern =
-    /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
-  for (const match of html.matchAll(anchorPattern)) {
-    const url = (match[1] || "").trim();
+  const folderPath: string[] = [];
+  const dlFolderOwnership: boolean[] = [];
+  let pendingFolderName = "";
+  const tokenPattern =
+    /<h3\b[^>]*>([\s\S]*?)<\/h3>|<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>|<\/?dl\b[^>]*>/gi;
+
+  for (const match of html.matchAll(tokenPattern)) {
+    const token = match[0] || "";
+    if (/^<h3\b/i.test(token)) {
+      pendingFolderName = decodeHtmlEntities(
+        stripHtmlTags(match[1] || "")
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+      continue;
+    }
+
+    if (/^<dl\b/i.test(token)) {
+      const ownsFolder = Boolean(pendingFolderName);
+      dlFolderOwnership.push(ownsFolder);
+      if (ownsFolder) {
+        folderPath.push(pendingFolderName);
+        pendingFolderName = "";
+      }
+      continue;
+    }
+
+    if (/^<\/dl\b/i.test(token)) {
+      const ownsFolder = dlFolderOwnership.pop();
+      if (ownsFolder) {
+        folderPath.pop();
+      }
+      pendingFolderName = "";
+      continue;
+    }
+
+    const url = (match[2] || "").trim();
     if (!shouldTrackHistoryUrlForImport(url)) {
+      pendingFolderName = "";
       continue;
     }
     const cleanedTitle = decodeHtmlEntities(
-      stripHtmlTags(match[2] || "")
+      stripHtmlTags(match[3] || "")
         .replace(/\s+/g, " ")
         .trim(),
     );
+    const normalizedFolderPath = normalizeImportedBookmarkFolderPath(folderPath);
     bookmarks.push({
       id: `bookmark-import-${randomUUID()}`,
       url,
       title: cleanedTitle || url,
+      ...(normalizedFolderPath.length > 0
+        ? { folderPath: normalizedFolderPath }
+        : {}),
       createdAt: utcNowIso(),
     });
+    pendingFolderName = "";
   }
   return bookmarks;
 }
@@ -388,11 +450,13 @@ export async function copyCookiesBetweenBrowserSessions(
 export function cloneBrowserBookmarkPayload(
   bookmark: BrowserBookmarkPayload,
 ): BrowserBookmarkPayload {
+  const folderPath = normalizeImportedBookmarkFolderPath(bookmark.folderPath);
   return {
     id: `bookmark-import-${randomUUID()}`,
     url: bookmark.url,
     title: bookmark.title,
     faviconUrl: bookmark.faviconUrl,
+    ...(folderPath.length > 0 ? { folderPath } : {}),
     createdAt: bookmark.createdAt,
   };
 }
@@ -447,10 +511,19 @@ export function mergeImportedBookmarksIntoWorkspace(
 
     const nextTitle = importedBookmark.title?.trim() || existing.title;
     const nextCreatedAt = existing.createdAt || importedBookmark.createdAt;
-    if (nextTitle !== existing.title || nextCreatedAt !== existing.createdAt) {
+    const nextFolderPath =
+      normalizeImportedBookmarkFolderPath(existing.folderPath).length > 0
+        ? normalizeImportedBookmarkFolderPath(existing.folderPath)
+        : normalizeImportedBookmarkFolderPath(importedBookmark.folderPath);
+    if (
+      nextTitle !== existing.title ||
+      nextCreatedAt !== existing.createdAt ||
+      !sameBookmarkFolderPath(existing.folderPath, nextFolderPath)
+    ) {
       bookmarkByUrl.set(importedBookmark.url, {
         ...existing,
         title: nextTitle,
+        ...(nextFolderPath.length > 0 ? { folderPath: nextFolderPath } : {}),
         createdAt: nextCreatedAt,
       });
       changedCount += 1;

--- a/desktop/electron/browser-pane/import-chromium.ts
+++ b/desktop/electron/browser-pane/import-chromium.ts
@@ -50,6 +50,12 @@ const CHROME_COOKIE_CBC_IV = Buffer.alloc(16, 0x20);
 const CHROME_WINDOWS_DPAPI_KEY_PREFIX = "DPAPI";
 const CHROME_WINDOWS_COOKIE_AEAD_PREFIXES = new Set(["v10", "v11"]);
 const CHROME_WINDOWS_APP_BOUND_COOKIE_PREFIX = "v20";
+const CHROME_BOOKMARK_ROOT_LABELS: Record<string, string> = {
+  bookmark_bar: "Bookmarks Bar",
+  other: "Other Bookmarks",
+  mobile: "Mobile Bookmarks",
+  synced: "Synced Bookmarks",
+};
 const BROWSER_IMPORT_PROFILE_DIR_PATTERNS = [
   /^Default$/,
   /^Profile \d+$/,
@@ -787,9 +793,28 @@ export function decodeChromeCookieValue(
   return valueBytes.toString("utf8");
 }
 
+function normalizeChromeBookmarkFolderName(value: unknown) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim();
+}
+
+function chromeBookmarkRootFolderPath(
+  rootKey: string,
+  root: ChromeBookmarkNodePayload,
+) {
+  const rootLabel =
+    normalizeChromeBookmarkFolderName(root.name) ||
+    CHROME_BOOKMARK_ROOT_LABELS[rootKey] ||
+    rootKey.replace(/[_-]+/g, " ").trim();
+  return rootLabel ? [rootLabel] : [];
+}
+
 function collectChromeBookmarkEntries(
   node: ChromeBookmarkNodePayload,
   bucket: BrowserBookmarkPayload[],
+  folderPath: string[],
 ) {
   if (node.type === "url" && typeof node.url === "string" && node.url.trim()) {
     bucket.push({
@@ -798,6 +823,7 @@ function collectChromeBookmarkEntries(
       title: typeof node.name === "string" && node.name.trim()
         ? node.name.trim()
         : node.url.trim(),
+      ...(folderPath.length > 0 ? { folderPath: [...folderPath] } : {}),
       createdAt: chromeTimestampMicrosToIso(node.date_added) ?? utcNowIso(),
     });
     return;
@@ -806,9 +832,13 @@ function collectChromeBookmarkEntries(
   if (!Array.isArray(node.children)) {
     return;
   }
+  const nextFolderPath =
+    node.type === "folder" && normalizeChromeBookmarkFolderName(node.name)
+      ? [...folderPath, normalizeChromeBookmarkFolderName(node.name)]
+      : folderPath;
   for (const child of node.children) {
     if (child && typeof child === "object") {
-      collectChromeBookmarkEntries(child, bucket);
+      collectChromeBookmarkEntries(child, bucket, nextFolderPath);
     }
   }
 }
@@ -827,9 +857,18 @@ export async function readChromeBookmarks(
       ? (parsed.roots as Record<string, ChromeBookmarkNodePayload>)
       : {};
   const bookmarks: BrowserBookmarkPayload[] = [];
-  for (const root of Object.values(roots)) {
+  for (const [rootKey, root] of Object.entries(roots)) {
     if (root && typeof root === "object") {
-      collectChromeBookmarkEntries(root, bookmarks);
+      const rootFolderPath = chromeBookmarkRootFolderPath(rootKey, root);
+      if (Array.isArray(root.children)) {
+        for (const child of root.children) {
+          if (child && typeof child === "object") {
+            collectChromeBookmarkEntries(child, bookmarks, rootFolderPath);
+          }
+        }
+        continue;
+      }
+      collectChromeBookmarkEntries(root, bookmarks, rootFolderPath);
     }
   }
   return bookmarks;

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -734,6 +734,7 @@ interface BrowserBookmarkPayload {
   url: string;
   title: string;
   faviconUrl?: string;
+  folderPath?: string[];
   createdAt: string;
 }
 

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -203,6 +203,7 @@ interface BrowserBookmarkPayload {
   url: string;
   title: string;
   faviconUrl?: string;
+  folderPath?: string[];
   createdAt: string;
 }
 

--- a/desktop/shared/browser-pane-protocol.ts
+++ b/desktop/shared/browser-pane-protocol.ts
@@ -72,6 +72,7 @@ export interface BrowserBookmarkPayload {
   url: string;
   title: string;
   faviconUrl?: string;
+  folderPath?: string[];
   createdAt: string;
 }
 

--- a/desktop/src/components/panes/BrowserPane.test.mjs
+++ b/desktop/src/components/panes/BrowserPane.test.mjs
@@ -39,6 +39,34 @@ test("browser pane exposes screenshot copy without browser comments", async () =
   assert.doesNotMatch(source, /px-1\.5 pb-1 text-\[11px\] text-muted-foreground/);
 });
 
+test("browser pane groups imported bookmark folders into a popover instead of the inline strip", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /import \{\s*Popover,\s*PopoverContent,\s*PopoverTrigger,\s*\} from "@\/components\/ui\/popover";/,
+  );
+  assert.match(
+    source,
+    /import \{ buildBrowserBookmarkTree \} from "@\/lib\/browserBookmarks";/,
+  );
+  assert.match(source, /const bookmarkTree = useMemo\(\s*\(\) => buildBrowserBookmarkTree\(bookmarks\),/);
+  assert.match(
+    source,
+    /const showBookmarkStrip =\s*\(\s*bookmarkTree\.rootBookmarks\.length > 0 \|\| bookmarkTree\.folders\.length > 0\s*\) &&\s*!isCompactPane;/,
+  );
+  assert.match(source, /Imported folders/);
+  assert.match(source, /bookmarkTree\.rootBookmarks\.slice\(0, 12\)/);
+  assert.match(source, /<ListTree className="size-3 shrink-0" \/>/);
+  assert.match(
+    source,
+    /const \[collapsedBookmarkFolderKeys, setCollapsedBookmarkFolderKeys\] =\s*useState<Set<string>>\(\(\) => new Set\(\)\);/,
+  );
+  assert.match(source, /aria-expanded=\{isExpanded\}/);
+  assert.match(source, /Collapse" : "Expand"} bookmark folder/);
+  assert.match(source, /<ChevronRight[\s\S]*rotate-90/);
+});
+
 test("browser pane exposes a single inline browser-space switcher", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/desktop/src/components/panes/BrowserPane.tsx
+++ b/desktop/src/components/panes/BrowserPane.tsx
@@ -12,7 +12,9 @@ import {
   Camera,
   ChevronLeft,
   ChevronRight,
+  FolderOpen,
   Globe,
+  ListTree,
   Loader2,
   MoreHorizontal,
   Plus,
@@ -29,6 +31,12 @@ import {
   BrowserCaptureStatusToast,
   useBrowserCaptureActions,
 } from "@/components/panes/useBrowserCaptureActions";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { buildBrowserBookmarkTree } from "@/lib/browserBookmarks";
 import { useBrowserGlowPreview } from "@/components/panes/useBrowserGlowPreview";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 
@@ -145,10 +153,18 @@ export function BrowserPane({
       EMPTY_BROWSER_STATE,
     [browserState],
   );
+  const bookmarkTree = useMemo(
+    () => buildBrowserBookmarkTree(bookmarks),
+    [bookmarks],
+  );
+  const [collapsedBookmarkFolderKeys, setCollapsedBookmarkFolderKeys] =
+    useState<Set<string>>(() => new Set());
   const isCompactPane = paneWidth > 0 && paneWidth <= 320;
   const isNarrowPane = paneWidth > 0 && paneWidth <= 240;
   const isActiveTabBusy = activeTab.loading || !activeTab.initialized;
-  const showBookmarkStrip = bookmarks.length > 0 && !isCompactPane;
+  const showBookmarkStrip =
+    (bookmarkTree.rootBookmarks.length > 0 || bookmarkTree.folders.length > 0) &&
+    !isCompactPane;
   const visibleBrowserSpace = browserState.space || DEFAULT_BROWSER_SPACE;
   const alternateBrowserSpace =
     visibleBrowserSpace === "user" ? "agent" : "user";
@@ -454,6 +470,80 @@ export function BrowserPane({
     () => bookmarks.find((bookmark) => bookmark.url === activeTab.url) ?? null,
     [activeTab.url, bookmarks],
   );
+  const renderBookmarkFolder = (
+    folder: ReturnType<typeof buildBrowserBookmarkTree>["folders"][number],
+    depth = 0,
+  ) => {
+    const isExpanded = !collapsedBookmarkFolderKeys.has(folder.key);
+    return (
+      <div key={folder.key} className="space-y-0.5">
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} bookmark folder ${folder.name}`}
+          onClick={() => {
+            setCollapsedBookmarkFolderKeys((current) => {
+              const next = new Set(current);
+              if (next.has(folder.key)) {
+                next.delete(folder.key);
+              } else {
+                next.add(folder.key);
+              }
+              return next;
+            });
+          }}
+          className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-foreground ${
+            depth === 0
+              ? "text-[10px] font-medium uppercase tracking-[0.08em]"
+              : "text-xs"
+          }`}
+          style={depth > 0 ? { paddingLeft: `${10 + depth * 14}px` } : undefined}
+        >
+          <ChevronRight
+            className={`size-3 shrink-0 transition-transform duration-150 ${
+              isExpanded ? "rotate-90" : ""
+            }`}
+          />
+          <FolderOpen className="size-3.5 shrink-0" />
+          <span className="truncate">{folder.name}</span>
+        </button>
+        {isExpanded ? (
+          <>
+            {folder.bookmarks.map((bookmark) => (
+              <Button
+                variant="ghost"
+                size="sm"
+                key={bookmark.id}
+                onClick={() => navigateTo(bookmark.url)}
+                className="h-auto w-full justify-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-accent"
+                style={{ paddingLeft: `${10 + (depth + 1) * 14}px` }}
+              >
+                <span className="flex min-w-0 items-center gap-2.5">
+                  {bookmark.faviconUrl ? (
+                    <img
+                      src={bookmark.faviconUrl}
+                      alt=""
+                      className="size-4 shrink-0 rounded-sm"
+                    />
+                  ) : (
+                    <span className="grid size-4 shrink-0 place-items-center rounded-sm bg-muted text-[8px] text-muted-foreground">
+                      •
+                    </span>
+                  )}
+                  <span className="block max-w-[220px] truncate text-sm text-foreground">
+                    {bookmark.title}
+                  </span>
+                </span>
+              </Button>
+            ))}
+            {folder.folders.map((childFolder) =>
+              renderBookmarkFolder(childFolder, depth + 1),
+            )}
+          </>
+        ) : null}
+      </div>
+    );
+  };
 
   const activeDownloadCount = useMemo(
     () =>
@@ -905,7 +995,36 @@ export function BrowserPane({
           <BrowserCaptureStatusToast message={actionStatus} />
           {showBookmarkStrip ? (
             <div className="flex min-h-6 items-center gap-0.5 overflow-x-auto px-1.5 py-0.5">
-              {bookmarks.slice(0, 12).map((bookmark) => (
+              {bookmarkTree.folders.length > 0 ? (
+                <Popover>
+                  <PopoverTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="shrink-0 px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
+                      >
+                        <span className="flex items-center gap-1.5">
+                          <ListTree className="size-3 shrink-0" />
+                          <span>Folders</span>
+                        </span>
+                      </Button>
+                    }
+                  />
+                  <PopoverContent
+                    align="start"
+                    side="bottom"
+                    sideOffset={6}
+                    className="max-h-80 w-80 gap-0 overflow-y-auto p-1"
+                  >
+                    <div className="px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                      Imported folders
+                    </div>
+                    {bookmarkTree.folders.map((folder) => renderBookmarkFolder(folder))}
+                  </PopoverContent>
+                </Popover>
+              ) : null}
+              {bookmarkTree.rootBookmarks.slice(0, 12).map((bookmark) => (
                 <Button
                   variant="ghost"
                   size="xs"

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.test.mjs
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.test.mjs
@@ -129,3 +129,27 @@ test("space browser explorer hides the bookmarks section when empty", async () =
   // Bookmarks block is conditional on hasBookmarks.
   assert.match(source, /\{hasBookmarks \? \(/);
 });
+
+test("space browser explorer preserves imported bookmark folders", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /import \{ buildBrowserBookmarkTree \} from "@\/lib\/browserBookmarks";/,
+  );
+  assert.match(source, /const bookmarkTree = useMemo\(\s*\(\) => buildBrowserBookmarkTree\(bookmarks\),/);
+  assert.match(
+    source,
+    /const hasBookmarks =\s*bookmarkTree\.rootBookmarks\.length > 0 \|\| bookmarkTree\.folders\.length > 0;/,
+  );
+  assert.match(source, /<FolderOpen className="size-3\.5 shrink-0" \/>/);
+  assert.match(
+    source,
+    /const \[collapsedBookmarkFolderKeys, setCollapsedBookmarkFolderKeys\] =\s*useState<Set<string>>\(\(\) => new Set\(\)\);/,
+  );
+  assert.match(source, /aria-expanded=\{isExpanded\}/);
+  assert.match(source, /Collapse" : "Expand"} bookmark folder/);
+  assert.match(source, /<ChevronRight[\s\S]*rotate-90/);
+  assert.match(source, /bookmarkTree\.folders\.map\(\(folder\) => renderBookmarkFolder\(folder\)\)/);
+  assert.match(source, /Saved/);
+});

--- a/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -4,7 +4,16 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Bot, Globe, Plus, Star, User, X } from "lucide-react";
+import {
+  Bot,
+  ChevronRight,
+  FolderOpen,
+  Globe,
+  Plus,
+  Star,
+  User,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -20,6 +29,8 @@ import {
   compareBrowserSessionOptions,
 } from "@/components/panes/browserSessionUi";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
+import { buildBrowserBookmarkTree } from "@/lib/browserBookmarks";
+import { cn } from "@/lib/utils";
 
 interface SpaceBrowserExplorerPaneProps {
   browserSpace: BrowserSpaceId;
@@ -137,6 +148,12 @@ export function SpaceBrowserExplorerPane({
       ),
     [agentSessions, runtimeStatesBySessionId],
   );
+  const bookmarkTree = useMemo(
+    () => buildBrowserBookmarkTree(bookmarks),
+    [bookmarks],
+  );
+  const [collapsedBookmarkFolderKeys, setCollapsedBookmarkFolderKeys] =
+    useState<Set<string>>(() => new Set());
   const hasAgentSessionBrowsers = sortedAgentSessions.length > 0;
 
   const sessionBrowserStatus = useMemo(
@@ -190,7 +207,8 @@ export function SpaceBrowserExplorerPane({
     );
   };
 
-  const hasBookmarks = bookmarks.length > 0;
+  const hasBookmarks =
+    bookmarkTree.rootBookmarks.length > 0 || bookmarkTree.folders.length > 0;
   const hasTabs = browserState.tabs.length > 0;
 
   // Slide direction mirrors the switcher button position — scopes slide in
@@ -199,6 +217,88 @@ export function SpaceBrowserExplorerPane({
     browserSpace === "user"
       ? "slide-in-from-left-3"
       : "slide-in-from-right-3";
+
+  const renderBookmarkButton = (
+    bookmark: BrowserBookmarkPayload,
+    depth = 0,
+  ) => (
+    <Button
+      key={bookmark.id}
+      variant="ghost"
+      size="sm"
+      onClick={() => openBookmark(bookmark)}
+      className="h-auto w-full justify-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-accent"
+      style={depth > 0 ? { paddingLeft: `${10 + depth * 14}px` } : undefined}
+    >
+      <Favicon
+        url={bookmark.faviconUrl}
+        className="size-4 shrink-0 rounded-sm"
+        fallback={
+          <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-muted text-muted-foreground">
+            <Star className="size-2.5" />
+          </div>
+        }
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-foreground">
+          {bookmark.title}
+        </div>
+      </div>
+    </Button>
+  );
+
+  const renderBookmarkFolder = (
+    folder: ReturnType<typeof buildBrowserBookmarkTree>["folders"][number],
+    depth = 0,
+  ): ReactNode => {
+    const isExpanded = !collapsedBookmarkFolderKeys.has(folder.key);
+    return (
+      <div key={folder.key} className="space-y-0.5">
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} bookmark folder ${folder.name}`}
+          onClick={() => {
+            setCollapsedBookmarkFolderKeys((current) => {
+              const next = new Set(current);
+              if (next.has(folder.key)) {
+                next.delete(folder.key);
+              } else {
+                next.add(folder.key);
+              }
+              return next;
+            });
+          }}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-md px-2.5 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+            depth === 0
+              ? "text-[10px] font-medium uppercase tracking-[0.08em]"
+              : "text-xs",
+          )}
+          style={depth > 0 ? { paddingLeft: `${10 + depth * 14}px` } : undefined}
+        >
+          <ChevronRight
+            className={cn(
+              "size-3 shrink-0 transition-transform duration-150",
+              isExpanded ? "rotate-90" : "",
+            )}
+          />
+          <FolderOpen className="size-3.5 shrink-0" />
+          <span className="truncate">{folder.name}</span>
+        </button>
+        {isExpanded ? (
+          <>
+            {folder.bookmarks.map((bookmark) =>
+              renderBookmarkButton(bookmark, depth + 1),
+            )}
+            {folder.folders.map((childFolder) =>
+              renderBookmarkFolder(childFolder, depth + 1),
+            )}
+          </>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
@@ -302,30 +402,23 @@ export function SpaceBrowserExplorerPane({
             <div className="px-2.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
               Bookmarks
             </div>
-            {bookmarks.map((bookmark) => (
-              <Button
-                key={bookmark.id}
-                variant="ghost"
-                size="sm"
-                onClick={() => openBookmark(bookmark)}
-                className="h-auto w-full justify-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-accent"
-              >
-                <Favicon
-                  url={bookmark.faviconUrl}
-                  className="size-4 shrink-0 rounded-sm"
-                  fallback={
-                    <div className="grid size-4 shrink-0 place-items-center rounded-sm bg-muted text-muted-foreground">
-                      <Star className="size-2.5" />
-                    </div>
-                  }
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm text-foreground">
-                    {bookmark.title}
+            {bookmarkTree.folders.map((folder) => renderBookmarkFolder(folder))}
+            {bookmarkTree.rootBookmarks.length > 0 ? (
+              bookmarkTree.folders.length > 0 ? (
+                <div className="pt-1">
+                  <div className="px-2.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                    Saved
                   </div>
+                  {bookmarkTree.rootBookmarks.map((bookmark) =>
+                    renderBookmarkButton(bookmark),
+                  )}
                 </div>
-              </Button>
-            ))}
+              ) : (
+                bookmarkTree.rootBookmarks.map((bookmark) =>
+                  renderBookmarkButton(bookmark),
+                )
+              )
+            ) : null}
           </div>
         ) : null}
 

--- a/desktop/src/lib/browserBookmarks.ts
+++ b/desktop/src/lib/browserBookmarks.ts
@@ -1,0 +1,113 @@
+export interface BrowserBookmarkFolderNode {
+  name: string;
+  key: string;
+  folders: BrowserBookmarkFolderNode[];
+  bookmarks: BrowserBookmarkPayload[];
+}
+
+interface MutableBrowserBookmarkFolderNode extends BrowserBookmarkFolderNode {
+  children: Map<string, MutableBrowserBookmarkFolderNode>;
+}
+
+interface BrowserBookmarkTree {
+  folders: BrowserBookmarkFolderNode[];
+  rootBookmarks: BrowserBookmarkPayload[];
+}
+
+function normalizeFolderSegment(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function browserBookmarkFolderPath(
+  bookmark: BrowserBookmarkPayload,
+): string[] {
+  if (!Array.isArray(bookmark.folderPath)) {
+    return [];
+  }
+  return bookmark.folderPath.map(normalizeFolderSegment).filter(Boolean);
+}
+
+function createFolderNode(
+  name: string,
+  key: string,
+): MutableBrowserBookmarkFolderNode {
+  return {
+    name,
+    key,
+    folders: [],
+    bookmarks: [],
+    children: new Map(),
+  };
+}
+
+function compareFolderNodes(
+  left: BrowserBookmarkFolderNode,
+  right: BrowserBookmarkFolderNode,
+) {
+  return left.name.localeCompare(right.name, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+function compareBookmarks(
+  left: BrowserBookmarkPayload,
+  right: BrowserBookmarkPayload,
+) {
+  const leftLabel = (left.title || left.url).trim();
+  const rightLabel = (right.title || right.url).trim();
+  return leftLabel.localeCompare(rightLabel, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+function finalizeFolderNode(
+  node: MutableBrowserBookmarkFolderNode,
+): BrowserBookmarkFolderNode {
+  return {
+    name: node.name,
+    key: node.key,
+    folders: Array.from(node.children.values())
+      .map(finalizeFolderNode)
+      .sort(compareFolderNodes),
+    bookmarks: [...node.bookmarks].sort(compareBookmarks),
+  };
+}
+
+export function buildBrowserBookmarkTree(
+  bookmarks: BrowserBookmarkPayload[],
+): BrowserBookmarkTree {
+  const root = createFolderNode("", "__root__");
+  const rootBookmarks: BrowserBookmarkPayload[] = [];
+
+  for (const bookmark of bookmarks) {
+    const folderPath = browserBookmarkFolderPath(bookmark);
+    if (folderPath.length === 0) {
+      rootBookmarks.push(bookmark);
+      continue;
+    }
+
+    let cursor = root;
+    for (const segment of folderPath) {
+      const nextKey =
+        cursor.key === "__root__" ? segment : `${cursor.key}/${segment}`;
+      const existing = cursor.children.get(segment);
+      if (existing) {
+        cursor = existing;
+        continue;
+      }
+      const created = createFolderNode(segment, nextKey);
+      cursor.children.set(segment, created);
+      cursor = created;
+    }
+    cursor.bookmarks.push(bookmark);
+  }
+
+  return {
+    folders: Array.from(root.children.values())
+      .map(finalizeFolderNode)
+      .sort(compareFolderNodes),
+    rootBookmarks,
+  };
+}

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -203,6 +203,7 @@ declare global {
     url: string;
     title: string;
     faviconUrl?: string;
+    folderPath?: string[];
     createdAt: string;
   }
 


### PR DESCRIPTION
## Summary
- preserve Chromium and Safari bookmark folder hierarchy during browser profile import
- render imported bookmarks as a folder tree in the browser explorer and browser pane instead of flattening them into the bookmark strip
- add collapsible bookmark folder disclosure controls and extend the related desktop source tests

## Validation
- npm --prefix desktop run typecheck
- node --test desktop/src/components/panes/BrowserPane.test.mjs desktop/src/components/panes/SpaceBrowserExplorerPane.test.mjs
- node --import tsx --test electron/browser-import-chrome.test.mjs
