### PR TITLE
fix(desktop): force-open preview pane on programmatic browser-space selection

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -2169,6 +2169,7 @@ function AppShellContent() {
           setSpaceExplorerMode("browser");
           setSpaceBrowserSpace(targetBrowserSpace);
           setSpaceDisplayView({ type: "browser" });
+          setSpaceWorkspacePanelCollapsed(false);
           setSpaceVisibility((previous) => ({
             ...previous,
             browser: true,


### PR DESCRIPTION
## Summary

Follow-up to #315. That PR force-opens the preview pane in two places — clicking a bookmark and activating a file in the explorer — but the *programmatic* browser-space selection path (where the app sets `spaceExplorerMode`, `spaceBrowserSpace`, and `spaceDisplayView` together) was missed.

Without this, selecting a browser space leaves the user with an active "browser" display while the pane is collapsed, so the navigation is invisible.

One-line fix: add `setSpaceWorkspacePanelCollapsed(false)` to that branch alongside the existing display-view setters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)