### PR TITLE
fix: harden requirement persistence and skill promotion guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # Repository Guidelines
 
+## Workspace Instruction Persistence
+Any requirement or rule mentioned by the user must be recorded in `AGENTS.md`, even when it appears scoped to a single turn or deliverable, unless the user explicitly says not to persist it.
+
+When the user changes, retracts, or supersedes a prior requirement, update `AGENTS.md` to reflect the latest instruction state instead of leaving stale rules behind.
+
+Use `AGENTS.md` as the canonical ledger of all user-stated requirements. After recording a requirement, classify it: always-on policy remains in `AGENTS.md`, while conditional, situational, or procedural requirements should also create or update a workspace-local skill.
+
+## Workspace Skills Index
+Keep a short index here for every workspace-local skill created from recorded requirements, including the skill id and when to use it. No workspace-local skills are currently installed.
+
 ## Commit & Pull Request Guidelines
 Commit history follows Conventional Commits (`feat:`, `fix:`, `migrate:`, `chore:`, etc.) and must use a detailed, structured message format.
 

--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -162,19 +162,7 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   );
   assert.match(
     prompt.systemPrompt,
-    /Create or update a workspace-local skill for reusable workflows/
-  );
-  assert.match(
-    prompt.systemPrompt,
-    /do not use skills for unconditional policy or one-off state\./i
-  );
-  assert.match(
-    prompt.systemPrompt,
-    /Put always-on workspace rules in `AGENTS\.md`/i
-  );
-  assert.match(
-    prompt.systemPrompt,
-    /use skills for reusable workflows that load when relevant/i
+    /Use `AGENTS\.md` as the requirement ledger\. Keep always-on policy there; turn conditional, situational, or procedural requirements into indexed workspace-local skills, using `skill-creator` when available\./i
   );
   assert.match(prompt.systemPrompt, /Session policy:/);
   assert.match(prompt.systemPrompt, /front-of-house workspace session/i);
@@ -485,7 +473,7 @@ test("composeAgentPrompt can inject a run-specific routing recovery override for
   assert.match(prompt.systemPrompt, /produce the report artifact/i);
 });
 
