### PR TITLE
ui(desktop): operator interactions — mention/picker primitives

### DIFF
--- a/desktop/src/components/ui/entity-mention.tsx
+++ b/desktop/src/components/ui/entity-mention.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+import { EntityChip, type EntityChipProps } from "@/components/ui/entity-chip";
+import { cn } from "@/lib/utils";
+
+/**
+ * EntityMention — inline reference to an entity inside prose. Visually
+ * a chip with a leading `@` glyph, sized to flow with body text. Use
+ * for `@workspace`, `@app`, `@session`, `@memory` etc. references in
+ * chat composers, agent prompts, skill descriptions.
+ *
+ * Distinct from EntityChip in two ways: (1) the `@` prefix marks it
+ * as a mention rather than a generic reference, (2) sizing aligns to
+ * `xs` by default so it fits inline without breaking line height.
+ *
+ * Pair with MentionPicker for entry; pair with EntityChip when the
+ * reference is structural (sidebar, breadcrumb) rather than mid-prose.
+ */
+export interface EntityMentionProps extends Omit<EntityChipProps, "label"> {
+  label: ReactNode;
+}
+
+export function EntityMention({
+  label,
+  size = "xs",
+  variant = "ghost",
+  interactive = true,
+  className,
+  ...props
+}: EntityMentionProps) {
+  return (
+    <EntityChip
+      label={
+        <>
+          <span aria-hidden="true" className="text-muted-foreground">
+            @
+          </span>
+          {label}
+        </>
+      }
+      size={size}
+      variant={variant}
+      interactive={interactive}
+      className={cn(
+        // Mentions sit inside text — keep them visually quiet so a
+        // paragraph with multiple mentions doesn't read as a wall of
+        // pills.
+        "text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/desktop/src/components/ui/mention-picker.tsx
+++ b/desktop/src/components/ui/mention-picker.tsx
@@ -1,0 +1,125 @@
+import { Command as CommandPrimitive } from "cmdk";
+import * as React from "react";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+/**
+ * MentionPicker — cmdk-backed list of mentionable entities, designed
+ * to sit inside a caret-anchored popover. Layout-agnostic: the host
+ * composer owns positioning (textarea ref + caret coords).
+ *
+ * Why standalone (not wrapped in Popover): mentions are caret-anchored,
+ * not button-anchored. The host composer fires the picker on every
+ * keystroke after `@`, with `query` being the text typed since. We
+ * mirror `query` into a screen-reader-only CommandInput so cmdk's
+ * filter runs against it without rendering a visible search box —
+ * the textarea is the visible input.
+ */
+export interface MentionItem {
+  /** Stable identifier — what gets inserted into the composer. */
+  id: string;
+  /** Visible label. ReactNode to allow icon + name composition. */
+  label: React.ReactNode;
+  /** Optional secondary line shown below the label. */
+  description?: React.ReactNode;
+  /** Plain-text aliases for fuzzy match. Recommended when `label`
+   *  is JSX (icon-wrapped name) since cmdk's text extraction can
+   *  miss the name through nested elements. */
+  keywords?: string[];
+  /** Disable selection without removing from list. */
+  disabled?: boolean;
+}
+
+export interface MentionGroup {
+  heading?: React.ReactNode;
+  items: MentionItem[];
+}
+
+export interface MentionPickerProps {
+  /** Either a flat list (single implicit group) or pre-grouped. */
+  items: MentionItem[] | MentionGroup[];
+  /** Current search query — text after the trigger character. */
+  query: string;
+  /** Fires with the selected item's id. Caller inserts the mention
+   *  and dismisses the picker. */
+  onSelect: (id: string) => void;
+  /** Empty-state label. */
+  emptyText?: string;
+  /** Width override; default 280px. */
+  width?: number;
+  className?: string;
+}
+
+function isGrouped(
+  items: MentionItem[] | MentionGroup[],
+): items is MentionGroup[] {
+  return items.length > 0 && "items" in items[0];
+}
+
+export function MentionPicker({
+  items,
+  query,
+  onSelect,
+  emptyText = "No matches.",
+  width = 280,
+  className,
+}: MentionPickerProps) {
+  const groups: MentionGroup[] = isGrouped(items) ? items : [{ items }];
+
+  return (
+    <Command
+      className={cn(
+        "overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-lg",
+        className,
+      )}
+      style={{ width }}
+    >
+      <CommandPrimitive.Input
+        value={query}
+        onValueChange={() => {
+          /* host composer drives query via its textarea — we just mirror */
+        }}
+        className="sr-only"
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+      <CommandList>
+        <CommandEmpty>{emptyText}</CommandEmpty>
+        {groups.map((group, groupIndex) => (
+          <CommandGroup
+            // biome-ignore lint/suspicious/noArrayIndexKey: groups are caller-defined and stable per render
+            key={groupIndex}
+            heading={group.heading}
+            className="p-1"
+          >
+            {group.items.map((item) => (
+              <CommandItem
+                key={item.id}
+                value={item.id}
+                keywords={item.keywords}
+                disabled={item.disabled}
+                onSelect={() => onSelect(item.id)}
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate">{item.label}</span>
+                  {item.description ? (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {item.description}
+                    </span>
+                  ) : null}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </Command>
+  );
+}


### PR DESCRIPTION
## Summary

Stacked on top of #292. First step toward the operator-interactions scope agreed in design discussion: ship the mention + caret-anchored picker grammar as **reusable primitives**, defer the chat composer integration to a focused follow-up.

## What's in

- **`EntityMention`** — extends `EntityChip` with a leading `@` glyph and inline-prose defaults (xs size, ghost variant). Canonical rendering for `@workspace` / `@app` / `@session` / `@memory` references inside body text.
- **`MentionPicker`** — cmdk-backed, caret-anchored list of mentionable items. Layout-agnostic; host composer owns positioning. Filter is driven via a screen-reader-only `CommandInput` mirroring the host's query, so the textarea remains the visible input.

## What's out (and why)

- **ChatPane integration** — ChatPane already has a custom slash-command menu (~500 lines, custom keyboard nav + filter). Replacing it warrants its own PR after #292's design system pivot is visually validated.
- **Inline rename** — needs new IPC handler (`workspace:renameWorkspace`) + main-process file rename + `workspace.json` metadata persistence. Not contained.
- **Cover system** — no render site (no workspace landing screen yet).

So this PR is a **primitives-only** delivery that unblocks the next focused PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build:renderer` clean
- [ ] Verify `MentionPicker` renders a list with cmdk filter when integrated (will happen in follow-up PR)
- [ ] Verify `EntityMention` flows inline with body text (will happen in follow-up PR)

## Stack

- Base: `refactor/desktop-settings-fullscreen` (#292)
- This PR's diff shows only the new commits beyond #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)