### PR TITLE
fix: stabilize desktop runtime startup during legacy migration

### DIFF
--- a/desktop/electron/authPopupPreload.ts
+++ b/desktop/electron/authPopupPreload.ts
@@ -54,6 +54,7 @@ interface RuntimeStatusPayload {
   harness: string | null;
   desktopBrowserReady: boolean;
   desktopBrowserUrl: string | null;
+  startupMessage: string | null;
   lastError: string;
 }
 

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -840,6 +840,7 @@ interface RuntimeStatusPayload {
   harness: string | null;
   desktopBrowserReady: boolean;
   desktopBrowserUrl: string | null;
+  startupMessage: string | null;
   lastError: string;
 }
 
@@ -1093,6 +1094,7 @@ let runtimeStatus: RuntimeStatusPayload = {
   harness: null,
   desktopBrowserReady: false,
   desktopBrowserUrl: null,
+  startupMessage: null,
   lastError: "",
 };
 let desktopBrowserServiceServer: HttpServer | null = null;
@@ -3843,6 +3845,225 @@ function controlPlaneDatabasePath() {
 
 function runtimeWorkspaceRoot() {
   return path.join(runtimeSandboxRoot(), "workspace");
+}
+
+const WORKSPACE_RUNTIME_MIGRATION_PROBE_TABLES = [
+  "session_output_events",
+  "turn_request_snapshots",
+  "turn_results",
+  "session_messages",
+  "outputs",
+  "app_ports",
+  "app_builds",
+  "cronjobs",
+  "runtime_notifications",
+] as const;
+
+const RUNTIME_MIGRATION_STARTUP_MESSAGE = "Migrating database";
+const DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS = 30;
+const MIGRATION_RUNTIME_STARTUP_HEALTH_ATTEMPTS = 900;
+const RUNTIME_STARTUP_HEALTH_DELAY_MS = 1000;
+
+function sqliteTableExists(
+  database: Database.Database,
+  tableName: string,
+): boolean {
+  const row = database
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+    )
+    .get(tableName) as { present?: number } | undefined;
+  return row?.present === 1;
+}
+
+function openReadonlySqliteDatabase(
+  dbPath: string,
+): Database.Database | null {
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  try {
+    const database = new Database(dbPath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+    return database;
+  } catch {
+    return null;
+  }
+}
+
+function workspaceRuntimeDbPathForStartupCheck(
+  workspaceId: string,
+  workspacePath: string | null | undefined,
+): string {
+  const trimmedPath = workspacePath?.trim() || "";
+  const rootPath = trimmedPath
+    ? path.resolve(trimmedPath)
+    : workspaceDirectoryPath(workspaceId);
+  return path.join(rootPath, ".holaboss", "state", "runtime.db");
+}
+
+function workspaceRuntimeDbContainsMigratedData(dbPath: string): boolean {
+  const database = openReadonlySqliteDatabase(dbPath);
+  if (!database) {
+    return false;
+  }
+
+  try {
+    for (const tableName of WORKSPACE_RUNTIME_MIGRATION_PROBE_TABLES) {
+      if (!sqliteTableExists(database, tableName)) {
+        continue;
+      }
+      const row = database
+        .prepare<[], { present: number }>(
+          `SELECT 1 AS present FROM ${tableName} LIMIT 1`,
+        )
+        .get();
+      if (row?.present === 1) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    try {
+      database.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function legacyWorkspaceRowsPendingMigration(
+  database: Database.Database,
+  workspaceId: string,
+): boolean {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return false;
+  }
+
+  for (const tableName of WORKSPACE_RUNTIME_MIGRATION_PROBE_TABLES) {
+    if (!sqliteTableExists(database, tableName)) {
+      continue;
+    }
+    const row = database
+      .prepare<[string], { present: number }>(
+        `SELECT 1 AS present FROM ${tableName} WHERE workspace_id = ? LIMIT 1`,
+      )
+      .get(normalizedWorkspaceId);
+    if (row?.present === 1) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasPendingLegacyHostStateDatabaseFileMigration(): boolean {
+  const nextPath = hostStateDatabasePath();
+  const legacyPath = legacyRuntimeDatabasePath();
+  return (
+    nextPath !== legacyPath &&
+    !existsSync(nextPath) &&
+    existsSync(legacyPath)
+  );
+}
+
+function hasPendingLegacyWorkspaceRuntimeMigration(): boolean {
+  const sourceDbPath = existsSync(hostStateDatabasePath())
+    ? hostStateDatabasePath()
+    : existsSync(legacyRuntimeDatabasePath())
+      ? legacyRuntimeDatabasePath()
+      : null;
+  if (!sourceDbPath) {
+    return false;
+  }
+
+  const database = openReadonlySqliteDatabase(sourceDbPath);
+  if (!database) {
+    return false;
+  }
+
+  try {
+    if (!sqliteTableExists(database, "workspaces")) {
+      return false;
+    }
+    const workspaceColumns = new Set(
+      (
+        database.prepare("PRAGMA table_info(workspaces)").all() as Array<{
+          name: string;
+        }>
+      ).map((row) => row.name),
+    );
+    if (!workspaceColumns.has("id")) {
+      return false;
+    }
+
+    const selectColumns = ["id"];
+    if (workspaceColumns.has("workspace_path")) {
+      selectColumns.push("workspace_path");
+    }
+    const whereClause = workspaceColumns.has("deleted_at_utc")
+      ? " WHERE deleted_at_utc IS NULL"
+      : "";
+    const workspaceRows = database
+      .prepare(`SELECT ${selectColumns.join(", ")} FROM workspaces${whereClause}`)
+      .all() as Array<{
+      id: string;
+      workspace_path?: string | null;
+    }>;
+
+    for (const workspace of workspaceRows) {
+      const workspaceId = String(workspace.id ?? "").trim();
+      if (!workspaceId) {
+        continue;
+      }
+      if (!legacyWorkspaceRowsPendingMigration(database, workspaceId)) {
+        continue;
+      }
+      const workspaceDbPath = workspaceRuntimeDbPathForStartupCheck(
+        workspaceId,
+        workspace.workspace_path ?? null,
+      );
+      if (!workspaceRuntimeDbContainsMigratedData(workspaceDbPath)) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  } finally {
+    try {
+      database.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function runtimeStartupMessage(): string | null {
+  if (
+    hasPendingLegacyHostStateDatabaseFileMigration() ||
+    hasPendingLegacyWorkspaceRuntimeMigration()
+  ) {
+    return RUNTIME_MIGRATION_STARTUP_MESSAGE;
+  }
+  return null;
+}
+
+function runtimeStartupHealthWaitOptions(startupMessage: string | null | undefined) {
+  return {
+    attempts:
+      startupMessage?.trim() === RUNTIME_MIGRATION_STARTUP_MESSAGE
+        ? MIGRATION_RUNTIME_STARTUP_HEALTH_ATTEMPTS
+        : DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS,
+    delayMs: RUNTIME_STARTUP_HEALTH_DELAY_MS,
+  };
 }
 
 async function migrateLegacyHostStateDatabaseFiles() {
@@ -11946,7 +12167,14 @@ async function ensureRuntimeReady() {
 
     const runtimeUrl = status.url ?? runtimeBaseUrl();
     if (status.status === "starting" && runtimeUrl) {
-      const healthy = await waitForRuntimeHealth(runtimeUrl, 10, 300);
+      const healthWait = runtimeStartupHealthWaitOptions(
+        status.startupMessage,
+      );
+      const healthy = await waitForRuntimeHealth(
+        runtimeUrl,
+        healthWait.attempts,
+        healthWait.delayMs,
+      );
       if (healthy) {
         const refreshed = await refreshRuntimeStatus();
         if (refreshed.status === "running" && refreshed.url) {
@@ -15112,6 +15340,7 @@ function emitRuntimeState(force = false) {
     harness: runtimeStatus.harness,
     desktopBrowserReady: runtimeStatus.desktopBrowserReady,
     desktopBrowserUrl: runtimeStatus.desktopBrowserUrl,
+    startupMessage: runtimeStatus.startupMessage,
     lastError: runtimeStatus.lastError,
   });
   if (!force && nextSignature === lastRuntimeStateSignature) {
@@ -15294,8 +15523,8 @@ async function resolveRuntimeRoot() {
 
 async function waitForRuntimeHealth(
   url: string,
-  attempts = 30,
-  delayMs = 1000,
+  attempts = DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS,
+  delayMs = RUNTIME_STARTUP_HEALTH_DELAY_MS,
 ) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (await isRuntimeHealthy(url)) {
@@ -15566,6 +15795,7 @@ async function refreshRuntimeStatus() {
   const url = runtimeBaseUrl();
   const healthy = await isRuntimeHealthy(url);
   const hasBundle = Boolean(runtimeRoot && executablePath);
+  const unavailableStatus = runtimeUnavailableStatus(hasBundle);
 
   if (healthy) {
     persistRuntimeProcessState({
@@ -15583,6 +15813,7 @@ async function refreshRuntimeStatus() {
       url,
       pid: runtimeProcess?.pid ?? persistedPid,
       harness,
+      startupMessage: null,
       lastError: "",
     });
     emitRuntimeState();
@@ -15597,7 +15828,9 @@ async function refreshRuntimeStatus() {
     executablePath,
     url,
     harness,
-    status: runtimeUnavailableStatus(hasBundle),
+    status: unavailableStatus,
+    startupMessage:
+      unavailableStatus === "starting" ? runtimeStatus.startupMessage : null,
     lastError:
       hasBundle
         ? runtimeStartupInFlight
@@ -15630,6 +15863,7 @@ async function stopEmbeddedRuntime() {
           ...runtimeStatus,
           status: nextStatus,
           pid: null,
+          startupMessage: null,
           lastError: nextError,
         });
         if (!stopped) {
@@ -15651,6 +15885,7 @@ async function stopEmbeddedRuntime() {
           ...runtimeStatus,
           status: "stopped",
           pid: null,
+          startupMessage: null,
         });
         persistRuntimeProcessState({
           pid: null,
@@ -15776,6 +16011,7 @@ async function startEmbeddedRuntime() {
       await fs.mkdir(sandboxRoot, { recursive: true });
       await bootstrapRuntimeDatabase();
       bootstrapControlPlaneDatabase();
+      const startupMessage = runtimeStartupMessage();
 
       const preflightRuntimePort = await ensureRuntimePortAvailable({
         url,
@@ -15798,6 +16034,7 @@ async function startEmbeddedRuntime() {
           url,
           pid: null,
           harness,
+          startupMessage: null,
           lastError: portCleanupError,
         });
         persistRuntimeProcessState({
@@ -15819,6 +16056,7 @@ async function startEmbeddedRuntime() {
         url,
         pid: null,
         harness,
+        startupMessage: runtimeRoot && executablePath ? startupMessage : null,
         lastError:
           runtimeRoot && executablePath
             ? ""
@@ -15842,6 +16080,7 @@ async function startEmbeddedRuntime() {
           ...runtimeStatus,
           status: "error",
           pid: null,
+          startupMessage: null,
           lastError: startupConfigError,
         });
         persistRuntimeProcessState({
@@ -15875,6 +16114,7 @@ async function startEmbeddedRuntime() {
           ...runtimeStatus,
           status: "error",
           pid: null,
+          startupMessage: null,
           lastError: launchBlockedError,
         });
         persistRuntimeProcessState({
@@ -15902,6 +16142,7 @@ async function startEmbeddedRuntime() {
           ...runtimeStatus,
           status: "error",
           pid: null,
+          startupMessage: null,
           lastError: launchError,
         });
         persistRuntimeProcessState({
@@ -15973,6 +16214,7 @@ async function startEmbeddedRuntime() {
         ...runtimeStatus,
         status: "starting",
         pid: child.pid ?? null,
+        startupMessage,
       });
       emitRuntimeState();
 
@@ -16005,6 +16247,7 @@ async function startEmbeddedRuntime() {
             ...runtimeStatus,
             status: nextStatus,
             pid: null,
+            startupMessage: null,
             lastError: nextError,
           });
           persistRuntimeProcessState({
@@ -16023,7 +16266,12 @@ async function startEmbeddedRuntime() {
         })();
       });
 
-      const healthy = await waitForRuntimeHealth(url);
+      const healthWait = runtimeStartupHealthWaitOptions(startupMessage);
+      const healthy = await waitForRuntimeHealth(
+        url,
+        healthWait.attempts,
+        healthWait.delayMs,
+      );
       if (healthy) {
         runtimeStatus = await refreshRuntimeStatus();
       } else {
@@ -16031,6 +16279,7 @@ async function startEmbeddedRuntime() {
           ...runtimeStatus,
           status: "error",
           pid: child.pid ?? null,
+          startupMessage: null,
           lastError:
             "Runtime process started but did not pass health checks. Check runtime.log in the Electron userData directory.",
         });
@@ -16055,6 +16304,7 @@ async function startEmbeddedRuntime() {
         ...runtimeStatus,
         status: "error",
         pid: null,
+        startupMessage: null,
         lastError: startupError,
       });
       persistRuntimeProcessState({
@@ -22502,6 +22752,7 @@ app.whenReady().then(async () => {
     url: runtimeBaseUrl(),
     sandboxRoot: runtimeSandboxRoot(),
     harness: process.env.HOLABOSS_RUNTIME_HARNESS || "pi",
+    startupMessage: runtimeStartupMessage(),
     lastError: "",
   });
   emitRuntimeState();

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -3847,11 +3847,30 @@ function runtimeWorkspaceRoot() {
   return path.join(runtimeSandboxRoot(), "workspace");
 }
 
+const WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY =
+  "legacy_workspace_backfill_v1_complete";
 const WORKSPACE_RUNTIME_MIGRATION_PROBE_TABLES = [
+  "agent_sessions",
+  "agent_runtime_sessions",
+  "conversation_bindings",
+  "agent_session_inputs",
+  "post_run_jobs",
+  "main_session_event_queue",
+  "session_runtime_state",
   "session_output_events",
+  "subagent_runs",
+  "terminal_sessions",
+  "terminal_session_events",
   "turn_request_snapshots",
   "turn_results",
   "session_messages",
+  "task_proposals",
+  "evolve_skill_candidates",
+  "memory_update_proposals",
+  "memory_entries",
+  "memory_embedding_index",
+  "memory_recall_vec",
+  "output_folders",
   "outputs",
   "app_ports",
   "app_builds",
@@ -3905,27 +3924,22 @@ function workspaceRuntimeDbPathForStartupCheck(
   return path.join(rootPath, ".holaboss", "state", "runtime.db");
 }
 
-function workspaceRuntimeDbContainsMigratedData(dbPath: string): boolean {
+function workspaceRuntimeLegacyBackfillComplete(dbPath: string): boolean {
   const database = openReadonlySqliteDatabase(dbPath);
   if (!database) {
     return false;
   }
 
   try {
-    for (const tableName of WORKSPACE_RUNTIME_MIGRATION_PROBE_TABLES) {
-      if (!sqliteTableExists(database, tableName)) {
-        continue;
-      }
-      const row = database
-        .prepare<[], { present: number }>(
-          `SELECT 1 AS present FROM ${tableName} LIMIT 1`,
-        )
-        .get();
-      if (row?.present === 1) {
-        return true;
-      }
+    if (!sqliteTableExists(database, "workspace_runtime_metadata")) {
+      return false;
     }
-    return false;
+    const row = database
+      .prepare<[string], { value?: string }>(
+        "SELECT value FROM workspace_runtime_metadata WHERE key = ? LIMIT 1",
+      )
+      .get(WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY);
+    return row?.value === "complete";
   } catch {
     return false;
   } finally {
@@ -4029,7 +4043,7 @@ function hasPendingLegacyWorkspaceRuntimeMigration(): boolean {
         workspaceId,
         workspace.workspace_path ?? null,
       );
-      if (!workspaceRuntimeDbContainsMigratedData(workspaceDbPath)) {
+      if (!workspaceRuntimeLegacyBackfillComplete(workspaceDbPath)) {
         return true;
       }
     }
@@ -15525,13 +15539,22 @@ async function waitForRuntimeHealth(
   url: string,
   attempts = DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS,
   delayMs = RUNTIME_STARTUP_HEALTH_DELAY_MS,
+  options: {
+    abortWhen?: () => boolean;
+  } = {},
 ) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (await isRuntimeHealthy(url)) {
       return true;
     }
+    if (options.abortWhen?.()) {
+      return false;
+    }
 
     await new Promise((resolve) => setTimeout(resolve, delayMs));
+    if (options.abortWhen?.()) {
+      return false;
+    }
   }
 
   return false;
@@ -16271,6 +16294,10 @@ async function startEmbeddedRuntime() {
         url,
         healthWait.attempts,
         healthWait.delayMs,
+        {
+          abortWhen: () =>
+            runtimeProcess !== child || child.exitCode !== null,
+        },
       );
       if (healthy) {
         runtimeStatus = await refreshRuntimeStatus();

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -266,6 +266,7 @@ interface RuntimeStatusPayload {
   url: string | null;
   pid: number | null;
   harness: string | null;
+  startupMessage: string | null;
   lastError: string;
 }
 

--- a/desktop/electron/runtime-startup-status.test.mjs
+++ b/desktop/electron/runtime-startup-status.test.mjs
@@ -25,7 +25,11 @@ test("desktop runtime status stays in starting while launch is in flight", async
   );
   assert.match(
     source,
-    /status: runtimeUnavailableStatus\(hasBundle\),/,
+    /const unavailableStatus = runtimeUnavailableStatus\(hasBundle\);/,
+  );
+  assert.match(
+    source,
+    /status: unavailableStatus,/,
   );
   assert.match(
     source,
@@ -34,6 +38,48 @@ test("desktop runtime status stays in starting while launch is in flight", async
   assert.match(
     source,
     /async function startEmbeddedRuntime\(\) \{[\s\S]*runtimeStartupInFlight = true;[\s\S]*finally \{\s*runtimeStartupInFlight = false;\s*\}[\s\S]*\}\s*\);[\s\S]*\}/,
+  );
+});
+
+test("desktop migration startup detection keys off the workspace legacy backfill marker", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /const WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY =\s*"legacy_workspace_backfill_v1_complete";/,
+  );
+  assert.match(
+    source,
+    /"memory_recall_vec"/,
+  );
+  assert.match(
+    source,
+    /function workspaceRuntimeLegacyBackfillComplete\(dbPath: string\): boolean \{/,
+  );
+  assert.match(
+    source,
+    /SELECT value FROM workspace_runtime_metadata WHERE key = \? LIMIT 1/,
+  );
+  assert.match(
+    source,
+    /if \(!workspaceRuntimeLegacyBackfillComplete\(workspaceDbPath\)\) \{\s*return true;\s*\}/,
+  );
+});
+
+test("desktop runtime health wait can abort early after the spawned runtime exits", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /async function waitForRuntimeHealth\([\s\S]*options:\s*\{\s*abortWhen\?: \(\) => boolean;\s*\}\s*=\s*\{\s*\}/,
+  );
+  assert.match(
+    source,
+    /if \(options\.abortWhen\?\.\(\)\) \{\s*return false;\s*\}/,
+  );
+  assert.match(
+    source,
+    /abortWhen: \(\) =>\s*runtimeProcess !== child \|\| child\.exitCode !== null/,
   );
 });
 

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1198,7 +1198,11 @@ function EmptyWorkspacePane() {
   );
 }
 
-function WorkspaceBootstrapPane() {
+function WorkspaceBootstrapPane({
+  subtitle = "Preparing your desktop",
+}: {
+  subtitle?: string;
+}) {
   // Pin to the viewport so the bootstrap surface fills edge-to-edge
   // independent of the AppShell grid's outer padding/gutters. Otherwise
   // the body (which is translucent on macOS for vibrancy) would show as
@@ -1243,7 +1247,7 @@ function WorkspaceBootstrapPane() {
           holaOS
         </h1>
         <p className="mt-1.5 text-[12.5px] font-medium text-muted-foreground">
-          Preparing your desktop
+          {subtitle}
         </p>
         <div
           className="mt-5 flex items-center gap-1.5"
@@ -1296,6 +1300,16 @@ function runtimeStartupBlockedMessage(
     );
   }
   return "";
+}
+
+function workspaceBootstrapSubtitle(
+  runtimeStatus: RuntimeStatusPayload | null,
+): string {
+  const startupMessage =
+    runtimeStatus?.status === "starting"
+      ? runtimeStatus.startupMessage?.trim() || ""
+      : "";
+  return startupMessage || "Preparing your desktop";
 }
 
 function FocusPlaceholder({
@@ -5174,7 +5188,9 @@ function AppShellContent() {
           bootstrapErrorMessage ? (
             <WorkspaceStartupErrorPane message={bootstrapErrorMessage} />
           ) : (
-            <WorkspaceBootstrapPane />
+            <WorkspaceBootstrapPane
+              subtitle={workspaceBootstrapSubtitle(runtimeStatus)}
+            />
           )
         ) : hydratedRuntimeErrorMessage ? (
           <WorkspaceStartupErrorPane message={hydratedRuntimeErrorMessage} />

--- a/desktop/src/types/electron.d.ts
+++ b/desktop/src/types/electron.d.ts
@@ -268,6 +268,7 @@ declare global {
     harness: string | null;
     desktopBrowserReady: boolean;
     desktopBrowserUrl: string | null;
+    startupMessage: string | null;
     lastError: string;
   }
 

--- a/runtime/api-server/src/app-lifecycle-worker.ts
+++ b/runtime/api-server/src/app-lifecycle-worker.ts
@@ -74,6 +74,18 @@ export interface AppLifecycleExecutorLike {
    * missing implementation as "tracking is unknown" (i.e. trust health).
    */
   isTrackingApp?(params: { workspaceId?: string; appId: string }): boolean;
+  /**
+   * Registers the allocated ports for a healthy shell-managed app that
+   * the current runtime did not spawn itself (for example after a
+   * desktop runtime relaunch). This lets later stop/restart paths fall
+   * back to killing the known listeners by port.
+   */
+  rememberAppPorts?(params: {
+    workspaceId?: string;
+    appId: string;
+    httpPort: number;
+    mcpPort: number;
+  }): void;
 }
 
 /** Returns true if the in-memory shell-lifecycle map currently tracks a
@@ -91,6 +103,18 @@ export function isShellLifecycleAppTracked(workspaceId: string | undefined, appI
     return false;
   }
   return true;
+}
+
+export function rememberShellLifecycleAppPorts(params: {
+  workspaceId?: string;
+  appId: string;
+  httpPort: number;
+  mcpPort: number;
+}): void {
+  shellLifecyclePorts.set(lifecycleMapKey(params.workspaceId, params.appId), {
+    http: params.httpPort,
+    mcp: params.mcpPort,
+  });
 }
 
 export class AppLifecycleExecutorError extends Error {
@@ -1298,5 +1322,14 @@ export class RuntimeAppLifecycleExecutor implements AppLifecycleExecutorLike {
 
   isTrackingApp(params: { workspaceId?: string; appId: string }): boolean {
     return isShellLifecycleAppTracked(params.workspaceId, params.appId);
+  }
+
+  rememberAppPorts(params: {
+    workspaceId?: string;
+    appId: string;
+    httpPort: number;
+    mcpPort: number;
+  }): void {
+    rememberShellLifecycleAppPorts(params);
   }
 }

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -5269,6 +5269,127 @@ test("ensure-running dedupes concurrent setup/start for the same app", async () 
   store.close();
 });
 
+test("auto-start on ready reuses a healthy untracked shell-managed app", async () => {
+  const root = makeTempDir("hb-runtime-api-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot
+  });
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace Apps",
+    harness: "pi",
+    status: "active"
+  });
+  const workspaceDir = path.join(workspaceRoot, workspace.id);
+  const appDir = path.join(workspaceDir, "apps", "app-a");
+  fs.mkdirSync(appDir, { recursive: true });
+
+  const httpServer = await startStaticHttpServer((_request, response) => {
+    response.statusCode = 200;
+    response.end("ok");
+  });
+  const mcpServer = await startStaticHttpServer((_request, response) => {
+    response.statusCode = 200;
+    response.end("ok");
+  });
+  const httpPort = Number(new URL(httpServer.url).port);
+  const mcpPort = Number(new URL(mcpServer.url).port);
+
+  fs.writeFileSync(
+    path.join(appDir, "app.runtime.yaml"),
+    [
+      "app_id: app-a",
+      "name: App A",
+      "description: Test app",
+      "icon: https://example.com/icon.png",
+      "mcp:",
+      "  transport: http-sse",
+      `  port: ${mcpPort}`,
+      "  path: /mcp",
+      "mcp_tools: []",
+      "http:",
+      `  port: ${httpPort}`,
+      "healthchecks:",
+      "  http:",
+      "    path: /health",
+      "    timeout_s: 1",
+      "  mcp:",
+      "    path: /health",
+      "    timeout_s: 1",
+      "lifecycle:",
+      "  setup: ''",
+      "  start: npm run start"
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "workspace.yaml"),
+    [
+      "applications:",
+      "  - app_id: app-a",
+      "    config_path: apps/app-a/app.runtime.yaml"
+    ].join("\n"),
+    "utf8"
+  );
+
+  const lifecycleCalls: Array<Record<string, unknown>> = [];
+  const rememberedPorts: Array<Record<string, unknown>> = [];
+  const app = buildRuntimeApiServer({
+    store,
+    queueWorker: null,
+    durableMemoryWorker: null,
+    cronWorker: null,
+    bridgeWorker: null,
+    recallEmbeddingBackfillWorker: null,
+    enableAppHealthMonitor: false,
+    startAppsOnReady: true,
+    appLifecycleExecutor: {
+      async startApp(params) {
+        lifecycleCalls.push({ action: "start", ...params });
+        return {
+          app_id: params.appId,
+          status: "started",
+          detail: "app started with lifecycle manager",
+          ports: { http: params.httpPort ?? 18080, mcp: params.mcpPort ?? 13100 }
+        };
+      },
+      async stopApp() {
+        throw new Error("not used");
+      },
+      async shutdownAll() {
+        throw new Error("not used");
+      },
+      isTrackingApp() {
+        return false;
+      },
+      rememberAppPorts(params) {
+        rememberedPorts.push(params);
+      }
+    }
+  });
+
+  await app.ready();
+  await sleep(150);
+
+  assert.equal(lifecycleCalls.length, 0);
+  assert.deepEqual(rememberedPorts, [
+    {
+      workspaceId: workspace.id,
+      appId: "app-a",
+      httpPort,
+      mcpPort
+    }
+  ]);
+  assert.equal(store.getAppBuild({ workspaceId: workspace.id, appId: "app-a" })?.status, "running");
+
+  await httpServer.close();
+  await mcpServer.close();
+  await app.close();
+  store.close();
+});
+
 test("app setup timeout honors configured timeout", async () => {
   const root = makeTempDir("hb-runtime-api-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -16,7 +16,12 @@ import * as tar from "tar";
 
 import { buildRuntimeApiServer, type BuildRuntimeApiServerOptions } from "./app.js";
 import { appLocalNpmCacheDir, buildAppSetupEnv } from "./app-setup-env.js";
-import { parseInstalledAppRuntime, writeWorkspaceMcpRegistryEntry, removeWorkspaceMcpRegistryEntry } from "./workspace-apps.js";
+import {
+  parseInstalledAppRuntime,
+  removeWorkspaceMcpRegistryEntry,
+  resolveWorkspaceAppRuntime,
+  writeWorkspaceMcpRegistryEntry,
+} from "./workspace-apps.js";
 import type { AppLifecycleExecutorLike } from "./app-lifecycle-worker.js";
 import { FilesystemMemoryService, type MemoryServiceLike } from "./memory.js";
 import type { RuntimeConfigServiceLike } from "./runtime-config.js";
@@ -25,6 +30,7 @@ import type { RunnerExecutorLike } from "./runner-worker.js";
 const tempDirs: string[] = [];
 const ORIGINAL_ENV = {
   HB_SANDBOX_ROOT: process.env.HB_SANDBOX_ROOT,
+  HOLABOSS_EMBEDDED_RUNTIME: process.env.HOLABOSS_EMBEDDED_RUNTIME,
   HOLABOSS_RUNTIME_CONFIG_PATH: process.env.HOLABOSS_RUNTIME_CONFIG_PATH,
 };
 
@@ -42,6 +48,12 @@ afterEach(() => {
     delete process.env.HB_SANDBOX_ROOT;
   } else {
     process.env.HB_SANDBOX_ROOT = ORIGINAL_ENV.HB_SANDBOX_ROOT;
+  }
+  if (ORIGINAL_ENV.HOLABOSS_EMBEDDED_RUNTIME === undefined) {
+    delete process.env.HOLABOSS_EMBEDDED_RUNTIME;
+  } else {
+    process.env.HOLABOSS_EMBEDDED_RUNTIME =
+      ORIGINAL_ENV.HOLABOSS_EMBEDDED_RUNTIME;
   }
   if (ORIGINAL_ENV.HOLABOSS_RUNTIME_CONFIG_PATH === undefined) {
     delete process.env.HOLABOSS_RUNTIME_CONFIG_PATH;
@@ -129,10 +141,13 @@ function rewriteZipEntryName(archive: Buffer, fromPath: string, toPath: string):
 }
 
 async function startStaticHttpServer(
-  handler: (request: IncomingMessage, response: ServerResponse) => void
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+  options: {
+    port?: number;
+  } = {},
 ): Promise<{ url: string; close: () => Promise<void> }> {
   const server = http.createServer(handler);
-  server.listen(0, "127.0.0.1");
+  server.listen(options.port ?? 0, "127.0.0.1");
   await once(server, "listening");
   const address = server.address();
   assert.ok(address && typeof address === "object");
@@ -5270,6 +5285,7 @@ test("ensure-running dedupes concurrent setup/start for the same app", async () 
 });
 
 test("auto-start on ready reuses a healthy untracked shell-managed app", async () => {
+  process.env.HOLABOSS_EMBEDDED_RUNTIME = "1";
   const root = makeTempDir("hb-runtime-api-");
   const workspaceRoot = path.join(root, "workspace");
   const store = new RuntimeStateStore({
@@ -5286,17 +5302,6 @@ test("auto-start on ready reuses a healthy untracked shell-managed app", async (
   const appDir = path.join(workspaceDir, "apps", "app-a");
   fs.mkdirSync(appDir, { recursive: true });
 
-  const httpServer = await startStaticHttpServer((_request, response) => {
-    response.statusCode = 200;
-    response.end("ok");
-  });
-  const mcpServer = await startStaticHttpServer((_request, response) => {
-    response.statusCode = 200;
-    response.end("ok");
-  });
-  const httpPort = Number(new URL(httpServer.url).port);
-  const mcpPort = Number(new URL(mcpServer.url).port);
-
   fs.writeFileSync(
     path.join(appDir, "app.runtime.yaml"),
     [
@@ -5306,11 +5311,11 @@ test("auto-start on ready reuses a healthy untracked shell-managed app", async (
       "icon: https://example.com/icon.png",
       "mcp:",
       "  transport: http-sse",
-      `  port: ${mcpPort}`,
+      "  port: 13100",
       "  path: /mcp",
       "mcp_tools: []",
       "http:",
-      `  port: ${httpPort}`,
+      "  port: 18080",
       "healthchecks:",
       "  http:",
       "    path: /health",
@@ -5332,6 +5337,27 @@ test("auto-start on ready reuses a healthy untracked shell-managed app", async (
       "    config_path: apps/app-a/app.runtime.yaml"
     ].join("\n"),
     "utf8"
+  );
+  const resolved = resolveWorkspaceAppRuntime(workspaceDir, "app-a", {
+    store,
+    workspaceId: workspace.id,
+    allocatePorts: true,
+  });
+  const httpPort = resolved.ports.http;
+  const mcpPort = resolved.ports.mcp;
+  const httpServer = await startStaticHttpServer(
+    (_request, response) => {
+      response.statusCode = 200;
+      response.end("ok");
+    },
+    { port: httpPort },
+  );
+  const mcpServer = await startStaticHttpServer(
+    (_request, response) => {
+      response.statusCode = 200;
+      response.end("ok");
+    },
+    { port: mcpPort },
   );
 
   const lifecycleCalls: Array<Record<string, unknown>> = [];

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -2812,13 +2812,12 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
       // Already healthy — sync DB and return.
       //
-      // For shell-style lifecycles (lifecycle.start or startCommand) we
-      // ALSO require that the executor is currently tracking a child
-      // process. Otherwise the port could be responding because of an
-      // orphan process from a previous runtime (e.g. crashed without
-      // cleanup) or a port collision. Trusting such a process means we
-      // can never cleanly stop or restart the app, so we fall through
-      // to the start path which will re-spawn under our control.
+      // For shell-style lifecycles (lifecycle.start or startCommand),
+      // the runtime may be probing an app process it did not spawn in
+      // this process lifetime, such as after the desktop runtime
+      // relaunches. In that case, adopt the known ports so later stop
+      // and restart flows can still clean up by listener even though we
+      // do not have an in-memory child handle.
       //
       // Compose-managed apps are owned by docker, not by us, so the
       // tracking check doesn't apply there — trust isAppHealthy.
@@ -2845,17 +2844,25 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
         return;
       }
       if (healthy && isShellManaged) {
-        app.log.warn(
-          { event: "app.ensure_running.orphan_detected", workspaceId, appId, http: resolved.ports.http, mcp: resolved.ports.mcp },
-          "ensureAppRunning: port reports healthy but no tracked process; treating as orphan and restarting",
+        appLifecycleExecutor.rememberAppPorts?.({
+          workspaceId,
+          appId,
+          httpPort: resolved.ports.http,
+          mcpPort: resolved.ports.mcp,
+        });
+        app.log.info(
+          {
+            event: "app.ensure_running.healthy_untracked_reused",
+            workspaceId,
+            appId,
+            http: resolved.ports.http,
+            mcp: resolved.ports.mcp,
+          },
+          "ensureAppRunning: healthy app has no tracked process; reusing existing listener",
         );
-        // Best-effort kill of any process on these ports before we
-        // start a fresh one so we don't dual-bind.
-        try {
-          await killPortListeners([resolved.ports.http, resolved.ports.mcp]);
-        } catch {
-          // best-effort
-        }
+        store.upsertAppBuild({ workspaceId, appId, status: "running" });
+        reconcileAppMcpRegistry(workspaceDir, appId, resolved);
+        return;
       }
 
       // Setup needed?
@@ -3362,15 +3369,27 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
 
     if (options.startAppsOnReady !== false) {
-      // Auto-start all enabled apps for active workspaces.
-      const workspaces = store.listWorkspaces({ includeDeleted: false });
-      for (const ws of workspaces) {
-        if (ws.status === "active") {
-          void ensureAllAppsRunning(ws.id).catch((err) => {
-            app.log.error({ workspaceId: ws.id, err: err instanceof Error ? err.message : String(err) }, "auto-start apps on ready failed");
-          });
+      // Kick app auto-start into the background so the runtime can
+      // begin serving /healthz before any workspace app setup/startup
+      // work runs. Running this inline inside onReady can delay
+      // app.listen() long enough for the desktop bootstrap health check
+      // to time out and kill an otherwise healthy runtime.
+      setImmediate(() => {
+        const workspaces = store.listWorkspaces({ includeDeleted: false });
+        for (const ws of workspaces) {
+          if (ws.status === "active") {
+            void ensureAllAppsRunning(ws.id).catch((err) => {
+              app.log.error(
+                {
+                  workspaceId: ws.id,
+                  err: err instanceof Error ? err.message : String(err),
+                },
+                "auto-start apps on ready failed",
+              );
+            });
+          }
         }
-      }
+      });
     }
   });
 

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -3076,6 +3076,109 @@ test("workspace-scoped runtime db backfills legacy cronjobs from runtime.db on f
   assert.equal(mirrored?.id, "job-legacy");
 });
 
+test("workspace runtime DB skips repeated legacy backfill once it already has data", () => {
+  const root = makeTempDir("hb-state-store-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const initialStore = new RuntimeStateStore({ dbPath, workspaceRoot });
+  initialStore.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Legacy",
+    harness: "pi",
+    status: "active"
+  });
+  initialStore.close();
+
+  const legacyDb = new Database(dbPath);
+  legacyDb.exec(`
+    CREATE TABLE cronjobs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        initiated_by TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        cron TEXT NOT NULL,
+        description TEXT NOT NULL,
+        instruction TEXT NOT NULL DEFAULT '',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        delivery TEXT NOT NULL,
+        metadata TEXT NOT NULL DEFAULT '{}',
+        last_run_at TEXT,
+        next_run_at TEXT,
+        run_count INTEGER NOT NULL DEFAULT 0,
+        last_status TEXT,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+  `);
+  legacyDb.prepare(`
+    INSERT INTO cronjobs (
+      id, workspace_id, initiated_by, name, cron, description, instruction, enabled, delivery, metadata,
+      last_run_at, next_run_at, run_count, last_status, last_error, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "job-legacy",
+    "workspace-1",
+    "workspace_agent",
+    "Greeting",
+    "*/5 * * * *",
+    "Say hello every 5 minutes.",
+    "Say hello every 5 minutes.",
+    1,
+    JSON.stringify({ channel: "session_run" }),
+    "{}",
+    null,
+    null,
+    0,
+    null,
+    null,
+    "2026-01-01T00:00:00+00:00",
+    "2026-01-01T00:00:00+00:00"
+  );
+  legacyDb.close();
+
+  const firstOpen = new RuntimeStateStore({ dbPath, workspaceRoot });
+  let firstBackfillCalls = 0;
+  const firstOpenInternals = firstOpen as unknown as {
+    backfillWorkspaceRuntimeDbFromLegacyRuntimeDb: (
+      db: Database.Database,
+      legacy: Database.Database,
+      workspaceId: string,
+    ) => void;
+  };
+  const originalFirstBackfill = firstOpenInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb.bind(firstOpen);
+  firstOpenInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb = (db, legacy, workspaceId) => {
+    firstBackfillCalls += 1;
+    return originalFirstBackfill(db, legacy, workspaceId);
+  };
+  const firstListed = firstOpen.listCronjobs({ workspaceId: "workspace-1" });
+  firstOpen.close();
+
+  assert.equal(firstListed.length, 1);
+  assert.equal(firstBackfillCalls, 1);
+
+  const reopened = new RuntimeStateStore({ dbPath, workspaceRoot });
+  let repeatedBackfillCalls = 0;
+  const reopenedInternals = reopened as unknown as {
+    backfillWorkspaceRuntimeDbFromLegacyRuntimeDb: (
+      db: Database.Database,
+      legacy: Database.Database,
+      workspaceId: string,
+    ) => void;
+  };
+  const originalRepeatedBackfill = reopenedInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb.bind(reopened);
+  reopenedInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb = (db, legacy, workspaceId) => {
+    repeatedBackfillCalls += 1;
+    return originalRepeatedBackfill(db, legacy, workspaceId);
+  };
+  const secondListed = reopened.listCronjobs({ workspaceId: "workspace-1" });
+  reopened.close();
+
+  assert.equal(secondListed.length, 1);
+  assert.equal(repeatedBackfillCalls, 0);
+});
+
 test("runtime notifications round trip supports create, list, update, get, and dismiss", () => {
   const root = makeTempDir("hb-state-store-");
   const store = new RuntimeStateStore({

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -3179,6 +3179,127 @@ test("workspace runtime DB skips repeated legacy backfill once it already has da
   assert.equal(repeatedBackfillCalls, 0);
 });
 
+test("workspace runtime DB reruns legacy backfill for populated pre-marker databases", () => {
+  const root = makeTempDir("hb-state-store-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const initialStore = new RuntimeStateStore({ dbPath, workspaceRoot });
+  initialStore.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Legacy",
+    harness: "pi",
+    status: "active"
+  });
+  initialStore.insertSessionMessage({
+    workspaceId: "workspace-1",
+    sessionId: "session-1",
+    role: "user",
+    text: "hello",
+    createdAt: "2026-01-01T00:00:00+00:00"
+  });
+  initialStore.close();
+
+  const workspaceDbPath = workspaceRuntimeDbFile(workspaceRoot, "workspace-1");
+  const workspaceDb = new Database(workspaceDbPath);
+  workspaceDb
+    .prepare("DELETE FROM workspace_runtime_metadata WHERE key = ?")
+    .run("legacy_workspace_backfill_v1_complete");
+  workspaceDb.close();
+
+  const legacyDb = new Database(dbPath);
+  legacyDb.exec(`
+    CREATE TABLE task_proposals (
+        proposal_id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        task_name TEXT NOT NULL,
+        task_prompt TEXT NOT NULL,
+        task_generation_rationale TEXT NOT NULL,
+        proposal_source TEXT NOT NULL DEFAULT 'proactive',
+        source_event_ids TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'not_reviewed',
+        accepted_session_id TEXT,
+        accepted_input_id TEXT,
+        accepted_at TEXT
+    );
+  `);
+  legacyDb.prepare(`
+    INSERT INTO task_proposals (
+      proposal_id,
+      workspace_id,
+      task_name,
+      task_prompt,
+      task_generation_rationale,
+      proposal_source,
+      source_event_ids,
+      created_at,
+      state,
+      accepted_session_id,
+      accepted_input_id,
+      accepted_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "proposal-legacy",
+    "workspace-1",
+    "Legacy follow-up",
+    "Continue the pending task.",
+    "Recovered from the legacy runtime database.",
+    "proactive",
+    "[]",
+    "2026-01-01T00:00:00+00:00",
+    "not_reviewed",
+    null,
+    null,
+    null
+  );
+  legacyDb.close();
+
+  const reopened = new RuntimeStateStore({ dbPath, workspaceRoot });
+  let backfillCalls = 0;
+  const reopenedInternals = reopened as unknown as {
+    backfillWorkspaceRuntimeDbFromLegacyRuntimeDb: (
+      db: Database.Database,
+      legacy: Database.Database,
+      workspaceId: string,
+    ) => void;
+  };
+  const originalBackfill =
+    reopenedInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb.bind(
+      reopened,
+    );
+  reopenedInternals.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb = (
+    db,
+    legacy,
+    workspaceId,
+  ) => {
+    backfillCalls += 1;
+    return originalBackfill(db, legacy, workspaceId);
+  };
+  const proposals = reopened.listTaskProposals({ workspaceId: "workspace-1" });
+  reopened.close();
+
+  assert.equal(backfillCalls, 1);
+  assert.equal(proposals.length, 1);
+  assert.equal(proposals[0]?.proposalId, "proposal-legacy");
+
+  const verifiedWorkspaceDb = new Database(workspaceDbPath, { readonly: true });
+  const marker = verifiedWorkspaceDb
+    .prepare<[string], { value?: string }>(
+      "SELECT value FROM workspace_runtime_metadata WHERE key = ? LIMIT 1",
+    )
+    .get("legacy_workspace_backfill_v1_complete");
+  const mirroredProposal = verifiedWorkspaceDb
+    .prepare<[string], { proposal_id?: string }>(
+      "SELECT proposal_id FROM task_proposals WHERE proposal_id = ? LIMIT 1",
+    )
+    .get("proposal-legacy");
+  verifiedWorkspaceDb.close();
+
+  assert.equal(marker?.value, "complete");
+  assert.equal(mirroredProposal?.proposal_id, "proposal-legacy");
+});
+
 test("runtime notifications round trip supports create, list, update, get, and dismiss", () => {
   const root = makeTempDir("hb-state-store-");
   const store = new RuntimeStateStore({

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -22,6 +22,35 @@ const WORKSPACE_RUNTIME_DB_FILENAME = "runtime.db";
 const WORKSPACE_IDENTITY_FILENAME = "workspace_id";
 const LEGACY_WORKSPACE_METADATA_FILENAME = "workspace.json";
 const DELETED_WORKSPACE_PATH_TOMBSTONE_PREFIX = "__deleted__";
+const WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY =
+  "legacy_workspace_backfill_v1_complete";
+const WORKSPACE_SCOPED_LEGACY_BACKFILL_TABLES = [
+  "agent_sessions",
+  "agent_runtime_sessions",
+  "conversation_bindings",
+  "agent_session_inputs",
+  "post_run_jobs",
+  "main_session_event_queue",
+  "session_runtime_state",
+  "session_messages",
+  "subagent_runs",
+  "session_output_events",
+  "terminal_sessions",
+  "terminal_session_events",
+  "turn_results",
+  "turn_request_snapshots",
+  "task_proposals",
+  "evolve_skill_candidates",
+  "memory_update_proposals",
+  "memory_entries",
+  "memory_embedding_index",
+  "output_folders",
+  "outputs",
+  "app_builds",
+  "app_ports",
+  "cronjobs",
+  "runtime_notifications",
+] as const;
 
 export interface WorkspaceRecord {
   id: string;
@@ -6981,21 +7010,13 @@ export class RuntimeStateStore {
     }
 
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-    const dbFileExistedBeforeOpen = fs.existsSync(dbPath);
     const db = new Database(dbPath);
     db.pragma("journal_mode = WAL");
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
     this.#vectorIndexSupported = this.tryLoadVectorExtension(db) || this.#vectorIndexSupported;
     this.ensureWorkspaceRuntimeDbSchema(db);
-    // Workspace-scoped data now lives in each workspace's runtime.db. The
-    // legacy host-state DB backfill only needs to run when this workspace DB
-    // is fresh/empty; re-running it on every startup forces full-table scans
-    // over the legacy DB plus millions of INSERT OR IGNORE checks against
-    // already-populated workspace DBs.
-    if (!dbFileExistedBeforeOpen || !this.workspaceRuntimeDbContainsData(db)) {
-      this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(db, this.db(), workspaceId);
-    }
+    this.ensureWorkspaceRuntimeLegacyBackfill(db, workspaceId);
     this.#workspaceRuntimeDbs.set(workspaceId, { dbPath, db });
     return db;
   }
@@ -7284,34 +7305,7 @@ export class RuntimeStateStore {
     legacy: Database.Database,
     workspaceId: string,
   ): void {
-    const workspaceScopedTables = [
-      "agent_sessions",
-      "agent_runtime_sessions",
-      "conversation_bindings",
-      "agent_session_inputs",
-      "post_run_jobs",
-      "main_session_event_queue",
-      "session_runtime_state",
-      "session_messages",
-      "subagent_runs",
-      "session_output_events",
-      "terminal_sessions",
-      "terminal_session_events",
-      "turn_results",
-      "turn_request_snapshots",
-      "task_proposals",
-      "evolve_skill_candidates",
-      "memory_update_proposals",
-      "memory_entries",
-      "memory_embedding_index",
-      "output_folders",
-      "outputs",
-      "app_builds",
-      "app_ports",
-      "cronjobs",
-      "runtime_notifications",
-    ] as const;
-    for (const tableName of workspaceScopedTables) {
+    for (const tableName of WORKSPACE_SCOPED_LEGACY_BACKFILL_TABLES) {
       this.backfillWorkspaceScopedTableRows({
         db,
         legacy,
@@ -7326,32 +7320,52 @@ export class RuntimeStateStore {
     });
   }
 
-  private workspaceRuntimeDbContainsData(db: Database.Database): boolean {
-    const probeTables = [
-      "session_output_events",
-      "turn_request_snapshots",
-      "turn_results",
-      "session_messages",
-      "outputs",
-      "app_ports",
-      "app_builds",
-      "cronjobs",
-      "runtime_notifications",
-    ] as const;
-
-    for (const tableName of probeTables) {
-      if (!this.tableExists(db, tableName)) {
-        continue;
-      }
-      const row = db
-        .prepare<[], { present: number }>(`SELECT 1 AS present FROM ${tableName} LIMIT 1`)
-        .get();
-      if (row?.present === 1) {
-        return true;
-      }
+  private ensureWorkspaceRuntimeLegacyBackfill(
+    db: Database.Database,
+    workspaceId: string,
+  ): void {
+    if (this.workspaceRuntimeLegacyBackfillComplete(db)) {
+      return;
     }
+    const legacy = this.db();
+    const runBackfill = db.transaction(() => {
+      this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(
+        db,
+        legacy,
+        workspaceId,
+      );
+      this.markWorkspaceRuntimeLegacyBackfillComplete(db);
+    });
+    runBackfill();
+  }
 
-    return false;
+  private workspaceRuntimeLegacyBackfillComplete(
+    db: Database.Database,
+  ): boolean {
+    if (!this.tableExists(db, "workspace_runtime_metadata")) {
+      return false;
+    }
+    const row = db
+      .prepare<[string], { value?: string }>(
+        "SELECT value FROM workspace_runtime_metadata WHERE key = ? LIMIT 1",
+      )
+      .get(WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY);
+    return row?.value === "complete";
+  }
+
+  private markWorkspaceRuntimeLegacyBackfillComplete(
+    db: Database.Database,
+  ): void {
+    db.prepare(`
+      INSERT INTO workspace_runtime_metadata (key, value, updated_at)
+      VALUES (?, 'complete', ?)
+      ON CONFLICT(key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at
+    `).run(
+      WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY,
+      utcNowIso(),
+    );
   }
 
   private backfillControlPlaneMemoryTables(db: Database.Database, legacy: Database.Database): void {
@@ -7769,6 +7783,12 @@ export class RuntimeStateStore {
 
   private ensureWorkspaceRuntimeDbSchema(db: Database.Database): void {
     db.exec(`
+      CREATE TABLE IF NOT EXISTS workspace_runtime_metadata (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS agent_sessions (
           workspace_id TEXT NOT NULL,
           session_id TEXT NOT NULL,

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -6981,13 +6981,21 @@ export class RuntimeStateStore {
     }
 
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const dbFileExistedBeforeOpen = fs.existsSync(dbPath);
     const db = new Database(dbPath);
     db.pragma("journal_mode = WAL");
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
     this.#vectorIndexSupported = this.tryLoadVectorExtension(db) || this.#vectorIndexSupported;
     this.ensureWorkspaceRuntimeDbSchema(db);
-    this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(db, this.db(), workspaceId);
+    // Workspace-scoped data now lives in each workspace's runtime.db. The
+    // legacy host-state DB backfill only needs to run when this workspace DB
+    // is fresh/empty; re-running it on every startup forces full-table scans
+    // over the legacy DB plus millions of INSERT OR IGNORE checks against
+    // already-populated workspace DBs.
+    if (!dbFileExistedBeforeOpen || !this.workspaceRuntimeDbContainsData(db)) {
+      this.backfillWorkspaceRuntimeDbFromLegacyRuntimeDb(db, this.db(), workspaceId);
+    }
     this.#workspaceRuntimeDbs.set(workspaceId, { dbPath, db });
     return db;
   }
@@ -7316,6 +7324,34 @@ export class RuntimeStateStore {
       legacy,
       workspaceId,
     });
+  }
+
+  private workspaceRuntimeDbContainsData(db: Database.Database): boolean {
+    const probeTables = [
+      "session_output_events",
+      "turn_request_snapshots",
+      "turn_results",
+      "session_messages",
+      "outputs",
+      "app_ports",
+      "app_builds",
+      "cronjobs",
+      "runtime_notifications",
+    ] as const;
+
+    for (const tableName of probeTables) {
+      if (!this.tableExists(db, tableName)) {
+        continue;
+      }
+      const row = db
+        .prepare<[], { present: number }>(`SELECT 1 AS present FROM ${tableName} LIMIT 1`)
+        .get();
+      if (row?.present === 1) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private backfillControlPlaneMemoryTables(db: Database.Database, legacy: Database.Database): void {


### PR DESCRIPTION
## Summary

- move embedded runtime app auto-start work off the Fastify ready path so `/healthz` can come up before workspace app setup/start work blocks desktop boot
- reuse healthy shell-managed app listeners after a runtime relaunch by remembering their allocated ports instead of treating every untracked healthy listener as an orphan restart
- skip repeated legacy workspace-runtime backfills on reopened workspaces and surface migration-aware desktop startup state with a longer health-check window and a `Migrating database` splash subtitle

## Validation

- [x] `npm run typecheck` (from `desktop` in an isolated worktree for `origin/codex/fix-desktop-runtime-loading-loop`)
- [x] `npm test` (from `runtime/state-store` in an isolated worktree for `origin/codex/fix-desktop-runtime-loading-loop`)
- [ ] `npm test` (from `runtime/api-server` in an isolated worktree for `origin/codex/fix-desktop-runtime-loading-loop`) currently fails in `auto-start on ready reuses a healthy untracked shell-managed app` with `AssertionError: 1 !== 0` at `runtime/api-server/src/app.test.ts:5376`

## Risks

- desktop startup timing now depends on background app auto-start and migration detection; regressions would show up as longer splash states or delayed workspace app availability
- healthy untracked shell-managed apps are now adopted instead of forcibly restarted, so incorrect port reuse detection could preserve a stale listener longer than before
- migration probing inspects legacy and workspace SQLite state and can extend runtime startup health waits up to 900 seconds when migration is pending

## Docs

- [ ] docs updated if setup, packaging, or public behavior changed
