### PR TITLE
fix: include workspace runtime db in diagnostics bundle

### DIFF
--- a/desktop/electron/diagnostics-bundle.ts
+++ b/desktop/electron/diagnostics-bundle.ts
@@ -10,6 +10,7 @@ export interface DiagnosticsBundleExportParams {
   runtimeLogPath: string;
   runtimeDbPath: string;
   runtimeConfigPath: string;
+  workspaceRuntimeDbPath?: string | null;
   workspaceId?: string | null;
   workspaceSummary?: Record<string, unknown> | null;
   summary: Record<string, unknown>;
@@ -403,6 +404,26 @@ export async function exportDiagnosticsBundle(
         archivePath: "host-state.db",
       });
       includedFiles.push("host-state.db");
+    }
+
+    const workspaceRuntimeDbPath = params.workspaceRuntimeDbPath?.trim() || "";
+    if (workspaceRuntimeDbPath) {
+      const workspaceRuntimeDbSnapshotPath = path.join(
+        stagingRoot,
+        "workspace-runtime.db",
+      );
+      if (
+        await backupRuntimeDatabase(
+          workspaceRuntimeDbPath,
+          workspaceRuntimeDbSnapshotPath,
+        )
+      ) {
+        entries.push({
+          sourcePath: workspaceRuntimeDbSnapshotPath,
+          archivePath: "workspace-runtime.db",
+        });
+        includedFiles.push("workspace-runtime.db");
+      }
     }
 
     const redactedConfigPath = path.join(

--- a/desktop/electron/diagnostics-export.test.mjs
+++ b/desktop/electron/diagnostics-export.test.mjs
@@ -6,7 +6,7 @@ const MAIN_PATH = new URL("./main.ts", import.meta.url);
 const PRELOAD_PATH = new URL("./preload.ts", import.meta.url);
 const BUNDLE_PATH = new URL("./diagnostics-bundle.ts", import.meta.url);
 const SETTINGS_DIALOG_PATH = new URL(
-  "../src/components/layout/SettingsDialog.tsx",
+  "../src/components/layout/SettingsScreenRoot.tsx",
   import.meta.url,
 );
 const RENDERER_TYPES_PATH = new URL(
@@ -24,10 +24,14 @@ test("desktop diagnostics export wires an About-pane button to the Electron brid
   );
 
   assert.match(settingsSource, /label="Diagnostics bundle"/);
-  assert.match(settingsSource, /label="Workspace"/);
+  assert.match(settingsSource, /heading="Export bundle for"/);
   assert.match(
     settingsSource,
-    /window\.electronAPI\.diagnostics\.exportBundle\(\{\s*workspaceId,\s*\}\)/,
+    /async function handleExportDiagnosticsBundle\(workspaceId: string\)/,
+  );
+  assert.match(
+    settingsSource,
+    /window\.electronAPI\.diagnostics\.exportBundle\(\{\s*workspaceId: trimmed,\s*\}\)/,
   );
   assert.match(
     preloadSource,
@@ -39,7 +43,7 @@ test("desktop diagnostics export wires an About-pane button to the Electron brid
   );
 });
 
-test("desktop diagnostics export snapshots runtime db and redacts runtime config", async () => {
+test("desktop diagnostics export snapshots host and workspace runtime dbs and redacts runtime config", async () => {
   const [mainSource, bundleSource] = await Promise.all([
     readFile(MAIN_PATH, "utf8"),
     readFile(BUNDLE_PATH, "utf8"),
@@ -52,11 +56,18 @@ test("desktop diagnostics export snapshots runtime db and redacts runtime config
   assert.match(mainSource, /runtimeLogPath: runtimeLogsPath\(\),/);
   assert.match(mainSource, /runtimeDbPath: runtimeDatabasePath\(\),/);
   assert.match(mainSource, /runtimeConfigPath: runtimeConfigPath\(\),/);
+  assert.match(
+    mainSource,
+    /const workspaceRuntimeDbPath = workspace\s*\?\s*workspaceRuntimeDbPathForStartupCheck\(\s*workspace\.id,\s*workspace\.workspace_path \?\? null,\s*\)\s*:\s*null;/,
+  );
+  assert.match(mainSource, /workspaceRuntimeDbPath,/);
   assert.match(mainSource, /workspaceId: workspace\?\.id \?\? null,/);
   assert.match(mainSource, /workspace: workspaceSummary,/);
   assert.match(mainSource, /shell\.showItemInFolder\(result\.bundlePath\);/);
   assert.match(bundleSource, /await database\.backup\(targetPath\);/);
   assert.match(bundleSource, /copyWorkspaceScopedRuntimeDatabase/);
+  assert.match(bundleSource, /params\.workspaceRuntimeDbPath\?\.trim\(\) \|\| ""/);
+  assert.match(bundleSource, /archivePath: "workspace-runtime\.db"/);
   assert.match(bundleSource, /workspace\.json/);
   assert.match(bundleSource, /runtime-config\.redacted\.json/);
   assert.match(bundleSource, /REDACTED_VALUE = "\[REDACTED\]"/);

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -4211,6 +4211,12 @@ async function exportDesktopDiagnosticsBundle(
 ) {
   const workspace = resolveDiagnosticsWorkspace(payload?.workspaceId ?? null);
   const workspaceSummary = diagnosticsWorkspaceSummary(workspace);
+  const workspaceRuntimeDbPath = workspace
+    ? workspaceRuntimeDbPathForStartupCheck(
+        workspace.id,
+        workspace.workspace_path ?? null,
+      )
+    : null;
   const downloadsDir = app.getPath("downloads");
   const bundlePath = path.join(
     downloadsDir,
@@ -4222,6 +4228,7 @@ async function exportDesktopDiagnosticsBundle(
     runtimeLogPath: runtimeLogsPath(),
     runtimeDbPath: runtimeDatabasePath(),
     runtimeConfigPath: runtimeConfigPath(),
+    workspaceRuntimeDbPath,
     workspaceId: workspace?.id ?? null,
     workspaceSummary,
     summary: {


### PR DESCRIPTION
## Summary

- export the selected workspace's `.holaboss/state/runtime.db` into diagnostics bundles as `workspace-runtime.db` alongside the existing `host-state.db` snapshot
- thread the workspace runtime DB path through the Electron diagnostics export entrypoint so the bundle captures workspace-local runtime state for the selected workspace
- update the diagnostics export regression test to match the current Settings screen wiring and assert the new workspace runtime DB artifact

## Validation

- [x] `node --test desktop/electron/diagnostics-export.test.mjs`
- [ ] `npm run desktop:typecheck`
  Fails in this environment because `tsc` is not installed on `PATH` after the desktop preflight scripts complete.
- [ ] `npm run runtime:test`

## Risks

- diagnostics bundles will be larger because they now include an additional SQLite snapshot when the selected workspace has a runtime DB
- if a selected workspace does not have `.holaboss/state/runtime.db`, the exporter will skip `workspace-runtime.db` and continue producing the rest of the bundle

## Docs

- [ ] docs updated if setup, packaging, or public behavior changed
