### PR TITLE
fix: harden embedded browser background hosting

### DIFF
--- a/desktop/electron/browser-background-render-host.test.mjs
+++ b/desktop/electron/browser-background-render-host.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const TAB_STATE_PATH = new URL("./browser-pane/tab-state.ts", import.meta.url);
+const HTTP_SERVICE_PATH = new URL("./browser-pane/http-service.ts", import.meta.url);
+
+test("browser tab state can temporarily host a background BrowserView in a hidden window", async () => {
+  const source = await readFile(TAB_STATE_PATH, "utf8");
+
+  assert.match(source, /async function withTemporarilyRenderedBrowserTab<T>\(/);
+  assert.match(source, /if \(\s*!options\.requireFocusedWindow &&\s*attachedView === tab\.view &&\s*hasVisibleBounds\(\)\s*\) \{\s*return callback\(\);\s*\}/s);
+  assert.match(source, /const host = new BrowserWindow\(\{\s*show: options\.requireFocusedWindow === true,\s*paintWhenInitiallyHidden: true,/s);
+  assert.match(source, /async function withBrowserTabHostedInWindow<T>\(/);
+  assert.match(source, /host\.setBrowserView\(tab\.view\);/);
+  assert.match(source, /tab\.view\.setBounds\(bounds\);/);
+  assert.match(source, /if \(options\.requireFocusedWindow === true\) \{\s*host\.show\(\);\s*host\.focus\(\);\s*await waitForBrowserWindowFocus\(host\);\s*tab\.view\.webContents\.focus\(\);\s*\}/s);
+  assert.match(source, /async function waitForRenderedBrowserFrame\(\s*tab: BrowserTabRecord,\s*\): Promise<boolean> \{/s);
+  assert.match(source, /await waitForRenderedBrowserViewport\(tab\);/);
+  assert.match(source, /webContents\.beginFrameSubscription\(\(\) => \{/);
+  assert.match(source, /webContents\.invalidate\(\);/);
+  assert.match(source, /webContents\.endFrameSubscription\(\);/);
+  assert.match(source, /if \(options\.waitForRenderedFrame === true\) \{\s*await waitForRenderedBrowserFrame\(tab\);\s*\}/s);
+  assert.match(source, /host\.setBrowserView\(null\);/);
+  assert.match(source, /host\.destroy\(\);/);
+});
+
+test("browser tab state reuses invisible agent input hosts behind a global queue", async () => {
+  const source = await readFile(TAB_STATE_PATH, "utf8");
+
+  assert.match(source, /const sharedAgentInputHosts = new Map<string, SharedAgentInputHostState>\(\);/);
+  assert.match(source, /let focusedAgentInputQueue = Promise\.resolve\(\);/);
+  assert.match(source, /function invisibleInputHostWindowBounds\(/);
+  assert.match(source, /transparent: true,/);
+  assert.match(source, /opacity: BACKGROUND_INPUT_HOST_OPACITY,/);
+  assert.match(source, /host\.setIgnoreMouseEvents\(true\);/);
+  assert.match(source, /async function withQueuedAgentInputHost<T>\(/);
+  assert.match(source, /const previousQueue = focusedAgentInputQueue;/);
+  assert.match(source, /scheduleSharedAgentInputHostDestroy\(workspaceId, hostState\);/);
+});
+
+test("desktop browser http service renders background tabs before evaluate and screenshot", async () => {
+  const source = await readFile(HTTP_SERVICE_PATH, "utf8");
+
+  assert.match(source, /withTemporarilyRenderedBrowserTab: <T>\(\s*tab: HttpServiceTabRecord,\s*callback: \(\) => Promise<T>,\s*options\?: \{\s*requireFocusedWindow\?: boolean;\s*workspaceId\?: string \| null;\s*waitForRenderedFrame\?: boolean;\s*\},\s*\) => Promise<T>;/s);
+  assert.match(source, /const result = await deps\.withTemporarilyRenderedBrowserTab\(\s*activeTab,\s*async \(\) =>\s*activeTab\.view\.webContents\.executeJavaScript\(expression\),/s);
+  assert.match(source, /async function captureBrowserScreenshotWithRetries\(/);
+  assert.match(source, /message\.includes\("UnknownVizError"\)/);
+  assert.match(source, /await tab\.view\.webContents\.executeJavaScript\("document\.readyState", true\);/);
+  assert.match(source, /const image = await deps\.withTemporarilyRenderedBrowserTab\(/);
+  assert.match(source, /captureBrowserScreenshotWithRetries\(activeTab\)/);
+  assert.match(source, /waitForRenderedFrame: true/);
+});
+
+test("desktop browser http service uses a focused temporary host for background input routes", async () => {
+  const source = await readFile(HTTP_SERVICE_PATH, "utf8");
+
+  assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/context-click"\)/);
+  assert.match(source, /await deps\.withTemporarilyRenderedBrowserTab\(\s*activeTab,\s*async \(\) =>\s*deps\.withProgrammaticBrowserInput\(/s);
+  assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/mouse"\)/);
+  assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/keyboard"\)/);
+  assert.match(source, /\{\s*requireFocusedWindow: true,\s*workspaceId: targetWorkspaceId,\s*\}/);
+});

--- a/desktop/electron/browser-context-menu.test.mjs
+++ b/desktop/electron/browser-context-menu.test.mjs
@@ -3,9 +3,11 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const MAIN_PATH = new URL("./main.ts", import.meta.url);
+const TAB_STATE_PATH = new URL("./browser-pane/tab-state.ts", import.meta.url);
+const HTTP_SERVICE_PATH = new URL("./browser-pane/http-service.ts", import.meta.url);
 
 test("browser tabs register a native context menu for BrowserView content", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const source = await readFile(TAB_STATE_PATH, "utf8");
 
   assert.match(source, /Menu,/);
   assert.match(source, /clipboard,/);
@@ -42,36 +44,46 @@ test("browser tabs register a native context menu for BrowserView content", asyn
 });
 
 test("desktop browser service exposes a real context-click endpoint for BrowserView input", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const source = await readFile(HTTP_SERVICE_PATH, "utf8");
 
   assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/context-click"\)/);
-  assert.match(source, /await withProgrammaticBrowserInput\(activeTab\.view\.webContents, async \(\) => \{/);
+  assert.match(source, /await deps\.withTemporarilyRenderedBrowserTab\(\s*activeTab,\s*async \(\) =>\s*deps\.withProgrammaticBrowserInput\(\s*activeTab\.view\.webContents,\s*async \(\) => \{/s);
   assert.match(source, /activeTab\.view\.webContents\.focus\(\);/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseMove",/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseDown",[\s\S]*button: "right",/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseUp",[\s\S]*button: "right",/);
+  assert.match(source, /\{\s*requireFocusedWindow: true,\s*workspaceId: targetWorkspaceId,\s*\}/);
 });
 
 test("desktop browser service exposes a real mouse endpoint for BrowserView input", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const source = await readFile(HTTP_SERVICE_PATH, "utf8");
 
   assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/mouse"\)/);
+  assert.match(source, /const expression = optionalExpressionPayload\(payload\.expression\);/);
   assert.match(source, /const action =\s*payload\.action === "double_click" \|\| payload\.action === "hover"/);
-  assert.match(source, /await withProgrammaticBrowserInput\(activeTab\.view\.webContents, async \(\) => \{/);
+  assert.match(source, /await deps\.withTemporarilyRenderedBrowserTab\(\s*activeTab,\s*async \(\) =>\s*deps\.withProgrammaticBrowserInput\(\s*activeTab\.view\.webContents,\s*async \(\) => \{/s);
+  assert.match(source, /executeJavaScript\(expression\)/);
   assert.match(source, /activeTab\.view\.webContents\.focus\(\);/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseMove",/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseDown",[\s\S]*button: "left",/);
   assert.match(source, /await activeTab\.view\.webContents\.sendInputEvent\(\{\s*type: "mouseUp",[\s\S]*button: "left",/);
   assert.match(source, /clickCount: 2,/);
+  assert.match(source, /\{\s*requireFocusedWindow: true,\s*workspaceId: targetWorkspaceId,\s*\}/);
 });
 
 test("desktop browser service exposes real keyboard input for rich editors", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const source = await readFile(HTTP_SERVICE_PATH, "utf8");
+  const mainSource = await readFile(MAIN_PATH, "utf8");
 
   assert.match(source, /if \(method === "POST" && pathname === "\/api\/v1\/browser\/keyboard"\)/);
-  assert.match(source, /await withProgrammaticBrowserInput\(activeTab\.view\.webContents, async \(\) => \{/);
+  assert.match(source, /await deps\.withTemporarilyRenderedBrowserTab\(\s*activeTab,\s*async \(\) =>\s*deps\.withProgrammaticBrowserInput\(\s*activeTab\.view\.webContents,\s*async \(\) => \{/s);
+  assert.match(source, /const index = positiveIntegerPayload\(payload\.index\);/);
+  assert.match(source, /const expression = optionalExpressionPayload\(payload\.expression\);/);
+  assert.match(source, /resolvedAction = serializeEvalResult\(\s*await activeTab\.view\.webContents\.executeJavaScript\(expression\),/s);
+  assert.match(source, /executeJavaScript\(\s*focusIndexedKeyboardTargetExpression\(index\),/s);
   assert.match(source, /await activeTab\.view\.webContents\.insertText\(text\);/);
-  assert.match(source, /async function clearFocusedBrowserTextInput\(/);
-  assert.match(source, /await sendBrowserKeyPress\(webContents, "A", \[selectAllModifier\]\);/);
-  assert.match(source, /await sendBrowserKeyPress\(activeTab\.view\.webContents, "Enter"\);/);
+  assert.match(source, /\{\s*requireFocusedWindow: true,\s*workspaceId: targetWorkspaceId,\s*\}/);
+  assert.match(mainSource, /async function clearFocusedBrowserTextInput\(/);
+  assert.match(mainSource, /await sendBrowserKeyPress\(webContents, "A", \[selectAllModifier\]\);/);
+  assert.match(source, /await deps\.sendBrowserKeyPress\(\s*activeTab\.view\.webContents,\s*"Enter",/s);
 });

--- a/desktop/electron/browser-pane/http-service.ts
+++ b/desktop/electron/browser-pane/http-service.ts
@@ -161,6 +161,15 @@ export interface BrowserHttpServiceDeps {
   ) => OperatorSurfaceContextPayload;
 
   browserPagePayload: (tab: HttpServiceTabRecord) => Record<string, unknown>;
+  withTemporarilyRenderedBrowserTab: <T>(
+    tab: HttpServiceTabRecord,
+    callback: () => Promise<T>,
+    options?: {
+      requireFocusedWindow?: boolean;
+      workspaceId?: string | null;
+      waitForRenderedFrame?: boolean;
+    },
+  ) => Promise<T>;
 
   withProgrammaticBrowserInput: <T>(
     webContents: WebContents,
@@ -182,6 +191,18 @@ export interface BrowserHttpService {
     response: ServerResponse<IncomingMessage>,
   ) => Promise<void>;
 }
+
+const INTERACTIVE_ELEMENTS_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "textarea",
+  "select",
+  "[role='button']",
+  "[role='link']",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]",
+].join(",");
 
 function tokenFromRequest(request: IncomingMessage): string {
   const raw = request.headers["x-holaboss-desktop-token"];
@@ -255,9 +276,90 @@ function serializeEvalResult(value: unknown): unknown {
   }
 }
 
+function positiveIntegerPayload(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : null;
+}
+
+function optionalExpressionPayload(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function focusIndexedKeyboardTargetExpression(index: number): string {
+  return `(() => {
+    const selector = ${JSON.stringify(INTERACTIVE_ELEMENTS_SELECTOR)};
+    const isVisible = (element) => {
+      if (!(element instanceof HTMLElement)) return false;
+      const rect = element.getBoundingClientRect();
+      const style = window.getComputedStyle(element);
+      return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+    };
+    const target = Array.from(document.querySelectorAll(selector)).filter((element) => isVisible(element))[${index - 1}] || null;
+    if (!(target instanceof HTMLElement)) {
+      throw new Error(${JSON.stringify(`No interactive element found for index ${index}.`)});
+    }
+    const editTarget =
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target.isContentEditable
+        ? target
+        : target.querySelector("input, textarea, [contenteditable]:not([contenteditable='false'])");
+    if (!(editTarget instanceof HTMLElement)) {
+      throw new Error(${JSON.stringify(`Element at index ${index} is not text-editable.`)});
+    }
+    editTarget.scrollIntoView({ block: "center", inline: "center", behavior: "instant" });
+    if (typeof editTarget.focus === "function") {
+      try {
+        editTarget.focus({ preventScroll: true });
+      } catch {
+        editTarget.focus();
+      }
+    }
+    return {
+      ok: true,
+      index: ${index},
+      tag_name: editTarget.tagName.toLowerCase(),
+      role: editTarget.getAttribute("role") || "",
+      editable: true,
+    };
+  })()`;
+}
+
 export function createBrowserHttpService(
   deps: BrowserHttpServiceDeps,
 ): BrowserHttpService {
+  async function captureBrowserScreenshotWithRetries(
+    tab: HttpServiceTabRecord,
+  ): Promise<import("electron").NativeImage> {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        return await tab.view.webContents.capturePage(undefined, {
+          stayHidden: true,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        const shouldRetry = message.includes("UnknownVizError");
+        if (!shouldRetry || attempt >= maxAttempts - 1) {
+          throw error;
+        }
+        try {
+          await tab.view.webContents.executeJavaScript("document.readyState", true);
+        } catch {
+          // Ignore renderer warmup failures and keep retrying.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+    throw new Error("Browser screenshot capture exhausted all retries.");
+  }
+
   async function handleRequest(
     request: IncomingMessage,
     response: ServerResponse<IncomingMessage>,
@@ -861,8 +963,11 @@ export function createBrowserHttpService(
           });
           return;
         }
-        const result =
-          await activeTab.view.webContents.executeJavaScript(expression);
+        const result = await deps.withTemporarilyRenderedBrowserTab(
+          activeTab,
+          async () =>
+            activeTab.view.webContents.executeJavaScript(expression),
+        );
         writeJson(response, 200, {
           tabId: activeTab.state.id,
           result: serializeEvalResult(result),
@@ -903,29 +1008,37 @@ export function createBrowserHttpService(
         if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFocused()) {
           mainWindow.focus();
         }
-        await deps.withProgrammaticBrowserInput(
-          activeTab.view.webContents,
-          async () => {
-            activeTab.view.webContents.focus();
-            await activeTab.view.webContents.sendInputEvent({
-              type: "mouseMove",
-              x,
-              y,
-            });
-            await activeTab.view.webContents.sendInputEvent({
-              type: "mouseDown",
-              x,
-              y,
-              button: "right",
-              clickCount: 1,
-            });
-            await activeTab.view.webContents.sendInputEvent({
-              type: "mouseUp",
-              x,
-              y,
-              button: "right",
-              clickCount: 1,
-            });
+        await deps.withTemporarilyRenderedBrowserTab(
+          activeTab,
+          async () =>
+            deps.withProgrammaticBrowserInput(
+              activeTab.view.webContents,
+              async () => {
+                activeTab.view.webContents.focus();
+                await activeTab.view.webContents.sendInputEvent({
+                  type: "mouseMove",
+                  x,
+                  y,
+                });
+                await activeTab.view.webContents.sendInputEvent({
+                  type: "mouseDown",
+                  x,
+                  y,
+                  button: "right",
+                  clickCount: 1,
+                });
+                await activeTab.view.webContents.sendInputEvent({
+                  type: "mouseUp",
+                  x,
+                  y,
+                  button: "right",
+                  clickCount: 1,
+                });
+              },
+            ),
+          {
+            requireFocusedWindow: true,
+            workspaceId: targetWorkspaceId,
           },
         );
         writeJson(response, 200, {
@@ -939,11 +1052,11 @@ export function createBrowserHttpService(
 
       if (method === "POST" && pathname === "/api/v1/browser/mouse") {
         const payload = await readJsonBody(request);
-        const x =
+        let x =
           typeof payload.x === "number" && Number.isFinite(payload.x)
             ? Math.round(payload.x)
             : NaN;
-        const y =
+        let y =
           typeof payload.y === "number" && Number.isFinite(payload.y)
             ? Math.round(payload.y)
             : NaN;
@@ -951,9 +1064,13 @@ export function createBrowserHttpService(
           payload.action === "double_click" || payload.action === "hover"
             ? payload.action
             : "click";
-        if (!Number.isFinite(x) || x < 0 || !Number.isFinite(y) || y < 0) {
+        const expression = optionalExpressionPayload(payload.expression);
+        if (
+          !expression &&
+          (!Number.isFinite(x) || x < 0 || !Number.isFinite(y) || y < 0)
+        ) {
           writeJson(response, 400, {
-            error: "Fields 'x' and 'y' must be non-negative numbers.",
+            error: "Fields 'x' and 'y' must be non-negative numbers when no expression is provided.",
           });
           return;
         }
@@ -974,47 +1091,86 @@ export function createBrowserHttpService(
         if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFocused()) {
           mainWindow.focus();
         }
-        await deps.withProgrammaticBrowserInput(
-          activeTab.view.webContents,
-          async () => {
-            activeTab.view.webContents.focus();
-            await activeTab.view.webContents.sendInputEvent({
-              type: "mouseMove",
-              x,
-              y,
-            });
-            if (action === "click" || action === "double_click") {
-              await activeTab.view.webContents.sendInputEvent({
-                type: "mouseDown",
-                x,
-                y,
-                button: "left",
-                clickCount: 1,
-              });
-              await activeTab.view.webContents.sendInputEvent({
-                type: "mouseUp",
-                x,
-                y,
-                button: "left",
-                clickCount: 1,
-              });
-            }
-            if (action === "double_click") {
-              await activeTab.view.webContents.sendInputEvent({
-                type: "mouseDown",
-                x,
-                y,
-                button: "left",
-                clickCount: 2,
-              });
-              await activeTab.view.webContents.sendInputEvent({
-                type: "mouseUp",
-                x,
-                y,
-                button: "left",
-                clickCount: 2,
-              });
-            }
+        let resolvedAction: unknown = null;
+        await deps.withTemporarilyRenderedBrowserTab(
+          activeTab,
+          async () =>
+            deps.withProgrammaticBrowserInput(
+              activeTab.view.webContents,
+              async () => {
+                activeTab.view.webContents.focus();
+                if (expression) {
+                  resolvedAction = serializeEvalResult(
+                    await activeTab.view.webContents.executeJavaScript(expression),
+                  );
+                  const resolvedPoint =
+                    resolvedAction &&
+                    typeof resolvedAction === "object" &&
+                    !Array.isArray(resolvedAction)
+                      ? (resolvedAction as Record<string, unknown>).result
+                      : null;
+                  x =
+                    resolvedPoint &&
+                    typeof resolvedPoint === "object" &&
+                    !Array.isArray(resolvedPoint) &&
+                    typeof (resolvedPoint as Record<string, unknown>).x === "number" &&
+                    Number.isFinite((resolvedPoint as Record<string, unknown>).x)
+                      ? Math.round((resolvedPoint as Record<string, unknown>).x as number)
+                      : NaN;
+                  y =
+                    resolvedPoint &&
+                    typeof resolvedPoint === "object" &&
+                    !Array.isArray(resolvedPoint) &&
+                    typeof (resolvedPoint as Record<string, unknown>).y === "number" &&
+                    Number.isFinite((resolvedPoint as Record<string, unknown>).y)
+                      ? Math.round((resolvedPoint as Record<string, unknown>).y as number)
+                      : NaN;
+                  if (!Number.isFinite(x) || x < 0 || !Number.isFinite(y) || y < 0) {
+                    throw new Error("Resolved browser mouse action did not provide valid coordinates.");
+                  }
+                }
+                await activeTab.view.webContents.sendInputEvent({
+                  type: "mouseMove",
+                  x,
+                  y,
+                });
+                if (action === "click" || action === "double_click") {
+                  await activeTab.view.webContents.sendInputEvent({
+                    type: "mouseDown",
+                    x,
+                    y,
+                    button: "left",
+                    clickCount: 1,
+                  });
+                  await activeTab.view.webContents.sendInputEvent({
+                    type: "mouseUp",
+                    x,
+                    y,
+                    button: "left",
+                    clickCount: 1,
+                  });
+                }
+                if (action === "double_click") {
+                  await activeTab.view.webContents.sendInputEvent({
+                    type: "mouseDown",
+                    x,
+                    y,
+                    button: "left",
+                    clickCount: 2,
+                  });
+                  await activeTab.view.webContents.sendInputEvent({
+                    type: "mouseUp",
+                    x,
+                    y,
+                    button: "left",
+                    clickCount: 2,
+                  });
+                }
+              },
+            ),
+          {
+            requireFocusedWindow: true,
+            workspaceId: targetWorkspaceId,
           },
         );
         writeJson(response, 200, {
@@ -1023,6 +1179,9 @@ export function createBrowserHttpService(
           action,
           x,
           y,
+          ...(resolvedAction && typeof resolvedAction === "object"
+            ? { resolved_action: resolvedAction }
+            : {}),
         });
         return;
       }
@@ -1037,6 +1196,8 @@ export function createBrowserHttpService(
             : "";
         const clear = payload.clear === true;
         const submit = payload.submit === true;
+        const index = positiveIntegerPayload(payload.index);
+        const expression = optionalExpressionPayload(payload.expression);
         if (action === "press" && !key) {
           writeJson(response, 400, {
             error: "Field 'key' is required for keyboard press actions.",
@@ -1060,26 +1221,47 @@ export function createBrowserHttpService(
         if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFocused()) {
           mainWindow.focus();
         }
-        await deps.withProgrammaticBrowserInput(
-          activeTab.view.webContents,
-          async () => {
-            activeTab.view.webContents.focus();
-            if (action === "press") {
-              await deps.sendBrowserKeyPress(activeTab.view.webContents, key);
-              return;
-            }
-            if (clear) {
-              await deps.clearFocusedBrowserTextInput(activeTab.view.webContents);
-            }
-            if (text) {
-              await activeTab.view.webContents.insertText(text);
-            }
-            if (submit) {
-              await deps.sendBrowserKeyPress(
-                activeTab.view.webContents,
-                "Enter",
-              );
-            }
+        let focusedTarget: unknown = null;
+        let resolvedAction: unknown = null;
+        await deps.withTemporarilyRenderedBrowserTab(
+          activeTab,
+          async () =>
+            deps.withProgrammaticBrowserInput(
+              activeTab.view.webContents,
+              async () => {
+                activeTab.view.webContents.focus();
+                if (expression) {
+                  resolvedAction = serializeEvalResult(
+                    await activeTab.view.webContents.executeJavaScript(expression),
+                  );
+                } else if (index !== null) {
+                  focusedTarget = serializeEvalResult(
+                    await activeTab.view.webContents.executeJavaScript(
+                      focusIndexedKeyboardTargetExpression(index),
+                    ),
+                  );
+                }
+                if (action === "press") {
+                  await deps.sendBrowserKeyPress(activeTab.view.webContents, key);
+                  return;
+                }
+                if (clear) {
+                  await deps.clearFocusedBrowserTextInput(activeTab.view.webContents);
+                }
+                if (text) {
+                  await activeTab.view.webContents.insertText(text);
+                }
+                if (submit) {
+                  await deps.sendBrowserKeyPress(
+                    activeTab.view.webContents,
+                    "Enter",
+                  );
+                }
+              },
+            ),
+          {
+            requireFocusedWindow: true,
+            workspaceId: targetWorkspaceId,
           },
         );
         writeJson(response, 200, {
@@ -1090,6 +1272,12 @@ export function createBrowserHttpService(
           key: action === "press" ? key : "",
           clear,
           submit,
+          ...(resolvedAction && typeof resolvedAction === "object"
+            ? { resolved_action: resolvedAction }
+            : {}),
+          ...(focusedTarget && typeof focusedTarget === "object"
+            ? (focusedTarget as Record<string, unknown>)
+            : {}),
         });
         return;
       }
@@ -1113,7 +1301,11 @@ export function createBrowserHttpService(
         const qualityRaw =
           typeof payload.quality === "number" ? payload.quality : 90;
         const quality = Math.max(0, Math.min(100, Math.round(qualityRaw)));
-        const image = await activeTab.view.webContents.capturePage();
+        const image = await deps.withTemporarilyRenderedBrowserTab(
+          activeTab,
+          async () => captureBrowserScreenshotWithRetries(activeTab),
+          { waitForRenderedFrame: true },
+        );
         const buffer = format === "jpeg" ? image.toJPEG(quality) : image.toPNG();
         const size = image.getSize();
         writeJson(response, 200, {

--- a/desktop/electron/browser-pane/tab-state.ts
+++ b/desktop/electron/browser-pane/tab-state.ts
@@ -23,10 +23,10 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import {
+  BrowserWindow,
   BrowserView,
   Menu,
   clipboard,
-  type BrowserWindow,
   type ContextMenuParams,
   type MenuItemConstructorOptions,
   type WebContents,
@@ -91,6 +91,20 @@ import {
   browserContextSuggestedFilename as browserContextSuggestedFilenameUtil,
   oppositeBrowserSpaceId,
 } from "./utils.js";
+
+const BACKGROUND_RENDER_HOST_WIDTH = 1280;
+const BACKGROUND_RENDER_HOST_HEIGHT = 900;
+const BACKGROUND_RENDER_VIEWPORT_POLL_ATTEMPTS = 10;
+const BACKGROUND_RENDER_VIEWPORT_POLL_DELAY_MS = 50;
+const BACKGROUND_RENDER_FRAME_TIMEOUT_MS = 1_000;
+const BACKGROUND_INPUT_HOST_OPACITY = 0.01;
+const SHARED_AGENT_INPUT_HOST_IDLE_MS = 30_000;
+
+interface SharedAgentInputHostState {
+  host: BrowserWindow | null;
+  activeView: BrowserView | null;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
 
 export interface BrowserTabRecord {
   view: BrowserView;
@@ -358,11 +372,23 @@ export interface BrowserPaneTabState {
     entry: Pick<BrowserHistoryEntryPayload, "url" | "title" | "faviconUrl">,
   ) => Promise<void>;
   browserPagePayload: (tab: BrowserTabRecord) => Record<string, unknown>;
+  withTemporarilyRenderedBrowserTab: <T>(
+    tab: BrowserTabRecord,
+    callback: () => Promise<T>,
+    options?: {
+      requireFocusedWindow?: boolean;
+      workspaceId?: string | null;
+      waitForRenderedFrame?: boolean;
+    },
+  ) => Promise<T>;
 }
 
 export function createBrowserPaneTabState(
   deps: BrowserPaneTabStateDeps,
 ): BrowserPaneTabState {
+  const sharedAgentInputHosts = new Map<string, SharedAgentInputHostState>();
+  let focusedAgentInputQueue = Promise.resolve();
+
   function hasVisibleBounds(): boolean {
     const b = deps.getBrowserBounds();
     return b.width > 0 && b.height > 0;
@@ -480,6 +506,387 @@ export function createBrowserPaneTabState(
     updateAttachedBrowserView();
   }
 
+  function backgroundRenderHostBounds(): BrowserBoundsPayload {
+    const bounds = deps.getBrowserBounds();
+    return {
+      x: 0,
+      y: 0,
+      width:
+        bounds.width > 0 ? bounds.width : BACKGROUND_RENDER_HOST_WIDTH,
+      height:
+        bounds.height > 0 ? bounds.height : BACKGROUND_RENDER_HOST_HEIGHT,
+    };
+  }
+
+  function invisibleInputHostWindowBounds(
+    viewBounds: BrowserBoundsPayload,
+  ): BrowserBoundsPayload {
+    const mainWindow = deps.getMainWindow();
+    const mainWindowBounds =
+      mainWindow && !mainWindow.isDestroyed() ? mainWindow.getBounds() : null;
+    return {
+      x: mainWindowBounds ? Math.round(mainWindowBounds.x) : 0,
+      y: mainWindowBounds ? Math.round(mainWindowBounds.y) : 0,
+      width: viewBounds.width,
+      height: viewBounds.height,
+    };
+  }
+
+  function ensureSharedAgentInputHostState(
+    workspaceId: string,
+  ): SharedAgentInputHostState {
+    const normalizedWorkspaceId = workspaceId.trim();
+    const existing = sharedAgentInputHosts.get(normalizedWorkspaceId);
+    if (existing) {
+      return existing;
+    }
+    const created: SharedAgentInputHostState = {
+      host: null,
+      activeView: null,
+      idleTimer: null,
+    };
+    sharedAgentInputHosts.set(normalizedWorkspaceId, created);
+    return created;
+  }
+
+  function clearSharedAgentInputHostIdleTimer(
+    hostState: SharedAgentInputHostState,
+  ): void {
+    if (!hostState.idleTimer) {
+      return;
+    }
+    clearTimeout(hostState.idleTimer);
+    hostState.idleTimer = null;
+  }
+
+  function destroySharedAgentInputHost(
+    workspaceId: string,
+    hostState?: SharedAgentInputHostState,
+  ): void {
+    const normalizedWorkspaceId = workspaceId.trim();
+    const state =
+      hostState ?? sharedAgentInputHosts.get(normalizedWorkspaceId) ?? null;
+    if (!state) {
+      return;
+    }
+    clearSharedAgentInputHostIdleTimer(state);
+    state.activeView = null;
+    const host = state.host;
+    state.host = null;
+    if (host && !host.isDestroyed()) {
+      host.setBrowserView(null);
+      host.destroy();
+    }
+    sharedAgentInputHosts.delete(normalizedWorkspaceId);
+  }
+
+  function scheduleSharedAgentInputHostDestroy(
+    workspaceId: string,
+    hostState: SharedAgentInputHostState,
+  ): void {
+    clearSharedAgentInputHostIdleTimer(hostState);
+    hostState.idleTimer = setTimeout(() => {
+      destroySharedAgentInputHost(workspaceId, hostState);
+    }, SHARED_AGENT_INPUT_HOST_IDLE_MS);
+  }
+
+  function ensureSharedAgentInputHostWindow(
+    workspaceId: string,
+    viewBounds: BrowserBoundsPayload,
+  ): SharedAgentInputHostState {
+    const hostState = ensureSharedAgentInputHostState(workspaceId);
+    clearSharedAgentInputHostIdleTimer(hostState);
+    const windowBounds = invisibleInputHostWindowBounds(viewBounds);
+    if (hostState.host && !hostState.host.isDestroyed()) {
+      hostState.host.setBounds(windowBounds);
+      return hostState;
+    }
+
+    const host = new BrowserWindow({
+      show: false,
+      skipTaskbar: true,
+      useContentSize: true,
+      x: windowBounds.x,
+      y: windowBounds.y,
+      width: windowBounds.width,
+      height: windowBounds.height,
+      backgroundColor: "#00000000",
+      transparent: true,
+      opacity: BACKGROUND_INPUT_HOST_OPACITY,
+      frame: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      movable: false,
+      webPreferences: {
+        sandbox: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+      },
+    });
+    host.setIgnoreMouseEvents(true);
+    host.on("closed", () => {
+      if (hostState.host === host) {
+        hostState.host = null;
+        hostState.activeView = null;
+        clearSharedAgentInputHostIdleTimer(hostState);
+        sharedAgentInputHosts.delete(workspaceId.trim());
+      }
+    });
+    hostState.host = host;
+    hostState.activeView = null;
+    return hostState;
+  }
+
+  async function waitForBrowserWindowFocus(host: BrowserWindow): Promise<void> {
+    for (
+      let attempt = 0;
+      attempt < BACKGROUND_RENDER_VIEWPORT_POLL_ATTEMPTS;
+      attempt += 1
+    ) {
+      if (host.isDestroyed() || host.isFocused()) {
+        return;
+      }
+      if (attempt < BACKGROUND_RENDER_VIEWPORT_POLL_ATTEMPTS - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, BACKGROUND_RENDER_VIEWPORT_POLL_DELAY_MS),
+        );
+      }
+    }
+  }
+
+  async function waitForRenderedBrowserViewport(
+    tab: BrowserTabRecord,
+  ): Promise<void> {
+    for (
+      let attempt = 0;
+      attempt < BACKGROUND_RENDER_VIEWPORT_POLL_ATTEMPTS;
+      attempt += 1
+    ) {
+      try {
+        const viewport = await tab.view.webContents.executeJavaScript(
+          "({ width: window.innerWidth, height: window.innerHeight })",
+          true,
+        );
+        if (
+          viewport &&
+          typeof viewport === "object" &&
+          typeof (viewport as { width?: unknown }).width === "number" &&
+          (viewport as { width: number }).width > 0 &&
+          typeof (viewport as { height?: unknown }).height === "number" &&
+          (viewport as { height: number }).height > 0
+        ) {
+          return;
+        }
+      } catch {
+        // Ignore transient renderer timing failures and keep polling.
+      }
+      if (attempt < BACKGROUND_RENDER_VIEWPORT_POLL_ATTEMPTS - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, BACKGROUND_RENDER_VIEWPORT_POLL_DELAY_MS),
+        );
+      }
+    }
+  }
+
+  async function waitForRenderedBrowserFrame(
+    tab: BrowserTabRecord,
+  ): Promise<boolean> {
+    await waitForRenderedBrowserViewport(tab);
+    const webContents = tab.view.webContents;
+    if (webContents.isDestroyed()) {
+      return false;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      let subscribed = false;
+      const timeout = setTimeout(() => {
+        finish(false);
+      }, BACKGROUND_RENDER_FRAME_TIMEOUT_MS);
+
+      const finish = (rendered: boolean) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        if (subscribed) {
+          try {
+            webContents.endFrameSubscription();
+          } catch {
+            // Ignore teardown errors while unwinding a temporary host.
+          }
+        }
+        resolve(rendered);
+      };
+
+      try {
+        webContents.beginFrameSubscription(() => {
+          finish(true);
+        });
+        subscribed = true;
+      } catch {
+        finish(false);
+        return;
+      }
+
+      try {
+        webContents.invalidate();
+      } catch {
+        finish(false);
+      }
+    });
+  }
+
+  async function withBrowserTabHostedInWindow<T>(
+    tab: BrowserTabRecord,
+    callback: () => Promise<T>,
+    host: BrowserWindow,
+    bounds: BrowserBoundsPayload,
+    options: {
+      requireFocusedWindow?: boolean;
+      waitForRenderedFrame?: boolean;
+      destroyHostOnComplete?: boolean;
+      sharedHostState?: SharedAgentInputHostState | null;
+    } = {},
+  ): Promise<T> {
+    const attachedView = deps.getAttachedView();
+    const mainWindow = deps.getMainWindow();
+    const wasAttachedToMainWindow = attachedView === tab.view;
+
+    if (
+      wasAttachedToMainWindow &&
+      mainWindow &&
+      !mainWindow.isDestroyed()
+    ) {
+      mainWindow.setBrowserView(null);
+      deps.setAttachedView(null);
+    }
+
+    if (options.sharedHostState?.activeView && options.sharedHostState.activeView !== tab.view) {
+      host.setBrowserView(null);
+      options.sharedHostState.activeView = null;
+    }
+
+    host.setBrowserView(tab.view);
+    if (options.sharedHostState) {
+      options.sharedHostState.activeView = tab.view;
+    }
+    tab.view.setBounds(bounds);
+
+    if (options.requireFocusedWindow === true) {
+      host.show();
+      host.focus();
+      await waitForBrowserWindowFocus(host);
+      tab.view.webContents.focus();
+    }
+
+    await waitForRenderedBrowserViewport(tab);
+    if (options.waitForRenderedFrame === true) {
+      await waitForRenderedBrowserFrame(tab);
+    }
+
+    try {
+      return await callback();
+    } finally {
+      if (options.sharedHostState?.activeView === tab.view) {
+        options.sharedHostState.activeView = null;
+      }
+      if (!host.isDestroyed()) {
+        host.setBrowserView(null);
+        if (options.destroyHostOnComplete === true) {
+          host.destroy();
+        }
+      }
+      if (wasAttachedToMainWindow && hasVisibleBounds()) {
+        updateAttachedBrowserView();
+      }
+    }
+  }
+
+  async function withQueuedAgentInputHost<T>(
+    workspaceId: string,
+    tab: BrowserTabRecord,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const previousQueue = focusedAgentInputQueue;
+    let releaseQueue!: () => void;
+    focusedAgentInputQueue = new Promise<void>((resolve) => {
+      releaseQueue = resolve;
+    });
+    await previousQueue.catch(() => undefined);
+
+    let hostState: SharedAgentInputHostState | null = null;
+    try {
+      const bounds = backgroundRenderHostBounds();
+      hostState = ensureSharedAgentInputHostWindow(workspaceId, bounds);
+      const host = hostState.host;
+      if (!host) {
+        throw new Error("Shared agent browser input host could not be created.");
+      }
+      return await withBrowserTabHostedInWindow(tab, callback, host, bounds, {
+        requireFocusedWindow: true,
+        sharedHostState: hostState,
+      });
+    } finally {
+      if (hostState) {
+        scheduleSharedAgentInputHostDestroy(workspaceId, hostState);
+      }
+      releaseQueue();
+    }
+  }
+
+  async function withTemporarilyRenderedBrowserTab<T>(
+    tab: BrowserTabRecord,
+    callback: () => Promise<T>,
+    options: {
+      requireFocusedWindow?: boolean;
+      workspaceId?: string | null;
+      waitForRenderedFrame?: boolean;
+    } = {},
+  ): Promise<T> {
+    const attachedView = deps.getAttachedView();
+    if (
+      !options.requireFocusedWindow &&
+      attachedView === tab.view &&
+      hasVisibleBounds()
+    ) {
+      return callback();
+    }
+
+    const normalizedWorkspaceId =
+      typeof options.workspaceId === "string" ? options.workspaceId.trim() : "";
+    if (options.requireFocusedWindow && normalizedWorkspaceId) {
+      return withQueuedAgentInputHost(normalizedWorkspaceId, tab, callback);
+    }
+
+    const bounds = backgroundRenderHostBounds();
+    const host = new BrowserWindow({
+      show: options.requireFocusedWindow === true,
+      paintWhenInitiallyHidden: true,
+      skipTaskbar: true,
+      useContentSize: true,
+      width: bounds.width,
+      height: bounds.height,
+      backgroundColor: "#050907",
+      frame: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      movable: false,
+      webPreferences: {
+        sandbox: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+      },
+    });
+    return withBrowserTabHostedInWindow(tab, callback, host, bounds, {
+      requireFocusedWindow: options.requireFocusedWindow,
+      destroyHostOnComplete: true,
+    });
+  }
+
   async function captureVisibleSnapshot(): Promise<BrowserVisibleSnapshotPayload | null> {
     const target = activeVisibleBrowserTarget();
     const activeTab = getActiveBrowserTab(
@@ -542,6 +949,15 @@ export function createBrowserPaneTabState(
   }
 
   function closeBrowserTabRecord(tab: BrowserTabRecord): void {
+    for (const hostState of sharedAgentInputHosts.values()) {
+      if (hostState.activeView !== tab.view || !hostState.host) {
+        continue;
+      }
+      if (!hostState.host.isDestroyed()) {
+        hostState.host.setBrowserView(null);
+      }
+      hostState.activeView = null;
+    }
     tab.view.webContents.removeAllListeners();
     void (
       tab.view.webContents as unknown as { close?: () => void }
@@ -1675,5 +2091,6 @@ export function createBrowserPaneTabState(
     emitHistoryState,
     recordHistoryVisit,
     browserPagePayload,
+    withTemporarilyRenderedBrowserTab,
   };
 }

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -17360,6 +17360,8 @@ const consumeBrowserDownloadOverride =
 const browserContextSuggestedFilename =
   browserPaneTabState.browserContextSuggestedFilename;
 const browserPagePayload = browserPaneTabState.browserPagePayload;
+const withTemporarilyRenderedBrowserTab =
+  browserPaneTabState.withTemporarilyRenderedBrowserTab;
 const setActiveBrowserTabInner = browserPaneTabState.setActiveBrowserTab;
 const closeBrowserTabInner = browserPaneTabState.closeBrowserTab;
 
@@ -17469,6 +17471,12 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
     operatorSurfaceContextPayload(workspaceId),
   browserPagePayload: (tab) =>
     browserPagePayload(tab as unknown as BrowserTabRecord),
+  withTemporarilyRenderedBrowserTab: (tab, callback, options) =>
+    withTemporarilyRenderedBrowserTab(
+      tab as unknown as BrowserTabRecord,
+      callback,
+      options,
+    ),
   withProgrammaticBrowserInput: (webContents, callback) =>
     withProgrammaticBrowserInput(webContents, callback),
   sendBrowserKeyPress: (webContents, keyCode, modifiers) =>

--- a/runtime/api-server/src/desktop-browser-tools.test.ts
+++ b/runtime/api-server/src/desktop-browser-tools.test.ts
@@ -877,12 +877,42 @@ test("desktop browser tool service exposes general find, act, wait, evaluate, an
     }
     if (request.url === "/api/v1/browser/mouse") {
       mouseBodies.push(body);
-      response.end(JSON.stringify({ ok: true, tabId: "tab-1", action: "click", x: 370, y: 104 }));
+      response.end(
+        JSON.stringify({
+          ok: true,
+          tabId: "tab-1",
+          action: "click",
+          x: 370,
+          y: 104,
+          resolved_action: {
+            ok: true,
+            action: "click",
+            target: { ref: "css:#new-button", text: "New" },
+            result: { x: 370, y: 104 },
+          },
+        }),
+      );
       return;
     }
     if (request.url === "/api/v1/browser/keyboard") {
       keyboardBodies.push(body);
-      response.end(JSON.stringify({ ok: true, tabId: "tab-1", action: "insert_text", text_length: 14, clear: true, submit: false }));
+      response.end(
+        JSON.stringify({
+          ok: true,
+          tabId: "tab-1",
+          action: "insert_text",
+          text_length: 14,
+          clear: true,
+          submit: false,
+          resolved_action: {
+            ok: true,
+            action: "fill",
+            target: { ref: "css:#editor", text: "" },
+            action_target: { ref: "css:#editor", role: "textbox", editable: true },
+            result: { focused: true },
+          },
+        }),
+      );
       return;
     }
     if (request.url === "/api/v1/browser/evaluate") {
@@ -908,35 +938,6 @@ test("desktop browser tool service exposes general find, act, wait, evaluate, an
                   bounding_box: { x: 292, y: 72, width: 156, height: 64 },
                 },
               ],
-            },
-          }),
-        );
-        return;
-      }
-      if (expression.includes('const action = "click"')) {
-        response.end(
-          JSON.stringify({
-            tabId: "tab-1",
-            result: {
-              ok: true,
-              action: "click",
-              target: { ref: "css:#new-button", text: "New" },
-              result: { x: 370, y: 104 },
-            },
-          }),
-        );
-        return;
-      }
-      if (expression.includes('const action = "fill"')) {
-        response.end(
-          JSON.stringify({
-            tabId: "tab-1",
-            result: {
-              ok: true,
-              action: "fill",
-              target: { ref: "css:#editor", text: "" },
-              action_target: { ref: "css:#editor", role: "textbox", editable: true },
-              result: { focused: true },
             },
           }),
         );
@@ -1075,7 +1076,11 @@ test("desktop browser tool service exposes general find, act, wait, evaluate, an
     );
     assert.deepEqual(actResult.page, { tabId: "tab-1", url: "https://example.com/app", title: "Example App" });
     assert.equal((actResult.browser_usage as { tool_id?: string }).tool_id, "browser_act");
-    assert.deepEqual(mouseBodies, [JSON.stringify({ action: "click", x: 370, y: 104 })]);
+    assert.equal(mouseBodies.length, 1);
+    const clickMouseBody = JSON.parse(mouseBodies[0]) as Record<string, unknown>;
+    assert.equal(clickMouseBody.action, "click");
+    assert.equal(typeof clickMouseBody.expression, "string");
+    assert.match(String(clickMouseBody.expression), /const action = "click"/);
 
     const fillResult = await service.execute("browser_act", {
       action: "fill",
@@ -1089,9 +1094,14 @@ test("desktop browser tool service exposes general find, act, wait, evaluate, an
       { ok: true, tabId: "tab-1", action: "insert_text", text_length: 14, clear: true, submit: false },
     );
     assert.equal((fillResult.browser_usage as { tool_id?: string }).tool_id, "browser_act");
-    assert.deepEqual(keyboardBodies, [
-      JSON.stringify({ action: "insert_text", text: "Robotics notes", clear: true, submit: false }),
-    ]);
+    assert.equal(keyboardBodies.length, 1);
+    const fillKeyboardBody = JSON.parse(keyboardBodies[0]) as Record<string, unknown>;
+    assert.equal(fillKeyboardBody.action, "insert_text");
+    assert.equal(fillKeyboardBody.text, "Robotics notes");
+    assert.equal(fillKeyboardBody.clear, true);
+    assert.equal(fillKeyboardBody.submit, false);
+    assert.equal(typeof fillKeyboardBody.expression, "string");
+    assert.match(String(fillKeyboardBody.expression), /const action = "fill"/);
 
     const checkResult = await service.execute("browser_act", {
       action: "check",
@@ -1134,8 +1144,6 @@ test("desktop browser tool service exposes general find, act, wait, evaluate, an
     const expressions = evaluateBodies.map((body) => String((JSON.parse(body) as { expression?: string }).expression ?? ""));
     const findExpression = expressions.find((expression) => expression.includes('"text":"New"')) ?? "";
     assert.match(findExpression, /"role":"button"/);
-    assert.ok(expressions.some((expression) => /const action = "click"/.test(expression)));
-    assert.ok(expressions.some((expression) => /const action = "fill"/.test(expression)));
     assert.ok(expressions.some((expression) => /const action = "check"/.test(expression)));
     assert.ok(expressions.some((expression) => /const condition = "element"/.test(expression)));
   } finally {
@@ -1360,7 +1368,6 @@ test("desktop browser tool service waits for browser downloads to start and comp
 test("desktop browser tool service supports inline wait_for and post_state on browser_type", async () => {
   const requests: string[] = [];
   const bodies: string[] = [];
-  let evaluateCount = 0;
   const browserServer = await startBrowserServer(async (request, response) => {
     requests.push(request.url ?? "");
     const chunks: Buffer[] = [];
@@ -1377,17 +1384,7 @@ test("desktop browser tool service supports inline wait_for and post_state on br
       return;
     }
     if (request.url === "/api/v1/browser/evaluate") {
-      evaluateCount += 1;
       const expression = String((JSON.parse(body) as { expression?: string }).expression ?? "");
-      if (evaluateCount === 1) {
-        response.end(
-          JSON.stringify({
-            tabId: "tab-1",
-            result: { ok: true, index: 1, tag_name: "input", role: "textbox", editable: true },
-          }),
-        );
-        return;
-      }
       if (expression.includes('const condition = "function"')) {
         response.end(
           JSON.stringify({
@@ -1437,6 +1434,10 @@ test("desktop browser tool service supports inline wait_for and post_state on br
           ok: true,
           tabId: "tab-1",
           action: "insert_text",
+          index: 1,
+          tag_name: "input",
+          role: "textbox",
+          editable: true,
           text_length: 12,
           clear: true,
           submit: false,
@@ -1501,7 +1502,6 @@ test("desktop browser tool service supports inline wait_for and post_state on br
     assert.equal((result.browser_usage as { wait_condition?: string }).wait_condition, "function");
     assert.equal((result.browser_usage as { detail?: string }).detail, "compact");
     assert.deepEqual(requests, [
-      "/api/v1/browser/evaluate",
       "/api/v1/browser/keyboard",
       "/api/v1/browser/evaluate",
       "/api/v1/browser/page",
@@ -1528,21 +1528,16 @@ test("desktop browser tool service avoids refetching page summaries for browser_
     }
     bodies.push(Buffer.concat(chunks).toString("utf8"));
     response.setHeader("content-type", "application/json; charset=utf-8");
-    if (request.url === "/api/v1/browser/evaluate") {
-      response.end(
-        JSON.stringify({
-          tabId: "tab-1",
-          result: { ok: true, index: 1, tag_name: "div", role: "textbox", editable: true }
-        })
-      );
-      return;
-    }
     if (request.url === "/api/v1/browser/keyboard") {
       response.end(
         JSON.stringify({
           ok: true,
           tabId: "tab-1",
           action: "insert_text",
+          index: 1,
+          tag_name: "div",
+          role: "textbox",
+          editable: true,
           text_length: 12,
           clear: true,
           submit: false,
@@ -1602,8 +1597,11 @@ test("desktop browser tool service avoids refetching page summaries for browser_
       }
     });
     assert.equal((typeBrowserUsage as { tool_id?: string }).tool_id, "browser_type");
-    assert.deepEqual(requests, ["/api/v1/browser/evaluate", "/api/v1/browser/keyboard"]);
-    assert.equal(bodies[1], JSON.stringify({ action: "insert_text", text: "search terms", clear: true, submit: false }));
+    assert.deepEqual(requests, ["/api/v1/browser/keyboard"]);
+    assert.equal(
+      bodies[0],
+      JSON.stringify({ action: "insert_text", index: 1, text: "search terms", clear: true, submit: false }),
+    );
   } finally {
     await browserServer.close();
   }

--- a/runtime/api-server/src/desktop-browser-tools.ts
+++ b/runtime/api-server/src/desktop-browser-tools.ts
@@ -2879,32 +2879,36 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
             "key is required for press actions"
           );
         }
-        let result = await this.#evaluate(
-          config,
-          isNativePointerAction(options.action)
-            ? browserPointerTargetExpression(options)
-            : isNativeTextAction(options.action)
-              ? browserKeyboardTargetExpression(options, { requireEditable: true })
-              : options.action === "press"
-                ? browserKeyboardTargetExpression(options, { requireEditable: false })
-                : browserActExpression(options),
-          context,
-        );
+        let result = isNativePointerAction(options.action) ||
+          isNativeTextAction(options.action) ||
+          options.action === "press"
+          ? {}
+          : await this.#evaluate(
+              config,
+              browserActExpression(options),
+              context,
+            );
         if (isNativePointerAction(options.action)) {
-          const point = asRecord(result.result);
-          const x = requiredNonNegativeInteger(point?.x, "x");
-          const y = requiredNonNegativeInteger(point?.y, "y");
           const nativeInput = await this.#browserFetch(config, {
             method: "POST",
             path: "/mouse",
-            body: { action: options.action, x, y },
+            body: {
+              action: options.action,
+              expression: browserPointerTargetExpression(options),
+            },
             workspaceId: context.workspaceId,
             sessionId: context.sessionId,
             space: context.space,
           });
+          const nativeInputResult = { ...nativeInput };
+          const resolvedAction = asRecord(nativeInputResult.resolved_action) ?? {};
+          delete nativeInputResult.resolved_action;
           result = {
-            ...result,
-            result: { ...(asRecord(result.result) ?? {}), native_input: nativeInput },
+            ...resolvedAction,
+            result: {
+              ...(asRecord(resolvedAction.result) ?? {}),
+              native_input: nativeInputResult,
+            },
           };
         } else if (isNativeTextAction(options.action)) {
           const nativeInput = await this.#browserFetch(config, {
@@ -2912,6 +2916,7 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
             path: "/keyboard",
             body: {
               action: "insert_text",
+              expression: browserKeyboardTargetExpression(options, { requireEditable: true }),
               text: options.value ?? "",
               clear: options.clear === null ? options.action === "fill" : options.clear,
               submit: options.submit,
@@ -2920,29 +2925,39 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
             sessionId: context.sessionId,
             space: context.space,
           });
+          const nativeInputResult = { ...nativeInput };
+          const resolvedAction = asRecord(nativeInputResult.resolved_action) ?? {};
+          delete nativeInputResult.resolved_action;
           result = {
-            ...result,
+            ...resolvedAction,
             result: {
-              ...(asRecord(result.result) ?? {}),
+              ...(asRecord(resolvedAction.result) ?? {}),
               value: options.value ?? "",
-              native_input: nativeInput,
+              native_input: nativeInputResult,
             },
           };
         } else if (options.action === "press") {
           const nativeInput = await this.#browserFetch(config, {
             method: "POST",
             path: "/keyboard",
-            body: { action: "press", key: options.key ?? "" },
+            body: {
+              action: "press",
+              expression: browserKeyboardTargetExpression(options, { requireEditable: false }),
+              key: options.key ?? "",
+            },
             workspaceId: context.workspaceId,
             sessionId: context.sessionId,
             space: context.space,
           });
+          const nativeInputResult = { ...nativeInput };
+          const resolvedAction = asRecord(nativeInputResult.resolved_action) ?? {};
+          delete nativeInputResult.resolved_action;
           result = {
-            ...result,
+            ...resolvedAction,
             result: {
-              ...(asRecord(result.result) ?? {}),
+              ...(asRecord(resolvedAction.result) ?? {}),
               key: options.key ?? "",
-              native_input: nativeInput,
+              native_input: nativeInputResult,
             },
           };
         }
@@ -3110,15 +3125,30 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
         const text = requiredString(args.text, "text");
         const clear = optionalBoolean(args.clear, true);
         const submit = optionalBoolean(args.submit, false);
-        const result = await this.#evaluate(config, indexedKeyboardTargetExpression(index), context);
         const nativeInput = await this.#browserFetch(config, {
           method: "POST",
           path: "/keyboard",
-          body: { action: "insert_text", text, clear, submit },
+          body: { action: "insert_text", index, text, clear, submit },
           workspaceId: context.workspaceId,
           sessionId: context.sessionId,
           space: context.space,
         });
+        const nativeInputResult = { ...nativeInput };
+        delete nativeInputResult.index;
+        delete nativeInputResult.tag_name;
+        delete nativeInputResult.role;
+        delete nativeInputResult.editable;
+        const actionResult = {
+          ok: true,
+          index,
+          ...(typeof nativeInput.tag_name === "string"
+            ? { tag_name: nativeInput.tag_name }
+            : {}),
+          ...(typeof nativeInput.role === "string"
+            ? { role: nativeInput.role }
+            : {}),
+          ...(nativeInput.editable === true ? { editable: true } : {}),
+        };
         const wait =
           postAction.waitFor
             ? await this.#waitForBrowserCondition(config, context, postAction.waitFor)
@@ -3131,11 +3161,10 @@ export class DesktopBrowserToolService implements DesktopBrowserToolServiceLike 
         return {
           ok: true,
           action: {
-            ...result,
+            ...actionResult,
             result: {
-              ...(asRecord(result.result) ?? {}),
               value: text,
-              native_input: nativeInput,
+              native_input: nativeInputResult,
             },
           },
           ...(wait ? { wait } : {}),


### PR DESCRIPTION
## Summary
- add temporary hidden BrowserView hosts plus a shared focused input host for background browser work
- route evaluate, screenshot, mouse, keyboard, and context-click through the hosted execution path
- make `browser_type` and native `browser_act` actions atomic so target resolution and native input happen in one request
- retry screenshot capture on transient Viz failures and add regression coverage for the new background-host behavior

## Validation
- `cd runtime/api-server && node --import tsx --test src/desktop-browser-tools.test.ts`
- `node --test desktop/electron/browser-context-menu.test.mjs desktop/electron/browser-background-render-host.test.mjs`
- `npm run desktop:typecheck`

## Notes
- This change is intended to keep subagent browser work inside the embedded browser path even when the user is not on the agent tab.
- Native background input still requires temporary app focus because Electron `sendInputEvent()` needs a focused containing window.
