### PR TITLE
fix: update installation script URL to use refs/heads/main for consis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ holaOS is an open agent computer for any digital work. It reimagines the compute
 For a fresh-machine bootstrap on macOS, Linux, or WSL, use the repository installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holaboss-ai/holaOS-priv/main/scripts/install.sh | bash -s -- --launch
+curl -fsSL https://raw.githubusercontent.com/holaboss-ai/holaOS/refs/heads/main/scripts/install.sh | bash -s -- --launch
 ```
 
 You can also follow the manual path if you want to control each setup step.


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to point to the correct repository URL for the installer script.

- Documentation update:
  * Changed the installer script URL in the installation instructions to use the public `holaboss-ai/holaOS` repository instead of the private `holaboss-ai/holaOS-priv` repository.