### PR TITLE
ui(desktop): tighten no-models empty state — cap composer width + slim CTA

### DIFF
--- a/desktop/src/components/panes/ChatPane/Composer/index.tsx
+++ b/desktop/src/components/panes/ChatPane/Composer/index.tsx
@@ -13,7 +13,6 @@ import {
 } from "react";
 import {
   ArrowLeft,
-  ArrowRight,
   ArrowUp,
   Check,
   ChevronRight,
@@ -977,35 +976,19 @@ export function Composer({
               }
             >
               {noAvailableModels ? (
-                <>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="lg"
-                    onClick={onOpenModelProviders}
-                    className={`shrink-0 justify-between rounded-lg bg-card text-xs font-semibold hover:border-primary hover:bg-card ${
-                      compactComposerControls ? "px-2.5" : ""
-                    }`}
-                    aria-label="Configure model providers"
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <Waypoints className="size-3.5 shrink-0 text-muted-foreground" />
-                      <span className="truncate">
-                        {compactComposerControls
-                          ? "Providers"
-                          : "Set up providers"}
-                      </span>
-                    </span>
-                    <ArrowRight className="size-3.5 shrink-0 text-muted-foreground" />
-                  </Button>
-                  <div
-                    className={`min-w-0 text-[10px] leading-5 text-muted-foreground ${
-                      compactComposerControls ? "hidden" : ""
-                    }`}
-                  >
-                    Open provider settings to connect a model.
-                  </div>
-                </>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onOpenModelProviders}
+                  className="shrink-0 gap-1.5 rounded-md text-xs font-medium hover:border-primary"
+                  aria-label="Configure model providers"
+                >
+                  <Waypoints className="size-3.5 text-muted-foreground" />
+                  <span className="truncate">
+                    {compactComposerControls ? "Providers" : "Set up providers"}
+                  </span>
+                </Button>
               ) : (
                 <ModelCombobox
                   selectedModel={selectedModel}

--- a/desktop/src/components/panes/ChatPane/index.tsx
+++ b/desktop/src/components/panes/ChatPane/index.tsx
@@ -7335,7 +7335,7 @@ export function ChatPane({
                   void loadOlderSessionHistory();
                 }
               }}
-              className={`chat-scrollbar-thin h-full min-h-0 overflow-x-hidden overflow-y-auto ${hasMessages ? "" : "flex items-center justify-center"}`}
+              className="chat-scrollbar-thin h-full min-h-0 overflow-x-hidden overflow-y-auto"
             >
               {hasMessages ? (
                 <div
@@ -7417,7 +7417,7 @@ export function ChatPane({
                 </div>
               ) : (
                 <div
-                  className={`mx-auto w-full ${CHAT_LAYOUT.contentMaxWidth} px-4 pb-10 pt-10 sm:px-5 ${
+                  className={`mx-auto flex min-h-full w-full ${CHAT_LAYOUT.contentMaxWidth} flex-col justify-center px-4 pb-10 pt-10 sm:px-5 ${
                     showHistoryRestoreScreen ? "invisible" : ""
                   }`}
                 >

--- a/desktop/src/components/panes/ChatPane/index.tsx
+++ b/desktop/src/components/panes/ChatPane/index.tsx
@@ -7417,7 +7417,7 @@ export function ChatPane({
                 </div>
               ) : (
                 <div
-                  className={`w-full px-4 pb-10 pt-10 sm:px-5 ${
+                  className={`mx-auto w-full ${CHAT_LAYOUT.contentMaxWidth} px-4 pb-10 pt-10 sm:px-5 ${
                     showHistoryRestoreScreen ? "invisible" : ""
                   }`}
                 >


### PR DESCRIPTION
## Summary

Two issues with the chat pane's "no provider configured" empty state on a wide pane:

- **Composer stretched the full pane width.** The empty-state composer wrapper was `w-full px-4 ...` with no max width, so on a wide window it sat orphaned across an ocean of empty space. Wrap it in `mx-auto` + `CHAT_LAYOUT.contentMaxWidth` (760px) to match the messages-state composer.
- **"Set up providers" CTA was bulky.** `size="lg"` (chunky), two icons framing the label (Waypoints + ArrowRight), and a standalone helper paragraph duplicating the placeholder copy. Replace with a tight `size="sm"` pill — single Waypoints icon, label only — and drop the redundant helper text since the textarea placeholder ("No models available. Configure a provider to start chatting.") already explains the state.

## Test plan

- [ ] Trigger the no-providers state (Settings → AI Providers → remove keys, sign out)
- [ ] Confirm composer is bounded to 760px and centered, not full pane width
- [ ] Confirm "Set up providers" button is the slim outlined pill (no right arrow, no ghost helper text below)
- [ ] Click the button → opens Settings → Providers pane
- [ ] Restore providers / sign back in → composer returns to normal model-selector state without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)