### PR TITLE
ui(desktop): expand explorer panel on first entry of a freshly-created workspace

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -1635,6 +1635,9 @@ function AppShellContent() {
     {},
   );
   const startupWorkspaceSelectionHandledRef = useRef(false);
+  const seenWorkspaceIdsRef = useRef<Set<string>>(new Set());
+  const newlyCreatedWorkspaceIdsRef = useRef<Set<string>>(new Set());
+  const workspaceListInitializedRef = useRef(false);
   const lastRestorableSpaceFileDisplayViewByWorkspaceRef = useRef<
     Record<string, RestorableSpaceFileDisplayView>
   >({});
@@ -3723,6 +3726,40 @@ function AppShellContent() {
     setSelectedWorkspaceId,
     workspaces,
   ]);
+
+  // Flag any workspace IDs that show up *after* the initial hydration as
+  // "freshly created in this session". Hydration itself never marks
+  // anything new — existing workspaces from a prior session land in seen
+  // before initialised flips true, so reload doesn't re-trigger expand.
+  useEffect(() => {
+    if (!hasHydratedWorkspaceList) {
+      return;
+    }
+    for (const workspace of workspaces) {
+      if (
+        workspaceListInitializedRef.current &&
+        !seenWorkspaceIdsRef.current.has(workspace.id)
+      ) {
+        newlyCreatedWorkspaceIdsRef.current.add(workspace.id);
+      }
+      seenWorkspaceIdsRef.current.add(workspace.id);
+    }
+    workspaceListInitializedRef.current = true;
+  }, [workspaces, hasHydratedWorkspaceList]);
+
+  // First time selectedWorkspaceId points at a freshly-created workspace,
+  // expand the explorer panel so the user lands on a fully-revealed
+  // surface. Consumed once — subsequent visits respect persisted state.
+  useEffect(() => {
+    const workspaceId = selectedWorkspaceId?.trim();
+    if (!workspaceId) {
+      return;
+    }
+    if (newlyCreatedWorkspaceIdsRef.current.has(workspaceId)) {
+      newlyCreatedWorkspaceIdsRef.current.delete(workspaceId);
+      setSpaceWorkspacePanelCollapsed(false);
+    }
+  }, [selectedWorkspaceId]);
 
   const handleChatComposerDraftTextChange = useCallback(
     (text: string) => {


### PR DESCRIPTION
## Summary

Newly created workspaces inherited the persisted `spaceWorkspacePanelCollapsed` localStorage value, which defaults to `true` (collapsed) when nothing is stored. So first-time users landed on a workspace with the file/browser explorer hidden — confusing for "I just made this, where is everything?".

Force-expand the explorer panel **once** on the first time a freshly-created workspace becomes selected, then defer to persistence.

## How it works

Three new refs in `AppShell.tsx`:

- `seenWorkspaceIdsRef: Set<string>` — every workspace ID we've ever observed in this session
- `newlyCreatedWorkspaceIdsRef: Set<string>` — workspace IDs added *after* the initial hydration (i.e. created in this session)
- `workspaceListInitializedRef: boolean` — flips true after the first post-hydration workspaces effect; gates whether new IDs count as "fresh"

Two new effects:
1. Watches `workspaces` + `hasHydratedWorkspaceList`. After the first run, any new ID appearing in the list gets added to `newlyCreatedWorkspaceIdsRef`.
2. Watches `selectedWorkspaceId`. If it matches a fresh ID, delete from set and call `setSpaceWorkspacePanelCollapsed(false)`.

## Why a ref Set instead of `created_at` heuristic

- **Reload safe**: refs reset on reload, hydration repopulates `seenIds` *before* the initialised flag flips, so existing workspaces from prior sessions are not re-flagged.
- **Per-workspace, one-shot**: the ID is removed from the Set on consume, so revisiting the workspace later in the same session respects whatever the user did with the panel.
- **Both creation paths covered**: `FirstWorkspacePane` (first-ever) and `createWorkspacePanelOpen` (subsequent) both grow the `workspaces` array — the trigger is array growth, not which UI created it.

`spaceVisibility` (agent / files / browser pane visibility) is intentionally **not** touched — `loadSpaceVisibility()` already returns all-true regardless of persisted state.

## Test plan

- [ ] Fresh install with no workspaces → create first workspace → explorer panel is expanded on entry
- [ ] Existing user with workspaces → create a new one from "+" → explorer is expanded on entry to the new workspace
- [ ] Reload after creating a workspace → returning to the same workspace honours whatever collapse state the user left it in (no re-expand)
- [ ] Existing user with multiple workspaces (no creation this session) → switching between them respects each's persisted state
- [ ] Manually collapse explorer on a freshly-created workspace, switch away, switch back → stays collapsed (consume happened on first entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)