### PR TITLE
feat(editor): @holaboss/editor v0 + pages/databases design

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource-variable/geist-mono": "^5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
         "@holaboss/app-sdk": "file:../sdk/app-sdk",
+        "@holaboss/editor": "file:../packages/editor",
         "@holaboss/runtime-client": "file:../sdk/runtime-client",
         "@iconify-json/catppuccin": "^1.2.17",
         "@iconify/react": "^6.0.2",
@@ -61,6 +62,37 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.6",
         "wait-on": "^8.0.5"
+      }
+    },
+    "../packages/editor": {
+      "name": "@holaboss/editor",
+      "version": "0.0.1",
+      "dependencies": {
+        "@tiptap/core": "^3.0.0",
+        "@tiptap/extension-bubble-menu": "^3.22.5",
+        "@tiptap/extension-code-block-lowlight": "^3.22.5",
+        "@tiptap/extension-drag-handle": "^3.22.5",
+        "@tiptap/extension-drag-handle-react": "^3.22.5",
+        "@tiptap/extension-placeholder": "^3.0.0",
+        "@tiptap/extension-task-item": "^3.0.0",
+        "@tiptap/extension-task-list": "^3.0.0",
+        "@tiptap/markdown": "^3.0.0",
+        "@tiptap/pm": "^3.0.0",
+        "@tiptap/react": "^3.0.0",
+        "@tiptap/starter-kit": "^3.0.0",
+        "@tiptap/suggestion": "^3.0.0",
+        "lowlight": "^3.3.0",
+        "tippy.js": "^6.3.7"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "../sdk/app-sdk": {
@@ -869,7 +901,8 @@
     "../sdk/app-sdk/node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "../sdk/app-sdk/node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -980,6 +1013,7 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1720,6 +1754,7 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1935,6 +1970,7 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -2445,7 +2481,8 @@
     "../sdk/app-sdk/node_modules/openapi-types": {
       "version": "12.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "../sdk/app-sdk/node_modules/openapi3-ts": {
       "version": "4.5.0",
@@ -2714,6 +2751,7 @@
       "version": "19.2.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2858,6 +2896,7 @@
       "version": "1.0.0-rc.12",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -3314,6 +3353,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3418,6 +3458,7 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3802,6 +3843,7 @@
     "../sdk/app-sdk/node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3845,6 +3887,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4259,6 +4302,7 @@
     "node_modules/@better-auth/core": {
       "version": "1.5.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
@@ -4376,10 +4420,12 @@
     },
     "node_modules/@better-auth/utils": {
       "version": "0.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21"
+      "version": "1.1.21",
+      "peer": true
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -4862,7 +4908,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4882,7 +4927,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4897,7 +4941,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4910,32 +4953,8 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4944,7 +4963,6 @@
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5551,6 +5569,10 @@
       "resolved": "../sdk/app-sdk",
       "link": true
     },
+    "node_modules/@holaboss/editor": {
+      "resolved": "../packages/editor",
+      "link": true
+    },
     "node_modules/@holaboss/runtime-client": {
       "resolved": "../sdk/runtime-client",
       "link": true
@@ -5945,7 +5967,6 @@
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6114,6 +6135,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6131,6 +6153,7 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -6141,6 +6164,7 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6499,6 +6523,7 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6513,6 +6538,7 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -6528,6 +6554,7 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -8190,6 +8217,7 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8251,19 +8279,18 @@
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8366,6 +8393,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8391,6 +8419,7 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8931,6 +8960,7 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -9038,6 +9068,7 @@
     "node_modules/better-auth": {
       "version": "1.5.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.5.5",
         "@better-auth/drizzle-adapter": "1.5.5",
@@ -9141,6 +9172,7 @@
     "node_modules/better-call": {
       "version": "1.3.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.1",
         "@better-fetch/fetch": "^1.1.21",
@@ -9160,6 +9192,7 @@
       "version": "12.8.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -9241,6 +9274,7 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9281,6 +9315,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9298,7 +9333,6 @@
     "node_modules/bson": {
       "version": "7.2.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -9945,6 +9979,7 @@
     "node_modules/conf": {
       "version": "15.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -10163,8 +10198,7 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10479,6 +10513,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10505,6 +10540,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10554,6 +10590,7 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10613,6 +10650,7 @@
       "version": "26.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -10808,6 +10846,7 @@
     "node_modules/eciesjs/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -10850,6 +10889,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -11038,7 +11078,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -11057,7 +11096,6 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -11214,6 +11252,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -11222,6 +11261,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11270,6 +11310,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12162,6 +12203,7 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -12178,6 +12220,7 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -12189,6 +12232,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12257,6 +12301,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12368,6 +12413,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12902,6 +12948,7 @@
     "node_modules/jose": {
       "version": "6.2.2",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12958,6 +13005,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13045,6 +13093,7 @@
     "node_modules/kysely": {
       "version": "0.28.14",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -13505,6 +13554,7 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13780,8 +13830,7 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -14610,7 +14659,6 @@
     "node_modules/mongodb-connection-string-url": {
       "version": "7.0.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -14731,6 +14779,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -14961,6 +15010,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15453,7 +15503,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -15469,7 +15518,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -15742,6 +15790,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15749,6 +15798,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15793,6 +15843,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15925,7 +15976,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16146,6 +16198,7 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -16367,6 +16420,7 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -16417,6 +16471,7 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16936,6 +16991,7 @@
       "version": "2.8.7",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -17001,13 +17057,13 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -17334,7 +17390,6 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17512,7 +17567,6 @@
     "node_modules/tr46": {
       "version": "5.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -17668,6 +17722,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -17701,6 +17756,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -17747,6 +17803,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18101,6 +18158,7 @@
     "node_modules/vite": {
       "version": "8.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -18231,7 +18289,6 @@
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -18239,7 +18296,6 @@
     "node_modules/whatwg-url": {
       "version": "14.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -18347,6 +18403,7 @@
     "node_modules/yaml": {
       "version": "2.8.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -18471,6 +18528,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "clean": "rm -rf out build",
     "rebuild:native": "node ./node_modules/@electron/rebuild/lib/cli.js -f -w better-sqlite3",
-    "predev": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs && node scripts/validate-dev-env.mjs && kill-port 5173 && npm run rebuild:native && node scripts/ensure-runtime-bundle.mjs && node scripts/patch-electron-plist.mjs",
-    "prebuild": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs",
-    "pretypecheck": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs",
+    "predev": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs && node scripts/ensure-editor.mjs && node scripts/validate-dev-env.mjs && kill-port 5173 && npm run rebuild:native && node scripts/ensure-runtime-bundle.mjs && node scripts/patch-electron-plist.mjs",
+    "prebuild": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs && node scripts/ensure-editor.mjs",
+    "pretypecheck": "node scripts/ensure-app-sdk.mjs && node scripts/ensure-runtime-client.mjs && node scripts/ensure-editor.mjs",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:electron:build\" \"npm:dev:runtime:watch\" \"npm:dev:electron:run\"",
     "dev:cp:local": "cross-env HOLABOSS_INTERNAL_DEV=1 npm run dev",
     "dev:cp:local:verbose": "cross-env HOLABOSS_INTERNAL_DEV=1 HOLABOSS_VERBOSE_TELEMETRY=1 npm run dev",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -64,6 +64,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@holaboss/app-sdk": "file:../sdk/app-sdk",
     "@holaboss/runtime-client": "file:../sdk/runtime-client",
+    "@holaboss/editor": "file:../packages/editor",
     "@iconify-json/catppuccin": "^1.2.17",
     "@iconify/react": "^6.0.2",
     "@sentry/electron": "^7.11.0",

--- a/desktop/scripts/ensure-editor.mjs
+++ b/desktop/scripts/ensure-editor.mjs
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const desktopRoot = process.cwd();
+const editorRoot = path.resolve(desktopRoot, "..", "packages", "editor");
+const editorNodeModulesPath = path.join(editorRoot, "node_modules");
+const editorSourceInputs = [
+  path.join(editorRoot, "package.json"),
+  path.join(editorRoot, "tsup.config.ts"),
+  path.join(editorRoot, "src"),
+];
+const editorRequiredOutputs = [
+  path.join(editorRoot, "dist", "index.js"),
+  path.join(editorRoot, "dist", "index.cjs"),
+  path.join(editorRoot, "dist", "index.d.ts"),
+  path.join(editorRoot, "dist", "styles.css"),
+];
+
+function newestExistingMtime(targetPath) {
+  if (!fs.existsSync(targetPath)) {
+    return 0;
+  }
+  const stat = fs.statSync(targetPath);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let newest = stat.mtimeMs;
+  for (const entry of fs.readdirSync(targetPath)) {
+    newest = Math.max(
+      newest,
+      newestExistingMtime(path.join(targetPath, entry)),
+    );
+  }
+  return newest;
+}
+
+function allOutputsExist() {
+  return editorRequiredOutputs.every((targetPath) => fs.existsSync(targetPath));
+}
+
+function runNpm(args) {
+  const result = spawnSync("npm", args, {
+    cwd: editorRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const outputsExist = allOutputsExist();
+const newestSourceStamp = Math.max(
+  ...editorSourceInputs.map((targetPath) => newestExistingMtime(targetPath)),
+);
+const newestOutputStamp = Math.max(
+  ...editorRequiredOutputs.map((targetPath) => newestExistingMtime(targetPath)),
+);
+const outputsStale = outputsExist && newestSourceStamp > newestOutputStamp;
+
+if (!outputsExist || outputsStale) {
+  if (!fs.existsSync(editorNodeModulesPath)) {
+    console.log(
+      "[ensure-editor] installing packages/editor dependencies for local desktop usage.",
+    );
+    runNpm(["install"]);
+  }
+
+  console.log(
+    outputsExist
+      ? "[ensure-editor] packages/editor build is stale; rebuilding."
+      : "[ensure-editor] packages/editor build output missing; building.",
+  );
+  runNpm(["run", "build"]);
+}

--- a/desktop/src/components/panes/FileExplorerPane.tsx
+++ b/desktop/src/components/panes/FileExplorerPane.tsx
@@ -4058,8 +4058,13 @@ export function FileExplorerPane({
                           <div className="w-full">{rowContent}</div>
                         ) : (
                           <div className="flex w-full min-w-0 items-center gap-1">
-                            <button
-                              type="button"
+                            {/* Row click target. Was a <button>, but rowContent
+                                contains the disclosure chevron <button>; nested
+                                buttons are invalid HTML and warn under React.
+                                Focus is managed by the parent role="treeitem"
+                                via the tree's roving tabindex, so a plain div
+                                with handlers is correct here. */}
+                            <div
                               draggable={!entryIsProtected}
                               onClick={() => {
                                 setSelectedPath(entry.absolutePath);
@@ -4123,10 +4128,9 @@ export function FileExplorerPane({
                                 dragPreviewRef.current = null;
                               }}
                               className="w-full min-w-0 cursor-pointer text-left"
-                              tabIndex={-1}
                             >
                               {rowContent}
-                            </button>
+                            </div>
                             <div className="flex shrink-0 items-center gap-0.5">
                               {onReferenceInChat ? (
                                 <Button

--- a/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -21,8 +21,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { MarkdownEditor } from "@holaboss/editor";
 import { DashboardRenderer } from "@/components/dashboard/DashboardRenderer";
-import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { PresentationPreview } from "@/components/panes/PresentationPreview";
 import {
   bumpDashboardRefreshKey,
@@ -176,39 +176,6 @@ export function InternalSurfacePane({
   }, [onOpenLinkInBrowser]);
 
   const previewAbsolutePath = preview?.absolutePath ?? null;
-  const handleLocalLinkInPreview = useCallback(
-    (href: string) => {
-      if (!onOpenLocalLink) {
-        return;
-      }
-      let raw = href.trim();
-      if (!raw) {
-        return;
-      }
-      if (raw.toLowerCase().startsWith("file://")) {
-        raw = raw.slice(7);
-      }
-      let cleaned = raw;
-      try {
-        cleaned = decodeURI(raw);
-      } catch {
-        cleaned = raw;
-      }
-      let absolute = cleaned;
-      if (!isAbsolutePath(cleaned)) {
-        const previewPath = previewAbsolutePath?.trim() ?? "";
-        const baseDir = previewPath
-          ? dirnameFromAbsolutePath(previewPath)
-          : (workspaceRootPath?.trim() ?? "");
-        if (!baseDir) {
-          return;
-        }
-        absolute = joinPath(baseDir, cleaned);
-      }
-      onOpenLocalLink(absolute);
-    },
-    [onOpenLocalLink, previewAbsolutePath, workspaceRootPath],
-  );
 
   useEffect(() => {
     if (!selectedWorkspaceId) {
@@ -376,7 +343,9 @@ export function InternalSurfacePane({
 
   const isMarkdownPreview = isMarkdownPreviewPayload(preview);
   const isHtmlPreview = isHtmlPreviewPayload(preview);
-  const supportsRenderedTextPreview = isMarkdownPreview || isHtmlPreview;
+  // Markdown is now WYSIWYG (handled by @holaboss/editor) — no preview/edit
+  // toggle. Only HTML still has a preview ↔ source-edit duality.
+  const supportsRenderedTextPreview = isHtmlPreview;
   const isDirty =
     preview?.kind === "text" && preview.isEditable
       ? previewDraft !== (preview.content ?? "")
@@ -710,22 +679,16 @@ export function InternalSurfacePane({
           </div>
 
           {/* Content */}
-          {isMarkdownPreview && textPreviewMode === "preview" ? (
+          {isMarkdownPreview ? (
             <div className="min-h-0 flex-1 overflow-auto">
-              <div className="mx-auto max-w-2xl px-6 py-6">
-                {previewDraft.trim() ? (
-                  <SimpleMarkdown
-                    className="chat-markdown text-sm leading-7 text-foreground"
-                    onLinkClick={openPreviewLink}
-                    onLocalLinkClick={handleLocalLinkInPreview}
-                  >
-                    {previewDraft}
-                  </SimpleMarkdown>
-                ) : (
-                  <div className="py-12 text-center text-xs text-muted-foreground">
-                    Empty file — switch to Edit to add content.
-                  </div>
-                )}
+              <div className="mx-auto w-full max-w-2xl">
+                <MarkdownEditor
+                  value={previewDraft}
+                  onChange={setPreviewDraft}
+                  readOnly={!preview.isEditable}
+                  placeholder="Press / for commands…"
+                  className="min-h-0 flex-1"
+                />
               </div>
             </div>
           ) : isHtmlPreview && textPreviewMode === "preview" ? (

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/electron/renderer";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "@holaboss/editor/styles.css";
 import {
   enrichRendererSentryEvent,
   pushRendererSentryActivity,

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -12,9 +12,28 @@ export default defineConfig({
     sourcemap: "hidden"
   },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src")
-    }
+    // Array form so we can use exact-match regexes — string aliases are
+    // prefix-matched and would break subpath imports.
+    alias: [
+      // Editor package: load from source so Vite owns the module graph and
+      // HMR works on every save in packages/editor/src/. The dist/ is only
+      // for non-Vite consumers (tests, packaging) and is built via tsup.
+      {
+        find: /^@holaboss\/editor$/,
+        replacement: path.resolve(__dirname, "../packages/editor/src/index.ts")
+      },
+      // Stylesheet subpath — same reason: load source so CSS edits HMR.
+      {
+        find: /^@holaboss\/editor\/styles\.css$/,
+        replacement: path.resolve(__dirname, "../packages/editor/src/styles.css")
+      },
+      { find: "@", replacement: path.resolve(__dirname, "src") }
+    ],
+    // Force a single React instance even when imported from linked packages.
+    // Without this, a bare `import "react"` inside the linked package's
+    // source can resolve to a different React copy and break hooks
+    // ("Cannot read properties of null (reading 'useRef')").
+    dedupe: ["react", "react-dom"]
   },
   server: {
     port: 5173,

--- a/docs/plans/2026-05-06-pages-and-databases-design.md
+++ b/docs/plans/2026-05-06-pages-and-databases-design.md
@@ -1,0 +1,2062 @@
+---
+title: Pages & Databases — Notion-style block editor + database engine
+date: 2026-05-06
+status: draft
+supersedes:
+  - 2026-04-28-dashboard-file-type-design.md
+  - 2026-04-30-dashboard-panels-v2.md
+  - 2026-04-30-dashboard-panels-v2-frozen.md (informally)
+deprecates:
+  - .dashboard YAML format (planned removal end of Phase 4)
+related:
+  - 2026-04-30-workspace-data-layer-tier2.md
+  - 2026-05-02-workspace-control-center-spec.md
+---
+
+# Pages & Databases — Notion-style block editor + database engine
+
+## 0. Status & decision summary
+
+This document is the **frozen v1 design** for replacing `.dashboard` YAML files with a Notion-style block editor + database engine living inside the holaOS sandbox runtime. It covers data model, runtime API, agent MCP surface, editor architecture, migration of existing `.dashboard` files, and the phased rollout plan.
+
+Decisions already made (do not reopen during implementation; raise a follow-up doc if circumstances change):
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Replace or extend `.dashboard`? | **Replace** | YAML is read-only, cannot host UI editing of data or schema. |
+| Edit data from UI? | **Yes — first-class** | Inline cell edits, schema edits, row CRUD must be a UI action. |
+| Schema source | **Two-tier**: user-owned databases (UI-editable) + module-owned tables (read-only, query-backed blocks) | Lets users build their own DBs without losing access to module data (twitter_posts, reddit_posts, ...). |
+| Agent authoring format | **Block JSON via MCP tools**, not a DSL | Lossless round-trip; no DSL→tree conversion layer. |
+| Real-time collaboration | **Not in v1**, but data model and mutation API designed to migrate to Yjs without rewriting storage | Single-sandbox deployment today; multi-user is a foreseeable next step. |
+| Editor framework | **Tiptap (DIY, no Pro template)** on top of ProseMirror | Decided 2026-05-06 after a reversal — see §22 for the full audit. Initial pick was Lexical based on architectural fit; the reversal was driven by **OSS production-footprint asymmetry** — Tiptap has named blue-chip OSS users (LinkedIn, GitLab, Anthropic, Twenty CRM, CopilotKit, Hyprnote, Hyperion, ...) plus 10+ years of ProseMirror battle-testing under Atlassian / NYT / Outline; Lexical's named OSS-product adoption is essentially Meta-internal (closed) + Payload CMS + a long tail of <100★ demos. Smaller community = fewer Stack Overflow answers, more issues open longer, more "Meta prioritises FB/IG hot path, not ours" risk. The user's "wrapper, not the framework" answer (a) leaves Tiptap acceptable as long as we do not reuse `@holaboss/editor`'s code. We will **not** purchase Tiptap Pro; the Notion-style UX is built on the open-source core, with `steven-tey/novel` and BlockNote's source as code references (no runtime dependency on either). Eliminated: BlockNote (custom blocks cannot nest — blocks `database_inline` inside columns/toggles), Plate (Slate-based collab story is the weakest), Lexical (architecturally clean but OSS adoption too thin to be the load-bearing dependency). Validated in Phase 0 POC. |
+| Data store | **Sandbox-local SQLite, normalized** (block per row, property_value per row) | Required for future CRDT mapping; per-workspace isolation matches existing model. |
+| File-system surface | **JSON file per page, written by runtime as side-effect** | Keeps File Explorer / git-style backup / agent file watch ergonomics; SQLite is the source of truth. |
+
+Out of v1 (deferred, listed so they don't creep in):
+
+- Real-time multi-user collaboration (presence, awareness, CRDT sync)
+- Permissions / sharing / ACLs (single sandbox = single user)
+- Page templates marketplace
+- Page-level history / versioning UI (writes are journaled, but UI lands later)
+- Mobile-optimised editor
+- Inline embeds (PDF, Figma, video) — only image/file/url for v1
+- AI-rewrite / summary built into editor (agents do this externally)
+
+---
+
+## 1. Goals & non-goals
+
+### 1.1 Goals
+
+1. **Full Notion-style block editor**: paragraph, headings, lists, code, quote, callout, toggle, divider, image, file, embed, plus database blocks. Slash menu, drag handles, block-level menu, keyboard-first authoring.
+2. **First-class typed databases**: text / number / checkbox / select / multi-select / date / url / person / file / relation / rollup / formula / created_time / last_edited_time properties, all editable from the UI.
+3. **Multiple views per database**: table / board / list / gallery / calendar / timeline. View configs (filter / sort / group / hidden / frozen) persist.
+4. **Row pages**: every row is a page that can be opened to edit its properties + author its own block tree.
+5. **Linked databases**: one database can be embedded in many pages with independent view config.
+6. **Query-backed blocks** for legacy/module data: KPI, chart, sql_table read from arbitrary SQL against `data.db` and module SQLite stores.
+7. **Agent ergonomics**: agents author block trees and database content via a small set of MCP tools that map 1:1 to user actions.
+8. **Migration path** from existing `.dashboard` YAML files (one-shot importer, transparent).
+9. **Collab-ready**: every primitive (block, row, property, property_value) has a stable ID, mutations are op-based, no array-index identity.
+
+### 1.2 Non-goals
+
+- Replacing `data.db` query semantics — module apps keep writing to their own tables. We do not migrate module data into the new database engine.
+- Hosting binary assets — files/images upload to a workspace `attachments/` folder and the block stores a relative path. Cloud blob storage is a separate concern.
+- Building a full formula language — v1 ships a subset (arithmetic, string concat, basic if/and/or, property refs, rollup helpers). No JS sandbox.
+- Schema-on-write enforcement at the SQLite level — types are enforced at the API boundary, not by column types. (Trade-off discussed in §6.4.)
+
+---
+
+## 2. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Workspace** | A user-isolated sandbox. Holds one runtime SQLite DB and zero or more pages/databases. Same as today's `workspace/<id>/`. |
+| **Page** | A document with a title, optional icon/cover, and an ordered tree of blocks. The unit a user opens. |
+| **Block** | A node in a page's content tree. Has a stable ID, type, content payload, and optional children. |
+| **Database** | A typed collection of rows. Has a schema (properties) and one or more views. Lives independently from pages and is referenced by `database_inline` / `database_linked` blocks. |
+| **Row** | An entry in a database. Has property values and is itself a page. |
+| **Property** | A typed column on a database. |
+| **Property value** | A row's value for one property. |
+| **View** | A named saved query+layout on a database. |
+| **Query-backed block** | A block (KPI, chart, sql_table) whose data comes from a raw SQL query against the workspace `data.db`, not from a user database. |
+| **Module data** | Tables owned by hola-boss-apps modules (`twitter_posts`, `reddit_posts`, `*_metrics_runs`, ...). Read-only from the user's perspective. |
+| **User database** | A database created by the user or agent inside the runtime. Read-write through the editor. |
+| **Runtime** | The in-sandbox Fastify server (`holaOS/runtime/api-server`, port 8080). Owner of all page/database state. |
+| **Editor** | The Tiptap/ProseMirror-based React frontend that opens pages. Lives in `holaOS/desktop/`. |
+
+---
+
+## 3. Architecture overview
+
+```
+┌─────────────────────── Sandbox ───────────────────────┐
+│                                                       │
+│  ┌────────── Editor (renderer process) ──────────┐    │
+│  │  Tiptap / ProseMirror core                     │    │
+│  │  ├── Standard nodes (paragraph, heading, ...)  │    │
+│  │  └── NodeViews (custom React subtrees)         │    │
+│  │       ├── DatabaseInlineNode  → DatabaseView   │    │
+│  │       ├── DatabaseLinkedNode  → DatabaseView   │    │
+│  │       ├── KpiBlockNode        → KpiBlock       │    │
+│  │       ├── ChartBlockNode      → ChartBlock     │    │
+│  │       └── SqlTableBlockNode   → SqlTableBlock  │    │
+│  │                                                │    │
+│  │  Mutation queue (op-based, optimistic)         │    │
+│  │  ├─ apply locally → Zustand store              │    │
+│  │  └─ POST /api/v1/pages/.../mutations           │    │
+│  └────────────────────────────────────────────────┘    │
+│                       ▲                                │
+│                       │ JSON-RPC + SSE                 │
+│                       ▼                                │
+│  ┌──────── Runtime API (Fastify, :8080) ─────────┐    │
+│  │  /pages, /blocks, /databases, /properties,     │    │
+│  │  /rows, /property_values, /views, /query       │    │
+│  │                                                │    │
+│  │  PagesService ──┐                              │    │
+│  │  BlocksService  ├─→ SQLite (pages.db)          │    │
+│  │  DatabasesSvc   │                              │    │
+│  │  RowsService ───┘                              │    │
+│  │                                                │    │
+│  │  QueryService ─────→ data.db (read-only)       │    │
+│  │                                                │    │
+│  │  EventBus ─────────→ SSE stream per page       │    │
+│  └────────────────────────────────────────────────┘    │
+│                       │                                │
+│                       ▼                                │
+│  ┌────── MCP server (agent tools, :13xxx) ────────┐    │
+│  │  pages.* / blocks.* / databases.* / query.run  │    │
+│  └────────────────────────────────────────────────┘    │
+│                                                        │
+└────────────────────────────────────────────────────────┘
+```
+
+**Two SQLite databases inside the sandbox:**
+
+- `state/pages.db` — owned by the page/database engine. New file. Contains pages, blocks, databases, properties, rows, property_values, views, relations, journal.
+- `state/data.db` — existing workspace shared SQLite. Owned by module apps. Read by query-backed blocks and the existing dashboard query path. Untouched by this design.
+
+**Why two**: domain isolation. `pages.db` schema migrations are owned by the runtime; `data.db` migrations are owned by modules. Mixing them creates lock contention and makes module install/uninstall messy.
+
+---
+
+## 4. Block JSON specification
+
+Every block has the same envelope:
+
+```ts
+interface Block {
+  id: string;            // UUIDv7 — see §10.1
+  page_id: string;
+  parent_block_id: string | null;
+  position: string;      // fractional index — see §10.2
+  type: BlockType;
+  content: BlockContent; // type-specific payload
+  created_at: string;    // ISO-8601
+  updated_at: string;    // ISO-8601
+}
+```
+
+`children` is **not** stored in `content` — it is implicit via `parent_block_id`. Reading a page does an `ORDER BY parent_block_id, position` walk; the runtime returns a flat list and the editor reconstructs the tree.
+
+### 4.1 Standard blocks
+
+```ts
+type BlockType =
+  | "paragraph"
+  | "heading_1" | "heading_2" | "heading_3"
+  | "bulleted_list_item" | "numbered_list_item"
+  | "to_do"
+  | "toggle"
+  | "quote"
+  | "callout"
+  | "code"
+  | "divider"
+  | "image"
+  | "file"
+  | "video"
+  | "embed"
+  | "bookmark"
+  | "table_of_contents"
+  | "column_list" | "column"     // multi-column layout
+  // Database / data blocks
+  | "database_inline"
+  | "database_linked"
+  | "kpi"
+  | "chart"
+  | "sql_table";
+```
+
+#### Rich text blocks (paragraph, headings, list items, quote, callout, toggle, code, to_do)
+
+```ts
+type RichText =
+  | { type: "text"; text: string; annotations: Annotations; link?: string }
+  | { type: "mention"; mention: Mention; annotations: Annotations }
+  | { type: "equation"; expression: string; annotations: Annotations };
+
+interface Annotations {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+  color?: ColorToken;
+  background?: ColorToken;
+}
+
+type Mention =
+  | { kind: "page"; page_id: string }
+  | { kind: "database"; database_id: string }
+  | { kind: "row"; row_id: string }
+  | { kind: "user"; user_id: string }
+  | { kind: "date"; date: string };
+```
+
+```jsonc
+// paragraph
+{ "type": "paragraph", "content": { "rich_text": [/* RichText */] } }
+
+// heading_1 / heading_2 / heading_3
+{ "type": "heading_2", "content": { "rich_text": [/* ... */], "is_toggleable": false } }
+
+// bulleted_list_item / numbered_list_item
+{ "type": "bulleted_list_item", "content": { "rich_text": [/* ... */] } }
+
+// to_do
+{ "type": "to_do", "content": { "rich_text": [/* ... */], "checked": false } }
+
+// toggle
+{ "type": "toggle", "content": { "rich_text": [/* ... */] } }
+// children stored as separate blocks with parent_block_id pointing here
+
+// quote
+{ "type": "quote", "content": { "rich_text": [/* ... */] } }
+
+// callout
+{
+  "type": "callout",
+  "content": {
+    "rich_text": [/* ... */],
+    "icon": { "kind": "emoji", "value": "💡" },  // or { kind: "url", value: "https://..." }
+    "color": "blue"
+  }
+}
+
+// code
+{
+  "type": "code",
+  "content": {
+    "rich_text": [/* plain text only */],
+    "language": "typescript",
+    "caption": [/* RichText */]
+  }
+}
+
+// divider
+{ "type": "divider", "content": {} }
+```
+
+#### Media blocks
+
+```jsonc
+// image
+{
+  "type": "image",
+  "content": {
+    "source": { "kind": "external", "url": "https://..." },
+    // OR { "kind": "internal", "path": "attachments/<uuid>.png" }
+    "caption": [/* RichText */],
+    "width": 800   // optional, in px
+  }
+}
+
+// file
+{
+  "type": "file",
+  "content": {
+    "source": { "kind": "internal", "path": "attachments/<uuid>.pdf" },
+    "name": "spec.pdf",
+    "size": 124032,
+    "caption": [/* RichText */]
+  }
+}
+
+// video, embed, bookmark — same shape as image with different rendering
+```
+
+#### Layout blocks
+
+```jsonc
+// column_list — purely structural, holds N column children
+{ "type": "column_list", "content": {} }
+
+// column — child of column_list, holds blocks
+{ "type": "column", "content": { "ratio": 0.5 } }
+```
+
+### 4.2 Database blocks
+
+```jsonc
+// database_inline: a database that lives only on this page
+{
+  "type": "database_inline",
+  "content": {
+    "database_id": "db_01HX...",
+    "default_view_id": "view_01HX..."
+  }
+}
+
+// database_linked: references a database that lives on another page
+{
+  "type": "database_linked",
+  "content": {
+    "database_id": "db_01HX...",
+    "view_id": "view_01HX...",       // linked DBs always pick a specific view
+    "view_overrides": {              // optional ad-hoc overrides w/o creating a saved view
+      "filter": { ... },
+      "sort": [ ... ]
+    }
+  }
+}
+```
+
+`database_inline` vs `database_linked`:
+
+- `database_inline`: deleting the block deletes the database. The database is "owned" by this block's page.
+- `database_linked`: deleting the block does not delete the database. The database has a different owner page.
+
+Every database must have exactly one owner page. When a `database_inline` block is deleted, the database is moved to trash (soft delete), not hard-deleted, so accidental deletes can be recovered for 30 days.
+
+### 4.3 Query-backed blocks
+
+These blocks read from arbitrary SQL against the workspace `data.db`. They are read-only and exist primarily for backward compatibility with `.dashboard` content and for surfacing module data.
+
+```jsonc
+// kpi
+{
+  "type": "kpi",
+  "content": {
+    "title": "Posts published",
+    "description": "Last 7 days",
+    "query": "SELECT COUNT(*) AS value FROM ...",
+    "format": "integer",
+    "currency": null,
+    "delta_query": "SELECT ... AS value FROM ...",
+    "target": 50,
+    "empty_state": "No posts yet."
+  }
+}
+
+// chart
+{
+  "type": "chart",
+  "content": {
+    "title": "Twitter activity",
+    "description": "Last 14 days",
+    "query": "SELECT date(...) AS day, ... FROM ...",
+    "chart": {
+      "kind": "line",                       // line | bar | area | pie | donut
+      "x": "day",
+      "y": ["refreshed", "skipped"],
+      "x_format": "date",
+      "y_format": "integer",
+      "stacked": false,
+      "legend": true
+    },
+    "empty_state": "No activity."
+  }
+}
+
+// sql_table — replaces the existing data_view panel for query-driven cases
+{
+  "type": "sql_table",
+  "content": {
+    "title": "All published content",
+    "description": null,
+    "query": "SELECT ... FROM ... LIMIT 50",
+    "views": [
+      {
+        "id": "v_01HX...",
+        "type": "table",
+        "name": "Table",
+        "columns": [
+          { "name": "platform", "label": "Platform",
+            "format": "tag",
+            "colors": { "twitter": "blue", "reddit": "orange" } },
+          { "name": "content", "label": "Post" },
+          { "name": "status", "format": "tag",
+            "colors": { "published": "green", "draft": "gray" } },
+          { "name": "published_at", "format": "datetime", "width": 170 }
+        ]
+      },
+      {
+        "id": "v_01HX...",
+        "type": "board",
+        "name": "By platform",
+        "group_by": "platform",
+        "card_title": "content",
+        "card_subtitle": "status",
+        "card_meta": "published_at"
+      }
+    ],
+    "default_view_id": "v_01HX..."
+  }
+}
+```
+
+Query-backed blocks **cannot** be edited inline (no cell editing). They re-run their query when the page opens, when the page receives an explicit refresh, or on the configured `refresh_interval_s`.
+
+### 4.4 Block content storage in SQLite
+
+```sql
+CREATE TABLE blocks (
+  id              TEXT PRIMARY KEY,
+  page_id         TEXT NOT NULL,
+  parent_block_id TEXT,
+  position        TEXT NOT NULL,           -- fractional index
+  type            TEXT NOT NULL,
+  content_json    TEXT NOT NULL,           -- JSON of BlockContent
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  deleted_at      TEXT,                    -- soft delete; nullable
+  FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_blocks_page ON blocks(page_id, parent_block_id, position) WHERE deleted_at IS NULL;
+```
+
+`content_json` is opaque JSON. We do not split into per-type columns; the type discriminator + JSON is sufficient and avoids a multi-table join on every page load.
+
+---
+
+## 5. Property type system
+
+A database has one or more **properties**. Each property has a stable ID, a name (mutable, unique within DB), a type, and a type-specific config. Property values for each row are stored as JSON in `property_values`.
+
+### 5.1 Property types
+
+| Type | Stored value (JSON) | Config | Editable | Notes |
+|---|---|---|---|---|
+| `text` | `{ "rich_text": RichText[] }` | — | yes | Inline rich text in cells |
+| `number` | `{ "value": number \| null }` | `{ format: "plain"\|"percent"\|"currency"\|"integer", currency?: string, decimals?: number }` | yes | |
+| `checkbox` | `{ "checked": boolean }` | — | yes | |
+| `select` | `{ "option_id": string \| null }` | `{ options: SelectOption[] }` | yes | Single-pick |
+| `multi_select` | `{ "option_ids": string[] }` | `{ options: SelectOption[] }` | yes | |
+| `date` | `{ "start": string, "end"?: string, "include_time": boolean, "tz"?: string }` | — | yes | ISO-8601 |
+| `url` | `{ "url": string \| null }` | — | yes | |
+| `email` | `{ "email": string \| null }` | — | yes | |
+| `phone` | `{ "phone": string \| null }` | — | yes | |
+| `person` | `{ "user_ids": string[] }` | — | yes | Multi-user. v1 only "self" since single-user. |
+| `file` | `{ "files": FileRef[] }` | — | yes | FileRef = `{ kind: "internal" \| "external", path/url, name, size }` |
+| `relation` | `{ "row_ids": string[] }` | `{ database_id: string, single: boolean, two_way?: { property_id: string } }` | yes | Two-way handled in §5.4 |
+| `rollup` | (computed) | `{ relation_property_id: string, target_property_id: string, function: RollupFn }` | no | See §5.5 |
+| `formula` | (computed) | `{ expression: string }` | no | See §5.6 |
+| `created_time` | (computed) | — | no | Equals row.created_at |
+| `created_by` | (computed) | — | no | v1: always self |
+| `last_edited_time` | (computed) | — | no | Updated on any property_value or row content change |
+| `last_edited_by` | (computed) | — | no | v1: always self |
+
+```ts
+interface SelectOption {
+  id: string;          // stable, never reused; renaming the option keeps id
+  name: string;
+  color: ColorToken;
+  position: string;    // fractional index for reorder
+}
+
+type RollupFn =
+  | "count" | "count_unique" | "count_empty" | "count_not_empty"
+  | "sum" | "average" | "min" | "max" | "median" | "range"
+  | "earliest" | "latest" | "date_range"
+  | "show_original" | "show_unique";
+
+type ColorToken =
+  | "default"
+  | "gray" | "brown" | "orange" | "yellow" | "green"
+  | "blue" | "purple" | "pink" | "red";
+```
+
+### 5.2 Property storage
+
+```sql
+CREATE TABLE properties (
+  id           TEXT PRIMARY KEY,
+  database_id  TEXT NOT NULL,
+  position     TEXT NOT NULL,           -- fractional index
+  name         TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  config_json  TEXT NOT NULL DEFAULT '{}',
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  deleted_at   TEXT,
+  UNIQUE (database_id, name) ON CONFLICT FAIL
+    WHERE deleted_at IS NULL,
+  FOREIGN KEY (database_id) REFERENCES databases(id) ON DELETE CASCADE
+);
+
+CREATE TABLE property_values (
+  row_id       TEXT NOT NULL,
+  property_id  TEXT NOT NULL,
+  value_json   TEXT NOT NULL,
+  PRIMARY KEY (row_id, property_id),
+  FOREIGN KEY (row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (property_id) REFERENCES properties(id) ON DELETE CASCADE
+);
+
+-- Expression indexes on hot value paths to speed up filters/sorts.
+CREATE INDEX idx_pv_text ON property_values(property_id, json_extract(value_json, '$.value'));
+```
+
+Why JSON per value rather than typed columns:
+
+- Schema evolves frequently (rename, retype, add). Typed-per-property would require ALTER on every property change.
+- SQLite's `json_extract` indexed expressions give us indexed lookups when needed.
+- Type changes (§5.3) become a JSON rewrite per row, which is bounded and journaled.
+
+The cost: cross-property numeric filters go through `json_extract` casts. For the row counts we expect (≤ 100k rows per DB in v1), this is fine. If a database grows past that we add a typed shadow column on the hot property; document this as an internal optimisation, not a user-visible feature.
+
+### 5.3 Type migration rules
+
+When `databases.update_property` changes a property's type:
+
+| From → To | Behaviour |
+|---|---|
+| `text` → `number` | Parse; on parse failure, value becomes `null` and the failure is logged to `journal` with the original value preserved. |
+| `text` → `select` | Treat the text as the option name; create option if missing; on multi-line text, trim and use first line. |
+| `text` → `multi_select` | Split by `, `. |
+| `select` → `multi_select` | Wrap option_id in array. |
+| `multi_select` → `select` | Take first option_id; warn. |
+| `select` → `text` | Render option name. |
+| `number` → `text` | Render with current format. |
+| `date` → `text` | ISO-8601 string. |
+| `url` ↔ `text` | String passthrough. |
+| Anything → `relation` | Drop value (set to empty). User must re-link. |
+| `relation` → anything | Drop value. |
+| Anything → `formula`/`rollup`/`created_*`/`last_edited_*` | Drop value (these are computed). |
+| `formula`/`rollup` → editable | Convert current computed value to a literal of the new type. |
+
+Migrations are atomic at the property level: if any row's value cannot be migrated and the rule says "fail", the whole change rolls back. The default behaviour above is "best-effort with journal", not "fail".
+
+### 5.4 Two-way relations
+
+A relation property can be **one-way** (default) or **two-way** (creates a paired property on the other database).
+
+Storage:
+
+```sql
+CREATE TABLE relations (
+  from_row_id     TEXT NOT NULL,
+  to_row_id       TEXT NOT NULL,
+  property_id     TEXT NOT NULL,         -- the property on the FROM side
+  PRIMARY KEY (from_row_id, property_id, to_row_id),
+  FOREIGN KEY (from_row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (to_row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (property_id) REFERENCES properties(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_relations_to ON relations(to_row_id, property_id);
+```
+
+Two-way: changing the relation on either side writes a single `relations` row. The "paired property" on the other database is just a stored property with `config.two_way.property_id` pointing back. Reads on either side are symmetric.
+
+When a two-way property is **deleted**, the paired property is also deleted; the rows themselves are not affected.
+
+### 5.5 Rollups
+
+A rollup property requires:
+
+- `relation_property_id`: a relation property on the same database
+- `target_property_id`: a property on the related database
+- `function`: a RollupFn
+
+Rollups are **computed on read**, not stored. The query engine resolves them in `databases.query`. To keep this efficient:
+
+- Each row keeps a cached `rollup_cache` JSON in `rows.cache_json` invalidated on related-property writes.
+- Cache invalidation: when row R is mutated, the runtime walks `relations` to find all rows pointing to R via any property, and invalidates their `rollup_cache`. This is `O(in-degree)` per write, acceptable for normal workloads.
+
+### 5.6 Formulas
+
+Formula DSL — small, documented subset, no JS sandbox:
+
+```
+expression  := atom (binop atom)*
+atom        := literal | property_ref | function_call | "(" expression ")"
+property_ref := "prop" "(" string_literal ")"
+function_call := identifier "(" expression ("," expression)* ")"
+binop       := "+" | "-" | "*" | "/" | "%" | "==" | "!=" | "<" | ">" | "<=" | ">="
+             | "and" | "or"
+literal     := number | string | "true" | "false" | "null"
+```
+
+Functions for v1:
+
+- Math: `abs`, `floor`, `ceil`, `round`, `min`, `max`, `pow`, `sqrt`
+- String: `concat`, `length`, `slice`, `replace`, `lower`, `upper`, `contains`, `starts_with`, `ends_with`
+- Date: `now`, `date`, `add_days`, `format_date`, `date_between`, `date_year`, `date_month`, `date_day`
+- Logic: `if(cond, a, b)`, `not`, `empty`, `not_empty`
+- Type: `to_string`, `to_number`, `to_bool`
+
+Parser + evaluator lives in `runtime/formula/`. Outputs are typed (number / string / bool / date) and the formula's own "result type" is stored in `config.result_type` for view rendering.
+
+Formulas are computed on read and cached in `rows.cache_json` keyed by property_id. Cache invalidation is property-graph-based: when property P is referenced by formula F, writes to P invalidate F's cache for the affected rows.
+
+---
+
+## 6. View system
+
+### 6.1 View types and config
+
+```ts
+type ViewType = "table" | "board" | "list" | "gallery" | "calendar" | "timeline";
+
+interface ViewBase {
+  id: string;
+  database_id: string;
+  type: ViewType;
+  name: string;
+  position: string;
+  filter: Filter | null;          // see §6.2
+  sort: Sort[];                   // see §6.2
+  hidden_property_ids: string[];
+  search_query?: string;          // optional persisted text search
+}
+
+interface TableViewConfig extends ViewBase {
+  type: "table";
+  frozen_property_ids: string[];  // pinned to left
+  property_widths: Record<string, number>;  // px; missing = auto
+  wrap: boolean;                  // wrap cell content
+}
+
+interface BoardViewConfig extends ViewBase {
+  type: "board";
+  group_by_property_id: string;   // must be select / multi_select / status / person / checkbox
+  group_visibility: Record<string, boolean>;     // option_id → shown
+  group_order: string[];          // option_ids
+  card_property_ids: string[];    // which properties to show on cards
+  card_size: "small" | "medium" | "large";
+  cover_property_id?: string;     // file/image property
+  cover_fit: "cover" | "contain";
+}
+
+interface ListViewConfig extends ViewBase {
+  type: "list";
+  primary_property_id: string;
+  secondary_property_id?: string;
+  meta_property_ids: string[];
+}
+
+interface GalleryViewConfig extends ViewBase {
+  type: "gallery";
+  cover_property_id?: string;
+  cover_fit: "cover" | "contain";
+  card_property_ids: string[];
+  card_size: "small" | "medium" | "large";
+}
+
+interface CalendarViewConfig extends ViewBase {
+  type: "calendar";
+  date_property_id: string;
+  end_date_property_id?: string;       // for spans
+  card_property_ids: string[];
+  default_zoom: "month" | "week" | "day";
+}
+
+interface TimelineViewConfig extends ViewBase {
+  type: "timeline";
+  start_property_id: string;
+  end_property_id: string;
+  group_by_property_id?: string;
+  bar_property_ids: string[];          // shown on bar
+  default_zoom: "year" | "quarter" | "month" | "week" | "day";
+}
+```
+
+### 6.2 Filter & sort DSL
+
+```ts
+type Filter =
+  | { kind: "and"; filters: Filter[] }
+  | { kind: "or"; filters: Filter[] }
+  | { kind: "leaf"; property_id: string; condition: Condition };
+
+type Condition =
+  // string-y (text, url, email, phone)
+  | { op: "equals" | "not_equals" | "contains" | "not_contains"
+        | "starts_with" | "ends_with"; value: string }
+  | { op: "is_empty" | "is_not_empty" }
+  // number / rollup-numeric
+  | { op: "gt" | "gte" | "lt" | "lte" | "eq" | "neq"; value: number }
+  // checkbox
+  | { op: "is_checked" | "is_unchecked" }
+  // select
+  | { op: "is" | "is_not"; value: string /* option_id */ }
+  // multi_select
+  | { op: "contains_any" | "contains_all" | "contains_none";
+      value: string[] /* option_ids */ }
+  // date
+  | { op: "date_eq" | "date_before" | "date_after"
+        | "date_on_or_before" | "date_on_or_after";
+      value: string /* ISO date */ }
+  | { op: "date_within"; preset: DatePreset }
+  // relation
+  | { op: "relation_contains" | "relation_not_contains";
+      value: string /* row_id */ };
+
+type DatePreset =
+  | "today" | "tomorrow" | "yesterday"
+  | "this_week" | "last_week" | "next_week"
+  | "this_month" | "last_month" | "next_month"
+  | "this_year" | "last_year"
+  | { kind: "past"; days: number }
+  | { kind: "future"; days: number };
+
+interface Sort {
+  property_id: string;
+  direction: "asc" | "desc";
+}
+```
+
+The runtime translates filters to SQL with parameterised queries. A small recursive walker emits `WHERE` fragments; nothing is interpolated as text.
+
+### 6.3 View storage
+
+```sql
+CREATE TABLE views (
+  id           TEXT PRIMARY KEY,
+  database_id  TEXT NOT NULL,
+  position     TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  config_json  TEXT NOT NULL,          -- the union above
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  deleted_at   TEXT,
+  FOREIGN KEY (database_id) REFERENCES databases(id) ON DELETE CASCADE
+);
+```
+
+Every database has at least one view (auto-created table view). Deleting the last view fails with `LAST_VIEW_REQUIRED`.
+
+### 6.4 Query execution: rows + view config → result
+
+`databases.query({ database_id, view_id?, filter?, sort?, limit, cursor })` resolves to:
+
+1. Load view config (if `view_id` given) and merge with explicit overrides — explicit wins.
+2. Build the SQL: `SELECT ... FROM rows JOIN property_values ... WHERE filter AND deleted_at IS NULL ORDER BY sort LIMIT ...`.
+3. Execute. Return `{ rows, total, next_cursor }`.
+
+Pagination uses cursor-based scrolling (`(position, id)` tuple) for stable ordering across mutations.
+
+For board view: the runtime returns rows pre-grouped (`{ groups: [{ key, rows[], count }] }`) when called with `group_by_property_id`, to save the editor a regroup pass.
+
+---
+
+## 7. SQLite DDL — full schema
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+PRAGMA synchronous = NORMAL;
+
+CREATE TABLE meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+INSERT INTO meta(key, value) VALUES ('schema_version', '1');
+
+-- Pages: a page is the unit a user opens
+CREATE TABLE pages (
+  id              TEXT PRIMARY KEY,
+  parent_page_id  TEXT,                       -- page hierarchy / nesting
+  database_id     TEXT,                       -- non-null when this page is a row
+  row_id          TEXT,                       -- rows.id when database_id is set
+  title           TEXT NOT NULL DEFAULT '',
+  icon_json       TEXT,                       -- { kind: "emoji"|"url", value }
+  cover_json      TEXT,                       -- { kind, source, position }
+  archived        INTEGER NOT NULL DEFAULT 0,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  deleted_at      TEXT,
+  FOREIGN KEY (parent_page_id) REFERENCES pages(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_pages_parent ON pages(parent_page_id) WHERE deleted_at IS NULL;
+CREATE INDEX idx_pages_row ON pages(row_id) WHERE row_id IS NOT NULL;
+
+-- Blocks: nodes inside a page's content tree
+CREATE TABLE blocks (
+  id              TEXT PRIMARY KEY,
+  page_id         TEXT NOT NULL,
+  parent_block_id TEXT,
+  position        TEXT NOT NULL,
+  type            TEXT NOT NULL,
+  content_json    TEXT NOT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  deleted_at      TEXT,
+  FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_blocks_page ON blocks(page_id, parent_block_id, position) WHERE deleted_at IS NULL;
+
+-- Databases
+CREATE TABLE databases (
+  id            TEXT PRIMARY KEY,
+  owner_page_id TEXT NOT NULL,                -- page where the inline block lives
+  owner_block_id TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  icon_json     TEXT,
+  description   TEXT,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL,
+  deleted_at    TEXT,
+  FOREIGN KEY (owner_page_id) REFERENCES pages(id) ON DELETE RESTRICT,
+  FOREIGN KEY (owner_block_id) REFERENCES blocks(id) ON DELETE RESTRICT
+);
+
+-- Properties
+CREATE TABLE properties (
+  id           TEXT PRIMARY KEY,
+  database_id  TEXT NOT NULL,
+  position     TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  config_json  TEXT NOT NULL DEFAULT '{}',
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  deleted_at   TEXT,
+  FOREIGN KEY (database_id) REFERENCES databases(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX uniq_properties_name ON properties(database_id, name) WHERE deleted_at IS NULL;
+
+-- Rows
+CREATE TABLE rows (
+  id           TEXT PRIMARY KEY,
+  database_id  TEXT NOT NULL,
+  page_id      TEXT NOT NULL,                 -- the row's page
+  position     TEXT NOT NULL,
+  cache_json   TEXT NOT NULL DEFAULT '{}',    -- formula/rollup cache
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  deleted_at   TEXT,
+  FOREIGN KEY (database_id) REFERENCES databases(id) ON DELETE CASCADE,
+  FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_rows_database ON rows(database_id, position) WHERE deleted_at IS NULL;
+
+-- Property values
+CREATE TABLE property_values (
+  row_id       TEXT NOT NULL,
+  property_id  TEXT NOT NULL,
+  value_json   TEXT NOT NULL,
+  PRIMARY KEY (row_id, property_id),
+  FOREIGN KEY (row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (property_id) REFERENCES properties(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_pv_value_text ON property_values(property_id, json_extract(value_json, '$.value'));
+
+-- Views
+CREATE TABLE views (
+  id           TEXT PRIMARY KEY,
+  database_id  TEXT NOT NULL,
+  position     TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  config_json  TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  deleted_at   TEXT,
+  FOREIGN KEY (database_id) REFERENCES databases(id) ON DELETE CASCADE
+);
+
+-- Relations (two-way, indexable both directions)
+CREATE TABLE relations (
+  from_row_id  TEXT NOT NULL,
+  to_row_id    TEXT NOT NULL,
+  property_id  TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  PRIMARY KEY (from_row_id, property_id, to_row_id),
+  FOREIGN KEY (from_row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (to_row_id) REFERENCES rows(id) ON DELETE CASCADE,
+  FOREIGN KEY (property_id) REFERENCES properties(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_relations_to ON relations(to_row_id, property_id);
+
+-- Mutation journal (for ops, undo, future CRDT)
+CREATE TABLE journal (
+  seq          INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT NOT NULL,
+  actor        TEXT NOT NULL,                 -- "user" | "agent:<name>" | "system"
+  page_id      TEXT,                          -- nullable: cross-page ops set NULL
+  op_kind      TEXT NOT NULL,                 -- e.g. "block.update"
+  op_json      TEXT NOT NULL,                 -- the op payload
+  inverse_json TEXT NOT NULL                  -- inverse op for undo
+);
+CREATE INDEX idx_journal_page ON journal(page_id, seq);
+
+-- Trash (soft-deleted resources, 30-day TTL, swept by background job)
+CREATE TABLE trash (
+  id           TEXT PRIMARY KEY,
+  kind         TEXT NOT NULL,                 -- "page"|"database"|"block"|"row"|...
+  payload_json TEXT NOT NULL,
+  deleted_at   TEXT NOT NULL,
+  expires_at   TEXT NOT NULL
+);
+```
+
+---
+
+## 8. Runtime API surface
+
+All endpoints are hosted by the in-sandbox runtime (`holaOS/runtime/api-server`) under `/api/v1/workspaces/:workspace_id/...`.
+
+JSON-RPC-flavoured. Every mutation returns `{ ok: true, result, op: { id, inverse } }` so the client can keep an undo stack and reconcile journal entries.
+
+### 8.1 Pages
+
+```
+GET    /pages                              ?parent_page_id&include_archived
+POST   /pages                              { parent_page_id?, title, icon? }
+GET    /pages/:id                          → { page, blocks[] }
+PATCH  /pages/:id                          { title?, icon?, cover?, archived? }
+DELETE /pages/:id                          → soft delete; cascade pages, blocks, dbs (if owner)
+POST   /pages/:id/restore
+POST   /pages/:id/duplicate                { include_children?: boolean }
+POST   /pages/:id/move                     { new_parent_page_id, position? }
+GET    /pages/:id/breadcrumbs              → ancestor list
+GET    /pages/:id/events                   (SSE stream — see §8.7)
+```
+
+### 8.2 Blocks
+
+```
+POST   /pages/:page_id/blocks              { parent_block_id?, position, type, content }
+PATCH  /blocks/:id                         { position?, content?, type? }
+   -- type changes restricted to compatible groups (paragraph ↔ heading_x ↔ list_*)
+DELETE /blocks/:id                         → soft delete
+POST   /blocks/:id/restore
+POST   /blocks/:id/move                    { new_parent_block_id?, new_page_id?, position }
+POST   /blocks/:id/duplicate
+POST   /pages/:page_id/blocks/batch        { ops: BlockOp[] }
+   -- atomic batch: insert, update, move, delete in one transaction.
+   -- Tiptap/ProseMirror commits multi-step transactions as one op batch.
+```
+
+### 8.3 Databases
+
+```
+POST   /databases                          { owner_page_id, owner_block_id, name, properties? }
+GET    /databases/:id                      → { database, properties[], views[], stats }
+PATCH  /databases/:id                      { name?, icon?, description? }
+DELETE /databases/:id                      → soft delete (cascade rows, properties, views)
+POST   /databases/:id/restore
+GET    /databases/:id/schema               → { properties[] }
+```
+
+### 8.4 Properties
+
+```
+POST   /databases/:db/properties           { name, type, config?, position? }
+PATCH  /properties/:id                     { name?, config?, position? }
+PATCH  /properties/:id/type                { type, config?, migration_options? }
+DELETE /properties/:id
+POST   /properties/:id/options             { name, color }    -- select/multi_select option add
+PATCH  /options/:id                        { name?, color?, position? }
+DELETE /options/:id                        -- removes option_id from all property_values
+```
+
+### 8.5 Rows
+
+```
+GET    /databases/:db/rows                 ?view_id&filter&sort&limit&cursor
+                                           → { rows[], total, next_cursor }
+POST   /databases/:db/rows                 { values?: { [property_id]: value }, position? }
+GET    /rows/:id                           → { row, property_values, page, blocks }
+PATCH  /rows/:id                           { values?: {...}, position? }
+DELETE /rows/:id                           → cascade delete row's page
+POST   /rows/:id/restore
+POST   /rows/batch                         { ops: RowOp[] }
+```
+
+### 8.6 Views
+
+```
+POST   /databases/:db/views                { type, name, config }
+PATCH  /views/:id                          { name?, config?, position? }
+DELETE /views/:id
+```
+
+### 8.7 Events (SSE)
+
+```
+GET /pages/:id/events
+   → text/event-stream
+```
+
+Event types:
+
+```
+event: block.created      data: { block }
+event: block.updated      data: { id, patch }
+event: block.deleted      data: { id }
+event: block.moved        data: { id, new_parent_block_id, new_position }
+event: page.updated       data: { id, patch }
+event: database.changed   data: { database_id, kind: "schema"|"row"|"view" }
+event: row.changed        data: { database_id, row_id, kind: "values"|"position"|"deleted" }
+```
+
+Subscribers join per-page; one stream covers everything that affects rendering for that page (including the embedded databases and their visible rows).
+
+### 8.8 Query (legacy / module data)
+
+```
+POST /query                                { sql }
+   → { ok, columns[], rows[][], elapsed_ms }
+```
+
+This is the existing `runDashboardQuery` endpoint, renamed. Used by `kpi`, `chart`, `sql_table` blocks. Read-only — runtime opens `data.db` with `mode=ro`.
+
+### 8.9 Search
+
+```
+GET /search                                ?q=...&kind=page|database&limit
+   → { results: [ { kind, id, title, snippet, page_path } ] }
+```
+
+Index: SQLite FTS5 on `pages.title`, all rich-text block content, and database/property names. Index updated synchronously on writes; full reindex available via runtime job.
+
+### 8.10 Attachments
+
+```
+POST   /attachments                        multipart/form-data → { path, name, size, mime }
+GET    /attachments/*                      stream file
+DELETE /attachments/:path
+```
+
+Files stored under `workspace/<id>/attachments/<uuid>.<ext>`. Block content references `path: "attachments/..."` — relative to workspace root.
+
+### 8.11 Trash
+
+```
+GET    /trash                              ?kind&before
+POST   /trash/:id/restore
+DELETE /trash/:id                          → permanent delete
+```
+
+Background job sweeps trash older than 30 days nightly.
+
+### 8.12 Undo / redo
+
+```
+POST /pages/:id/undo                       → applies inverse of most recent journal entry
+POST /pages/:id/redo
+```
+
+Undo is per-page locally. The journal records inverse ops at write time so undo is `O(1)`. Cross-page undo (e.g. moved a block to another page) is bounded — the inverse op moves it back.
+
+---
+
+## 9. Agent MCP tool surface
+
+These are the tools an agent calls. Each maps 1:1 to a runtime API endpoint, with input/output sized to fit a typical LLM tool call (no oversized blobs in responses).
+
+### 9.1 Page tools
+
+```
+pages.create({ parent_page_id?, title, icon? })
+   → { page_id }
+
+pages.get({ page_id, include_blocks?: boolean = true })
+   → { page, blocks?[] }
+   -- when include_blocks=true and the page is large (> 200 blocks),
+      response is paginated; agent must call pages.get_blocks for more.
+
+pages.get_blocks({ page_id, after_block_id?, limit?: number = 100 })
+   → { blocks[], next_after_block_id? }
+
+pages.update({ page_id, title?, icon?, cover?, archived? })
+   → { ok }
+
+pages.delete({ page_id })
+   → { ok }
+
+pages.move({ page_id, new_parent_page_id, position? })
+   → { ok }
+
+pages.list({ parent_page_id?, query?, limit?: number = 50, cursor? })
+   → { pages: [{ id, title, icon, parent_page_id, updated_at }], next_cursor? }
+```
+
+### 9.2 Block tools
+
+```
+blocks.append({ page_id, parent_block_id?, blocks: BlockSpec[] })
+   → { block_ids[] }
+   -- BlockSpec is the partial block: { type, content, children? }
+   -- children supported recursively for convenience; runtime flattens.
+
+blocks.insert({ page_id, after_block_id?, before_block_id?, blocks: BlockSpec[] })
+   → { block_ids[] }
+
+blocks.update({ block_id, content?: PartialContent, type? })
+   → { ok }
+
+blocks.delete({ block_id })
+   → { ok }
+
+blocks.move({ block_id, new_parent_block_id?, new_page_id?, position })
+   → { ok }
+```
+
+### 9.3 Database tools
+
+```
+databases.create({
+  owner_page_id,
+  name,
+  properties: PropertySpec[],     // schema
+  initial_view?: ViewSpec
+})
+   → { database_id, owner_block_id, default_view_id }
+   -- The runtime creates the database_inline block automatically and returns its id.
+
+databases.get({ database_id })
+   → { database, properties[], views[], stats: { row_count } }
+
+databases.update({ database_id, name?, icon?, description? })
+
+databases.add_property({
+  database_id,
+  property: PropertySpec
+})
+   → { property_id }
+
+databases.update_property({
+  property_id,
+  name?, config?, position?
+})
+
+databases.change_property_type({
+  property_id,
+  new_type,
+  new_config?,
+  on_failure?: "drop_value" | "abort"
+})
+   → { migrated: number, dropped: number }
+
+databases.delete_property({ property_id })
+
+databases.add_row({
+  database_id,
+  values?: { [property_name]: any },
+  // Names accepted as ergonomic shortcut; resolved server-side.
+  // For agents that have property_ids, also accept value_ids.
+  values_by_id?: { [property_id]: any },
+  position?: "first" | "last" | { after_row_id: string }
+})
+   → { row_id, page_id }
+
+databases.update_row({
+  row_id,
+  values?: { ... },
+  values_by_id?: { ... }
+})
+
+databases.delete_row({ row_id })
+
+databases.query({
+  database_id,
+  filter?, sort?, group_by_property_id?,
+  property_ids?: string[],         // projection — return only these
+  limit?: number = 50,
+  cursor?
+})
+   → { rows[], total, next_cursor? }
+   -- rows are { id, page_id, values: { [property_id]: { name, type, value } } }
+
+databases.create_view({
+  database_id,
+  type, name, config
+})
+   → { view_id }
+
+databases.update_view({ view_id, name?, config? })
+databases.delete_view({ view_id })
+```
+
+### 9.4 Query-backed block tools (legacy / module data)
+
+```
+query.run({ sql, parameters? })
+   → { columns[], rows[][], elapsed_ms }
+
+blocks.append_kpi({ page_id, parent_block_id?, title, query, format?, ... })
+blocks.append_chart({ page_id, parent_block_id?, title, query, chart })
+blocks.append_sql_table({ page_id, parent_block_id?, title, query, views })
+   -- thin sugar over blocks.append for agents that come from the .dashboard world.
+```
+
+### 9.5 Tool naming / namespacing
+
+All tools live under the `pages.*` / `blocks.*` / `databases.*` / `query.*` MCP namespaces, exposed by the **runtime's MCP server** alongside existing module MCP servers. The MCP discriminator is the prefix `pages_create`, `databases_add_row`, etc. (underscore separator, matching existing module convention `twitter_create_post`).
+
+---
+
+## 10. Cross-cutting concerns
+
+### 10.1 IDs
+
+UUIDv7 everywhere. Time-prefixed so:
+- Default ordering is meaningful (newest at end without an extra `position`).
+- ID is unique across actors without coordination — important for offline edits and agent writes.
+
+Format: `{kind_prefix}_{uuidv7-base32}`. E.g. `page_01HX7K…`, `block_01HX7K…`, `db_01HX7K…`.
+
+### 10.2 Fractional indexing
+
+`position` columns use **string fractional indices** (`a0`, `a0V`, `a1`, ...) not floats. Floats lose precision on N-th midpoint insertions; strings are stable forever.
+
+Library: `fractional-indexing` (BSD). Algorithm: "between(a, b)" returns a string strictly between a and b. Initial positions are spaced; rebalance is rare.
+
+Reorder operations write only the moved item's position. Conflict resolution under future CRDT collapses naturally (Y.Map of position strings + LWW per ID).
+
+### 10.3 Mutation operations and journal
+
+Every mutation is internally an **op**:
+
+```ts
+type Op =
+  | { kind: "block.create"; block: Block }
+  | { kind: "block.update"; id: string; patch: Partial<Block> }
+  | { kind: "block.delete"; id: string }
+  | { kind: "block.move"; id: string; from: Loc; to: Loc }
+  | { kind: "row.create"; row: Row; property_values: PropertyValue[] }
+  | { kind: "row.update_value"; row_id: string; property_id: string; value: any }
+  | { kind: "property.create" | "property.update" | "property.delete"; ... }
+  | ...
+```
+
+Each op has a deterministic inverse, written to `journal.inverse_json` at the same time. Undo replays the inverse. This is also the **CRDT seam**: when we move to Yjs, ops translate to Y.Doc transactions and we stop journaling locally (the Y.Doc is the journal). The op shapes do not change.
+
+### 10.4 Optimistic updates
+
+Frontend mutation flow (Tiptap → store → API):
+
+1. User edit produces a ProseMirror transaction (via Tiptap command).
+2. Command handler builds an op, applies it to local Zustand store, returns immediately so the editor re-renders.
+3. Op is queued in a per-page mutation queue (FIFO).
+4. Queue worker POSTs to runtime; on success, marks op committed.
+5. On failure: roll back the op locally, surface a toast.
+
+The queue is per-page so blocking ops do not stall other pages. Each op has a client-generated ID matched server-side (idempotent).
+
+### 10.5 Rate limits & batching
+
+- Editor batches block-level mutations within a 50ms window into one `blocks/batch` request. Typing a paragraph rarely sends more than one HTTP request per second.
+- Agent tool calls are **not** rate-limited at the runtime layer — agents typically issue tens of ops, not thousands. If we see runaway tool calls in practice, add a per-session quota.
+
+### 10.6 File system materialization
+
+Source of truth: SQLite. But the runtime keeps a **rendered JSON mirror** on disk so agents and File Explorer can see pages as files:
+
+```
+workspace/<id>/pages/<page_id>.page.json           — page + blocks
+workspace/<id>/databases/<database_id>.database.json — db + properties + views
+workspace/<id>/attachments/<uuid>.<ext>
+```
+
+Mirror is rewritten by a debounced job (250ms) after writes. **Files are read-only from the user's perspective**: editing the JSON file doesn't sync back to SQLite. They exist for backup / git inspection / agent diff. (Agents should mutate via tools, not by writing files.)
+
+If a user *really* wants to edit JSON manually, they can — the runtime accepts a `POST /pages/:id/import` that reads the on-disk JSON and replays it as ops. This is a power-user / recovery feature, not a primary path.
+
+`.dashboard` files in `dashboards/` are deprecated but remain readable through Phase 4 by a compat shim that loads them, runs the migrator (§12), and exposes the resulting page IDs. Phase 4 ends with the directory deleted.
+
+### 10.7 Permissions
+
+Single-sandbox / single-user — no permissions in v1. Document the intent: when collab arrives, every page/database carries `permissions: { read[], write[] }` in `meta_json`, default to `[*]` for backwards compat.
+
+### 10.8 Error model
+
+```
+4xx errors:
+   { error: { code: "VALIDATION" | "NOT_FOUND" | "CONFLICT"
+                    | "TYPE_MIGRATION_FAILED" | "LAST_VIEW_REQUIRED"
+                    | "RELATION_TARGET_MISSING" | ...,
+              message, details? } }
+5xx: { error: { code: "INTERNAL", message, request_id } }
+```
+
+Validation errors include a path (e.g. `properties[2].config.options[0].color`) so the editor can highlight the offending field.
+
+### 10.9 Logging & observability
+
+- Runtime emits structured logs (existing pino setup). Every mutation logs `{ event: "page.block.update", outcome: "success", page_id, block_id, op_kind, duration_ms }`.
+- Slow-query log: any `databases.query` over 250ms logs the SQL plan.
+- Counters: page open count, ops/sec, undo invocations, query durations. Surface in `/api/v1/runtime/status`.
+
+---
+
+## 11. Editor architecture
+
+### 11.1 Stack
+
+- **Tiptap v3** (`@tiptap/core`, `@tiptap/react`, `@tiptap/pm` ProseMirror peer)
+- **ProseMirror** (transitively, exposed when we need direct schema/transform access)
+- **y-prosemirror** (deferred — installed at Phase 7, not before)
+- **Zustand** (per-workspace global state — pages list, active page, mutation queue)
+- **React 19** (existing desktop app)
+- **Tailwind v4** (existing tokens)
+- **@dnd-kit/core** (drag handles, board reorder, column reorder)
+- **@tanstack/react-table** (table view inside `database_inline` — purely presentational; we own state)
+- **fractional-indexing** (the npm package)
+- **uuidv7**
+
+No reuse of `@holaboss/editor` source — that package is a separate Tiptap wrapper the user judged not fit for purpose. New package: `holaOS/desktop/src/lib/editor/` (not a workspace package — purely local for now; promote to a package if frontend wants to consume). Reference projects (read, do **not** depend on): `steven-tey/novel`, `TypeCellOS/BlockNote` source, `ueberdosis/tiptap-templates`.
+
+### 11.2 ProseMirror schema / Tiptap node taxonomy
+
+Standard / extended Tiptap nodes for most blocks:
+
+| Block | Tiptap extension |
+|---|---|
+| paragraph | `@tiptap/extension-paragraph` |
+| heading_* | `@tiptap/extension-heading` (levels 1–3) |
+| bulleted_list_item | `@tiptap/extension-bullet-list` + `@tiptap/extension-list-item` |
+| numbered_list_item | `@tiptap/extension-ordered-list` + list-item |
+| to_do | `@tiptap/extension-task-list` + `@tiptap/extension-task-item` |
+| toggle | custom `ToggleNode` extending `Node` (ProseMirror `Node`, content `block+`) |
+| quote | `@tiptap/extension-blockquote` |
+| callout | custom `CalloutNode` (block+, attrs: `icon`, `color`) |
+| code | `@tiptap/extension-code-block` (+ Shiki for highlighting) |
+| divider | `@tiptap/extension-horizontal-rule` |
+
+NodeView-rendered (custom React subtree, atomic from ProseMirror's POV):
+
+| Block | Tiptap node | React component |
+|---|---|---|
+| image / file / video / embed / bookmark | custom `MediaNode` (atom, attrs: `source`, `caption`, `width`) | `<MediaBlock>` via `ReactNodeViewRenderer` |
+| database_inline | `DatabaseInlineNode` (atom) | `<DatabaseInlineBlock>` |
+| database_linked | `DatabaseLinkedNode` (atom) | `<DatabaseLinkedBlock>` |
+| kpi | `KpiNode` (atom) | `<KpiBlock>` |
+| chart | `ChartNode` (atom) | `<ChartBlock>` |
+| sql_table | `SqlTableNode` (atom) | `<SqlTableBlock>` |
+| column_list / column | structural nodes (ProseMirror block container) | — |
+
+NodeView pattern: each custom node declares `addNodeView(() => ReactNodeViewRenderer(<Component>))`. The React component receives `node`, `updateAttributes`, `selected`, and is rendered by ProseMirror in a stable DOM slot. For our use case all custom blocks are `atom: true` — ProseMirror does not descend into them — which means the inner database/cell editors are owned entirely by our React tree, not by ProseMirror's transaction system. Cell edits don't go through Tiptap commands; they go through the same op queue described in §10.3.
+
+Each NodeView serializes its content payload via `parseHTML` / `renderHTML` for HTML I/O, and `addAttributes` for JSON I/O. Round-trip with our runtime block format is via `editor.getJSON()` / `editor.commands.setContent(json)` plus a thin layer that maps Tiptap's `{ type, attrs, content }` shape to our block envelope. The mapping is bidirectional and total for the standard set.
+
+### 11.3 Extensions
+
+Tiptap extensions to ship in Phase 1, ordered by criticality:
+
+1. **PersistenceExtension** — registers a transaction handler (`editor.on('transaction')`) that diffs `editor.state.doc` against the previous doc, derives the minimum op set, and pushes to the mutation queue. The diff algorithm walks ProseMirror's step list (`tr.steps`) — each `Step` (`ReplaceStep`, `AddMarkStep`, `RemoveMarkStep`, `AttrStep`) maps to one or more ops. This avoids re-implementing diff from scratch.
+2. **SlashCommandExtension** — `/` triggers menu (use `@tiptap/suggestion` infrastructure; same suggestion API powers mentions and emoji).
+3. **DragHandleExtension** — left-margin handle for drag-to-reorder + "+" affordance. Reference: `tiptap-extension-global-drag-handle`. We may fork rather than depend, since the package is small and we want stable behaviour.
+4. **BlockMenuExtension** — per-block context menu (turn-into, duplicate, copy link, color, delete). Built on `BubbleMenu`/`FloatingMenu` Tiptap primitives.
+5. **MarkdownShortcutsExtension** — bundled inputRules for `# `, `## `, `- `, `> `, "```", `[]`. Tiptap's `@tiptap/extension-input-rule` is the base.
+6. **MentionExtension** — `@tiptap/extension-mention` extended for our four mention kinds (page/database/row/user).
+7. **AutoLinkExtension** — `@tiptap/extension-link` + paste handler that decides bookmark vs inline link based on cursor context.
+8. **TableOfContentsExtension** — outline derived from heading nodes; Tiptap ships `@tiptap/extension-table-of-contents` (Pro) but the OSS pattern is straightforward — implement directly.
+9. **EmojiPickerExtension** — `:` triggers picker, same `@tiptap/suggestion` infrastructure.
+10. **LinkExtension** — Cmd-K link editing UI (`@tiptap/extension-link` + custom bubble UI).
+11. **CodeHighlightExtension** — `@tiptap/extension-code-block-lowlight` with Shiki. Existing desktop already uses Shiki (`apps/electron/src/renderer/components/shiki/ShikiCodeEditor.tsx` in craft-agents-oss is one reference, though the runtime is separate).
+
+Inline marks: `@tiptap/extension-bold`, `italic`, `underline`, `strike`, `code`, `text-color`, `highlight`. Standard.
+
+Forbidden / explicitly NOT used: `@tiptap/pro/*` (paid; we DIY equivalents). `@holaboss/editor` (existing wrapper; do not import).
+
+### 11.4 Database block — internal architecture
+
+`<DatabaseInlineBlock>` is a self-contained React subtree:
+
+```
+<DatabaseInlineBlock database_id view_id>
+  <DatabaseToolbar>
+    <ViewTabs views[] active />
+    <DatabaseTitle editable />
+    <ToolbarButtons>
+      <FilterMenu />
+      <SortMenu />
+      <PropertyMenu />
+      <NewRowButton />
+    </ToolbarButtons>
+  </DatabaseToolbar>
+  <DatabaseView>
+    {viewType === "table"     && <TableView />}
+    {viewType === "board"     && <BoardView />}
+    {viewType === "list"      && <ListView />}
+    {viewType === "gallery"   && <GalleryView />}
+    {viewType === "calendar"  && <CalendarView />}
+    {viewType === "timeline"  && <TimelineView />}
+  </DatabaseView>
+</DatabaseInlineBlock>
+```
+
+State: each open database mounts a `useDatabase(database_id, view_id)` hook that:
+
+1. Fetches `databases.get` once.
+2. Subscribes to the page's SSE stream for `database.changed` / `row.changed` events filtered by this database_id.
+3. Maintains rows in a paginated cache keyed by view config + cursor.
+4. Exposes mutation helpers (`addRow`, `updateValue`, `addProperty`, ...) that go through the same op queue as the editor.
+
+Cell editors are property-type-keyed:
+
+```
+const CELL_EDITORS = {
+  text: TextCell,
+  number: NumberCell,
+  checkbox: CheckboxCell,
+  select: SelectCell,
+  multi_select: MultiSelectCell,
+  date: DateCell,
+  url: UrlCell,
+  ...
+};
+```
+
+Each cell editor has shape `{ value, onChange, property, row }`. Inline editing mounts the editor in-place; clicking out commits.
+
+### 11.5 Row page
+
+Opening a row (clicking the row's first cell or the "open" affordance) navigates to the row's page. The row page renders:
+
+```
+<RowPage page_id row_id>
+  <PageHeader>
+    <Cover />
+    <Icon />
+    <Title editable />
+    <PropertiesPanel>
+      <PropertyRow property=... value=... onChange=... />
+      ...
+      <AddPropertyButton />
+    </PropertiesPanel>
+  </PageHeader>
+  <PageContent>
+    <PageEditor blocks={page.blocks} />   {/* Tiptap EditorContent under the hood */}
+  </PageContent>
+</RowPage>
+```
+
+The properties panel is the same set of cell editors used in the table view — they are reused.
+
+### 11.6 Routing
+
+Existing `holaOS/desktop` is Electron; the app shell mounts an `InternalSurfacePane` which today picks renderers by file extension. We replace that branch with a "page surface" that takes a `page_id`:
+
+```
+<InternalSurfacePane>
+  preview.kind === "page" → <PageSurface page_id />
+  preview.kind === "file" + ext === ".dashboard" → <LegacyDashboardRenderer /> (compat, Phases 0-4)
+  preview.kind === "file" → <FileRenderer />
+</InternalSurfacePane>
+```
+
+`PageSurface` mounts the editor with the page's blocks, the breadcrumb header, and the SSE subscription. Tabs in the AppShell can hold multiple `PageSurface` instances (multi-tab editing).
+
+### 11.7 Theming
+
+Use existing `holaOS/desktop` Tailwind tokens. New tokens added:
+- `--page-max-width` (default 720px, "wide" 1200px toggleable per page)
+- `--page-cover-height` (220px)
+- `--block-handle-size` (24px)
+- Property type colours map to existing OKLch palette (`green`, `blue`, ...) — no new tokens.
+
+Density: editor follows the same dense / craft-quality direction as Cursor. No giant whitespace, no pill-y buttons in the editor surface.
+
+### 11.8 Accessibility
+
+- All cell editors are keyboard-navigable (Tab / arrow / Enter / Esc).
+- Block menu has keyboard equivalent (Cmd-/ on macOS).
+- Slash menu trapped focus; Esc closes.
+- ARIA: each block has `role="article"` or `role="row"` as appropriate; database tables use `role="grid"`.
+- Reduced motion: respect `prefers-reduced-motion` for any block reorder transitions.
+
+---
+
+## 12. Migration from `.dashboard`
+
+### 12.1 One-shot migrator
+
+A runtime job `migrators.dashboard_to_page` runs on startup if `meta.dashboard_migrated_at` is unset.
+
+For each `*.dashboard` file in `workspace/<id>/files/dashboards/`:
+
+1. Parse YAML using existing `dashboardSchema.ts`.
+2. Create a new page: title from YAML `title`, description converted to a paragraph block right under the title, parent_page = a new top-level "Migrated dashboards" page.
+3. Walk panels in order, emit blocks:
+   - `text` → markdown blocks (markdown→Tiptap via `@tiptap/extension-markdown` import; or our own thin converter if the extension doesn't cover all our blocks).
+   - `kpi` → `kpi` block (preserve `query`, `delta_query`, `target`, `format`, `currency`, `empty_state`).
+   - `stat_grid` → a `column_list` containing `column` children, each with one `kpi` block.
+   - `chart` → `chart` block (preserve `query`, `chart` config).
+   - `data_view` → `sql_table` block, with all views preserved as `sql_table.views`.
+4. Apply `width: half/third` by wrapping adjacent narrow blocks in `column_list`.
+5. Store original YAML in `pages.meta_json.legacy_dashboard_yaml` for one release cycle (reversibility).
+6. Move the original file to `workspace/<id>/files/dashboards.archive/`.
+
+Migrator emits a report: `{ migrated: N, failed: M, skipped: K }` to `journal` and `runtime.log`.
+
+### 12.2 Reverse migration (escape hatch)
+
+For one release after Phase 4 ships, `migrators.page_to_dashboard` can convert simple pages back to `.dashboard` YAML — only if the page contains nothing but query-backed blocks and text. Used by users who must export to YAML for some reason. Drop this hatch in the next release.
+
+### 12.3 Module-shipped dashboards
+
+Some modules (twitter, linkedin, reddit) ship `.dashboard` files in their `dashboards/` directory. These get migrated on app install:
+
+1. App install lifecycle adds a hook: after `lifecycle.setup`, run migrator on the app's `dashboards/` directory.
+2. Each migrated dashboard becomes a page under the app's namespace page (e.g. "Twitter / Twitter metrics").
+3. The app no longer ships `.dashboard` files in v2 — the install hook accepts JSON page exports (`*.page.json`).
+4. Apps already shipping `.dashboard` keep working until Phase 4 ships; after that, modules must convert.
+
+Affected modules: `twitter`, `linkedin`, `reddit` (per current repo). Owners of those modules sign off on the migration via PR review.
+
+### 12.4 Acceptance check
+
+Migration success criteria for a `.dashboard` file:
+
+- All panels appear as blocks in the same order.
+- KPI / chart / sql_table blocks render data identical to the legacy renderer (visual parity tested via screenshot diff in Storybook).
+- Width hints (`full`/`half`/`third`) preserved through `column_list` layout.
+- `description`, `empty_state`, `refresh_interval_s` preserved.
+
+Anything we cannot represent (none today, but future-proof) logs a warning and falls back to a paragraph block with the YAML excerpt.
+
+---
+
+## 13. Sandbox runtime integration
+
+### 13.1 Code layout
+
+```
+holaOS/runtime/api-server/src/
+├── index.ts                 # Fastify bootstrap (existing)
+├── pages/                   # NEW
+│   ├── routes.ts            # /pages, /blocks
+│   ├── service.ts           # PagesService
+│   ├── persistence.ts       # SQLite read/write for pages, blocks
+│   ├── events.ts            # SSE bus
+│   ├── ops.ts               # Op type + inverse computation
+│   ├── materializer.ts      # On-disk JSON mirror writer
+│   └── migrator/
+│       └── dashboard.ts     # .dashboard → page conversion
+├── databases/               # NEW
+│   ├── routes.ts
+│   ├── service.ts
+│   ├── properties.ts
+│   ├── values.ts
+│   ├── views.ts
+│   ├── filter-sql.ts        # Filter DSL → SQL
+│   ├── relations.ts
+│   ├── rollups.ts
+│   └── formula/
+│       ├── parser.ts
+│       └── evaluator.ts
+├── attachments/             # NEW
+├── search/                  # NEW (FTS5 wrapper)
+├── trash/                   # NEW
+├── workspace-apps.ts        # existing — module app lifecycle
+└── workspaces.ts            # existing — file CRUD (will not host pages)
+```
+
+Existing `runDashboardQuery` IPC stays in place, exposed as `POST /query` (renamed in Phase 4).
+
+### 13.2 SQLite migrations
+
+`pages.db` is a separate file from `data.db`. Migrations live in `runtime/api-server/src/pages/migrations/` and run on runtime startup:
+
+- `0001_initial.sql` — full schema from §7
+- Future migrations append; never edit committed migrations
+- `meta.schema_version` tracks the current schema
+- Backwards compatibility: a runtime upgrade with a higher `schema_version` than the DB triggers migrations; downgrades refuse to start (log error, exit non-zero — same convention as data.db migrations).
+
+### 13.3 IPC and contracts
+
+Frontend talks to runtime over the existing Electron IPC (`window.electronAPI.workspace.*`). Add:
+
+```ts
+window.electronAPI.workspace = {
+  ...existing,
+  pages: {
+    list, get, create, update, delete, move, restore, duplicate, breadcrumbs,
+    blocks: { append, insert, update, delete, move, batch },
+    events: (page_id) => EventSource,
+  },
+  databases: {
+    create, get, update, delete,
+    properties: { add, update, changeType, delete, addOption, updateOption, deleteOption },
+    rows: { list, get, create, update, delete, batch },
+    views: { create, update, delete },
+    query: ( ... ),
+  },
+  attachments: { upload, delete },
+  search: ( ... ),
+  trash: { list, restore, purge },
+  undo, redo,
+};
+```
+
+Each method is a wrapper that POSTs to runtime via the existing privileged HTTP channel.
+
+### 13.4 Backwards compatibility windows
+
+| Feature | Available through | Removed in |
+|---|---|---|
+| `.dashboard` YAML files (read) | Phase 4 | Phase 5 |
+| `.dashboard` YAML files (write by agent) | Phase 1 | Phase 2 |
+| `runDashboardQuery` IPC name | Phase 4 | Phase 5 |
+| Existing `dashboardSchema.ts` | Phase 4 (used by migrator) | Phase 5 |
+
+---
+
+## 14. Phased rollout
+
+Each phase is a deployable increment. No phase ships partial — internal feature flags hide WIP. Estimates assume one engineer full-time.
+
+### Phase 0 — Foundation (1–2 weeks)
+
+**Goal**: prove the editor + persistence shape with a minimal end-to-end slice **and de-risk the four research-flagged Tiptap/ProseMirror concerns** before committing the entire design to it.
+
+- [ ] Tiptap scaffolding in `holaOS/desktop/src/lib/editor/`. Render paragraph + heading.
+- [ ] Define block JSON schema (TypeScript types, Zod validators) + the bidirectional mapping `OurBlock ↔ Tiptap JSON`.
+- [ ] Add `pages.db` to runtime; ship `0001_initial.sql`.
+- [ ] Implement `POST /pages`, `GET /pages/:id`, `POST /blocks`, `PATCH /blocks/:id`, `DELETE /blocks/:id`.
+- [ ] Implement op + inverse + journal.
+- [ ] PersistenceExtension: ProseMirror transaction → op → POST.
+- [ ] PageSurface mounts editor; loads page on file extension `.page` (provisional UX).
+- [ ] Mutation queue with optimistic update + rollback.
+
+**Risk-burn-down checklist** (each must pass before Phase 1 start; failing any one triggers a hard reconsideration of the editor choice):
+
+- [ ] **R1 — NodeView hosts a self-contained React island.** Build a throwaway `DatabaseInlineNode` (`atom: true`, NodeView-rendered) that renders a React subtree containing a contenteditable cell editor; verify (a) cursor on the parent paragraph is preserved when clicking into / out of the island, (b) the cell editor's own selection works independently of ProseMirror's, (c) typing in the cell does **not** trigger a ProseMirror transaction on the parent doc, (d) `selected` prop reaches the React component when the island is selected as a whole. Reference: Tiptap NodeView docs + BlockNote source for atom-with-React-island patterns.
+- [ ] **R2 — ProseMirror transaction → op minimal-diff algorithm.** Walk `tr.steps` (ReplaceStep / AddMarkStep / RemoveMarkStep / AttrStep) and emit one or more ops per step. Property-based test: fuzz 1000 random op sequences, apply via `editor.commands`, derive diff from each transaction, replay diff to a fresh editor, assert `editor.getJSON()` equality. Target: zero divergence in 1000 runs.
+- [ ] **R3 — Performance baseline.** 5000-block paragraph document, p95 keystroke latency < 50ms on M-series Mac. **This is the riskiest item** — Tiptap has documented slowness past 1500 nodes (issues #4491, #3340). Mitigation toolkit if R3 fails: (a) virtualised rendering (mount only viewport + buffer), (b) ProseMirror `view.update()` throttling, (c) smaller schema (fewer marks per text node). If none of these clear < 50ms p95, this is a fork in the road — see fallback below.
+- [ ] **R4 — Tiptap JSON ↔ our block JSON round-trip.** All 9 standard block types parse from our block envelope into Tiptap JSON and back, byte-equivalent. Includes attribute preservation through `editor.getJSON()` and `editor.commands.setContent()`.
+- [ ] **R5 — Pin Tiptap version.** Pin `@tiptap/core@^3.x` and `@tiptap/pm@^3.x` (current stable at Phase 0 start). Lockfile committed. Bump policy: minor bumps reviewed monthly; majors only at phase boundaries.
+
+Exit criteria:
+1. R1–R5 all pass.
+2. Open a new page, type paragraphs and headings, close + reopen — content persists.
+3. Two windows of the same page each see the other's edits via SSE within 200ms.
+
+Fallback: if R3 fails irreparably (5000 blocks always > 100ms p95 even with virtualisation), re-evaluate Lexical for performance specifically — its immutable reconciler scales further. The rest of the design (data model, API, agent surface, block JSON spec) is editor-agnostic and survives the swap unchanged. R1, R2, R4 are unlikely to fail given Tiptap's maturity; if they do, the cause is most likely our schema design, not the framework.
+
+### Phase 1 — Page MVP (3 weeks)
+
+**Goal**: usable rich editor for plain pages.
+
+- [ ] Block types: paragraph, heading_1/2/3, bulleted/numbered list, to_do, toggle, quote, callout, code, divider.
+- [ ] Slash menu (CommandsPlugin).
+- [ ] Drag handle (DragHandlePlugin).
+- [ ] Block menu (BlockMenuPlugin).
+- [ ] Markdown shortcuts.
+- [ ] Mentions (page references).
+- [ ] Inline formatting (bold, italic, underline, strikethrough, code, color, link).
+- [ ] Undo/redo.
+- [ ] File explorer integration: pages appear as `.page` items; double-click opens.
+- [ ] Page hierarchy: parent pages, breadcrumbs, sidebar tree.
+- [ ] Search: pages by title.
+- [ ] Image / file upload via attachments.
+- [ ] On-disk JSON mirror.
+
+Exit criteria: a user can write a long-form Notion-style page with all standard blocks and feel it is "a real editor".
+
+### Phase 2 — Database MVP (3–4 weeks)
+
+**Goal**: inline databases with the most useful property types and the table view.
+
+- [ ] Database creation (slash → "/database").
+- [ ] DatabaseInlineNode + DatabaseInlineBlock React component.
+- [ ] Properties: text, number, checkbox, select, multi_select, date, url.
+- [ ] Inline cell editing.
+- [ ] Add / remove / rename / reorder properties.
+- [ ] Add / delete rows.
+- [ ] Table view with column resize, reorder, freeze.
+- [ ] Filter DSL + UI (one filter group: AND).
+- [ ] Sort UI (single + multi-key).
+- [ ] Hidden properties.
+- [ ] Pagination / virtual scroll (>1000 rows).
+
+Exit criteria: a user can `slash → database`, build a simple tracker (e.g. "tasks" with text, status select, date), filter by status, sort by date.
+
+### Phase 3 — Multiple views + linked databases (3 weeks)
+
+**Goal**: Notion-feature parity on view system.
+
+- [ ] Board view (group_by select / multi_select).
+- [ ] List view.
+- [ ] Gallery view (with image cover).
+- [ ] Calendar view (month/week/day).
+- [ ] Timeline view.
+- [ ] Multiple views per database, view tabs UI.
+- [ ] OR filter groups.
+- [ ] DatabaseLinkedNode (`database_linked` block).
+- [ ] "Open as full page" — every database has a dedicated route showing the database surface.
+
+Exit criteria: a user can switch views on a tracker, drag rows between board columns, link the same database from another page with a different filter.
+
+### Phase 4 — Query-backed blocks + `.dashboard` migration (2 weeks)
+
+**Goal**: legacy parity. After this phase, `.dashboard` is gone.
+
+- [ ] `kpi`, `chart`, `sql_table` blocks.
+- [ ] One-shot migrator (§12).
+- [ ] Module install hook integration.
+- [ ] Storybook visual diff harness for migrated pages.
+- [ ] Deprecate `.dashboard` write path; agents that try get an error pointing at the new tools.
+
+Exit criteria: every existing `.dashboard` file in the showcase workspace renders as a page with no visual regressions.
+
+### Phase 5 — Row pages + relations + rollups (3 weeks)
+
+- [ ] Row pages (open row → full page editor).
+- [ ] Relation property + property picker.
+- [ ] Two-way relations.
+- [ ] Rollup property + inline picker.
+- [ ] Rollup cache invalidation.
+- [ ] Search includes row content (FTS5).
+
+Exit criteria: a user can build a "projects + tasks" two-database setup with a relation and a rollup that shows the count of open tasks per project.
+
+### Phase 6 — Formula + advanced properties (2 weeks)
+
+- [ ] Formula DSL + evaluator (§5.6).
+- [ ] Formula cache invalidation graph.
+- [ ] `created_time`, `created_by`, `last_edited_time`, `last_edited_by` (the last two are no-ops while single-user).
+- [ ] `person` property scaffold (kept dormant until collab phase).
+- [ ] `file` property type.
+
+### Phase 7 — Collaboration (4–6 weeks, deferred)
+
+- [ ] Wrap blocks/rows in Y.Map. Map every op to a Y.Doc transaction.
+- [ ] Provider integration (decision deferred — partykit / liveblocks / self-host with WebSocket).
+- [ ] Presence (cursors, selection, who's editing).
+- [ ] Awareness (typing indicators).
+- [ ] Conflict UX for property type changes.
+- [ ] Offline mode: local-only ops queue → sync on reconnect.
+- [ ] Backfill: existing pages get a Y.Doc snapshot built from their SQLite state on first multi-user open.
+
+This phase is deliberately not scheduled here. The data model and op shape are designed so Phase 7 is additive, not a rewrite.
+
+---
+
+## 15. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Tiptap transaction → op translation has subtle bugs (lost edits) | High initially | High | Property-based test (random op sequences → fuzz; assert SQLite ↔ Tiptap JSON round-trip equivalence). Explicit op types per ProseMirror Step kind. |
+| Database query perf degrades past 100k rows | Medium | Medium | Indexed json_extract; documented limit; fallback to typed shadow column on hot properties (per-DB internal, opaque to users). |
+| Type migration loses data | Medium | High | Journal preserves original; UI confirmation dialog lists impact ("12 rows will become null"). |
+| File-system mirror diverges from SQLite | Medium | Low | Mirror is debounced and idempotent; runtime treats SQLite as truth, never reads the mirror back during writes. Periodic reconciler (every 5 min) detects drift and rewrites. |
+| Migration of existing `.dashboard` produces wrong layouts | Medium | Low | Visual-diff harness in Phase 4. Deprecation window — keep originals in `dashboards.archive/` for two releases. |
+| Tiptap performance fails R3 at 5000 blocks | Medium | High | Phase 0 specifically validates this; fallback toolkit listed inline (virtualisation, transaction throttling, schema slimming). Last-resort fallback is Lexical; the data model and API survive the swap unchanged. |
+| Tiptap maintainer pivots toward paid Pro features | Low | Medium | We avoid all `@tiptap/pro/*` packages. Even if Pro-only extensions multiply, OSS core is healthy — ProseMirror itself is independent and 10+ years stable underneath. |
+| Yjs migration in Phase 7 is harder than expected | Low | High | Op shape is the seam; CRDT migration constraints (§10.3, §10.2, §10.1) are enforced from Phase 0. Property-based tests run for both local-store and Yjs backends in Phase 7. |
+| Module apps can't migrate their `.dashboard` files in time | Medium | Medium | Phase 4 migrator runs on app install; modules can ship JSON exports going forward. Compat shim through Phase 5 if needed. |
+| Agents flood the runtime with tool calls | Low | Low | Per-session quota added if observed. Tool schemas are tight (small inputs, paginated outputs). |
+| Single-DB SQLite contention under heavy editing | Low | Medium | WAL mode, single-writer pattern, batched ops. If observed, split journal to its own file. |
+
+---
+
+## 16. Open questions
+
+These are decisions that block specific phases but not the overall design. Surface and resolve before the relevant phase starts.
+
+1. **Sidebar / page tree UX** — does the desktop app's sidebar host the page tree, or does it stay in the file explorer surface? *(Resolve before Phase 1.)*
+2. **Workspace-scoped or sandbox-scoped page tree?** Confirmed sandbox-scoped (per-workspace, per-user) above; revisit only if a multi-workspace shared page surface becomes a product requirement.
+3. **Cover image source** — only attachments and external URLs in v1, or also Unsplash integration? *(Resolve before Phase 1.)*
+4. **Search scope** — does cross-page search index module data (twitter_posts content)? Probably no in v1 (keeps the index small and avoids exposing content the user might consider "system" data). *(Resolve before Phase 5.)*
+5. **Agent author identity** — `journal.actor = "agent:<name>"`. How are agent names assigned? Suggest using the agent's session_id / agent_run_id from the existing harness. *(Resolve before Phase 1.)*
+6. **Templates** — out of v1, but where do they live (page-tree / a special folder / a marketplace)? *(Plan in v2.)*
+7. **Exports** — Markdown / PDF / CSV. Out of v1. CSV from a database view makes sense in Phase 3+; defer.
+8. **Tiptap version pin** — Tiptap v3 is stable. We pin `@tiptap/core@^3.x` per phase and bump deliberately at phase boundaries. *(Set the pin in Phase 0.)*
+
+---
+
+## 17. Appendix A — Concrete payload examples
+
+### 17.1 Create a page with an inline database
+
+```jsonc
+// 1. Create the page
+POST /api/v1/workspaces/W/pages
+{ "title": "Tasks" }
+→ { "page_id": "page_01HX..." }
+
+// 2. Add a database_inline block
+POST /api/v1/workspaces/W/pages/page_01HX/blocks
+{
+  "position": "a0",
+  "type": "database_inline",
+  "content": { "database_id": null }   // runtime fills after databases.create
+}
+
+// 3. Create the database, owned by that block
+POST /api/v1/workspaces/W/databases
+{
+  "owner_page_id": "page_01HX...",
+  "owner_block_id": "block_01HX...",
+  "name": "Tasks",
+  "properties": [
+    { "name": "Title",  "type": "text", "position": "a0" },
+    { "name": "Status", "type": "select", "position": "a1",
+      "config": { "options": [
+        { "id": "opt_01", "name": "todo",     "color": "gray",   "position": "a0" },
+        { "id": "opt_02", "name": "doing",    "color": "blue",   "position": "a1" },
+        { "id": "opt_03", "name": "done",     "color": "green",  "position": "a2" }
+      ] } },
+    { "name": "Due", "type": "date", "position": "a2" }
+  ],
+  "initial_view": {
+    "type": "table",
+    "name": "All",
+    "config": {
+      "frozen_property_ids": [],
+      "property_widths": {},
+      "wrap": false,
+      "filter": null,
+      "sort": [],
+      "hidden_property_ids": []
+    }
+  }
+}
+→ { "database_id": "db_01HX...", "default_view_id": "view_01HX..." }
+```
+
+### 17.2 Add a row
+
+```jsonc
+POST /api/v1/workspaces/W/databases/db_01HX/rows
+{
+  "values": {
+    "Title":  { "rich_text": [{ "type": "text", "text": "Ship pages MVP" }] },
+    "Status": { "option_id": "opt_02" },
+    "Due":    { "start": "2026-05-20", "include_time": false }
+  }
+}
+→ { "row_id": "row_01HX...", "page_id": "page_01HX..." }
+```
+
+### 17.3 Filter+sort query
+
+```jsonc
+POST /api/v1/workspaces/W/databases/db_01HX/rows:query
+{
+  "filter": {
+    "kind": "and",
+    "filters": [
+      { "kind": "leaf", "property_id": "prop_status",
+        "condition": { "op": "is_not", "value": "opt_03" } },
+      { "kind": "leaf", "property_id": "prop_due",
+        "condition": { "op": "date_within", "preset": "this_week" } }
+    ]
+  },
+  "sort": [{ "property_id": "prop_due", "direction": "asc" }],
+  "limit": 50
+}
+→ {
+    "rows": [...],
+    "total": 7,
+    "next_cursor": null
+  }
+```
+
+### 17.4 Agent: append a heading and a database
+
+```jsonc
+// Agent tool call
+{
+  "name": "blocks.append",
+  "arguments": {
+    "page_id": "page_01HX...",
+    "blocks": [
+      { "type": "heading_2", "content": { "rich_text": [
+          { "type": "text", "text": "This week's tasks" }
+        ] } },
+      { "type": "database_inline",
+        "content": { "database_id": "db_01HX..." } }
+    ]
+  }
+}
+```
+
+---
+
+## 18. Appendix B — Initial SQLite seed
+
+```sql
+-- Inserted on first runtime start for each workspace.
+INSERT INTO meta(key, value) VALUES
+  ('schema_version', '1'),
+  ('created_at', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+-- A "Welcome" page seeded so the user lands on something.
+INSERT INTO pages(id, parent_page_id, title, created_at, updated_at)
+VALUES (
+  'page_welcome', NULL, 'Welcome',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+);
+INSERT INTO blocks(id, page_id, parent_block_id, position, type, content_json, created_at, updated_at)
+VALUES (
+  'block_welcome_p1', 'page_welcome', NULL, 'a0', 'paragraph',
+  '{"rich_text":[{"type":"text","text":"Welcome to your workspace."}]}',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+);
+```
+
+---
+
+## 19. Appendix C — File-system layout after migration
+
+```
+workspace/<id>/
+├── workspace.json           — workspace metadata (existing)
+├── workspace.yaml           — runtime config (existing)
+├── apps/                    — module apps (existing, unchanged)
+├── pages/                   — NEW: page JSON mirror, one file per page
+│   ├── page_01HX....page.json
+│   └── page_01HY....page.json
+├── databases/               — NEW: database JSON mirror
+│   └── db_01HX....database.json
+├── attachments/             — NEW: image/file uploads
+│   ├── 01HX....png
+│   └── 01HY....pdf
+└── dashboards.archive/      — NEW (post-Phase-4): legacy .dashboard files
+    └── charts-showcase.dashboard
+```
+
+State (SQLite) lives at `state/pages.db` (new) alongside existing `state/runtime.db` and `state/data.db`.
+
+---
+
+## 20. Appendix D — Testing strategy
+
+| Layer | Tests |
+|---|---|
+| Block JSON schema | Zod parse round-trip; reject malformed payloads with detailed error path. |
+| Op + inverse | Property-based: random op sequences → apply → apply inverses in reverse → state equal initial. |
+| SQLite persistence | Integration: every API endpoint exercised; assert on resulting tables. |
+| Editor (Tiptap) | Component tests with `@tiptap/react`'s test helpers + ProseMirror's test runner: type, slash command, drag-reorder; verify generated ops match expectation. |
+| Filter DSL → SQL | Snapshot tests over a fixture grid of (filter, expected SQL). |
+| Migrator | Each `.dashboard` fixture → page → screenshot diff against legacy renderer. |
+| Type migration | Matrix test: every (from, to) pair exercised on a fixture row. |
+| End-to-end | Playwright: open new page → type → add database → add row → reload → assert content. |
+| Performance | Bench: 10k-row database table view scroll; cell edit latency p95 < 100ms; page open p95 < 200ms. |
+
+CI: tests run on every PR. The fuzz suite runs nightly with a fixed seed; regressions block release.
+
+---
+
+## 21. Appendix E — Glossary mapping (old → new)
+
+| Old (`.dashboard`) | New (page + block) |
+|---|---|
+| `.dashboard` file | `.page.json` mirror; primary representation is in SQLite |
+| `panel` | `block` |
+| `panel.type = kpi` | `block.type = kpi` (query-backed) |
+| `panel.type = chart` | `block.type = chart` (query-backed) |
+| `panel.type = data_view` | `block.type = sql_table` (query-backed) OR `database_inline` (native) |
+| `panel.type = text` | rich-text blocks (paragraph / heading / list / ...) |
+| `panel.type = stat_grid` | `column_list` of `kpi` blocks |
+| `panel.width = full/half/third` | `column_list` with `column.ratio` |
+| `views` inside `data_view` | `views` table on database (or `sql_table.views` for query-backed) |
+| `query` (SQL) | `query` field on query-backed blocks; replaced by structured filter for native databases |
+| `default_view` | `default_view_id` |
+| `colors` map | property-level select option color, or table column color config |
+
+---
+
+---
+
+## 22. Appendix F — Editor framework research (2026-05-06)
+
+Recorded so the editor decision is auditable; do not edit unless re-running the research.
+
+### 22.0 Decision history
+
+| Date | Decision | Reason |
+|---|---|---|
+| 2026-05-06 (am) | **Lexical** | Architectural fit: clean node model, `@lexical/yjs` for collab, NodeState for typed block JSON, performance scaling. |
+| 2026-05-06 (pm) | **Reversed → Tiptap (DIY, no Pro)** | OSS production-footprint asymmetry: Tiptap has named blue-chip OSS users (LinkedIn, GitLab, Anthropic, Twenty CRM, CopilotKit, Hyprnote, Hyperion) plus 10+ years of ProseMirror battle-testing under Atlassian / NYT / Outline. Lexical's named OSS-product adoption is essentially Meta-internal (closed) + Payload CMS + a long tail of <100★ demos. The architectural-fit advantage doesn't outweigh the community / longevity risk for a small team. The user's clarification (a) — "the wrapper is at fault, not Tiptap-the-framework" — removes the previous coupling concern as long as we don't import `@holaboss/editor`. |
+
+### 22.1 Candidates evaluated
+
+| Framework | Underlying | Status | License |
+|---|---|---|---|
+| Lexical | Custom (Meta) | v0.44.x, pre-1.0 since 2022 | MIT |
+| Tiptap (DIY, no Pro) | ProseMirror | v3, stable | MIT |
+| BlockNote | Tiptap → ProseMirror | v0.x, active | MPL-2.0 |
+| Plate | Slate | active | MIT |
+| BlockSuite (AFFiNE) | Custom (Yjs-native) | active, tied to AFFiNE | MIT |
+
+### 22.2 Eliminated
+
+- **BlockNote**: custom blocks cannot nest (TypeCellOS/BlockNote#1540, open). Our `database_inline` must live inside `column_list` / `toggle` / `callout`. Custom blocks render in a separate React root, breaking Context. At least one team migrated off citing "rigid schema structure".
+- **Plate (Slate)**: Slate's collaboration story is the weakest of the four; persistent slate / slate-react / slate-dom dependency conflicts in 2025; Slate normalisation perf issues require chunking workarounds.
+- **BlockSuite**: AFFiNE-coupled, framework abstraction comparable to ProseMirror — would re-do the work AFFiNE's team did. Not realistic for our headcount.
+
+### 22.3 Lexical vs Tiptap final comparison (post-reversal)
+
+| Dimension | Lexical | Tiptap (DIY) | Notes |
+|---|---|---|---|
+| Named OSS production users | 🟡 Meta-internal (closed) + Payload CMS + long tail <100★ | ✅ LinkedIn, GitLab, Anthropic, Twenty CRM, CopilotKit, Hyprnote, Hyperion, AppSmith… | **The deciding factor.** |
+| Underlying-engine track record | 🟡 5 yrs (Lexical, 2021) | ✅ 10+ yrs (ProseMirror, 2015) at Atlassian / NYT / Outline scale | ProseMirror is a fundamentally older, more battle-tested core. |
+| Agent block-JSON authoring | ✅ NodeState + import/exportJSON | ✅ Tiptap JSON `{ type, attrs, content }` is also clean | Both are tractable. Tiptap's schema-bound JSON is widely documented. |
+| Yjs collab integration | ✅ `@lexical/yjs` | ✅ `y-prosemirror` (older, more production cases) | y-prosemirror has more known-good deployments. |
+| Database React island | ✅ DecoratorNode | ✅ `ReactNodeViewRenderer` on `atom: true` node | Both work. NodeView pattern has more public examples (BlockNote source). |
+| Large-document perf | ✅ Immutable reconciler | 🟡 Issues #4491, #3340 (1500+ nodes ⇒ slow) | **Real Tiptap risk.** Phase 0 R3 specifically validates; fallback toolkit listed in §14 Phase 0. |
+| Time-to-Notion-feel | 🟡 Build everything ourselves; few public references | ✅ DIY from Novel + BlockNote source as code references | Tiptap reference material is much denser. |
+| API stability | 🟡 v0.44.x, pre-1.0 since 2022 | ✅ v3 stable | |
+| Ecosystem / extensions | 🟡 LexKit, Luthor — both <1k★, both 2025 | ✅ ~50+ official + large community | |
+| Coupling with `@holaboss/editor` | None (different family) | Same family but **different wrapper** | User clarified (a): framework fine, wrapper not. We do not import the wrapper's source. |
+| Stack Overflow / GitHub answer density | 🟡 Thinner — fewer questions, slower issue close | ✅ Much denser | Material when stuck. |
+
+### 22.4 Why we reversed
+
+The original Lexical pick was made on architectural fit. The reversal is on **production-evidence weight**.
+
+Architectural fit advantages of Lexical (clean DecoratorNode, NodeState, immutable reconciler) are real but **theoretical for our scale**. We are a small team building a new product on a young framework — what matters most is:
+
+1. **When stuck, can we find an answer fast?** Tiptap wins by 10×.
+2. **When the maintainer makes a tough trade-off, is our use case represented?** Tiptap's commercial OSS-native maintainership (ueberdosis) cares about a broad customer base. Lexical's maintainer (Meta) prioritises FB/IG/WhatsApp internals. Our needs are not on Meta's roadmap.
+3. **If the framework dies tomorrow, who picks it up?** ProseMirror has a decade of independent contributors. Lexical's core contributors are concentrated at Meta.
+
+Tiptap's two real downsides:
+- **Performance past 1500 nodes** — the only material risk. Phase 0 R3 measures it on our actual block shape; we have a fallback toolkit (virtualisation + transaction throttling + schema slimming) before Lexical re-evaluation becomes the answer.
+- **Pro-tier creep** — Tiptap monetises advanced templates / extensions. We commit explicitly to OSS core only and DIY everything Pro covers.
+
+Both are manageable. The OSS-adoption asymmetry is harder to fix.
+
+### 22.5 Sources consulted
+
+Round 1 (architectural-fit comparison, led to Lexical pick):
+- Liveblocks, "Which rich text editor framework should you choose in 2025?" — comparison + Lexical Yjs root-node note.
+- PkgPulse, "Tiptap vs Lexical vs Slate vs Quill 2026".
+- BuildPilot, "Tiptap vs Lexical vs Plate 2026".
+- Velt, "Best Rich Text Editors in 2026".
+- facebook/lexical Releases (v0.44.0, 2026), Wiki Roadmap, Discussion #5011.
+- Lexical Collaboration FAQ, Discussion #3161 (decorator selection), Issue #6613 (custom node children).
+- ueberdosis/tiptap Issue #4491 (large content slow), Issue #3340 (incremental input slow), Discussion #4746 (Notion-style impl).
+- TypeCellOS/BlockNote Issue #1540 (custom blocks cannot nest), Issue #1360 (decorator request).
+- udecode/plate Issue #4599 (Slate version conflict), Plate Troubleshooting docs.
+- toeverything/blocksuite (AFFiNE editor framework) — architecture docs.
+- DEV.to "Why I chose Lexical over Tiptap" (codeideal).
+- steven-tey/novel — DIY Tiptap Notion-style reference.
+- Tiptap pricing page (Pro Notion-like template = Start plan ≥ $149/mo).
+
+Round 2 (OSS adoption audit, led to reversal):
+- Tiptap "open-source-to-platform" page — named OSS production users.
+- openalternative.co/stacks/tiptap — 10+ OSS apps using Tiptap (Twenty CRM, CopilotKit, Hyprnote, Hyperion, AppSmith, Whop, ...).
+- gitnux Lexical statistics 2026 — adoption breakdown ("1234 companies via npm trends"; named OSS = Payload CMS + Vercel templates + 4 unspecified enterprise SaaS).
+- npm `@payloadcms/richtext-lexical` — confirmed Payload's official Lexical adapter (v3.84.0, 2026).
+- GitHub topic `lexical-editor` — long tail inspection: highest-starred non-official repos under 200★, most are demos.
+- Eddyter "Most Popular WYSIWYG Editor 2026" — share-of-downloads.
+
+End of research record.
+
+---
+
+End of v1 design.

--- a/packages/editor/.gitignore
+++ b/packages/editor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/packages/editor/.npmrc
+++ b/packages/editor/.npmrc
@@ -1,0 +1,6 @@
+# Disable npm v7+ auto-install of peer dependencies.
+# react / react-dom are declared as peerDependencies; they should be supplied
+# by the consumer (desktop), not installed inside this package's node_modules.
+# Two react copies = "Cannot read properties of null (reading 'useRef')"
+# inside the consumer because hooks dispatcher state is per-module.
+legacy-peer-deps=true

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1,0 +1,87 @@
+# @holaboss/editor
+
+Tiptap-based block editor for holaOS.
+
+**v0 status**: Markdown editor only. Plugged into desktop's `.md` / `.mdx` /
+`.markdown` file editing surface as the replacement for the previous plain
+`<textarea>`. Future versions add Notion-style blocks (slash menu, drag handle,
+embedded databases) per the design doc:
+
+- `holaOS/docs/plans/2026-05-06-pages-and-databases-design.md`
+
+## Usage
+
+```tsx
+import "@holaboss/editor/styles.css";
+import { MarkdownEditor } from "@holaboss/editor";
+
+function MyPane({ value, onChange }) {
+  return (
+    <MarkdownEditor
+      value={value}
+      onChange={onChange}
+      placeholder="Start typing…"
+    />
+  );
+}
+```
+
+`value` is the markdown source (string). `onChange` fires after each
+transaction with the updated markdown.
+
+## Imperative API
+
+```tsx
+const ref = useRef<MarkdownEditorRef>(null);
+// ref.current.getMarkdown()
+// ref.current.setMarkdown(md)
+// ref.current.focus()
+// ref.current.editor   // raw Tiptap editor
+```
+
+## Stack
+
+- `@tiptap/core` v3 + `@tiptap/react`
+- `@tiptap/starter-kit` (paragraph, headings, lists, code, blockquote, hr,
+  hard break, history)
+- `@tiptap/extension-link`
+- `@tiptap/extension-placeholder`
+- `tiptap-markdown` for markdown ↔ document round-trip
+
+## Build
+
+```bash
+npm install
+npm run build       # produces dist/{index.js,index.cjs,index.d.ts,styles.css}
+npm run typecheck
+```
+
+## Adding a new `@tiptap/*` extension
+
+This package has `legacy-peer-deps=true` (in `.npmrc`) to keep `react` /
+`react-dom` out of `node_modules` and prevent duplicate React instances in
+Vite consumers. **Side effect**: npm will not auto-install ANY peer
+dependencies, including internal `@tiptap/*` peers.
+
+When adding a new `@tiptap/*` package:
+
+1. Run `npm view @tiptap/<new-pkg> peerDependencies` to see its peers.
+2. Add every `@tiptap/*` peer to this package's `dependencies` explicitly,
+   pinned to the same version range as the rest of the family (`^3.x`).
+3. Do NOT add `react` / `react-dom` — those stay out, satisfied by the
+   consumer.
+4. Re-run `npm install`, then `npm run typecheck` and `npm run build`.
+
+Symptom of a missing internal peer: Vite errors with
+`Failed to resolve import "@tiptap/extension-foo"` from the bundled
+extension package. The fix is to add the missing peer to dependencies.
+
+## Future scope
+
+- Slash menu (Phase 1)
+- Drag handle, block-level menu (Phase 1)
+- Custom blocks: callout, toggle, columns (Phase 1)
+- `database_inline`, `database_linked`, `kpi`, `chart`, `sql_table` (Phase 2+)
+- Yjs collab via `y-prosemirror` (Phase 7)
+
+Do not add new features here without first updating the design doc.

--- a/packages/editor/package-lock.json
+++ b/packages/editor/package-lock.json
@@ -1,0 +1,2490 @@
+{
+  "name": "@holaboss/editor",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@holaboss/editor",
+      "version": "0.0.1",
+      "dependencies": {
+        "@tiptap/core": "^3.0.0",
+        "@tiptap/extension-bubble-menu": "^3.22.5",
+        "@tiptap/extension-code-block-lowlight": "^3.22.5",
+        "@tiptap/extension-collaboration": "^3.22.5",
+        "@tiptap/extension-drag-handle": "^3.22.5",
+        "@tiptap/extension-drag-handle-react": "^3.22.5",
+        "@tiptap/extension-node-range": "^3.22.5",
+        "@tiptap/extension-placeholder": "^3.0.0",
+        "@tiptap/extension-task-item": "^3.0.0",
+        "@tiptap/extension-task-list": "^3.0.0",
+        "@tiptap/markdown": "^3.0.0",
+        "@tiptap/pm": "^3.0.0",
+        "@tiptap/react": "^3.0.0",
+        "@tiptap/starter-kit": "^3.0.0",
+        "@tiptap/suggestion": "^3.0.0",
+        "@tiptap/y-tiptap": "^3.0.0",
+        "lowlight": "^3.3.0",
+        "tippy.js": "^6.3.7",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.5.tgz",
+      "integrity": "sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.5.tgz",
+      "integrity": "sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.5.tgz",
+      "integrity": "sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.5.tgz",
+      "integrity": "sha512-yrNlFQQJY5MmhBpmD8tnmaSmyUQrEvgyPKa3bzVeWEhDSG1CW4A0ZSMx3hrA9yFO0HWfw3IJmvSCycEZQBalpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.5.tgz",
+      "integrity": "sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.5.tgz",
+      "integrity": "sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.5.tgz",
+      "integrity": "sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block-lowlight": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block-lowlight/-/extension-code-block-lowlight-3.22.5.tgz",
+      "integrity": "sha512-lT0SxhjkDL1tKSeVDduV+SJ6kHdNFcbYBaUAwTufRtDt8FIYcSX6tWj5cPEXOFrC0PlJu7ybCnTEbXBdFP8Bnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/extension-code-block": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "highlight.js": "^11",
+        "lowlight": "^2 || ^3"
+      }
+    },
+    "node_modules/@tiptap/extension-collaboration": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.22.5.tgz",
+      "integrity": "sha512-3rax34HKSo8L5ihv5iGxISNBUIdVP0Fq9O6T/mq4kQOLhVhNbqwr9I/lWOvaz24nPE7u5Vkz0Ii3zWGlzxyPPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "@tiptap/y-tiptap": "^3.0.2",
+        "yjs": "^13"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.5.tgz",
+      "integrity": "sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-drag-handle": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.22.5.tgz",
+      "integrity": "sha512-ClpgtNJZTUctQDB64KAZjhowZUK3QwFCiYJBXMg/fk9YzYHZ1L9qjzjqUcHiCsbQN9ILNZY1q9CQkce1LzKlrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/extension-collaboration": "3.22.5",
+        "@tiptap/extension-node-range": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "@tiptap/y-tiptap": "^3.0.2"
+      }
+    },
+    "node_modules/@tiptap/extension-drag-handle-react": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.22.5.tgz",
+      "integrity": "sha512-DAjwBdh6SSYr+c7lDA8D3SQrpGooO2qdOGkU83oIYgGrV0mAjiNhTa1/+S1J+rfBACiakhFn0rC+mELcECAnYQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-drag-handle": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "@tiptap/react": "3.22.5",
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.5.tgz",
+      "integrity": "sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.5.tgz",
+      "integrity": "sha512-dhem4sTPhyQgQ+pFp2Oud4k4FSQz9PVMgeQAC9288SmGwxBkJNveDAw6sKTMrumqDvwkJrtslXIupq9TZYQnzg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.5.tgz",
+      "integrity": "sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.5.tgz",
+      "integrity": "sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.5.tgz",
+      "integrity": "sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.5.tgz",
+      "integrity": "sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.5.tgz",
+      "integrity": "sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.5.tgz",
+      "integrity": "sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.5.tgz",
+      "integrity": "sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.5.tgz",
+      "integrity": "sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.5.tgz",
+      "integrity": "sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-node-range": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.22.5.tgz",
+      "integrity": "sha512-1C00Dur+8KNjcKcI6nuYY4RFOrp/1YUFR04Wj0VZVc8L8l4jCXS+JY+aYtTwKjxcXIH3UzplfwoRZj9thn98pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.5.tgz",
+      "integrity": "sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.5.tgz",
+      "integrity": "sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.5.tgz",
+      "integrity": "sha512-MZAohQ3FCS763BkhGXgaWRya6WruZjwRwEAkXP8vkxbERzl2OJRjniS4uXCWzAlRb3ttE103SnY7LMdM8FvsXw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.5.tgz",
+      "integrity": "sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-3.22.5.tgz",
+      "integrity": "sha512-OVJKiq67lU+RiC6slIhhgTJBlP/Vads6MZ7Ld5wxzCtWMdGKDuzQ1dgF7vrMEs7mhSeSH3phNcIdQ5ypYftZ9w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-3.22.5.tgz",
+      "integrity": "sha512-SfZeJSALtFODs0i3fml1TSi4vQ4Uopu0p/LndK+mX5FGNBtNmWiy7Wr5cH03ANfzj8c2EzfGIyH+F2/V0HLK9g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.5.tgz",
+      "integrity": "sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.5.tgz",
+      "integrity": "sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.5.tgz",
+      "integrity": "sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/markdown": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.22.5.tgz",
+      "integrity": "sha512-lLuAySaY5EYNYLe7e4507B9yQMAEDJdOKy0g85UNFV8giorYLQx56aV2O94Qb9gv3egs5inkwVRNfeJzOWAwig==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^17.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.5.tgz",
+      "integrity": "sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.5.tgz",
+      "integrity": "sha512-36WHEs+vPmB//V1ff7Ujcnpz7Ey5g8lhpI/0+hoanSbdiPMTQ7qZVWwMovIkMKDlqWVp2fxBgeYM1861jyFzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.5",
+        "@tiptap/extension-floating-menu": "^3.22.5"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.5.tgz",
+      "integrity": "sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.5",
+        "@tiptap/extension-blockquote": "^3.22.5",
+        "@tiptap/extension-bold": "^3.22.5",
+        "@tiptap/extension-bullet-list": "^3.22.5",
+        "@tiptap/extension-code": "^3.22.5",
+        "@tiptap/extension-code-block": "^3.22.5",
+        "@tiptap/extension-document": "^3.22.5",
+        "@tiptap/extension-dropcursor": "^3.22.5",
+        "@tiptap/extension-gapcursor": "^3.22.5",
+        "@tiptap/extension-hard-break": "^3.22.5",
+        "@tiptap/extension-heading": "^3.22.5",
+        "@tiptap/extension-horizontal-rule": "^3.22.5",
+        "@tiptap/extension-italic": "^3.22.5",
+        "@tiptap/extension-link": "^3.22.5",
+        "@tiptap/extension-list": "^3.22.5",
+        "@tiptap/extension-list-item": "^3.22.5",
+        "@tiptap/extension-list-keymap": "^3.22.5",
+        "@tiptap/extension-ordered-list": "^3.22.5",
+        "@tiptap/extension-paragraph": "^3.22.5",
+        "@tiptap/extension-strike": "^3.22.5",
+        "@tiptap/extension-text": "^3.22.5",
+        "@tiptap/extension-underline": "^3.22.5",
+        "@tiptap/extensions": "^3.22.5",
+        "@tiptap/pm": "^3.22.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.22.5.tgz",
+      "integrity": "sha512-Uv79Ht/o4mx1GWIT65jeQTE67LMrA+K7d8p51XOe9PJw0H0fS3iCdeMJ8tAo3h6QrMJFejdsB7z8jJL9UbAnhA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/y-tiptap": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.3.tgz",
+      "integrity": "sha512-8UvuV4lTisCE9cMTc/X8kRyTn9edUO7Kball0I6wb17VwZSjNDfh/YKtP4O5vcPawEzFHQIvZGq/k1h37kAf0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.100"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@holaboss/editor",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Tiptap-based block editor for holaOS. v0 ships a Markdown editor for .md files; future versions add Notion-style blocks and embedded databases.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@tiptap/core": "^3.0.0",
+    "@tiptap/extension-bubble-menu": "^3.22.5",
+    "@tiptap/extension-code-block-lowlight": "^3.22.5",
+    "@tiptap/extension-collaboration": "^3.22.5",
+    "@tiptap/extension-drag-handle": "^3.22.5",
+    "@tiptap/extension-drag-handle-react": "^3.22.5",
+    "@tiptap/extension-node-range": "^3.22.5",
+    "@tiptap/extension-placeholder": "^3.0.0",
+    "@tiptap/extension-task-item": "^3.0.0",
+    "@tiptap/extension-task-list": "^3.0.0",
+    "@tiptap/markdown": "^3.0.0",
+    "@tiptap/pm": "^3.0.0",
+    "@tiptap/react": "^3.0.0",
+    "@tiptap/starter-kit": "^3.0.0",
+    "@tiptap/suggestion": "^3.0.0",
+    "@tiptap/y-tiptap": "^3.0.0",
+    "lowlight": "^3.3.0",
+    "tippy.js": "^6.3.7",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/editor/src/MarkdownEditor.tsx
+++ b/packages/editor/src/MarkdownEditor.tsx
@@ -1,0 +1,234 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Editor, EditorContent, ReactNodeViewRenderer, useEditor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import TaskList from "@tiptap/extension-task-list";
+import TaskItem from "@tiptap/extension-task-item";
+import { Markdown } from "@tiptap/markdown";
+import { DragHandle } from "@tiptap/extension-drag-handle-react";
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import { createLowlight, common } from "lowlight";
+import type { Node } from "@tiptap/pm/model";
+
+import { SlashCommand } from "./extensions/SlashCommand";
+import { BubbleToolbar } from "./extensions/BubbleToolbar";
+import { DragHandleColumn } from "./extensions/DragHandleColumn";
+import { CodeBlockView } from "./extensions/CodeBlockView";
+
+// Highlight common languages out of the box. `common` covers ~37 languages
+// (js/ts/python/rust/go/sql/json/html/css/bash/md/etc.) at ~70KB. If size
+// matters later we can swap to a hand-picked subset.
+const lowlight = createLowlight(common);
+
+export interface MarkdownEditorProps {
+  /** The markdown source. Treated as the controlled value. */
+  value: string;
+  /** Called with the updated markdown after each transaction. */
+  onChange?: (markdown: string) => void;
+  /** Placeholder shown when the document is empty. */
+  placeholder?: string;
+  /** Read-only mode (no edits accepted). */
+  readOnly?: boolean;
+  /** Autofocus on mount. */
+  autoFocus?: boolean;
+  /** Extra class on the outer wrapper. Inner ProseMirror surface gets a fixed class for styling. */
+  className?: string;
+  /** Notified once when the editor instance is created. Useful for parent toolbars. */
+  onReady?: (editor: Editor) => void;
+}
+
+export interface MarkdownEditorRef {
+  /** Returns the current markdown source. */
+  getMarkdown: () => string;
+  /** Replaces the document with new markdown. */
+  setMarkdown: (markdown: string) => void;
+  /** Underlying Tiptap editor (escape hatch for advanced consumers). */
+  editor: Editor | null;
+  /** Move focus into the editor. */
+  focus: () => void;
+}
+
+// Tiptap-managed Markdown editor.
+//
+// v0 scope (matches design doc Phase 0): paragraph, headings, lists, code
+// blocks, blockquote, hr, hard break, links, basic marks. Slash menu / drag
+// handle / custom blocks land in Phase 1.
+//
+// Markdown round-trip uses the official @tiptap/markdown v3 extension:
+//   - parse:     editor.commands.setContent(md, { contentType: 'markdown' })
+//   - serialize: editor.getMarkdown()
+export const MarkdownEditor = forwardRef<
+  MarkdownEditorRef,
+  MarkdownEditorProps
+>(function MarkdownEditor(
+  { value, onChange, placeholder, readOnly = false, autoFocus, className, onReady },
+  ref,
+) {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const extensions = useMemo(
+    () => [
+      StarterKit.configure({
+        // Disable StarterKit's plain code block — we replace it with the
+        // lowlight-powered version below for syntax highlighting.
+        codeBlock: false,
+        heading: { levels: [1, 2, 3] },
+        link: {
+          openOnClick: false,
+          autolink: true,
+          HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
+        },
+      }),
+      CodeBlockLowlight.extend({
+        addNodeView() {
+          return ReactNodeViewRenderer(CodeBlockView);
+        },
+      }).configure({
+        lowlight,
+        defaultLanguage: null,
+        HTMLAttributes: { class: "hb-md-code" },
+      }),
+      Placeholder.configure({
+        placeholder: ({ editor, node }) => {
+          // Show a "press / for commands" hint on empty paragraphs to teach
+          // the slash menu without needing a separate onboarding step.
+          if (node.type.name === "paragraph" && editor.isFocused) {
+            return "Press / for commands…";
+          }
+          return placeholder ?? "Start writing…";
+        },
+        showOnlyCurrent: true,
+        emptyEditorClass: "hb-md-empty",
+      }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Markdown,
+      SlashCommand,
+    ],
+    [placeholder],
+  );
+
+  const editor = useEditor({
+    extensions,
+    content: value,
+    contentType: "markdown",
+    editable: !readOnly,
+    autofocus: autoFocus ?? false,
+    onUpdate({ editor }) {
+      onChangeRef.current?.(editor.getMarkdown());
+    },
+  });
+
+  // Notify parent once the editor is ready.
+  const readyFiredRef = useRef(false);
+  useEffect(() => {
+    if (editor && !readyFiredRef.current) {
+      readyFiredRef.current = true;
+      onReady?.(editor);
+    }
+  }, [editor, onReady]);
+
+  // Reflect external value changes without overwriting in-flight edits.
+  // We compare against the editor's current markdown to avoid an update cycle.
+  useEffect(() => {
+    if (!editor) return;
+    const current = editor.getMarkdown();
+    if (current === value) return;
+    const wasFocused = editor.isFocused;
+    editor.commands.setContent(value, {
+      contentType: "markdown",
+      emitUpdate: false,
+    });
+    if (wasFocused) editor.commands.focus("end");
+  }, [editor, value]);
+
+  // Reflect read-only flag changes.
+  useEffect(() => {
+    if (!editor) return;
+    if (editor.isEditable === !readOnly) return;
+    editor.setEditable(!readOnly);
+  }, [editor, readOnly]);
+
+  useImperativeHandle(
+    ref,
+    (): MarkdownEditorRef => ({
+      getMarkdown: () => (editor ? editor.getMarkdown() : value),
+      setMarkdown: (md: string) => {
+        editor?.commands.setContent(md, {
+          contentType: "markdown",
+          emitUpdate: true,
+        });
+      },
+      get editor() {
+        return editor ?? null;
+      },
+      focus: () => editor?.commands.focus(),
+    }),
+    [editor, value],
+  );
+
+  // Track the currently-hovered node so the drag-handle column can know
+  // what "+" should insert next to. Tiptap's DragHandle gives us this via
+  // its onNodeChange callback.
+  const [activeNode, setActiveNode] = useState<{ node: Node | null; pos: number }>({
+    node: null,
+    pos: 0,
+  });
+
+  return (
+    <div className={`hb-md-editor ${className ?? ""}`.trim()}>
+      {editor && !readOnly ? (
+        <DragHandle
+          editor={editor}
+          className="hb-drag-handle"
+          onNodeChange={({ node, pos }) => setActiveNode({ node, pos })}
+        >
+          <DragHandleColumn editor={editor} node={activeNode.node} pos={activeNode.pos} />
+        </DragHandle>
+      ) : null}
+      {editor ? (
+        <BubbleMenu
+          editor={editor}
+          // Mount the bubble into document.body so the parent's overflow:auto
+          // doesn't clip it. Critical — without this, the bubble renders
+          // but sits inside .hb-md-editor__content and gets clipped.
+          appendTo={() => document.body}
+          // Use the plugin's built-in shouldShow:
+          //   - editor focused
+          //   - selection non-empty
+          //   - selection contains text (not just an empty block)
+          //   - editor is editable
+          // We additionally hide inside code blocks where marks are noise.
+          shouldShow={({ editor, view, state, from, to }) => {
+            if (!view.hasFocus()) return false;
+            if (state.selection.empty) return false;
+            if (editor.isActive("codeBlock")) return false;
+            const hasText = state.doc.textBetween(from, to).length > 0;
+            return hasText;
+          }}
+          // Reduce the default 250ms debounce — Notion-feel needs <100ms.
+          updateDelay={50}
+          options={{
+            placement: "top",
+            offset: 8,
+            flip: true,
+            shift: { padding: 8 },
+          }}
+          data-hb-bubble-root=""
+        >
+          <BubbleToolbar editor={editor} />
+        </BubbleMenu>
+      ) : null}
+      <EditorContent editor={editor} className="hb-md-editor__content" />
+    </div>
+  );
+});

--- a/packages/editor/src/extensions/BlockMenu.tsx
+++ b/packages/editor/src/extensions/BlockMenu.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { Editor } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
+
+import {
+  IconChevronDown,
+  IconCopy,
+  IconTrash,
+} from "../icons";
+import { TURN_INTO_OPTIONS } from "./blockTypes";
+
+export interface BlockMenuProps {
+  editor: Editor;
+  /** The currently-targeted block (set by drag handle's onNodeChange). */
+  node: PMNode | null;
+  /** Position of that block in the document. */
+  pos: number;
+  /** Anchor element — menu pops below this. Usually the grip button. */
+  anchor: HTMLElement | null;
+  /** Whether the menu is open. Parent controls. */
+  open: boolean;
+  /** Called when the menu wants to close. */
+  onClose: () => void;
+}
+
+// Menu shown when the user clicks the drag handle "grip" on a block.
+// Notion-style actions: Turn into → submenu, Duplicate, Delete.
+//
+// Rendered into document.body via portal so popover overflow / z-index
+// behaves cleanly. Position is computed against the anchor element's rect.
+export function BlockMenu({
+  editor,
+  node,
+  pos,
+  anchor,
+  open,
+  onClose,
+}: BlockMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [turnIntoOpen, setTurnIntoOpen] = useState(false);
+
+  // Position the menu under the anchor.
+  useLayoutEffect(() => {
+    if (!open || !anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setMenuPos({ top: rect.bottom + 6, left: rect.left });
+  }, [open, anchor]);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (menuRef.current?.contains(target)) return;
+      if (anchor?.contains(target)) return;
+      onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, anchor, onClose]);
+
+  // Reset submenu state whenever the menu reopens.
+  useEffect(() => {
+    if (!open) setTurnIntoOpen(false);
+  }, [open]);
+
+  if (!open) return null;
+
+  const close = () => {
+    onClose();
+    setTurnIntoOpen(false);
+  };
+
+  const onDuplicate = () => {
+    if (!node) return;
+    const insertAt = pos + node.nodeSize;
+    editor.chain().focus().insertContentAt(insertAt, node.toJSON()).run();
+    close();
+  };
+
+  const onDelete = () => {
+    if (!node) return;
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: pos, to: pos + node.nodeSize })
+      .run();
+    close();
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="hb-block-menu"
+      style={{ top: menuPos.top, left: menuPos.left }}
+      role="menu"
+    >
+      {/* Turn-into row with submenu */}
+      <div className="hb-block-menu__turn">
+        <button
+          type="button"
+          className="hb-block-menu__item"
+          onMouseEnter={() => setTurnIntoOpen(true)}
+          onClick={() => setTurnIntoOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={turnIntoOpen}
+        >
+          <span className="hb-block-menu__item-label">Turn into</span>
+          <IconChevronDown className="hb-block-menu__chevron" />
+        </button>
+        {turnIntoOpen ? (
+          <div role="menu" className="hb-block-menu__submenu">
+            {TURN_INTO_OPTIONS.map((opt) => {
+              const Icon = opt.icon;
+              const active = opt.isActive(editor);
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="menuitem"
+                  data-active={active || undefined}
+                  className="hb-block-menu__subitem"
+                  onClick={() => {
+                    opt.apply(editor);
+                    close();
+                  }}
+                >
+                  <Icon className="hb-block-menu__subicon" />
+                  <span>{opt.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="hb-block-menu__divider" role="separator" />
+
+      <button
+        type="button"
+        className="hb-block-menu__item"
+        onMouseEnter={() => setTurnIntoOpen(false)}
+        onClick={onDuplicate}
+      >
+        <IconCopy className="hb-block-menu__item-icon" aria-hidden />
+        <span className="hb-block-menu__item-label">Duplicate</span>
+        <span className="hb-block-menu__shortcut">⌘D</span>
+      </button>
+
+      <button
+        type="button"
+        className="hb-block-menu__item hb-block-menu__item--danger"
+        onMouseEnter={() => setTurnIntoOpen(false)}
+        onClick={onDelete}
+      >
+        <IconTrash className="hb-block-menu__item-icon" aria-hidden />
+        <span className="hb-block-menu__item-label">Delete</span>
+        <span className="hb-block-menu__shortcut">Del</span>
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/editor/src/extensions/BubbleToolbar.tsx
+++ b/packages/editor/src/extensions/BubbleToolbar.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import type { Editor } from "@tiptap/core";
+
+import {
+  IconBold,
+  IconCode,
+  IconItalic,
+  IconLink,
+  IconStrike,
+  IconUnderline,
+  IconChevronDown,
+} from "../icons";
+import { TURN_INTO_OPTIONS, currentTurnIntoLabel } from "./blockTypes";
+
+interface BubbleToolbarProps {
+  editor: Editor;
+}
+
+interface MarkButton {
+  id: string;
+  label: string;
+  shortcut: string;
+  icon: typeof IconBold;
+  isActive: (e: Editor) => boolean;
+  toggle: (e: Editor) => void;
+  enabled?: (e: Editor) => boolean;
+}
+
+const MARK_BUTTONS: MarkButton[] = [
+  {
+    id: "bold",
+    label: "Bold",
+    shortcut: "⌘B",
+    icon: IconBold,
+    isActive: (e) => e.isActive("bold"),
+    toggle: (e) => e.chain().focus().toggleBold().run(),
+  },
+  {
+    id: "italic",
+    label: "Italic",
+    shortcut: "⌘I",
+    icon: IconItalic,
+    isActive: (e) => e.isActive("italic"),
+    toggle: (e) => e.chain().focus().toggleItalic().run(),
+  },
+  {
+    id: "underline",
+    label: "Underline",
+    shortcut: "⌘U",
+    icon: IconUnderline,
+    isActive: (e) => e.isActive("underline"),
+    toggle: (e) => e.chain().focus().toggleUnderline().run(),
+  },
+  {
+    id: "strike",
+    label: "Strikethrough",
+    shortcut: "⌘⇧X",
+    icon: IconStrike,
+    isActive: (e) => e.isActive("strike"),
+    toggle: (e) => e.chain().focus().toggleStrike().run(),
+  },
+  {
+    id: "code",
+    label: "Inline code",
+    shortcut: "⌘E",
+    icon: IconCode,
+    isActive: (e) => e.isActive("code"),
+    toggle: (e) => e.chain().focus().toggleCode().run(),
+  },
+];
+
+// Bubble toolbar shown when text is selected. Notion-style: a single dense
+// row of inline-mark buttons + a "Turn into" dropdown for changing the block
+// type without leaving the selection.
+export function BubbleToolbar({ editor }: BubbleToolbarProps) {
+  const [turnIntoOpen, setTurnIntoOpen] = useState(false);
+
+  const onLinkClick = () => {
+    const previous = editor.getAttributes("link").href as string | undefined;
+    const url = window.prompt("Link URL", previous ?? "");
+    if (url === null) return; // cancelled
+    if (url === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
+  };
+
+  return (
+    <div className="hb-bubble" role="toolbar">
+      {/* Turn-into dropdown */}
+      <div className="hb-bubble__turn">
+        <button
+          type="button"
+          className="hb-bubble__turn-trigger"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            setTurnIntoOpen((v) => !v);
+          }}
+          aria-haspopup="menu"
+          aria-expanded={turnIntoOpen}
+        >
+          <span className="hb-bubble__turn-label">{currentTurnIntoLabel(editor)}</span>
+          <IconChevronDown className="hb-bubble__chevron" />
+        </button>
+        {turnIntoOpen ? (
+          <div
+            role="menu"
+            className="hb-bubble__turn-menu"
+            onMouseLeave={() => setTurnIntoOpen(false)}
+          >
+            {TURN_INTO_OPTIONS.map((opt) => {
+              const Icon = opt.icon;
+              const active = opt.isActive(editor);
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="menuitem"
+                  data-active={active || undefined}
+                  className="hb-bubble__turn-item"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    opt.apply(editor);
+                    setTurnIntoOpen(false);
+                  }}
+                >
+                  <Icon className="hb-bubble__turn-icon" />
+                  <span>{opt.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+
+      <span className="hb-bubble__sep" aria-hidden="true" />
+
+      {/* Inline marks */}
+      {MARK_BUTTONS.map((b) => {
+        const Icon = b.icon;
+        const active = b.isActive(editor);
+        return (
+          <button
+            key={b.id}
+            type="button"
+            data-active={active || undefined}
+            className="hb-bubble__btn"
+            title={`${b.label} (${b.shortcut})`}
+            aria-label={b.label}
+            aria-pressed={active}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              b.toggle(editor);
+            }}
+          >
+            <Icon className="hb-bubble__icon" />
+          </button>
+        );
+      })}
+
+      <span className="hb-bubble__sep" aria-hidden="true" />
+
+      <button
+        type="button"
+        data-active={editor.isActive("link") || undefined}
+        className="hb-bubble__btn"
+        title="Link (⌘K)"
+        aria-label="Link"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onLinkClick();
+        }}
+      >
+        <IconLink className="hb-bubble__icon" />
+      </button>
+    </div>
+  );
+}

--- a/packages/editor/src/extensions/CodeBlockView.tsx
+++ b/packages/editor/src/extensions/CodeBlockView.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { NodeViewContent, NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+
+import { IconCheck, IconCopy } from "../icons";
+
+// React NodeView for fenced code blocks. Mirrors what Tiptap's default
+// `addNodeView` would render (`<pre><code>`) and adds:
+//   - language pill (read-only display in v0)
+//   - Copy button that lifts text out of the node, writes to clipboard,
+//     and flashes a "Copied" state for 1.2s
+export function CodeBlockView({ node }: NodeViewProps) {
+  const [copied, setCopied] = useState(false);
+  const language = (node.attrs.language as string | null) ?? null;
+
+  const onCopy = () => {
+    const text = node.textContent ?? "";
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
+  };
+
+  return (
+    <NodeViewWrapper as="pre" className="hb-md-code-wrap" data-language={language || undefined}>
+      <div className="hb-md-code__chrome" contentEditable={false}>
+        {language ? (
+          <span className="hb-md-code__lang" aria-label={`Language: ${language}`}>
+            {language}
+          </span>
+        ) : (
+          <span className="hb-md-code__lang hb-md-code__lang--muted">Plain</span>
+        )}
+        <button
+          type="button"
+          className="hb-md-code__copy"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onCopy}
+          aria-label="Copy code"
+          data-copied={copied || undefined}
+        >
+          {copied ? (
+            <>
+              <IconCheck className="hb-md-code__copy-icon" />
+              <span>Copied</span>
+            </>
+          ) : (
+            <>
+              <IconCopy className="hb-md-code__copy-icon" />
+              <span>Copy</span>
+            </>
+          )}
+        </button>
+      </div>
+      <NodeViewContent<"code"> as="code" className={language ? `language-${language}` : undefined} />
+    </NodeViewWrapper>
+  );
+}

--- a/packages/editor/src/extensions/DragHandleColumn.tsx
+++ b/packages/editor/src/extensions/DragHandleColumn.tsx
@@ -1,0 +1,100 @@
+import { useRef, useState } from "react";
+import type { Editor } from "@tiptap/core";
+import type { Node } from "@tiptap/pm/model";
+
+import { IconGrip, IconPlus } from "../icons";
+import { BlockMenu } from "./BlockMenu";
+
+interface DragHandleColumnProps {
+  editor: Editor;
+  /** Current hovered node, supplied by Tiptap's DragHandle via onNodeChange. */
+  node: Node | null;
+  /** Position of that node in the document. */
+  pos: number;
+}
+
+// Notion-style left-margin handle column. Three affordances:
+//   - "+" inserts a new empty paragraph after the current block
+//   - "::" with quick click → opens block menu (Turn into / Duplicate / Delete)
+//   - "::" with mousedown + drag → reorders block (Tiptap plugin handles)
+//
+// Click vs drag is distinguished by mouse movement: if the user moves the
+// pointer beyond a small threshold between mousedown and mouseup, treat as
+// drag (do nothing — Tiptap owns it). Otherwise treat as click and open
+// the menu.
+export function DragHandleColumn({ editor, node, pos }: DragHandleColumnProps) {
+  const [hovered, setHovered] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const gripRef = useRef<HTMLButtonElement | null>(null);
+  const downRef = useRef<{ x: number; y: number } | null>(null);
+
+  const onAddClick = () => {
+    if (!node) return;
+    const insertAt = pos + node.nodeSize;
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(insertAt, { type: "paragraph" })
+      .setTextSelection(insertAt + 1)
+      .run();
+  };
+
+  const onGripMouseDown = (e: React.MouseEvent) => {
+    // Record mousedown location. We don't preventDefault here because
+    // Tiptap's drag-handle plugin needs the native mousedown to start drag.
+    downRef.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const onGripMouseUp = (e: React.MouseEvent) => {
+    const start = downRef.current;
+    downRef.current = null;
+    if (!start) return;
+    const dx = Math.abs(e.clientX - start.x);
+    const dy = Math.abs(e.clientY - start.y);
+    // 4px threshold — beyond this is a drag, ProseMirror handled it.
+    if (dx > 4 || dy > 4) return;
+    setMenuOpen((v) => !v);
+  };
+
+  return (
+    <>
+      <div
+        className="hb-drag-col"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        data-hovered={hovered || menuOpen || undefined}
+      >
+        <button
+          type="button"
+          className="hb-drag-col__btn"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onAddClick}
+          aria-label="Add block below"
+          title="Add block below"
+        >
+          <IconPlus className="hb-drag-col__icon" />
+        </button>
+        <button
+          ref={gripRef}
+          type="button"
+          className="hb-drag-col__btn hb-drag-col__btn--grip"
+          onMouseDown={onGripMouseDown}
+          onMouseUp={onGripMouseUp}
+          aria-label="Open block menu, drag to reorder"
+          title="Click for menu • drag to move"
+        >
+          <IconGrip className="hb-drag-col__icon" />
+        </button>
+      </div>
+
+      <BlockMenu
+        editor={editor}
+        node={node}
+        pos={pos}
+        anchor={gripRef.current}
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+      />
+    </>
+  );
+}

--- a/packages/editor/src/extensions/SlashCommand.ts
+++ b/packages/editor/src/extensions/SlashCommand.ts
@@ -1,0 +1,124 @@
+import { Extension, type Range } from "@tiptap/core";
+import { ReactRenderer } from "@tiptap/react";
+import Suggestion, {
+  type SuggestionOptions,
+  type SuggestionProps,
+  type SuggestionKeyDownProps,
+} from "@tiptap/suggestion";
+import tippy, { type Instance as TippyInstance } from "tippy.js";
+
+import {
+  defaultSlashItems,
+  filterSlashItems,
+  SlashMenuList,
+  type SlashItem,
+  type SlashMenuListHandle,
+} from "./SlashMenuList";
+
+interface SlashCommandOptions {
+  suggestion: Omit<SuggestionOptions<SlashItem>, "editor">;
+}
+
+// Slash-command extension. Triggers on `/`, opens a tippy popup with the
+// SlashMenuList component, hands keyboard control to the list, and runs the
+// chosen item's command on the editor.
+export const SlashCommand = Extension.create<SlashCommandOptions>({
+  name: "slashCommand",
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: "/",
+        startOfLine: false,
+        // Allow `/` mid-word so the menu still triggers if the user is in the
+        // middle of editing a paragraph; can revisit if it gets noisy.
+        allowSpaces: false,
+        items: ({ query }: { query: string }) =>
+          filterSlashItems(defaultSlashItems(), query).slice(0, 10),
+        command: ({ editor, range, props }) => {
+          (props as SlashItem).command({ editor, range });
+        },
+        render: () => {
+          let component: ReactRenderer<SlashMenuListHandle> | null = null;
+          let popup: TippyInstance[] | null = null;
+
+          return {
+            onStart(props: SuggestionProps<SlashItem>) {
+              component = new ReactRenderer(SlashMenuList, {
+                props: {
+                  items: props.items,
+                  command: (item: SlashItem) => props.command(item),
+                  editor: props.editor,
+                  range: props.range,
+                },
+                editor: props.editor,
+              });
+
+              if (!props.clientRect) return;
+
+              popup = tippy("body", {
+                getReferenceClientRect: () => {
+                  const rect = props.clientRect?.();
+                  return rect ?? new DOMRect();
+                },
+                appendTo: () => document.body,
+                content: component.element,
+                showOnCreate: true,
+                interactive: true,
+                trigger: "manual",
+                placement: "bottom-start",
+                maxWidth: "none",
+                offset: [0, 6],
+                animation: false,
+                theme: "hb-slash",
+              });
+            },
+
+            onUpdate(props: SuggestionProps<SlashItem>) {
+              component?.updateProps({
+                items: props.items,
+                command: (item: SlashItem) => props.command(item),
+                editor: props.editor,
+                range: props.range,
+              });
+
+              if (!props.clientRect || !popup) return;
+              popup[0]?.setProps({
+                getReferenceClientRect: () => {
+                  const rect = props.clientRect?.();
+                  return rect ?? new DOMRect();
+                },
+              });
+            },
+
+            onKeyDown(props: SuggestionKeyDownProps) {
+              if (props.event.key === "Escape") {
+                popup?.[0]?.hide();
+                return true;
+              }
+              return component?.ref?.onKeyDown(props.event) ?? false;
+            },
+
+            onExit() {
+              popup?.[0]?.destroy();
+              component?.destroy();
+              popup = null;
+              component = null;
+            },
+          };
+        },
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+
+export type { SlashItem, Range };

--- a/packages/editor/src/extensions/SlashMenuList.tsx
+++ b/packages/editor/src/extensions/SlashMenuList.tsx
@@ -1,0 +1,306 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Editor, Range } from "@tiptap/core";
+import type { ComponentType, SVGProps } from "react";
+
+import {
+  IconCodeBlock,
+  IconDivider,
+  IconHeading1,
+  IconHeading2,
+  IconHeading3,
+  IconList,
+  IconListChecks,
+  IconListOrdered,
+  IconQuote,
+  IconText,
+} from "../icons";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface SlashItem {
+  /** Stable id, used as React key. */
+  id: string;
+  /** Section the item belongs to. Items with the same `section` are grouped. */
+  section: string;
+  /** Title shown to the user. */
+  title: string;
+  /** Optional second line. */
+  subtitle?: string;
+  /** Search-only synonyms (lowercase). */
+  keywords?: string[];
+  /** Visual icon, drawn at the left of the item. */
+  icon: IconComponent;
+  /** Optional keyboard shortcut hint shown at the right. */
+  shortcut?: string;
+  /** Action invoked when this item is selected. */
+  command: (ctx: { editor: Editor; range: Range }) => void;
+}
+
+export interface SlashMenuListProps {
+  items: SlashItem[];
+  command: (item: SlashItem) => void;
+  /** Provided by Tiptap's Suggestion plugin so we can call commands directly. */
+  editor: Editor;
+  /** The matched range for the slash query — passed through if the command needs it. */
+  range: Range;
+}
+
+export interface SlashMenuListHandle {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+// Keyboard-driven list, rendered inside a tippy popup. Notion-style:
+// section headers, icons, two-line items, keyboard hints, mouse hover sync.
+export const SlashMenuList = forwardRef<SlashMenuListHandle, SlashMenuListProps>(
+  function SlashMenuList({ items, command }, ref) {
+    const [activeIndex, setActiveIndex] = useState(0);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+    // Group items by section while keeping their original order.
+    const groups = useMemo(() => {
+      const out: Array<{ section: string; items: SlashItem[] }> = [];
+      for (const it of items) {
+        const last = out[out.length - 1];
+        if (last && last.section === it.section) last.items.push(it);
+        else out.push({ section: it.section, items: [it] });
+      }
+      return out;
+    }, [items]);
+
+    // Reset selection when the candidate list changes (user kept typing).
+    useEffect(() => {
+      setActiveIndex(0);
+    }, [items]);
+
+    // Keep the active item visible inside the scroll container.
+    useLayoutEffect(() => {
+      const el = itemRefs.current[activeIndex];
+      el?.scrollIntoView({ block: "nearest" });
+    }, [activeIndex]);
+
+    const select = (index: number) => {
+      const item = items[index];
+      if (!item) return;
+      command(item);
+    };
+
+    useImperativeHandle(
+      ref,
+      (): SlashMenuListHandle => ({
+        onKeyDown: (event) => {
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setActiveIndex((i) => (i + items.length - 1) % Math.max(items.length, 1));
+            return true;
+          }
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setActiveIndex((i) => (i + 1) % Math.max(items.length, 1));
+            return true;
+          }
+          if (event.key === "Enter" || event.key === "Tab") {
+            event.preventDefault();
+            select(activeIndex);
+            return true;
+          }
+          return false;
+        },
+      }),
+      [activeIndex, items],
+    );
+
+    if (items.length === 0) {
+      return (
+        <div ref={containerRef} className="hb-slash hb-slash--empty">
+          <div className="hb-slash__empty-title">No matches</div>
+          <div className="hb-slash__empty-hint">Try a different word.</div>
+        </div>
+      );
+    }
+
+    let runningIndex = 0;
+    return (
+      <div ref={containerRef} className="hb-slash" role="listbox">
+        {groups.map((group) => (
+          <div key={group.section} className="hb-slash__group">
+            <div className="hb-slash__section">{group.section}</div>
+            {group.items.map((item) => {
+              const index = runningIndex++;
+              const Icon = item.icon;
+              const active = index === activeIndex;
+              return (
+                <button
+                  key={item.id}
+                  ref={(el) => {
+                    itemRefs.current[index] = el;
+                  }}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  data-active={active || undefined}
+                  className="hb-slash__item"
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    select(index);
+                  }}
+                >
+                  <span className="hb-slash__icon-wrap" aria-hidden="true">
+                    <Icon className="hb-slash__icon" />
+                  </span>
+                  <span className="hb-slash__body">
+                    <span className="hb-slash__title">{item.title}</span>
+                    {item.subtitle ? (
+                      <span className="hb-slash__subtitle">{item.subtitle}</span>
+                    ) : null}
+                  </span>
+                  {item.shortcut ? (
+                    <span className="hb-slash__shortcut">{item.shortcut}</span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    );
+  },
+);
+
+// Default command catalogue. Order matters — items appear in this order
+// within their section. Sections render in the order their first item
+// appears here.
+export function defaultSlashItems(): SlashItem[] {
+  return [
+    {
+      id: "paragraph",
+      section: "Basic blocks",
+      title: "Text",
+      subtitle: "Plain paragraph",
+      keywords: ["text", "paragraph", "p"],
+      icon: IconText,
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setNode("paragraph").run(),
+    },
+    {
+      id: "heading-1",
+      section: "Basic blocks",
+      title: "Heading 1",
+      subtitle: "Large section heading",
+      keywords: ["h1", "title", "#"],
+      icon: IconHeading1,
+      shortcut: "#",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setNode("heading", { level: 1 }).run(),
+    },
+    {
+      id: "heading-2",
+      section: "Basic blocks",
+      title: "Heading 2",
+      subtitle: "Medium section heading",
+      keywords: ["h2", "##"],
+      icon: IconHeading2,
+      shortcut: "##",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setNode("heading", { level: 2 }).run(),
+    },
+    {
+      id: "heading-3",
+      section: "Basic blocks",
+      title: "Heading 3",
+      subtitle: "Small section heading",
+      keywords: ["h3", "###"],
+      icon: IconHeading3,
+      shortcut: "###",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setNode("heading", { level: 3 }).run(),
+    },
+    {
+      id: "bulleted-list",
+      section: "Lists",
+      title: "Bulleted list",
+      subtitle: "Simple bulleted list",
+      keywords: ["ul", "list", "unordered"],
+      icon: IconList,
+      shortcut: "-",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+    },
+    {
+      id: "numbered-list",
+      section: "Lists",
+      title: "Numbered list",
+      subtitle: "Ordered list",
+      keywords: ["ol", "ordered", "1."],
+      icon: IconListOrdered,
+      shortcut: "1.",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+    },
+    {
+      id: "todo-list",
+      section: "Lists",
+      title: "To-do list",
+      subtitle: "Track tasks with checkboxes",
+      keywords: ["task", "checkbox", "todo", "[]"],
+      icon: IconListChecks,
+      shortcut: "[ ]",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).toggleTaskList().run(),
+    },
+    {
+      id: "quote",
+      section: "Other",
+      title: "Quote",
+      subtitle: "Capture a quotation",
+      keywords: ["blockquote", ">"],
+      icon: IconQuote,
+      shortcut: ">",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setNode("paragraph").toggleBlockquote().run(),
+    },
+    {
+      id: "code-block",
+      section: "Other",
+      title: "Code block",
+      subtitle: "Fenced code with syntax",
+      keywords: ["code", "```", "snippet"],
+      icon: IconCodeBlock,
+      shortcut: "```",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+    },
+    {
+      id: "divider",
+      section: "Other",
+      title: "Divider",
+      subtitle: "Horizontal rule",
+      keywords: ["hr", "rule", "line", "---"],
+      icon: IconDivider,
+      shortcut: "---",
+      command: ({ editor, range }) =>
+        editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+    },
+  ];
+}
+
+// Filters by title + keywords, case-insensitive. Empty query returns the full
+// catalogue so the menu shows up immediately on `/`.
+export function filterSlashItems(items: SlashItem[], query: string): SlashItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+  return items.filter((item) => {
+    if (item.title.toLowerCase().includes(q)) return true;
+    if (item.keywords?.some((k) => k.toLowerCase().includes(q))) return true;
+    return false;
+  });
+}

--- a/packages/editor/src/extensions/blockTypes.ts
+++ b/packages/editor/src/extensions/blockTypes.ts
@@ -1,0 +1,96 @@
+import type { Editor } from "@tiptap/core";
+import type { ComponentType, SVGProps } from "react";
+
+import {
+  IconHeading1,
+  IconHeading2,
+  IconHeading3,
+  IconList,
+  IconListChecks,
+  IconListOrdered,
+  IconQuote,
+  IconText,
+} from "../icons";
+
+export type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface TurnIntoOption {
+  id: string;
+  label: string;
+  icon: IconComponent;
+  isActive: (e: Editor) => boolean;
+  apply: (e: Editor) => void;
+}
+
+// Shared catalogue of "turn into" block-type conversions, used by both the
+// bubble toolbar (selection-driven) and the block menu (drag-handle click).
+export const TURN_INTO_OPTIONS: TurnIntoOption[] = [
+  {
+    id: "paragraph",
+    label: "Text",
+    icon: IconText,
+    isActive: (e) =>
+      e.isActive("paragraph") &&
+      !e.isActive("heading") &&
+      !e.isActive("bulletList") &&
+      !e.isActive("orderedList") &&
+      !e.isActive("taskList") &&
+      !e.isActive("blockquote") &&
+      !e.isActive("codeBlock"),
+    apply: (e) => e.chain().focus().setNode("paragraph").run(),
+  },
+  {
+    id: "h1",
+    label: "Heading 1",
+    icon: IconHeading1,
+    isActive: (e) => e.isActive("heading", { level: 1 }),
+    apply: (e) => e.chain().focus().setNode("heading", { level: 1 }).run(),
+  },
+  {
+    id: "h2",
+    label: "Heading 2",
+    icon: IconHeading2,
+    isActive: (e) => e.isActive("heading", { level: 2 }),
+    apply: (e) => e.chain().focus().setNode("heading", { level: 2 }).run(),
+  },
+  {
+    id: "h3",
+    label: "Heading 3",
+    icon: IconHeading3,
+    isActive: (e) => e.isActive("heading", { level: 3 }),
+    apply: (e) => e.chain().focus().setNode("heading", { level: 3 }).run(),
+  },
+  {
+    id: "bullet-list",
+    label: "Bulleted list",
+    icon: IconList,
+    isActive: (e) => e.isActive("bulletList"),
+    apply: (e) => e.chain().focus().toggleBulletList().run(),
+  },
+  {
+    id: "ordered-list",
+    label: "Numbered list",
+    icon: IconListOrdered,
+    isActive: (e) => e.isActive("orderedList"),
+    apply: (e) => e.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    id: "task-list",
+    label: "To-do list",
+    icon: IconListChecks,
+    isActive: (e) => e.isActive("taskList"),
+    apply: (e) => e.chain().focus().toggleTaskList().run(),
+  },
+  {
+    id: "quote",
+    label: "Quote",
+    icon: IconQuote,
+    isActive: (e) => e.isActive("blockquote"),
+    apply: (e) => e.chain().focus().toggleBlockquote().run(),
+  },
+];
+
+export const currentTurnIntoLabel = (editor: Editor): string => {
+  const match = TURN_INTO_OPTIONS.find((o) => o.isActive(editor));
+  return match?.label ?? "Text";
+};

--- a/packages/editor/src/icons.tsx
+++ b/packages/editor/src/icons.tsx
@@ -1,0 +1,199 @@
+// Inline SVG icons (lucide-style, 24x24 viewBox, currentColor stroke).
+// Kept in this package so consumers don't need to wire an icon set.
+// Sized through the parent's `font-size` via `1em` width/height.
+
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+const base = (extra?: Partial<SVGProps<SVGSVGElement>>): SVGProps<SVGSVGElement> => ({
+  width: "1em",
+  height: "1em",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+  ...extra,
+});
+
+export const IconBold = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M6 4h8a4 4 0 0 1 0 8H6z" />
+    <path d="M6 12h9a4 4 0 0 1 0 8H6z" />
+  </svg>
+);
+
+export const IconItalic = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <line x1="19" y1="4" x2="10" y2="4" />
+    <line x1="14" y1="20" x2="5" y2="20" />
+    <line x1="15" y1="4" x2="9" y2="20" />
+  </svg>
+);
+
+export const IconUnderline = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M6 4v6a6 6 0 0 0 12 0V4" />
+    <line x1="4" y1="20" x2="20" y2="20" />
+  </svg>
+);
+
+export const IconStrike = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M16 4H9a3 3 0 0 0-2.83 4" />
+    <path d="M14 12a4 4 0 0 1 0 8H6" />
+    <line x1="4" y1="12" x2="20" y2="12" />
+  </svg>
+);
+
+export const IconCode = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+export const IconLink = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
+
+export const IconText = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <polyline points="4 7 4 4 20 4 20 7" />
+    <line x1="9" y1="20" x2="15" y2="20" />
+    <line x1="12" y1="4" x2="12" y2="20" />
+  </svg>
+);
+
+export const IconHeading1 = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M4 12h8" />
+    <path d="M4 18V6" />
+    <path d="M12 18V6" />
+    <path d="M17 12l3-2v8" />
+  </svg>
+);
+
+export const IconHeading2 = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M4 12h8" />
+    <path d="M4 18V6" />
+    <path d="M12 18V6" />
+    <path d="M21 18h-4c0-4 4-3 4-6 0-1.5-2-2.5-4-1" />
+  </svg>
+);
+
+export const IconHeading3 = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M4 12h8" />
+    <path d="M4 18V6" />
+    <path d="M12 18V6" />
+    <path d="M17.5 10.5c1.7-1 3.5 0 3.5 1.5a2 2 0 0 1-2 2" />
+    <path d="M17 17.5c2 1.5 4 .3 4-1.5a2 2 0 0 0-2-2" />
+  </svg>
+);
+
+export const IconList = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <line x1="8" y1="6" x2="21" y2="6" />
+    <line x1="8" y1="12" x2="21" y2="12" />
+    <line x1="8" y1="18" x2="21" y2="18" />
+    <line x1="3" y1="6" x2="3.01" y2="6" />
+    <line x1="3" y1="12" x2="3.01" y2="12" />
+    <line x1="3" y1="18" x2="3.01" y2="18" />
+  </svg>
+);
+
+export const IconListOrdered = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <line x1="10" y1="6" x2="21" y2="6" />
+    <line x1="10" y1="12" x2="21" y2="12" />
+    <line x1="10" y1="18" x2="21" y2="18" />
+    <path d="M4 6h1v4" />
+    <path d="M4 10h2" />
+    <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
+  </svg>
+);
+
+export const IconListChecks = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="m3 17 2 2 4-4" />
+    <path d="m3 7 2 2 4-4" />
+    <line x1="13" y1="6" x2="21" y2="6" />
+    <line x1="13" y1="12" x2="21" y2="12" />
+    <line x1="13" y1="18" x2="21" y2="18" />
+  </svg>
+);
+
+export const IconQuote = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z" />
+    <path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z" />
+  </svg>
+);
+
+export const IconCodeBlock = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <polyline points="10 10 7 13 10 16" />
+    <polyline points="14 10 17 13 14 16" />
+  </svg>
+);
+
+export const IconDivider = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <line x1="3" y1="12" x2="21" y2="12" />
+  </svg>
+);
+
+export const IconChevronDown = (p: IconProps) => (
+  <svg {...base({ strokeWidth: 2.5 })} {...p}>
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+export const IconPlus = (p: IconProps) => (
+  <svg {...base({ strokeWidth: 2.25 })} {...p}>
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+export const IconCopy = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <rect x="9" y="9" width="11" height="11" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+export const IconTrash = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <line x1="10" y1="11" x2="10" y2="17" />
+    <line x1="14" y1="11" x2="14" y2="17" />
+  </svg>
+);
+
+export const IconCheck = (p: IconProps) => (
+  <svg {...base({ strokeWidth: 2.5 })} {...p}>
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+export const IconGrip = (p: IconProps) => (
+  <svg {...base()} {...p}>
+    <circle cx="9" cy="6" r="1.25" />
+    <circle cx="9" cy="12" r="1.25" />
+    <circle cx="9" cy="18" r="1.25" />
+    <circle cx="15" cy="6" r="1.25" />
+    <circle cx="15" cy="12" r="1.25" />
+    <circle cx="15" cy="18" r="1.25" />
+  </svg>
+);

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,0 +1,5 @@
+export { MarkdownEditor } from "./MarkdownEditor";
+export type {
+  MarkdownEditorProps,
+  MarkdownEditorRef,
+} from "./MarkdownEditor";

--- a/packages/editor/src/markdown.ts
+++ b/packages/editor/src/markdown.ts
@@ -1,0 +1,12 @@
+// Markdown serialisation lives inside the live Tiptap editor:
+//   - parse:     editor.commands.setContent(markdown)  (with Markdown extension)
+//   - serialize: editor.storage.markdown.getMarkdown()
+//
+// We keep this file as a stub for future standalone helpers (e.g. server-side
+// rendering, agent-authored markdown without a live editor instance). When we
+// need them we'll instantiate a headless editor and pump markdown through it.
+//
+// Intentionally not exporting anything yet — keeps the package surface
+// honest to what's implemented.
+
+export {};

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -1,0 +1,985 @@
+/* @holaboss/editor — v0 styles
+ *
+ * Designed to inherit from the host's typography. The host's design tokens
+ * (--background, --foreground, --accent, --border, --muted-foreground)
+ * drive the chrome — we read them when present and fall back to neutral
+ * values otherwise.
+ *
+ * All selectors are scoped to .hb-md-editor / .hb-bubble / .hb-slash. */
+
+:root {
+  --hb-radius: 0.5rem;
+  --hb-radius-sm: 0.375rem;
+  --hb-shadow-popup: 0 1px 2px rgba(0, 0, 0, 0.04),
+                     0 8px 24px -8px rgba(0, 0, 0, 0.18),
+                     0 12px 48px -12px rgba(0, 0, 0, 0.12);
+}
+
+/* Bridge to host design tokens. When the host (desktop) defines shadcn-style
+ * vars (`--popover`, `--accent`, `--border`, ...), pick them up; otherwise
+ * fall back to neutral defaults. Authors can override `--hb-*` directly to
+ * theme the editor without touching shadcn vars.
+ *
+ * Set on :root because bubble menu / slash menu render into document.body
+ * via tippy and are not descendants of .hb-md-editor. */
+:root {
+  --hb-popup-bg: var(--popover, #ffffff);
+  --hb-popup-fg: var(--popover-foreground, #0f172a);
+  --hb-popup-border: var(--border, rgba(15, 23, 42, 0.1));
+  --hb-popup-icon-bg: color-mix(in oklab, var(--foreground, #0f172a) 5%, transparent);
+  --hb-accent: var(--primary, #3b82f6);
+  --hb-on-accent: var(--primary-foreground, #ffffff);
+}
+
+/* ===== Editor surface ============================================== */
+
+.hb-md-editor {
+  position: relative;
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.hb-md-editor__content {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+.hb-md-editor .ProseMirror {
+  flex: 1 1 auto;
+  min-height: 0;
+  outline: none;
+  padding: 1.5rem 1.5rem 4rem;
+  font-size: 0.9375rem;       /* 15px */
+  line-height: 1.7;
+  color: inherit;
+  caret-color: currentColor;
+}
+
+.hb-md-editor .ProseMirror > * + * {
+  margin-top: 0.5em;
+}
+
+/* Subtle row-level hover. Only on direct children of ProseMirror so
+ * inline marks don't trigger it. The padding + negative margin keeps the
+ * highlight slightly wider than the text without shifting layout. */
+.hb-md-editor .ProseMirror > *:not(pre):not(hr) {
+  position: relative;
+  border-radius: 0.25rem;
+  padding: 1px 4px;
+  margin-left: -4px;
+  margin-right: -4px;
+  transition: background-color 80ms ease;
+}
+.hb-md-editor .ProseMirror > *:not(pre):not(hr):hover {
+  background: color-mix(in oklab, currentColor 3%, transparent);
+}
+
+.hb-md-editor .ProseMirror p {
+  margin: 0;
+}
+
+/* Headings — Notion uses tighter top margins, larger weight */
+.hb-md-editor .ProseMirror h1,
+.hb-md-editor .ProseMirror h2,
+.hb-md-editor .ProseMirror h3 {
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  margin-top: 1.6em;
+  margin-bottom: 0.15em;
+}
+.hb-md-editor .ProseMirror h1 {
+  font-size: 1.875rem;        /* 30px */
+  letter-spacing: -0.02em;
+  margin-top: 0.85em;
+}
+.hb-md-editor .ProseMirror h2 { font-size: 1.5rem; }      /* 24px */
+.hb-md-editor .ProseMirror h3 { font-size: 1.1875rem; }   /* 19px */
+
+/* Lists */
+.hb-md-editor .ProseMirror ul,
+.hb-md-editor .ProseMirror ol {
+  padding-left: 1.5em;
+  margin: 0;
+}
+.hb-md-editor .ProseMirror ul { list-style: disc; }
+.hb-md-editor .ProseMirror ol { list-style: decimal; }
+.hb-md-editor .ProseMirror li > p {
+  margin: 0.15em 0;
+}
+.hb-md-editor .ProseMirror li::marker {
+  color: color-mix(in oklab, currentColor 50%, transparent);
+}
+
+/* Inline marks */
+.hb-md-editor .ProseMirror code {
+  padding: 0.125em 0.375em;
+  border-radius: 0.3125rem;
+  background: color-mix(in oklab, currentColor 9%, transparent);
+  font-size: 0.86em;
+  font-family: ui-monospace, "Geist Mono", "SF Mono", "JetBrains Mono", monospace;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+.hb-md-editor .ProseMirror a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, currentColor 35%, transparent);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1.25px;
+  transition: text-decoration-color 120ms ease;
+}
+.hb-md-editor .ProseMirror a:hover {
+  text-decoration-color: currentColor;
+}
+
+/* Code blocks */
+.hb-md-editor .ProseMirror pre {
+  padding: 0.875rem 1rem;
+  border-radius: var(--hb-radius);
+  background: color-mix(in oklab, currentColor 6%, transparent);
+  border: 1px solid color-mix(in oklab, currentColor 8%, transparent);
+  overflow-x: auto;
+  font-size: 0.8125rem;       /* 13px */
+  line-height: 1.6;
+  margin: 0.75em 0;
+}
+.hb-md-editor .ProseMirror pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/* Blockquote */
+.hb-md-editor .ProseMirror blockquote {
+  margin: 0.5em 0;
+  padding: 0.125rem 0 0.125rem 1rem;
+  border-left: 3px solid color-mix(in oklab, currentColor 30%, transparent);
+  color: color-mix(in oklab, currentColor 78%, transparent);
+  font-style: normal;
+}
+.hb-md-editor .ProseMirror blockquote > * + * { margin-top: 0.25em; }
+
+/* Horizontal rule */
+.hb-md-editor .ProseMirror hr {
+  border: 0;
+  border-top: 1px solid color-mix(in oklab, currentColor 14%, transparent);
+  margin: 1.5em 0;
+}
+
+/* Placeholder (rendered by @tiptap/extension-placeholder) */
+.hb-md-editor .ProseMirror .is-empty:not(.hb-md-empty)::before {
+  content: attr(data-placeholder);
+  color: color-mix(in oklab, currentColor 35%, transparent);
+  pointer-events: none;
+  float: left;
+  height: 0;
+}
+.hb-md-editor .ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: color-mix(in oklab, currentColor 35%, transparent);
+  pointer-events: none;
+  float: left;
+  height: 0;
+}
+
+/* Selection */
+.hb-md-editor .ProseMirror ::selection {
+  background: color-mix(in oklab, var(--hb-accent, #3b82f6) 22%, transparent);
+}
+
+/* ===== Task list (to-do) =========================================== */
+
+.hb-md-editor .ProseMirror ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li {
+  display: flex;
+  gap: 0.5em;
+  align-items: flex-start;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > label {
+  user-select: none;
+  flex-shrink: 0;
+  margin-top: 0.32em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"] {
+  appearance: none;
+  width: 1em;
+  height: 1em;
+  border: 1.5px solid color-mix(in oklab, currentColor 35%, transparent);
+  border-radius: 0.25rem;
+  background: transparent;
+  cursor: pointer;
+  display: inline-grid;
+  place-content: center;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"]::before {
+  content: "";
+  width: 0.55em;
+  height: 0.32em;
+  border-left: 1.75px solid var(--hb-on-accent, #fff);
+  border-bottom: 1.75px solid var(--hb-on-accent, #fff);
+  transform: rotate(-45deg) translate(0.05em, -0.08em);
+  transform-origin: center;
+  opacity: 0;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"]:checked {
+  background: var(--hb-accent, #3b82f6);
+  border-color: var(--hb-accent, #3b82f6);
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"]:checked::before {
+  opacity: 1;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.hb-md-editor .ProseMirror ul[data-type="taskList"] > li[data-checked="true"] > div {
+  color: color-mix(in oklab, currentColor 50%, transparent);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklab, currentColor 35%, transparent);
+}
+
+/* ===== Slash menu ================================================== */
+
+.hb-slash {
+  display: flex;
+  flex-direction: column;
+  min-width: 280px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 0.375rem;
+  border-radius: var(--hb-radius);
+  background: var(--hb-popup-bg, #ffffff);
+  color: var(--hb-popup-fg, #0f172a);
+  border: 1px solid var(--hb-popup-border, rgba(15, 23, 42, 0.1));
+  box-shadow: var(--hb-shadow-popup);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  animation: hb-pop-in 100ms ease-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  .hb-slash {
+    background: var(--hb-popup-bg, #18181b);
+    color: var(--hb-popup-fg, #fafafa);
+    border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+  }
+}
+.dark .hb-slash {
+  background: var(--hb-popup-bg, #18181b);
+  color: var(--hb-popup-fg, #fafafa);
+  border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+}
+
+.hb-slash--empty {
+  align-items: stretch;
+  padding: 1rem 0.875rem 0.875rem;
+  min-width: 220px;
+}
+.hb-slash__empty-title {
+  font-weight: 500;
+}
+.hb-slash__empty-hint {
+  margin-top: 0.125rem;
+  font-size: 0.8125rem;
+  color: color-mix(in oklab, currentColor 55%, transparent);
+}
+
+.hb-slash__group + .hb-slash__group {
+  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-slash__section {
+  padding: 0.375rem 0.625rem 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, currentColor 50%, transparent);
+}
+
+.hb-slash__item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.4375rem 0.5rem;
+  border-radius: var(--hb-radius-sm);
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 80ms ease;
+}
+
+.hb-slash__item:hover,
+.hb-slash__item[data-active] {
+  background: color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-slash__icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--hb-radius-sm);
+  background: var(--hb-popup-icon-bg, rgba(15, 23, 42, 0.04));
+  color: color-mix(in oklab, currentColor 80%, transparent);
+  font-size: 1rem;
+}
+.dark .hb-slash__icon-wrap,
+@media (prefers-color-scheme: dark) {
+  .hb-slash__icon-wrap {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}
+
+.hb-slash__icon {
+  width: 1.0625rem;
+  height: 1.0625rem;
+}
+
+.hb-slash__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.0625rem;
+}
+
+.hb-slash__title {
+  font-weight: 500;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hb-slash__subtitle {
+  font-size: 0.75rem;
+  color: color-mix(in oklab, currentColor 55%, transparent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hb-slash__shortcut {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-family: ui-monospace, "Geist Mono", monospace;
+  color: color-mix(in oklab, currentColor 50%, transparent);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.25rem;
+  background: color-mix(in oklab, currentColor 5%, transparent);
+}
+
+/* Tippy strips its wrapper styling so our menus own the visual chrome.
+ * We DON'T import tippy.css — own classes cover what we need. */
+.tippy-box[data-theme~="hb-slash"] {
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  border-radius: 0;
+}
+.tippy-box[data-theme~="hb-slash"] > .tippy-content {
+  padding: 0;
+}
+
+/* ===== Bubble menu (selection toolbar) ============================= */
+
+.hb-bubble {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0.0625rem;
+  padding: 0.1875rem;
+  border-radius: 0.5rem;
+  background: var(--hb-popup-bg, #ffffff);
+  color: var(--hb-popup-fg, #0f172a);
+  border: 1px solid var(--hb-popup-border, rgba(15, 23, 42, 0.1));
+  box-shadow: var(--hb-shadow-popup);
+  font-size: 0.875rem;
+  user-select: none;
+  animation: hb-pop-in 100ms ease-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  .hb-bubble {
+    background: var(--hb-popup-bg, #18181b);
+    color: var(--hb-popup-fg, #fafafa);
+    border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+  }
+}
+.dark .hb-bubble {
+  background: var(--hb-popup-bg, #18181b);
+  color: var(--hb-popup-fg, #fafafa);
+  border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+}
+
+.hb-bubble__sep {
+  display: inline-block;
+  align-self: stretch;
+  width: 1px;
+  margin: 0.125rem 0.1875rem;
+  background: color-mix(in oklab, currentColor 12%, transparent);
+}
+
+.hb-bubble__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.875rem;
+  height: 1.875rem;
+  border: 0;
+  border-radius: 0.3125rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 80ms ease, color 80ms ease;
+}
+
+.hb-bubble__btn:hover {
+  background: color-mix(in oklab, currentColor 9%, transparent);
+}
+
+.hb-bubble__btn[data-active] {
+  background: color-mix(in oklab, var(--hb-accent, currentColor) 14%, transparent);
+  color: var(--hb-accent, currentColor);
+}
+
+.hb-bubble__icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Turn-into dropdown */
+.hb-bubble__turn {
+  position: relative;
+  display: inline-flex;
+}
+
+.hb-bubble__turn-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  height: 1.875rem;
+  padding: 0 0.5rem;
+  border: 0;
+  border-radius: 0.3125rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 80ms ease;
+}
+
+.hb-bubble__turn-trigger:hover {
+  background: color-mix(in oklab, currentColor 9%, transparent);
+}
+
+.hb-bubble__turn-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.hb-bubble__chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  opacity: 0.7;
+}
+
+.hb-bubble__turn-menu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem;
+  border-radius: var(--hb-radius);
+  background: var(--hb-popup-bg, #ffffff);
+  color: var(--hb-popup-fg, #0f172a);
+  border: 1px solid var(--hb-popup-border, rgba(15, 23, 42, 0.1));
+  box-shadow: var(--hb-shadow-popup);
+  z-index: 1;
+  animation: hb-pop-in 100ms ease-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  .hb-bubble__turn-menu {
+    background: var(--hb-popup-bg, #18181b);
+    color: var(--hb-popup-fg, #fafafa);
+    border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+  }
+}
+.dark .hb-bubble__turn-menu {
+  background: var(--hb-popup-bg, #18181b);
+  color: var(--hb-popup-fg, #fafafa);
+  border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+}
+
+.hb-bubble__turn-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border: 0;
+  border-radius: var(--hb-radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 80ms ease;
+}
+
+.hb-bubble__turn-item:hover,
+.hb-bubble__turn-item[data-active] {
+  background: color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-bubble__turn-icon {
+  width: 1rem;
+  height: 1rem;
+  color: color-mix(in oklab, currentColor 75%, transparent);
+}
+
+/* ===== Animations =================================================== */
+
+@keyframes hb-pop-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-2px) scale(0.97);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hb-slash,
+  .hb-bubble,
+  .hb-bubble__turn-menu {
+    animation: none;
+  }
+  .hb-slash__item,
+  .hb-bubble__btn,
+  .hb-bubble__turn-trigger,
+  .hb-bubble__turn-item,
+  .hb-drag-col__btn {
+    transition: none;
+  }
+}
+
+/* ===== Drag handle (left margin) ==================================== */
+
+/* Tiptap's DragHandle ships its own outer wrapper. We style by class. The
+ * plugin sets position:absolute and updates left/top on hover. */
+.hb-drag-handle {
+  display: flex;
+  align-items: center;
+  z-index: 5;
+  pointer-events: auto;
+}
+
+.hb-drag-col {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.0625rem;
+  padding: 0.125rem;
+  border-radius: 0.375rem;
+  opacity: 0;
+  transform: translateX(2px);
+  transition: opacity 100ms ease, transform 100ms ease;
+}
+.hb-drag-handle:hover .hb-drag-col,
+.hb-drag-col[data-hovered] {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.hb-drag-col__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: color-mix(in oklab, currentColor 50%, transparent);
+  cursor: pointer;
+  transition: background-color 80ms ease, color 80ms ease;
+}
+
+.hb-drag-col__btn:hover {
+  color: currentColor;
+  background: color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-drag-col__btn--grip {
+  cursor: grab;
+}
+.hb-drag-col__btn--grip:active {
+  cursor: grabbing;
+}
+
+.hb-drag-col__icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+/* ===== Block menu (drag handle click target) ======================== */
+
+.hb-block-menu {
+  position: fixed;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  padding: 0.25rem;
+  border-radius: var(--hb-radius);
+  background: var(--hb-popup-bg);
+  color: var(--hb-popup-fg);
+  border: 1px solid var(--hb-popup-border);
+  box-shadow: var(--hb-shadow-popup);
+  font-size: 0.875rem;
+  animation: hb-pop-in 100ms ease-out;
+}
+
+.hb-block-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  border: 0;
+  border-radius: var(--hb-radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 80ms ease, color 80ms ease;
+  position: relative;
+}
+
+.hb-block-menu__item:hover {
+  background: color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-block-menu__item--danger:hover {
+  color: oklch(0.55 0.22 25);
+  background: color-mix(in oklab, oklch(0.55 0.22 25) 10%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+  .hb-block-menu__item--danger:hover {
+    color: oklch(0.78 0.18 25);
+  }
+}
+.dark .hb-block-menu__item--danger:hover {
+  color: oklch(0.78 0.18 25);
+}
+
+.hb-block-menu__item-icon {
+  width: 1rem;
+  height: 1rem;
+  color: color-mix(in oklab, currentColor 65%, transparent);
+}
+.hb-block-menu__item:hover .hb-block-menu__item-icon {
+  color: currentColor;
+}
+
+.hb-block-menu__item-label {
+  flex: 1 1 auto;
+}
+
+.hb-block-menu__chevron {
+  width: 0.875rem;
+  height: 0.875rem;
+  opacity: 0.55;
+}
+
+.hb-block-menu__shortcut {
+  font-size: 0.75rem;
+  font-family: ui-monospace, "Geist Mono", monospace;
+  color: color-mix(in oklab, currentColor 50%, transparent);
+}
+
+.hb-block-menu__divider {
+  height: 1px;
+  margin: 0.25rem 0.125rem;
+  background: color-mix(in oklab, currentColor 10%, transparent);
+}
+
+/* Submenu — pops to the right of the parent item. */
+.hb-block-menu__turn {
+  position: relative;
+}
+
+.hb-block-menu__submenu {
+  position: absolute;
+  top: -0.25rem;
+  left: calc(100% + 0.375rem);
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem;
+  border-radius: var(--hb-radius);
+  background: var(--hb-popup-bg);
+  color: var(--hb-popup-fg);
+  border: 1px solid var(--hb-popup-border);
+  box-shadow: var(--hb-shadow-popup);
+  animation: hb-pop-in 100ms ease-out;
+}
+
+.hb-block-menu__subitem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  border: 0;
+  border-radius: var(--hb-radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 80ms ease;
+}
+
+.hb-block-menu__subitem:hover,
+.hb-block-menu__subitem[data-active] {
+  background: color-mix(in oklab, currentColor 8%, transparent);
+}
+
+.hb-block-menu__subicon {
+  width: 1rem;
+  height: 1rem;
+  color: color-mix(in oklab, currentColor 70%, transparent);
+}
+
+/* ===== Code block chrome (NodeView) ================================= */
+
+.hb-md-editor .ProseMirror pre.hb-md-code-wrap {
+  position: relative;
+  padding: 0;       /* re-set; chrome row + content carry their own padding */
+  overflow: hidden; /* contain rounded corners + chrome */
+}
+
+.hb-md-code__chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4375rem 0.625rem 0.4375rem 0.875rem;
+  border-bottom: 1px solid color-mix(in oklab, currentColor 6%, transparent);
+  background: color-mix(in oklab, currentColor 3%, transparent);
+  font-size: 0.6875rem;
+  user-select: none;
+}
+
+.hb-md-code__lang {
+  font-family: ui-monospace, "Geist Mono", monospace;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in oklab, currentColor 60%, transparent);
+}
+.hb-md-code__lang--muted {
+  font-style: italic;
+  color: color-mix(in oklab, currentColor 40%, transparent);
+}
+
+.hb-md-code__copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+  padding: 0.1875rem 0.5rem;
+  border: 0;
+  border-radius: 0.3125rem;
+  background: transparent;
+  color: color-mix(in oklab, currentColor 60%, transparent);
+  font: inherit;
+  font-size: 0.6875rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 80ms ease, background-color 80ms ease, color 80ms ease;
+}
+
+.hb-md-editor .ProseMirror pre.hb-md-code-wrap:hover .hb-md-code__copy,
+.hb-md-code__copy:focus-visible,
+.hb-md-code__copy[data-copied] {
+  opacity: 1;
+}
+
+.hb-md-code__copy:hover {
+  background: color-mix(in oklab, currentColor 8%, transparent);
+  color: currentColor;
+}
+
+.hb-md-code__copy[data-copied] {
+  color: oklch(0.62 0.16 145);
+}
+@media (prefers-color-scheme: dark) {
+  .hb-md-code__copy[data-copied] { color: oklch(0.82 0.15 145); }
+}
+.dark .hb-md-code__copy[data-copied] { color: oklch(0.82 0.15 145); }
+
+.hb-md-code__copy-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.hb-md-editor .ProseMirror pre.hb-md-code-wrap > code {
+  display: block;
+  padding: 0.875rem 1rem;
+  background: transparent;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+/* ===== Syntax highlighting (highlight.js token classes via lowlight) === */
+
+/* Tokens map to highlight.js classnames. Colors are chosen to read well in
+ * both light and dark; we use OKLch so they auto-tone in dark mode without
+ * needing two themes. */
+
+.hb-md-editor .ProseMirror pre code {
+  /* Reset — token spans handle their own colors */
+  color: inherit;
+}
+
+.hb-md-editor .ProseMirror .hljs-comment,
+.hb-md-editor .ProseMirror .hljs-quote {
+  color: color-mix(in oklab, currentColor 45%, transparent);
+  font-style: italic;
+}
+
+.hb-md-editor .ProseMirror .hljs-keyword,
+.hb-md-editor .ProseMirror .hljs-selector-tag,
+.hb-md-editor .ProseMirror .hljs-literal,
+.hb-md-editor .ProseMirror .hljs-section,
+.hb-md-editor .ProseMirror .hljs-link {
+  color: oklch(0.55 0.22 295);              /* purple */
+}
+@media (prefers-color-scheme: dark) {
+  .hb-md-editor .ProseMirror .hljs-keyword,
+  .hb-md-editor .ProseMirror .hljs-selector-tag,
+  .hb-md-editor .ProseMirror .hljs-literal,
+  .hb-md-editor .ProseMirror .hljs-section,
+  .hb-md-editor .ProseMirror .hljs-link {
+    color: oklch(0.78 0.18 305);
+  }
+}
+.dark .hb-md-editor .ProseMirror .hljs-keyword,
+.dark .hb-md-editor .ProseMirror .hljs-selector-tag,
+.dark .hb-md-editor .ProseMirror .hljs-literal,
+.dark .hb-md-editor .ProseMirror .hljs-section,
+.dark .hb-md-editor .ProseMirror .hljs-link {
+  color: oklch(0.78 0.18 305);
+}
+
+.hb-md-editor .ProseMirror .hljs-string,
+.hb-md-editor .ProseMirror .hljs-title,
+.hb-md-editor .ProseMirror .hljs-name,
+.hb-md-editor .ProseMirror .hljs-type,
+.hb-md-editor .ProseMirror .hljs-attribute,
+.hb-md-editor .ProseMirror .hljs-symbol,
+.hb-md-editor .ProseMirror .hljs-bullet,
+.hb-md-editor .ProseMirror .hljs-addition,
+.hb-md-editor .ProseMirror .hljs-variable,
+.hb-md-editor .ProseMirror .hljs-template-tag,
+.hb-md-editor .ProseMirror .hljs-template-variable {
+  color: oklch(0.62 0.16 145);              /* green */
+}
+@media (prefers-color-scheme: dark) {
+  .hb-md-editor .ProseMirror .hljs-string,
+  .hb-md-editor .ProseMirror .hljs-title,
+  .hb-md-editor .ProseMirror .hljs-name,
+  .hb-md-editor .ProseMirror .hljs-type,
+  .hb-md-editor .ProseMirror .hljs-attribute,
+  .hb-md-editor .ProseMirror .hljs-symbol,
+  .hb-md-editor .ProseMirror .hljs-bullet,
+  .hb-md-editor .ProseMirror .hljs-addition,
+  .hb-md-editor .ProseMirror .hljs-variable,
+  .hb-md-editor .ProseMirror .hljs-template-tag,
+  .hb-md-editor .ProseMirror .hljs-template-variable {
+    color: oklch(0.82 0.15 145);
+  }
+}
+.dark .hb-md-editor .ProseMirror .hljs-string,
+.dark .hb-md-editor .ProseMirror .hljs-title,
+.dark .hb-md-editor .ProseMirror .hljs-name,
+.dark .hb-md-editor .ProseMirror .hljs-type,
+.dark .hb-md-editor .ProseMirror .hljs-attribute,
+.dark .hb-md-editor .ProseMirror .hljs-symbol,
+.dark .hb-md-editor .ProseMirror .hljs-bullet,
+.dark .hb-md-editor .ProseMirror .hljs-addition,
+.dark .hb-md-editor .ProseMirror .hljs-variable,
+.dark .hb-md-editor .ProseMirror .hljs-template-tag,
+.dark .hb-md-editor .ProseMirror .hljs-template-variable {
+  color: oklch(0.82 0.15 145);
+}
+
+.hb-md-editor .ProseMirror .hljs-number,
+.hb-md-editor .ProseMirror .hljs-deletion,
+.hb-md-editor .ProseMirror .hljs-meta {
+  color: oklch(0.6 0.18 35);                /* orange */
+}
+@media (prefers-color-scheme: dark) {
+  .hb-md-editor .ProseMirror .hljs-number,
+  .hb-md-editor .ProseMirror .hljs-deletion,
+  .hb-md-editor .ProseMirror .hljs-meta {
+    color: oklch(0.78 0.16 50);
+  }
+}
+.dark .hb-md-editor .ProseMirror .hljs-number,
+.dark .hb-md-editor .ProseMirror .hljs-deletion,
+.dark .hb-md-editor .ProseMirror .hljs-meta {
+  color: oklch(0.78 0.16 50);
+}
+
+.hb-md-editor .ProseMirror .hljs-function .hljs-title,
+.hb-md-editor .ProseMirror .hljs-class .hljs-title,
+.hb-md-editor .ProseMirror .hljs-built_in,
+.hb-md-editor .ProseMirror .hljs-builtin-name {
+  color: oklch(0.58 0.16 235);              /* blue */
+}
+@media (prefers-color-scheme: dark) {
+  .hb-md-editor .ProseMirror .hljs-function .hljs-title,
+  .hb-md-editor .ProseMirror .hljs-class .hljs-title,
+  .hb-md-editor .ProseMirror .hljs-built_in,
+  .hb-md-editor .ProseMirror .hljs-builtin-name {
+    color: oklch(0.78 0.13 235);
+  }
+}
+.dark .hb-md-editor .ProseMirror .hljs-function .hljs-title,
+.dark .hb-md-editor .ProseMirror .hljs-class .hljs-title,
+.dark .hb-md-editor .ProseMirror .hljs-built_in,
+.dark .hb-md-editor .ProseMirror .hljs-builtin-name {
+  color: oklch(0.78 0.13 235);
+}
+
+.hb-md-editor .ProseMirror .hljs-emphasis { font-style: italic; }
+.hb-md-editor .ProseMirror .hljs-strong { font-weight: 600; }

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "declaration": true,
+    "declarationMap": false
+  },
+  "include": ["src"]
+}

--- a/packages/editor/tsup.config.ts
+++ b/packages/editor/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ["react", "react-dom"],
+  loader: { ".css": "copy" },
+  publicDir: false,
+  onSuccess: "cp src/styles.css dist/styles.css",
+});


### PR DESCRIPTION
## Summary

Establishes the foundation for the long-term **Pages & Databases** roadmap and lands the first user-facing piece: a Notion-style WYSIWYG markdown editor that replaces the previous textarea + read-only preview pair on `.md` / `.mdx` / `.markdown` files.

Three logical commits, reviewable independently:

1. **`docs(plans)`** — pages and databases design v1 (frozen, 2062 lines)
2. **`feat(editor)`** — `@holaboss/editor` v0 package + desktop integration
3. **`fix(desktop)`** — button-in-button HTML warning in FileExplorerPane

### Design doc (commit 1)

`docs/plans/2026-05-06-pages-and-databases-design.md` — full v1 spec covering:

- Two-tier data model: user-owned databases (UI-editable) + module-owned tables (read-only, query-backed blocks)
- Block JSON spec for every block type (paragraph, heading, list, callout, toggle, code, database_inline, database_linked, kpi, chart, sql_table, …)
- Property type system (text / number / select / date / relation / rollup / formula / …) with type-migration rules
- View system (table / board / list / gallery / calendar / timeline) with structured filter + sort DSL
- Full SQLite DDL for `pages.db`
- Runtime API surface (`/pages`, `/blocks`, `/databases`, `/properties`, `/rows`, `/views`, `/query`)
- Agent MCP tool surface
- Editor framework decision: **Tiptap (DIY, no Pro template)** on top of ProseMirror — chosen over Lexical after a documented reversal in §22 driven by OSS production-footprint asymmetry
- Phase 0–7 rollout with explicit risk burn-down checklist (R1–R5)
- One-shot migrator from `.dashboard` YAML

### Editor package (commit 2)

`packages/editor/` — new shared package `@holaboss/editor`. Tiptap v3 core + a curated set of extensions, no `@tiptap/pro/*`.

**Notion-quality features (v0):**
- Slash menu with sections, icons, keyboard hints
- Bubble toolbar on selection (Turn into + inline marks + link)
- Drag handle column on hover (`+` to insert below, `::` to drag, click for menu)
- Block menu on grip click (Turn into / Duplicate / Delete) with submenu
- Code block syntax highlighting via lowlight (37 languages)
- Code block React NodeView with Copy button + language pill
- Subtle block hover background
- Task list with custom orange checkbox + completed-state styling
- Markdown round-trip via `@tiptap/markdown` (official v3 extension)
- Self-contained inline-SVG icon set, no external icon dependency
- Design token bridging — picks up host's shadcn vars (`--popover`, `--primary`, `--border`) when present
- Dark mode + light mode + `prefers-reduced-motion`

**Desktop integration:**
- `vite.config.ts`: `dedupe: ['react', 'react-dom']` + alias `@holaboss/editor` → `packages/editor/src/index.ts` for HMR
- `main.tsx`: import `@holaboss/editor/styles.css`
- `InternalSurfacePane.tsx`: drop preview/edit toggle for markdown files (markdown is now WYSIWYG-only); only HTML files keep the preview/edit toggle
- Removes now-unused `SimpleMarkdown` + `handleLocalLinkInPreview` helpers

**Package conventions** (mirrors `sdk/app-sdk`):
- `.gitignore` excludes `dist/`, `node_modules/`
- `.npmrc` with `legacy-peer-deps=true` to keep `react`/`react-dom` out of the package's `node_modules` (prevents duplicate React in Vite consumers — known issue with `file:` linked packages)
- README documents the implication: every internal `@tiptap/*` peer must be added to `dependencies` explicitly

### FileExplorerPane fix (commit 3)

The folder row in `FileExplorerPane.tsx` previously wrapped its content in a `<button>` containing the disclosure-chevron `<button>`. Nested interactive elements are invalid HTML and trigger a hydration warning in React 19. Changed outer wrapper to `<div>` — focus is managed by the parent `role="treeitem"` via roving-tabindex, so this is behavior-neutral.

## Test plan

- [ ] `cd packages/editor && npm install && npm run typecheck && npm run build` — package builds cleanly
- [ ] `cd desktop && npm install && npm run typecheck` — desktop typechecks
- [ ] `npm run desktop:dev` — open a `.md` file:
  - [ ] No preview/edit toggle in the toolbar (markdown is WYSIWYG)
  - [ ] Type `# heading` → becomes H1 immediately
  - [ ] Type `/` → slash menu opens with 3 sections, icons, keyboard hints
  - [ ] Select text → bubble toolbar floats above selection
  - [ ] Hover any block → left-margin `+` and `::` column appears
  - [ ] Click `::` → block menu opens (Turn into / Duplicate / Delete)
  - [ ] Drag `::` → block reorders
  - [ ] ` ```typescript ` → enter → code block with hljs syntax highlighting
  - [ ] Hover code block → Copy button appears top-right; click → ✓ Copied feedback
  - [ ] Switch desktop theme → all popups, accents, selections track the theme
- [ ] Open the file explorer with folders → no React hydration warning in console; all click / double-click / drag-drop on folder rows still works

## Out of scope (deferred)

- Phase 0 of pages/databases (R1–R5 risk burn-down, `pages.db`, runtime API)
- Custom blocks beyond markdown set (database_inline, kpi, chart, sql_table)
- Drag handle for nested blocks (list items, blockquotes) — currently top-level only
- Code block language picker (currently set via markdown `\`\`\`lang` only)
- Image / file upload via the editor (markdown's `![]()` syntax still works)
- Real-time collaboration (Yjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)