### PR TITLE
fix(desktop): unblock main process during browser-profile import (keychain prompt input race)

### DIFF
--- a/desktop/electron/browser-import-chrome.test.mjs
+++ b/desktop/electron/browser-import-chrome.test.mjs
@@ -105,7 +105,8 @@ test("desktop browser import flow discovers a Chrome profile and imports bookmar
   );
 
   // Cookie decryption helpers (mac keychain + Windows DPAPI + AES).
-  assert.match(chromiumSource, /execFileSync\(\s*"security",/);
+  assert.match(chromiumSource, /execFileAsync\(\s*"security",/);
+  assert.doesNotMatch(chromiumSource, /execFileSync\(\s*"security",/);
   assert.match(chromiumSource, /pbkdf2Sync\(\s*safeStoragePassword,/);
   assert.match(
     chromiumSource,

--- a/desktop/electron/browser-pane/import-chromium.ts
+++ b/desktop/electron/browser-pane/import-chromium.ts
@@ -7,7 +7,12 @@
  *
  * Extracted from `electron/main.ts` (BP-P2a). Behaviour is unchanged.
  */
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SECURITY_PROMPT_TIMEOUT_MS = 90_000;
 import {
   createDecipheriv,
   createHash,
@@ -599,41 +604,42 @@ export function chromeEncryptedCookieVersion(encryptedValue: Buffer) {
   return /^v\d\d$/.test(prefix) ? prefix : null;
 }
 
-function readChromeSafeStoragePasswordMac() {
+async function runSecurityFindGenericPassword(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("security", args, {
+    encoding: "utf8",
+    timeout: SECURITY_PROMPT_TIMEOUT_MS,
+  });
+  return stdout.trim();
+}
+
+async function readChromeSafeStoragePasswordMac(): Promise<string> {
   for (const serviceName of CHROME_COOKIE_SAFE_STORAGE_SERVICE_NAMES) {
     for (const accountName of CHROME_COOKIE_SAFE_STORAGE_ACCOUNT_NAMES) {
       try {
-        const password = execFileSync(
-          "security",
-          [
-            "find-generic-password",
-            "-w",
-            "-s",
-            serviceName,
-            "-a",
-            accountName,
-          ],
-          { encoding: "utf8" },
-        ).trim();
-        if (password) {
-          return password;
-        }
+        const password = await runSecurityFindGenericPassword([
+          "find-generic-password",
+          "-w",
+          "-s",
+          serviceName,
+          "-a",
+          accountName,
+        ]);
+        if (password) return password;
       } catch {
-        // Try the next service/account pair.
+        // try next pair
       }
     }
 
     try {
-      const password = execFileSync(
-        "security",
-        ["find-generic-password", "-w", "-s", serviceName],
-        { encoding: "utf8" },
-      ).trim();
-      if (password) {
-        return password;
-      }
+      const password = await runSecurityFindGenericPassword([
+        "find-generic-password",
+        "-w",
+        "-s",
+        serviceName,
+      ]);
+      if (password) return password;
     } catch {
-      // Try the next service name.
+      // try next service name
     }
   }
 
@@ -671,12 +677,12 @@ export function readChromeWindowsEncryptedKey(userDataDir: string) {
   return encryptedKeyWithHeader.subarray(header.length);
 }
 
-function runPowerShellScriptSync(command: string) {
+async function runPowerShellScript(command: string): Promise<string> {
   const shells = ["powershell.exe", "powershell"];
   let lastError: unknown = null;
   for (const shellName of shells) {
     try {
-      return execFileSync(
+      const { stdout } = await execFileAsync(
         shellName,
         [
           "-NoProfile",
@@ -687,7 +693,8 @@ function runPowerShellScriptSync(command: string) {
           command,
         ],
         { encoding: "utf8" },
-      ).trim();
+      );
+      return stdout.trim();
     } catch (error) {
       lastError = error;
     }
@@ -697,7 +704,7 @@ function runPowerShellScriptSync(command: string) {
     : new Error("PowerShell was not available.");
 }
 
-function decryptWindowsDpapi(input: Buffer) {
+async function decryptWindowsDpapi(input: Buffer): Promise<Buffer> {
   const base64Input = input.toString("base64");
   const command = [
     "$ErrorActionPreference='Stop'",
@@ -706,7 +713,7 @@ function decryptWindowsDpapi(input: Buffer) {
     `$plaintext=[System.Security.Cryptography.ProtectedData]::Unprotect($bytes,$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser)`,
     `[Convert]::ToBase64String($plaintext)`,
   ].join(";");
-  const output = runPowerShellScriptSync(command);
+  const output = await runPowerShellScript(command);
   if (!output) {
     throw new Error("Windows DPAPI decryption returned an empty result.");
   }
@@ -1017,7 +1024,7 @@ export async function importChromiumFamilyCookiesIntoWorkspaceSession(
   let windowsEncryptionKey: Buffer | null = null;
   if (process.platform === "darwin") {
     try {
-      safeStoragePassword = readChromeSafeStoragePasswordMac();
+      safeStoragePassword = await readChromeSafeStoragePasswordMac();
     } catch (error) {
       return {
         importedCount: 0,
@@ -1032,7 +1039,7 @@ export async function importChromiumFamilyCookiesIntoWorkspaceSession(
   } else if (process.platform === "win32") {
     try {
       const encryptedKey = readChromeWindowsEncryptedKey(path.dirname(profileDir));
-      windowsEncryptionKey = decryptWindowsDpapi(encryptedKey);
+      windowsEncryptionKey = await decryptWindowsDpapi(encryptedKey);
     } catch (error) {
       return {
         importedCount: 0,


### PR DESCRIPTION
## Symptom

Importing Chrome profile cookies (Set Up Browser Profile → Import from a browser → Chrome) triggers the macOS keychain authorization dialog ("security wants to use your confidential information stored in 'Chrome Safe Storage'…"). The dialog is **visible and mouse-clickable**, but the **password field rejects keystrokes** — or accepts them only after several attempts, depending on focus race timing. Some users can never get past it.

## Root cause

\`readChromeSafeStoragePasswordMac\` (and \`decryptWindowsDpapi\` on Windows) shelled out via **\`execFileSync\`**. That blocks the **Electron main thread** for the full duration of the prompt. With the main JS event loop frozen:

- macOS marks our app as not-responding territory
- Window-manager focus routing for the system modal dialog stalls — the prompt is owned by \`securityd\` but its focus context is tied to the calling app's process
- Keystrokes are dropped or queued unpredictably, while mouse clicks (which route directly to the dialog's window) still work

## Fix

Convert the two subprocess shellouts to async (\`execFile\` via \`promisify\`):

- \`readChromeSafeStoragePasswordMac\` → async, with a 90s timeout on the keychain prompt
- \`runPowerShellScriptSync\` → \`runPowerShellScript\` (async)
- \`decryptWindowsDpapi\` → async (chains the PowerShell change)
- Two call sites in the already-\`async\` outer \`importChromiumFamilyCookiesIntoWorkspaceSession\` add \`await\`

Main thread stays responsive while the OS dialog is up → focus flows to it normally → keyboard input works first try.

Test assertion updated to require \`execFileAsync\` over \`execFileSync\` so a future refactor can't silently regress to the blocking call.

## Test plan

- [ ] On macOS: Set Up Browser Profile → Import from Chrome with no existing keychain ACL → password field accepts typing on first try
- [ ] During the keychain prompt, app remains responsive (drag the workspace window, click sidebar items)
- [ ] Import completes after Allow / Always Allow
- [ ] Wrong password / Cancel returns gracefully (timeout doesn't fire prematurely)
- [ ] On Windows (best-effort, smoke): import completes; PowerShell DPAPI decryption produces the same key as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)