-test("composeAgentPrompt instructs main sessions to persist durable workspace rules into AGENTS.md when the tool is available", () => {
+test("composeAgentPrompt instructs main sessions to record all user requirements into AGENTS.md when the tool is available", () => {
   const capabilityManifest = buildAgentCapabilityManifest({
     defaultTools: ["read"],
     extraTools: ["holaboss_update_workspace_instructions"],
@@ -508,11 +496,50 @@ test("composeAgentPrompt instructs main sessions to persist durable workspace ru
 
   assert.match(
     prompt.systemPrompt,
-    /persist them in root `AGENTS\.md` with `holaboss_update_workspace_instructions`/i,
+    /When the user states any requirement, rule, preference, constraint, or template, record it in root `AGENTS\.md` with `holaboss_update_workspace_instructions`/i,
   );
   assert.match(
     prompt.systemPrompt,
-    /Do not update `AGENTS\.md` for instructions that are clearly one-off/i,
+    /Record it even when it appears turn-scoped; skip only if the user explicitly says not to persist it\./i,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /conditional, situational, or procedural requirements into indexed workspace-local skills, using `skill-creator` when available\./i,
+  );
+});
+
+test("composeBaseAgentPrompt instructs direct sessions to record all user requirements into AGENTS.md when the tool is available", () => {
+  const capabilityManifest = buildAgentCapabilityManifest({
+    defaultTools: ["read"],
+    extraTools: ["holaboss_update_workspace_instructions"],
+    runtimeToolIds: ["holaboss_update_workspace_instructions"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    toolServerIdMap: {},
+  });
+
+  const prompt = composeBaseAgentPrompt("You are concise.", {
+    defaultTools: ["read"],
+    extraTools: ["holaboss_update_workspace_instructions"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    sessionKind: "workspace_session",
+    sessionMode: "code",
+    harnessId: "pi",
+    capabilityManifest,
+  });
+
+  assert.match(
+    prompt.systemPrompt,
+    /When the user states any requirement, rule, preference, constraint, or template, record it in root `AGENTS\.md` with `holaboss_update_workspace_instructions`/i,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /Record it even when it appears turn-scoped; skip only if the user explicitly says not to persist it\./i,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /conditional, situational, or procedural requirements into indexed workspace-local skills, using `skill-creator` when available\./i,
   );
 });
 

--- a/runtime/api-server/src/agent-runtime-prompt.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.ts
@@ -679,13 +679,12 @@ export function buildBaseAgentPromptSections(
     "Use coordination tools instead of hidden state. The newest user message is primary.",
     "Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.",
     "Ask for missing identity details instead of guessing.",
-    "Put always-on workspace rules in `AGENTS.md`; use skills for reusable workflows that load when relevant.",
-    "Create or update a workspace-local skill for reusable workflows; do not use skills for unconditional policy or one-off state."
+    "Use `AGENTS.md` as the requirement ledger. Keep always-on policy there; turn conditional, situational, or procedural requirements into indexed workspace-local skills, using `skill-creator` when available."
   ];
   if (hasWorkspaceInstructionUpdateTool(request)) {
     executionLines.push(
-      "When the user gives durable workspace-wide rules, recurring output templates, or lasting instruction-following constraints that should apply in future work, persist them in root `AGENTS.md` with `holaboss_update_workspace_instructions` instead of relying only on transient context.",
-      "Do not update `AGENTS.md` for instructions that are clearly one-off and scoped only to the current deliverable."
+      "When the user states any requirement, rule, preference, constraint, or template, record it in root `AGENTS.md` with `holaboss_update_workspace_instructions` instead of relying only on transient context.",
+      "Record it even when it appears turn-scoped; skip only if the user explicitly says not to persist it."
     );
   }
   if (capabilityManifest?.browser_tools.length) {
@@ -931,13 +930,12 @@ export function buildMainSessionPromptSections(
     "Use coordination tools instead of hidden state. The newest user message is primary.",
     "Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.",
     "Ask for missing identity details instead of guessing.",
-    "Put always-on workspace rules in `AGENTS.md`; use skills for reusable workflows that load when relevant.",
-    "Create or update a workspace-local skill for reusable workflows; do not use skills for unconditional policy or one-off state."
+    "Use `AGENTS.md` as the requirement ledger. Keep always-on policy there; turn conditional, situational, or procedural requirements into indexed workspace-local skills, using `skill-creator` when available."
   ];
   if (hasWorkspaceInstructionUpdateTool(request)) {
     conversationLines.push(
-      "When the user gives durable workspace-wide rules, recurring output templates, or lasting instruction-following constraints that should apply in future work, persist them in root `AGENTS.md` with `holaboss_update_workspace_instructions` instead of relying only on transient context.",
-      "Do not update `AGENTS.md` for instructions that are clearly one-off and scoped only to the current deliverable."
+      "When the user states any requirement, rule, preference, constraint, or template, record it in root `AGENTS.md` with `holaboss_update_workspace_instructions` instead of relying only on transient context.",
+      "Record it even when it appears turn-scoped; skip only if the user explicitly says not to persist it."
     );
   }
   if (normalizedSessionKind === "onboarding") {

--- a/runtime/harnesses/src/runtime-agent-tools.ts
+++ b/runtime/harnesses/src/runtime-agent-tools.ts
@@ -119,7 +119,7 @@ export const RUNTIME_AGENT_TOOL_DEFINITIONS = [
   {
     id: "holaboss_update_workspace_instructions",
     description:
-      "Read or update the root AGENTS.md file for durable workspace rules, recurring output templates, and lasting instruction-following constraints while preserving user-authored content outside the managed section.",
+      "Read or update the root AGENTS.md file to record user-stated requirements, rules, preferences, templates, and instruction-following constraints while preserving user-authored content outside the managed section.",
     policy: "mutate"
   },
   {

--- a/runtime/harnesses/src/runtime-capability-tools.ts
+++ b/runtime/harnesses/src/runtime-capability-tools.ts
@@ -812,15 +812,17 @@ function runtimeToolPromptGuidelines(toolId: RuntimeAgentToolId): string[] {
   }
   if (toolId === "holaboss_update_workspace_instructions") {
     return [
-      "Use `holaboss_update_workspace_instructions` when the user gives durable workspace-wide rules, recurring output templates, or lasting instruction-following constraints that should persist in root `AGENTS.md`.",
+      "Use `holaboss_update_workspace_instructions` when the user gives any requirement, rule, preference, constraint, or template that should be recorded in root `AGENTS.md`.",
+      "Default to recording it even when it appears scoped only to the current deliverable or turn; only skip it when the user explicitly says not to record it.",
+      "After recording the requirement in `AGENTS.md`, if it is conditional, situational, or procedural rather than always-on policy, also create or update a workspace-local skill and keep a short skills index entry in `AGENTS.md`.",
       "Use `read_current` before replacing the managed section when you need to preserve or refine existing workspace instructions.",
-      "Use `append_rule` for concise durable rules, `remove_rule` to retract one, and `replace_managed_section` for structured markdown templates or larger rule sets.",
-      "Do not use this tool for one-off instructions that are clearly scoped only to the current deliverable or turn.",
+      "Use `append_rule` for concise rules, `remove_rule` to retract one, and `replace_managed_section` for structured markdown templates, indexes, or larger rule sets.",
     ];
   }
   if (toolId === "skill") {
     return [
       "Use `skill` when a workspace or embedded skill is relevant and you need its canonical guidance block.",
+      "When creating or updating a workspace-local skill from a recorded requirement, load `skill-creator` when available and follow its canonical `skills/<skill-id>/SKILL.md` format.",
       "Pass the specific skill id or name in `name` instead of paraphrasing the skill body yourself.",
       "Use `args` only for short follow-up instructions that should accompany the skill block.",
     ];


### PR DESCRIPTION
## Summary

This changes the runtime guidance so requirement capture and skill promotion are driven directly by the system prompt rather than by evolve review flow.

- record user-stated requirements into `AGENTS.md` by default
- treat `AGENTS.md` as the requirement ledger for workspace policy
- classify recorded requirements so always-on policy stays in `AGENTS.md` while conditional, situational, or procedural requirements become workspace-local skills
- explicitly reference the embedded `skill-creator` guidance when promoting recorded requirements into workspace skills
- add workspace `AGENTS.md` scaffolding for instruction persistence and a skills index
- update prompt and tool-guidance tests for the stronger persistence and skill-routing behavior

## Context

This is intended to make requirement capture and skill creation purely system-prompt guided. It does not change `evolve-skill-review.ts`.

## Validation

- `node --import tsx --test src/agent-runtime-prompt.test.ts`

## UI / Screenshots

- N/A, prompt/runtime guidance only

## Linked

- None