### PR TITLE
fix(desktop): send thinking_value from Control Center command bar

### DIFF
--- a/desktop/src/components/layout/WorkspaceControlCenter.tsx
+++ b/desktop/src/components/layout/WorkspaceControlCenter.tsx
@@ -1332,6 +1332,7 @@ function WorkspaceCommandBar({
     setChatModelPreference,
     requiresModelProviderSetup,
     modelSelectionUnavailableReason,
+    effectiveThinkingValue,
   } = useChatComposerModelSelection();
 
   const noAvailableModels =
@@ -1409,6 +1410,7 @@ function WorkspaceCommandBar({
         session_id: ensured.session.session_id,
         priority: 0,
         model: resolvedChatModel || null,
+        thinking_value: effectiveThinkingValue,
       });
       void queued;
       setText("");

--- a/desktop/src/lib/chat/useChatComposerModelSelection.ts
+++ b/desktop/src/lib/chat/useChatComposerModelSelection.ts
@@ -3,6 +3,7 @@ import {
   CHAT_MODEL_PRESETS,
   CHAT_MODEL_STORAGE_KEY,
   CHAT_MODEL_USE_RUNTIME_DEFAULT,
+  CHAT_THINKING_STORAGE_KEY,
   DEPRECATED_CHAT_MODELS,
   LEGACY_UNAVAILABLE_CHAT_MODELS,
   RUNTIME_MODEL_CAPABILITY_ALIASES,
@@ -14,6 +15,7 @@ import type {
 } from "@/components/panes/ChatPane/types";
 import { DEFAULT_RUNTIME_MODEL, useDesktopAuthSession } from "@/lib/auth/authClient";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import * as modelCatalog from "../../../shared/model-catalog";
 
 function sessionUserId(
   session: { user?: { id?: string | null } | null } | null | undefined,
@@ -92,6 +94,56 @@ function normalizeStoredChatModelPreference(value: string | null | undefined) {
   return stored;
 }
 
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStoredChatThinkingPreferences(
+  value: string | null | undefined,
+): Record<string, string> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (!isStringRecord(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        )
+        .map(([key, raw]) => [key.trim(), raw.trim()])
+        .filter(([key, raw]) => Boolean(key) && Boolean(raw)),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function loadStoredChatThinkingPreferences(): Record<string, string> {
+  try {
+    return normalizeStoredChatThinkingPreferences(
+      localStorage.getItem(CHAT_THINKING_STORAGE_KEY),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function runtimeModelThinkingValues(
+  model: RuntimeProviderModelPayload,
+): string[] {
+  if (!Array.isArray(model.thinkingValues)) return [];
+  const seen = new Set<string>();
+  const values: string[] = [];
+  for (const value of model.thinkingValues) {
+    if (typeof value !== "string") continue;
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    values.push(normalized);
+  }
+  return values;
+}
+
 function loadStoredChatModelPreference() {
   try {
     return normalizeStoredChatModelPreference(
@@ -117,6 +169,12 @@ export interface ChatComposerModelSelection {
   modelSelectionUnavailableReason: string;
   requiresModelProviderSetup: boolean;
   hasConfiguredProviderCatalog: boolean;
+  selectedModelSupportsReasoning: boolean;
+  selectedThinkingValues: string[];
+  selectedDefaultThinkingValue: string | null;
+  chatThinkingPreferences: Record<string, string>;
+  setSelectedThinkingValue: (value: string | null) => void;
+  effectiveThinkingValue: string | null;
 }
 
 export function useChatComposerModelSelection(): ChatComposerModelSelection {
@@ -145,6 +203,21 @@ export function useChatComposerModelSelection(): ChatComposerModelSelection {
   const setChatModelPreference = useCallback((value: string) => {
     setChatModelPreferenceRaw(value);
   }, []);
+
+  const [chatThinkingPreferences, setChatThinkingPreferences] = useState(
+    loadStoredChatThinkingPreferences,
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        CHAT_THINKING_STORAGE_KEY,
+        JSON.stringify(chatThinkingPreferences),
+      );
+    } catch {
+      // ignore persistence failures
+    }
+  }, [chatThinkingPreferences]);
 
   const isSignedIn = Boolean(sessionUserId(authSessionState.data));
   const holabossProxyModelsAvailable =
@@ -307,6 +380,58 @@ export function useChatComposerModelSelection(): ChatComposerModelSelection {
         ? "Managed models are finishing setup. Refresh runtime binding or use another provider."
         : "No models available. Configure a provider to start chatting.";
 
+  const selectedConfiguredModel = resolvedChatModel
+    ? (visibleConfiguredProviderModelGroups
+        .flatMap((providerGroup) => providerGroup.models)
+        .find((model) => model.token === resolvedChatModel) ?? null)
+    : null;
+  const selectedFallbackModelMetadata =
+    !selectedConfiguredModel &&
+    !hasConfiguredProviderCatalog &&
+    holabossProxyModelsAvailable &&
+    resolvedChatModel
+      ? modelCatalog.catalogMetadataForProviderModel(
+          "holaboss_model_proxy",
+          resolvedChatModel,
+        )
+      : null;
+  const selectedModelSupportsReasoning = selectedConfiguredModel
+    ? selectedConfiguredModel.reasoning === true
+    : Boolean(selectedFallbackModelMetadata?.reasoning);
+  const selectedThinkingValues = selectedConfiguredModel
+    ? runtimeModelThinkingValues(selectedConfiguredModel)
+    : (selectedFallbackModelMetadata?.thinkingValues ?? []);
+  const selectedDefaultThinkingValue = selectedConfiguredModel
+    ? selectedConfiguredModel.defaultThinkingValue?.trim() || null
+    : (selectedFallbackModelMetadata?.defaultThinkingValue ?? null);
+  const selectedStoredThinkingValue = resolvedChatModel
+    ? (chatThinkingPreferences[resolvedChatModel] ?? "").trim()
+    : "";
+  const effectiveThinkingValue =
+    !selectedModelSupportsReasoning || selectedThinkingValues.length === 0
+      ? null
+      : selectedThinkingValues.includes(selectedStoredThinkingValue)
+        ? selectedStoredThinkingValue
+        : selectedThinkingValues.includes("medium")
+          ? "medium"
+          : selectedDefaultThinkingValue &&
+              selectedThinkingValues.includes(selectedDefaultThinkingValue)
+            ? selectedDefaultThinkingValue
+            : (selectedThinkingValues[0] ?? null);
+
+  const setSelectedThinkingValue = useCallback(
+    (value: string | null) => {
+      if (!resolvedChatModel) return;
+      const normalized = value?.trim() ?? "";
+      if (!normalized) return;
+      setChatThinkingPreferences((current) => ({
+        ...current,
+        [resolvedChatModel]: normalized,
+      }));
+    },
+    [resolvedChatModel],
+  );
+
   return {
     isSignedIn,
     chatModelPreference,
@@ -322,5 +447,11 @@ export function useChatComposerModelSelection(): ChatComposerModelSelection {
     modelSelectionUnavailableReason,
     requiresModelProviderSetup,
     hasConfiguredProviderCatalog,
+    selectedModelSupportsReasoning,
+    selectedThinkingValues,
+    selectedDefaultThinkingValue,
+    chatThinkingPreferences,
+    setSelectedThinkingValue,
+    effectiveThinkingValue,
   };
 }


### PR DESCRIPTION
## Summary

Submitting a message from a Control Center card to a brand-new workspace (without ever entering the workspace itself) failed for reasoning-capable models with:

```
openai/gpt-5.5: 404 Item with id 'rs_<id>' not found.
Items are not persisted when \`store\` is set to false.
Try again with \`store\` set to true, or remove this item from your input.
```

ChatPane's composer was the only surface that derived an `effectiveThinkingValue` and passed it to `queueSessionInput`. The Control Center command bar (`WorkspaceCommandBar`) only forwarded `model`, leaving `thinking_value` off the payload — the upstream proxy then treated the request as a malformed reasoning call.

## Approach

Centralize the derivation in `useChatComposerModelSelection`:

- Hook now also stores `chatThinkingPreferences` (mirroring ChatPane's `localStorage`-backed state, same `CHAT_THINKING_STORAGE_KEY`)
- Returns `effectiveThinkingValue`, `selectedThinkingValues`, `selectedDefaultThinkingValue`, `selectedModelSupportsReasoning`, `setSelectedThinkingValue`
- `WorkspaceCommandBar.handleSubmit` consumes `effectiveThinkingValue` and includes it in the `queueSessionInput` payload

ChatPane keeps its own local derivation for now — parallel state hydrated from the same `localStorage` key, so on-mount values agree. A follow-up can swap ChatPane to consume the hook's values to make the source of truth single instead of replicated.

## Repro (pre-fix)

1. Open a fresh workspace (do **not** enter it)
2. Type a message in the Control Center card composer
3. Send → upstream API error above

## Test plan

- [ ] Open a fresh workspace, send from Control Center card without entering → succeeds (no `rs_... not found` error)
- [ ] Open an existing workspace, change thinking value in ChatPane, return to Control Center, send → uses the updated thinking value (mount-time consistency)
- [ ] Send from Control Center to a non-reasoning model → `thinking_value` is `null`, payload accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)