### PR TITLE
ui(desktop): default landing to last workspace + redesign control center & top toolbar

### DIFF
--- a/desktop/src/components/layout/AppShell.test.mjs
+++ b/desktop/src/components/layout/AppShell.test.mjs
@@ -601,9 +601,12 @@ test("app shell uses the top toolbar for shell navigation and removes the left r
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
   assert.match(source, /type ShellView = "control_center" \| "space";/);
+  // Default landing changed from "control_center" to "space" — the app
+  // resumes the user's last workspace on launch (Cursor/VSCode/Notion
+  // convention; control center remains opt-in via the toolbar).
   assert.match(
     source,
-    /const \[activeShellView, setActiveShellView\] =\s*useState<ShellView>\("control_center"\);/,
+    /const \[activeShellView, setActiveShellView\] =\s*useState<ShellView>\("space"\);/,
   );
   assert.match(source, /const handleOpenControlCenter = useCallback\(\(\) => \{/);
   assert.match(source, /const handleEnterWorkspace = useCallback\(\s*\(workspaceId: string\) => \{/);
@@ -637,17 +640,22 @@ test("app shell uses the top toolbar for shell navigation and removes the left r
   assert.doesNotMatch(source, /LeftNavigationRail/);
 });
 
-test("app shell auto-enters the sole workspace after startup hydration", async () => {
+test("app shell defaults to the user's last workspace on startup", async () => {
   const source = await readFile(APP_SHELL_PATH, "utf8");
 
+  // Default activeShellView is "space" — control center is opt-in.
+  assert.match(source, /useState<ShellView>\("space"\)/);
+
+  // Startup ref renamed to reflect general scope (no longer single-workspace-only).
   assert.match(
     source,
-    /const singleWorkspaceStartupEntryHandledRef = useRef\(false\);/,
+    /const startupWorkspaceSelectionHandledRef = useRef\(false\);/,
   );
-  assert.match(
-    source,
-    /useEffect\(\(\) => \{\s*if \(singleWorkspaceStartupEntryHandledRef\.current\) \{\s*return;\s*\}\s*if \(!hasHydratedWorkspaceList\) \{\s*return;\s*\}\s*singleWorkspaceStartupEntryHandledRef\.current = true;\s*if \(activeShellView !== "control_center" \|\| workspaces\.length !== 1\) \{\s*return;\s*\}\s*handleEnterWorkspace\(workspaces\[0\]\?\.id \?\? ""\);\s*\}, \[\s*activeShellView,\s*handleEnterWorkspace,\s*hasHydratedWorkspaceList,\s*workspaces,\s*\]\);/,
-  );
+
+  // Auto-pick most-recent workspace when stored selection is invalid.
+  assert.match(source, /workspaces\.length === 0/);
+  assert.match(source, /selectionIsValid/);
+  assert.match(source, /setSelectedWorkspaceId\(fallbackWorkspaceId\)/);
 });
 
 test("app shell no longer renders the dedicated app mode after removing the left rail", async () => {

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1428,7 +1428,7 @@ function AppShellContent() {
     setCreateWorkspacePanelAnchorWorkspaceId,
   ] = useState("");
   const [activeShellView, setActiveShellView] =
-    useState<ShellView>("control_center");
+    useState<ShellView>("space");
   const [agentView, setAgentView] = useState<AgentView>({ type: "chat" });
   const [chatFocusRequestKey, setChatFocusRequestKey] = useState(1);
   const [chatSessionJumpRequest, setChatSessionJumpRequest] = useState<{
@@ -1575,7 +1575,7 @@ function AppShellContent() {
   const knownTaskProposalIdsByWorkspaceRef = useRef<Record<string, string[]>>(
     {},
   );
-  const singleWorkspaceStartupEntryHandledRef = useRef(false);
+  const startupWorkspaceSelectionHandledRef = useRef(false);
   const lastRestorableSpaceFileDisplayViewByWorkspaceRef = useRef<
     Record<string, RestorableSpaceFileDisplayView>
   >({});
@@ -3641,23 +3641,33 @@ function AppShellContent() {
   );
 
   useEffect(() => {
-    if (singleWorkspaceStartupEntryHandledRef.current) {
+    if (startupWorkspaceSelectionHandledRef.current) {
       return;
     }
     if (!hasHydratedWorkspaceList) {
       return;
     }
-
-    singleWorkspaceStartupEntryHandledRef.current = true;
-    if (activeShellView !== "control_center" || workspaces.length !== 1) {
+    if (workspaces.length === 0) {
       return;
     }
 
-    handleEnterWorkspace(workspaces[0]?.id ?? "");
+    startupWorkspaceSelectionHandledRef.current = true;
+
+    const trimmedSelected = selectedWorkspaceId?.trim() || "";
+    const selectionIsValid =
+      trimmedSelected !== "" &&
+      workspaces.some((workspace) => workspace.id === trimmedSelected);
+
+    if (!selectionIsValid) {
+      const fallbackWorkspaceId = workspaces[0]?.id ?? "";
+      if (fallbackWorkspaceId) {
+        setSelectedWorkspaceId(fallbackWorkspaceId);
+      }
+    }
   }, [
-    activeShellView,
-    handleEnterWorkspace,
     hasHydratedWorkspaceList,
+    selectedWorkspaceId,
+    setSelectedWorkspaceId,
     workspaces,
   ]);
 

--- a/desktop/src/components/layout/TopTabsBar.tsx
+++ b/desktop/src/components/layout/TopTabsBar.tsx
@@ -38,6 +38,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
 import {
@@ -307,24 +312,38 @@ export function TopTabsBar({
           className={`${integratedTitleBar ? "window-no-drag " : ""}flex min-w-0 items-center justify-self-end gap-1.5`}
         >
           {!controlCenterActive ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onOpenControlCenter?.()}
-              className="h-7 shrink-0 rounded-full px-2.5 text-xs"
-            >
-              <Home className="size-3.5" />
-              Control Center
-            </Button>
-          ) : null}
-          {isBillingAvailable ? (
-            <CreditsPill
-              balance={overview?.creditsBalance ?? 0}
-              isLoading={isBillingLoading}
-              isLowBalance={isLowBalance}
-              onClick={() => onOpenBilling?.()}
-            />
-          ) : null}
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="bordered"
+                    size="icon-sm"
+                    aria-label="Show all workspaces"
+                    onClick={() => onOpenControlCenter?.()}
+                  >
+                    <Home />
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">Show all workspaces</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="bordered"
+                    size="icon-sm"
+                    aria-label="Create new workspace"
+                    onClick={() => onOpenWorkspaceCreatePanel?.()}
+                  >
+                    <Plus />
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">Create new workspace</TooltipContent>
+            </Tooltip>
+          )}
           {!controlCenterActive ? (
             <div
               ref={workspaceSwitcherRef}
@@ -359,6 +378,14 @@ export function TopTabsBar({
                 />
               </Button>
             </div>
+          ) : null}
+          {isBillingAvailable ? (
+            <CreditsPill
+              balance={overview?.creditsBalance ?? 0}
+              isLoading={isBillingLoading}
+              isLowBalance={isLowBalance}
+              onClick={() => onOpenBilling?.()}
+            />
           ) : null}
           <RuntimeStatusIndicator status={runtimeStatus} />
           <DropdownMenu>

--- a/desktop/src/components/layout/WorkspaceControlCenter.tsx
+++ b/desktop/src/components/layout/WorkspaceControlCenter.tsx
@@ -1,7 +1,5 @@
 import {
   ArrowUpRight,
-  ChevronLeft,
-  ChevronRight,
   GripVertical,
   Loader2,
   SendHorizontal,
@@ -16,7 +14,6 @@ import {
   useState,
   type DragEvent as ReactDragEvent,
   type KeyboardEvent,
-  type WheelEvent as ReactWheelEvent,
 } from "react";
 import {
   ArtifactBrowserModal,
@@ -41,30 +38,15 @@ import { cn } from "@/lib/utils";
 const PREVIEW_HISTORY_LIMIT = 18;
 const PREVIEW_MESSAGE_LIMIT = 12;
 const PREVIEW_OUTPUT_LIMIT = 80;
-const WORKSPACE_CARD_MIN_WIDTH = 320;
-const WORKSPACE_CARD_MIN_HEIGHT = 320;
-const WORKSPACE_CARD_MAX_HEIGHT = 480;
-const WORKSPACE_CARD_VISIBLE_ROWS = 2;
-const CONTROL_CENTER_WHEEL_SWIPE_THRESHOLD_PX = 140;
-const CONTROL_CENTER_WHEEL_SWIPE_RESET_MS = 180;
+const WORKSPACE_CARD_MIN_WIDTH = 360;
 const CONTROL_CENTER_TERMINAL_REFRESH_DELAYS_MS = [150, 500, 1_500, 3_000];
 const CONTROL_CENTER_IDLE_RECONCILE_INTERVAL_MS = 2500;
 const CONTROL_CENTER_RUNTIME_POLL_INTERVAL_MS = 750;
+const CARD_VISIBILITY_THRESHOLD = 0.5;
 
 type PreviewChatMessage = ChatMessage & {
   optimistic?: boolean;
 };
-
-function shouldIgnoreControlCenterSwipeGesture(target: EventTarget | null) {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-  return Boolean(
-    target.closest(
-      'textarea, input, select, [contenteditable="true"], [data-control-center-swipe-ignore="true"]',
-    ),
-  );
-}
 
 interface WorkspaceControlCenterProps {
   workspaces: WorkspaceRecordPayload[];
@@ -254,11 +236,11 @@ function statusAccentClassName(state: RuntimeCardState) {
       return "bg-destructive";
     case "queued":
     case "waiting":
-      return "bg-amber-500";
+      return "bg-warning";
     case "working":
-      return "bg-primary";
+      return "bg-primary animate-pulse";
     default:
-      return "bg-emerald-500";
+      return "bg-success";
   }
 }
 
@@ -1140,27 +1122,24 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
 
   return (
     <Card
+      size="sm"
       onPointerDownCapture={() => onSelectWorkspace(workspaceId)}
       onFocusCapture={() => onSelectWorkspace(workspaceId)}
       onDragEnter={() => onDragEnterWorkspace(workspaceId)}
       onDragOver={onDragOverWorkspace}
       onDrop={(event) => onDropWorkspace(event, workspaceId)}
       className={cn(
-        "relative h-full min-h-0 min-w-0 border border-border/70 bg-card py-0 shadow-md",
-        isDragging ? "cursor-grabbing opacity-70" : "",
-        isDragTarget
-          ? "border-primary/70 ring-2 ring-primary/28 ring-inset"
-          : "",
+        "relative h-full min-h-0 min-w-0 gap-0 bg-card py-0 transition-colors",
+        isDragging && "cursor-grabbing opacity-70",
+        isDragTarget && "ring-2 ring-primary ring-inset",
         hasUnreadCompletionHighlight
-          ? "border-primary/65 shadow-[0_16px_48px_-24px_color-mix(in_oklch,var(--primary)_44%,transparent)]"
-          : isSelected
-          ? "border-border/90 shadow-[0_12px_28px_-24px_color-mix(in_oklch,var(--foreground)_18%,transparent)]"
-          : "",
+          ? "shadow-tinted-brand"
+          : isSelected && "ring-1 ring-border ring-inset",
       )}
     >
-      <CardHeader className="border-b border-border/70 px-2.5 py-1.5">
+      <CardHeader className="gap-0 border-b border-border px-3 py-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="flex min-w-0 flex-1 items-center gap-2 text-[0.95rem]">
+          <CardTitle className="flex min-w-0 flex-1 items-center gap-2 text-sm">
             <Button
               type="button"
               variant="ghost"
@@ -1169,32 +1148,32 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
               aria-label={`Reorder ${workspace.name}`}
               onDragStart={(event) => onDragStartWorkspace(event, workspaceId)}
               onDragEnd={onDragEndWorkspace}
-              className="h-6 w-6 shrink-0 cursor-grab rounded-md text-muted-foreground hover:text-foreground active:cursor-grabbing"
+              className="h-6 w-6 shrink-0 cursor-grab rounded-md text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
             >
               <GripVertical className="size-3.5" />
             </Button>
             <span
               className={cn(
-                "inline-flex h-2.5 w-2.5 shrink-0 rounded-full",
+                "inline-flex h-2 w-2 shrink-0 rounded-full",
                 statusAccentClassName(runtimeCardState),
               )}
             />
             <span className="truncate">{workspace.name}</span>
             {workspace.folder_state === "missing" ? (
-              <span className="inline-flex items-center gap-1 text-[10px] text-warning">
+              <span className="inline-flex items-center gap-1 text-xs text-warning">
                 <TriangleAlert className="size-3.5" />
                 Missing folder
               </span>
             ) : null}
           </CardTitle>
-          <div className="flex shrink-0 items-center gap-1.5">
-            <span className="text-[10px] text-muted-foreground">
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="text-xs text-muted-foreground">
               {formatLastActivityLabel(lastActivityAt)}
             </span>
-            {runtimeCardState !== "working" && runtimeCardState !== "queued" ? (
+            {runtimeCardState === "waiting" || runtimeCardState === "error" ? (
               <Badge
                 variant={previewStatusVariant(runtimeCardState)}
-                className="h-6 rounded-full px-2 text-[11px]"
+                className="h-6 rounded-full px-2 text-xs"
               >
                 {previewStatusLabel(runtimeCardState)}
               </Badge>
@@ -1203,20 +1182,20 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
               variant="ghost"
               size="sm"
               onClick={handleEnterWorkspace}
-              className="h-6 rounded-full px-2.5 text-[11px]"
+              className="h-6 rounded-full px-2.5 text-xs hover:bg-accent"
             >
-              Enter workspace
+              Enter
               <ArrowUpRight className="size-3.5" />
             </Button>
           </div>
         </div>
       </CardHeader>
 
-      <CardContent className="flex min-h-0 flex-1 flex-col gap-1.5 px-2.5 pb-2 pt-1.5">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-0 pb-0 pt-0">
         <div
           ref={previewScrollerRef}
           onScroll={handlePreviewScroll}
-          className="min-h-0 flex-1 overflow-y-auto rounded-[18px] border border-border/70 bg-muted/25 px-2.5 py-1.5"
+          className="min-h-0 flex-1 overflow-y-auto px-3 py-2"
         >
           {isLoading ? (
             <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
@@ -1260,13 +1239,13 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
         </div>
 
         {errorMessage ? (
-          <div className="theme-chat-system-bubble rounded-xl border px-3 py-2 text-xs">
+          <div className="theme-chat-system-bubble mx-3 rounded-md border px-3 py-2 text-xs">
             {errorMessage}
           </div>
         ) : null}
 
-        <div className="rounded-[18px] border border-border/70 bg-background/82 p-1.5 shadow-sm">
-          <div className="flex items-end gap-1.5">
+        <div className="border-t border-border bg-fg-2 px-3 py-2">
+          <div className="flex items-end gap-2">
             <textarea
               value={composerText}
               onChange={(event) => setComposerText(event.target.value)}
@@ -1281,7 +1260,7 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
                     ? "Wait for the current run to finish."
                     : "Message this workspace directly..."
               }
-              className="min-h-[40px] max-h-[84px] flex-1 resize-none rounded-[14px] border border-border/70 bg-transparent px-3 py-2 text-sm leading-5 outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="min-h-[36px] max-h-[84px] flex-1 resize-none rounded-md border border-border bg-background px-3 py-2 text-sm leading-5 outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <Button
               variant="default"
@@ -1295,7 +1274,7 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
                 isResponding ||
                 workspaceUnavailable
               }
-              className="h-8 self-center rounded-full px-3 shrink-0"
+              className="h-9 shrink-0 rounded-md px-3"
             >
               {isSubmitting ? (
                 <Loader2 className="size-3.5 animate-spin" />
@@ -1336,19 +1315,14 @@ export function WorkspaceControlCenter({
   onCardComposerSubmit,
   onWorkspaceCompletion,
 }: WorkspaceControlCenterProps) {
+  void cardsPerRow;
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const [gridColumnCount, setGridColumnCount] = useState(() =>
-    Math.max(1, Math.min(cardsPerRow, workspaces.length || 1)),
-  );
-  const [visibleRowCount, setVisibleRowCount] = useState(1);
-  const [cardHeight, setCardHeight] = useState(WORKSPACE_CARD_MAX_HEIGHT);
-  const [pageCount, setPageCount] = useState(1);
-  const [currentPage, setCurrentPage] = useState(0);
-  const [allowVerticalOverflow, setAllowVerticalOverflow] = useState(false);
+  const cardNodesRef = useRef<Map<string, HTMLDivElement>>(new Map());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const visibleIdsRef = useRef<Set<string>>(new Set());
+  const previousHighlightIdsRef = useRef<Set<string>>(new Set());
   const [draggedWorkspaceId, setDraggedWorkspaceId] = useState("");
   const [dragTargetWorkspaceId, setDragTargetWorkspaceId] = useState("");
-  const wheelSwipeAccumulationRef = useRef(0);
-  const wheelSwipeResetTimerRef = useRef<number | null>(null);
 
   const sortedWorkspaces = useMemo(() => {
     return [...workspaces].sort((left, right) => {
@@ -1367,17 +1341,6 @@ export function WorkspaceControlCenter({
     [orderedWorkspaceIds, sortedWorkspaces],
   );
 
-  const cardsPerPage = Math.max(1, gridColumnCount * visibleRowCount);
-  const pageContentHeight =
-    visibleRowCount * cardHeight + 16 * (visibleRowCount - 1);
-  const pagedWorkspaces = useMemo(() => {
-    const pages: WorkspaceRecordPayload[][] = [];
-    for (let index = 0; index < orderedWorkspaces.length; index += cardsPerPage) {
-      pages.push(orderedWorkspaces.slice(index, index + cardsPerPage));
-    }
-    return pages;
-  }, [cardsPerPage, orderedWorkspaces]);
-  const currentPageWorkspaces = pagedWorkspaces[currentPage] ?? [];
   const highlightedWorkspaceIdSet = useMemo(
     () =>
       new Set(
@@ -1389,195 +1352,94 @@ export function WorkspaceControlCenter({
   );
 
   useEffect(() => {
-    onVisibleWorkspaceIdsChange(
-      currentPageWorkspaces
-        .map((workspace) => workspace.id.trim())
-        .filter(Boolean),
+    const viewport = viewportRef.current;
+    if (!viewport || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let changed = false;
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset.workspaceId;
+          if (!id) {
+            continue;
+          }
+          const wasVisible = visibleIdsRef.current.has(id);
+          if (entry.isIntersecting && !wasVisible) {
+            visibleIdsRef.current.add(id);
+            changed = true;
+          } else if (!entry.isIntersecting && wasVisible) {
+            visibleIdsRef.current.delete(id);
+            changed = true;
+          }
+        }
+        if (changed) {
+          onVisibleWorkspaceIdsChange(Array.from(visibleIdsRef.current));
+        }
+      },
+      { root: viewport, threshold: CARD_VISIBILITY_THRESHOLD },
     );
-  }, [currentPageWorkspaces, onVisibleWorkspaceIdsChange]);
+    observerRef.current = observer;
+    for (const node of cardNodesRef.current.values()) {
+      observer.observe(node);
+    }
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+    };
+  }, [onVisibleWorkspaceIdsChange]);
 
   useEffect(() => {
     return () => {
+      visibleIdsRef.current.clear();
       onVisibleWorkspaceIdsChange([]);
     };
   }, [onVisibleWorkspaceIdsChange]);
 
   useEffect(() => {
-    const viewport = viewportRef.current;
-    if (!viewport) {
+    const previous = previousHighlightIdsRef.current;
+    const newlyHighlighted: string[] = [];
+    for (const id of highlightedWorkspaceIdSet) {
+      if (!previous.has(id)) {
+        newlyHighlighted.push(id);
+      }
+    }
+    previousHighlightIdsRef.current = new Set(highlightedWorkspaceIdSet);
+    if (newlyHighlighted.length === 0) {
       return;
     }
-
-    const measure = () => {
-      const scrollStyles = window.getComputedStyle(viewport);
-      const paddingLeft =
-        Number.parseFloat(scrollStyles.paddingLeft || "0") || 0;
-      const paddingRight =
-        Number.parseFloat(scrollStyles.paddingRight || "0") || 0;
-      const paddingTop = Number.parseFloat(scrollStyles.paddingTop || "0") || 0;
-      const paddingBottom =
-        Number.parseFloat(scrollStyles.paddingBottom || "0") || 0;
-      const availableWidth = Math.max(
-        0,
-        viewport.clientWidth - paddingLeft - paddingRight,
-      );
-      const availableHeight = Math.max(
-        0,
-        viewport.clientHeight - paddingTop - paddingBottom,
-      );
-      const rowGap = 16;
-      const columnGap = 16;
-      const maxColumnsByWidth = Math.max(
-        1,
-        Math.floor(
-          (availableWidth + columnGap) /
-            (WORKSPACE_CARD_MIN_WIDTH + columnGap),
-        ),
-      );
-      const columnCount = Math.max(
-        1,
-        Math.min(cardsPerRow, workspaces.length || 1, maxColumnsByWidth),
-      );
-      const totalRowCount = Math.max(
-        1,
-        Math.ceil(workspaces.length / columnCount),
-      );
-      const maxVisibleRowsByHeight = Math.max(
-        1,
-        Math.floor(
-          (availableHeight + rowGap) / (WORKSPACE_CARD_MIN_HEIGHT + rowGap),
-        ),
-      );
-      const visibleRowCount = Math.max(
-        1,
-        Math.min(
-          WORKSPACE_CARD_VISIBLE_ROWS,
-          totalRowCount,
-          maxVisibleRowsByHeight,
-        ),
-      );
-      const fittedHeight = Math.floor(
-        (availableHeight - rowGap * (visibleRowCount - 1)) / visibleRowCount,
-      );
-      const nextHeight = Math.max(
-        availableHeight >= WORKSPACE_CARD_MIN_HEIGHT
-          ? WORKSPACE_CARD_MIN_HEIGHT
-          : Math.max(1, fittedHeight),
-        Math.min(WORKSPACE_CARD_MAX_HEIGHT, fittedHeight),
-      );
-      const nextPageCount = Math.max(
-        1,
-        Math.ceil(totalRowCount / visibleRowCount),
-      );
-      setGridColumnCount((current) =>
-        current === columnCount ? current : columnCount,
-      );
-      setVisibleRowCount((current) =>
-        current === visibleRowCount ? current : visibleRowCount,
-      );
-      setPageCount((current) =>
-        current === nextPageCount ? current : nextPageCount,
-      );
-      setAllowVerticalOverflow((current) => {
-        const nextAllowVerticalOverflow =
-          availableHeight > 0 && availableHeight < WORKSPACE_CARD_MIN_HEIGHT;
-        return current === nextAllowVerticalOverflow
-          ? current
-          : nextAllowVerticalOverflow;
-      });
-      setCardHeight((current) => (current === nextHeight ? current : nextHeight));
-    };
-
-    measure();
-
-    if (typeof ResizeObserver === "undefined") {
-      window.addEventListener("resize", measure);
-      return () => {
-        window.removeEventListener("resize", measure);
-      };
+    const targetId = newlyHighlighted[newlyHighlighted.length - 1];
+    if (!targetId) {
+      return;
     }
+    const node = cardNodesRef.current.get(targetId);
+    if (node) {
+      node.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "nearest",
+      });
+    }
+  }, [highlightedWorkspaceIdSet]);
 
-    const resizeObserver = new ResizeObserver(() => {
-      measure();
-    });
-    resizeObserver.observe(viewport);
-    window.addEventListener("resize", measure);
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener("resize", measure);
-    };
-  }, [cardsPerRow, workspaces.length]);
-
-  useEffect(() => {
-    setCurrentPage((current) => Math.max(0, Math.min(pageCount - 1, current)));
-  }, [pageCount]);
-
-  useEffect(() => {
-    return () => {
-      if (wheelSwipeResetTimerRef.current) {
-        window.clearTimeout(wheelSwipeResetTimerRef.current);
+  const attachCardNode = useCallback(
+    (workspaceId: string, node: HTMLDivElement | null) => {
+      const id = workspaceId.trim();
+      if (!id) {
+        return;
       }
-    };
-  }, []);
-
-  const navigatePage = useCallback(
-    (direction: -1 | 1) => {
-      setCurrentPage((current) =>
-        Math.max(0, Math.min(pageCount - 1, current + direction)),
-      );
+      const previous = cardNodesRef.current.get(id);
+      if (previous && previous !== node) {
+        observerRef.current?.unobserve(previous);
+      }
+      if (node) {
+        cardNodesRef.current.set(id, node);
+        observerRef.current?.observe(node);
+      } else {
+        cardNodesRef.current.delete(id);
+      }
     },
-    [pageCount],
-  );
-
-  const canPageBackward = currentPage > 0;
-  const canPageForward = currentPage < pageCount - 1;
-
-  const handleWheelSwipe = useCallback(
-    (event: ReactWheelEvent<HTMLDivElement>) => {
-      if (pageCount <= 1 || shouldIgnoreControlCenterSwipeGesture(event.target)) {
-        return;
-      }
-      const horizontalDistance = Math.abs(event.deltaX);
-      const verticalDistance = Math.abs(event.deltaY);
-      if (
-        horizontalDistance < 18 ||
-        horizontalDistance <= verticalDistance * 1.15
-      ) {
-        return;
-      }
-
-      if ((event.deltaX > 0 && currentPage >= pageCount - 1) ||
-          (event.deltaX < 0 && currentPage <= 0)) {
-        return;
-      }
-
-      wheelSwipeAccumulationRef.current += event.deltaX;
-      if (wheelSwipeResetTimerRef.current) {
-        window.clearTimeout(wheelSwipeResetTimerRef.current);
-      }
-      wheelSwipeResetTimerRef.current = window.setTimeout(() => {
-        wheelSwipeAccumulationRef.current = 0;
-        wheelSwipeResetTimerRef.current = null;
-      }, CONTROL_CENTER_WHEEL_SWIPE_RESET_MS);
-
-      event.preventDefault();
-
-      if (
-        Math.abs(wheelSwipeAccumulationRef.current) <
-        CONTROL_CENTER_WHEEL_SWIPE_THRESHOLD_PX
-      ) {
-        return;
-      }
-
-      const direction = wheelSwipeAccumulationRef.current > 0 ? 1 : -1;
-      wheelSwipeAccumulationRef.current = 0;
-      if (wheelSwipeResetTimerRef.current) {
-        window.clearTimeout(wheelSwipeResetTimerRef.current);
-        wheelSwipeResetTimerRef.current = null;
-      }
-      navigatePage(direction as -1 | 1);
-    },
-    [currentPage, navigatePage, pageCount],
+    [],
   );
 
   const handleDragStartWorkspace = useCallback(
@@ -1653,67 +1515,39 @@ export function WorkspaceControlCenter({
   );
 
   return (
-    <section className="relative flex h-full min-h-0 min-w-0 overflow-hidden">
+    <section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
       <div
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "radial-gradient(circle at 12% 10%, color-mix(in oklch, var(--primary) 14%, transparent), transparent 26%), radial-gradient(circle at 82% 14%, color-mix(in oklch, var(--secondary) 12%, transparent), transparent 22%), radial-gradient(circle at 50% 100%, color-mix(in oklch, var(--primary) 8%, transparent), transparent 30%)",
-        }}
-      />
-      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-0 min-w-0 flex-1 items-stretch gap-0 px-0 sm:gap-px sm:px-0.5">
-          {pageCount > 1 ? (
-            <div className="flex min-h-0 w-3.5 shrink-0 flex-col items-center justify-center">
-              {canPageBackward ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="icon"
-                  aria-label="Previous control center page"
-                  onClick={() => navigatePage(-1)}
-                  className="h-10 w-full self-center justify-center rounded-[8px] border border-transparent bg-transparent px-0 text-foreground/60 shadow-none transition-colors hover:bg-black/8 hover:text-foreground dark:hover:bg-white/10"
-                >
-                  <ChevronLeft className="-translate-x-px size-3" />
-                </Button>
-              ) : (
-                <span className="block h-10 w-3.5 shrink-0" />
-              )}
-            </div>
-          ) : null}
-          <div
-            ref={viewportRef}
-            onWheelCapture={handleWheelSwipe}
-            className={cn(
-              "min-h-0 min-w-0 flex-1 overflow-x-hidden px-0 pb-1 pt-1 sm:px-0.5",
-              allowVerticalOverflow ? "overflow-y-auto" : "overflow-y-hidden",
-            )}
-            style={{ touchAction: "pan-x pinch-zoom" }}
-          >
-            <div
-              key={`page-${currentPage}`}
-              className="grid min-w-0 gap-4"
-              style={{
-                minHeight: `${pageContentHeight}px`,
-                gridAutoRows: `${cardHeight}px`,
-                gridTemplateColumns: `repeat(${gridColumnCount}, minmax(0, 1fr))`,
-              }}
-            >
-              {currentPageWorkspaces.map((workspace) => (
+        ref={viewportRef}
+        className="min-h-0 min-w-0 flex-1 overflow-x-auto overflow-y-hidden px-4 py-3"
+      >
+        <div
+          className="flex h-full gap-3"
+          style={{ minWidth: "min-content" }}
+        >
+          {orderedWorkspaces.map((workspace) => {
+            const id = workspace.id.trim();
+            return (
+              <div
+                key={workspace.id}
+                ref={(node) => attachCardNode(id, node)}
+                data-workspace-id={id}
+                className="h-full min-w-0 shrink-0 grow"
+                style={{
+                  flexBasis: 0,
+                  minWidth: WORKSPACE_CARD_MIN_WIDTH,
+                }}
+              >
                 <WorkspaceControlCenterCard
-                  key={workspace.id}
                   workspace={workspace}
-                  isSelected={workspace.id === (selectedWorkspaceId || "").trim()}
+                  isSelected={id === (selectedWorkspaceId || "").trim()}
                   composerModel={composerModel}
-                  isDragging={draggedWorkspaceId === workspace.id.trim()}
+                  isDragging={draggedWorkspaceId === id}
                   isDragTarget={
                     Boolean(draggedWorkspaceId) &&
-                    dragTargetWorkspaceId === workspace.id.trim() &&
-                    draggedWorkspaceId !== workspace.id.trim()
+                    dragTargetWorkspaceId === id &&
+                    draggedWorkspaceId !== id
                   }
-                  hasUnreadCompletionHighlight={highlightedWorkspaceIdSet.has(
-                    workspace.id.trim(),
-                  )}
+                  hasUnreadCompletionHighlight={highlightedWorkspaceIdSet.has(id)}
                   onSelectWorkspace={onSelectWorkspace}
                   onEnterWorkspace={onEnterWorkspace}
                   onOpenOutput={onOpenOutput}
@@ -1725,49 +1559,10 @@ export function WorkspaceControlCenter({
                   onCardComposerSubmit={onCardComposerSubmit}
                   onWorkspaceCompletion={onWorkspaceCompletion}
                 />
-              ))}
-            </div>
-          </div>
-          {pageCount > 1 ? (
-            <div className="flex min-h-0 w-3.5 shrink-0 flex-col items-center justify-center">
-              {canPageForward ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="icon"
-                  aria-label="Next control center page"
-                  onClick={() => navigatePage(1)}
-                  className="h-10 w-full self-center justify-center rounded-[8px] border border-transparent bg-transparent px-0 text-foreground/60 shadow-none transition-colors hover:bg-black/8 hover:text-foreground dark:hover:bg-white/10"
-                >
-                  <ChevronRight className="translate-x-px size-3" />
-                </Button>
-              ) : (
-                <span className="block h-10 w-3.5 shrink-0" />
-              )}
-            </div>
-          ) : null}
+              </div>
+            );
+          })}
         </div>
-        {pageCount > 1 ? (
-          <div className="relative flex h-6 shrink-0 items-center justify-center pb-1">
-            <div className="pointer-events-none flex items-center gap-1 rounded-full border border-border/60 bg-background/82 px-1.5 py-0.5 shadow-sm backdrop-blur-sm">
-              {Array.from({ length: pageCount }, (_, pageIndex) => (
-                <button
-                  key={`page-indicator-${pageIndex}`}
-                  type="button"
-                  aria-label={`Go to control center page ${pageIndex + 1}`}
-                  aria-pressed={pageIndex === currentPage}
-                  onClick={() => setCurrentPage(pageIndex)}
-                  className={cn(
-                    "pointer-events-auto h-1.5 w-1.5 rounded-full transition-all",
-                    pageIndex === currentPage
-                      ? "bg-foreground"
-                      : "bg-foreground/25 hover:bg-foreground/45",
-                  )}
-                />
-              ))}
-            </div>
-          </div>
-        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

The remaining half of the original landing/toolbar redesign — the TopTabsBar style cleanup parts already shipped in #275; this change covers the workspace control center redesign + the AppShell default view + the TopTabsBar entries that surface the new affordances.

## What changes

**AppShell**
- Default \`activeShellView\` is now \`"space"\` instead of \`"control_center"\` — the app resumes the user's last workspace on launch (matches Cursor/VSCode/Notion convention; control center remains opt-in via the toolbar).
- Auto-select most-recent workspace when the stored selection is invalid.
- Rename startup ref to reflect general scope (was single-workspace-only patch): \`singleWorkspaceStartupEntryHandledRef\` → \`startupWorkspaceSelectionHandledRef\`.

**WorkspaceControlCenter**
- Replace the grid + page-chevrons + dot-indicators layout with a flex-grow + min-width horizontal scroll lane (craft-agents-oss DNA). **Net -205 lines.**
- IntersectionObserver-based visibility tracking; \`scrollIntoView\` when \`highlightedWorkspaceIds\` grows.
- Adopt design system tokens: \`bg-fg-2\` / \`border-border\` / \`shadow-tinted-brand\`, \`rounded-md\` / \`rounded-2xl\`, no opacity hacks on tokens, no magic radii.
- Card chrome: drop nested bordered preview/composer cards; pulse the status dot during "working"; badge only shows for waiting/error states.

**TopTabsBar**
- Restore the Create-workspace entry that was hidden alongside the workspace switcher when control center is active.
- Regroup buttons: **navigation** (Home/Plus + workspace switcher), **status** (Credits + Runtime), **account** (Avatar).
- Home/Plus become icon-only with Tooltip + aria-label. The bordered variant + token cleanup landed in #275, so this PR only adds the new entry shape, not duplicate styling.

**Test**
- \`AppShell.test.mjs\` assertions updated for the new default (\`"space"\` not \`"control_center"\`) and the renamed startup ref.

## Files

| Path | Change |
|---|---|
| \`desktop/src/components/layout/AppShell.tsx\` | default view + startup selection |
| \`desktop/src/components/layout/WorkspaceControlCenter.tsx\` | full redesign (-205 net) |
| \`desktop/src/components/layout/TopTabsBar.tsx\` | CC-mode Plus entry, Home tooltip, regroup |
| \`desktop/src/components/layout/AppShell.test.mjs\` | assertion update for the contract change |

## Test plan

- [x] \`npm run desktop:typecheck\` — clean
- [x] \`npm --prefix desktop run build:renderer\` — clean
- [x] \`AppShell.test.mjs\` + \`SpaceApplicationsExplorerPane.test.mjs\` — same pass count as upstream/main baseline (the lone failure is a pre-existing assertion on \`updateNotification\` shape, unrelated to this PR)
- [ ] Manual: launch desktop with an existing workspace, confirm it lands directly in the workspace (not control center)
- [ ] Manual: click the Home button to enter control center, verify the new horizontal-lane workspace list scrolls correctly with many workspaces
- [ ] Manual: in control center, click the Plus button — confirm Create-workspace flow opens (this entry was hidden in the old design)
- [ ] Manual: light + dark theme — verify card chrome, status dots, badge visibility match the design tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)