### PR TITLE
fix(desktop): popup theme palette ignored real app theme names

### DIFF
--- a/desktop/electron/browser-pane/popups.ts
+++ b/desktop/electron/browser-pane/popups.ts
@@ -525,20 +525,14 @@ function createAddressSuggestionsPopupHtml(themeCss: string): string {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Suggestions</title>
     <style>
-      :root { color-scheme: dark; }
       * { box-sizing: border-box; }
       body {
         margin: 0;
-        font-family: "IBM Plex Sans", "Segoe UI Variable", sans-serif;
         background: transparent;
-        color: #deeee6;
       }
       .panel {
         margin: 6px 0 0;
         border-radius: 14px;
-        border: 1px solid rgba(87, 255, 173, 0.18);
-        background: linear-gradient(180deg, rgba(17, 19, 22, 0.98), rgba(12, 15, 18, 0.98));
-        box-shadow: 0 18px 42px rgba(0, 0, 0, 0.36);
         overflow: hidden;
       }
       .list {
@@ -551,18 +545,13 @@ function createAddressSuggestionsPopupHtml(themeCss: string): string {
         align-items: center;
         gap: 10px;
         border: 0;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+        border-bottom: 1px solid var(--popup-border-soft);
         background: transparent;
-        color: rgba(222, 238, 230, 0.84);
         padding: 10px 12px;
         text-align: left;
         cursor: pointer;
       }
       .item:last-child { border-bottom: 0; }
-      .item:hover,
-      .item.active {
-        background: rgba(124, 146, 184, 0.12);
-      }
       .icon {
         width: 14px;
         height: 14px;
@@ -580,7 +569,6 @@ function createAddressSuggestionsPopupHtml(themeCss: string): string {
         white-space: nowrap;
         font-size: 12px;
         font-weight: 600;
-        color: rgba(236, 239, 243, 0.92);
       }
       .url {
         overflow: hidden;
@@ -588,13 +576,12 @@ function createAddressSuggestionsPopupHtml(themeCss: string): string {
         white-space: nowrap;
         margin-top: 2px;
         font-size: 10px;
-        color: rgba(160, 167, 176, 0.72);
+        color: var(--popup-text-subtle);
       }
       .clock {
         width: 14px;
         text-align: center;
         flex: 0 0 auto;
-        color: rgba(160, 167, 176, 0.55);
         font-size: 12px;
       }
       ${themeCss}

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -2303,196 +2303,52 @@ interface PopupThemePalette {
   error: string;
 }
 
+function isLightAppTheme(theme: string): boolean {
+  return theme.endsWith("-light") || theme === "holaboss" || theme === "sepia" || theme === "paper";
+}
+
 function getPopupThemePalette(theme: string): PopupThemePalette {
-  switch (theme) {
-    case "holaboss":
-      return {
-        fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
-        text: "rgba(33, 38, 49, 0.94)",
-        textMuted: "rgba(109, 117, 131, 0.84)",
-        textSubtle: "rgba(109, 117, 131, 0.68)",
-        accent: "rgb(247, 90, 84)",
-        accentStrong: "rgb(233, 117, 109)",
-        border: "rgba(224, 228, 236, 0.78)",
-        borderSoft: "rgba(224, 228, 236, 0.42)",
-        hover: "rgba(247, 90, 84, 0.08)",
-        panelBg: "rgba(255, 255, 255, 0.98)",
-        panelBgAlt: "rgba(248, 249, 252, 0.98)",
-        controlBg: "rgba(248, 250, 253, 0.94)",
-        shadow: "0 12px 30px rgba(25, 33, 53, 0.08)",
-        emptyBg: "rgba(250, 245, 244, 0.92)",
-        error: "rgba(184, 67, 67, 0.94)",
-      };
-    case "sepia":
-      return {
-        fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
-        text: "rgba(74, 54, 39, 0.94)",
-        textMuted: "rgba(133, 108, 87, 0.84)",
-        textSubtle: "rgba(133, 108, 87, 0.68)",
-        accent: "rgb(183, 139, 98)",
-        accentStrong: "rgb(160, 124, 92)",
-        border: "rgba(203, 186, 165, 0.7)",
-        borderSoft: "rgba(203, 186, 165, 0.34)",
-        hover: "rgba(93, 70, 46, 0.05)",
-        panelBg: "rgba(255, 251, 246, 0.98)",
-        panelBgAlt: "rgba(246, 240, 232, 0.98)",
-        controlBg: "rgba(245, 241, 234, 0.94)",
-        shadow: "0 10px 28px rgba(93, 70, 46, 0.12)",
-        emptyBg: "rgba(251, 248, 242, 0.92)",
-        error: "rgba(181, 72, 72, 0.92)",
-      };
-    case "paper":
-      return {
-        fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
-        text: "rgba(78, 64, 52, 0.94)",
-        textMuted: "rgba(138, 119, 103, 0.84)",
-        textSubtle: "rgba(138, 119, 103, 0.68)",
-        accent: "rgb(143, 115, 90)",
-        accentStrong: "rgb(114, 90, 70)",
-        border: "rgba(216, 203, 185, 0.72)",
-        borderSoft: "rgba(216, 203, 185, 0.34)",
-        hover: "rgba(93, 70, 46, 0.045)",
-        panelBg: "rgba(255, 253, 249, 0.98)",
-        panelBgAlt: "rgba(245, 241, 234, 0.98)",
-        controlBg: "rgba(245, 241, 234, 0.92)",
-        shadow: "0 10px 28px rgba(93, 70, 46, 0.1)",
-        emptyBg: "rgba(251, 248, 243, 0.92)",
-        error: "rgba(181, 72, 72, 0.92)",
-      };
-    case "slate":
-      return {
-        fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
-        text: "rgba(232, 236, 242, 0.94)",
-        textMuted: "rgba(156, 168, 184, 0.84)",
-        textSubtle: "rgba(156, 168, 184, 0.68)",
-        accent: "rgb(124, 146, 184)",
-        accentStrong: "rgb(95, 120, 163)",
-        border: "rgba(67, 81, 102, 0.62)",
-        borderSoft: "rgba(67, 81, 102, 0.28)",
-        hover: "rgba(255, 255, 255, 0.04)",
-        panelBg: "rgba(21, 26, 34, 0.98)",
-        panelBgAlt: "rgba(14, 17, 22, 0.98)",
-        controlBg: "rgba(14, 17, 22, 0.94)",
-        shadow: "0 14px 32px rgba(0, 0, 0, 0.28)",
-        emptyBg: "rgba(21, 26, 34, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "graphite":
-      return {
-        fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
-        text: "rgba(236, 239, 243, 0.94)",
-        textMuted: "rgba(160, 167, 176, 0.84)",
-        textSubtle: "rgba(160, 167, 176, 0.68)",
-        accent: "rgb(139, 148, 158)",
-        accentStrong: "rgb(111, 119, 128)",
-        border: "rgba(79, 86, 94, 0.64)",
-        borderSoft: "rgba(79, 86, 94, 0.28)",
-        hover: "rgba(255, 255, 255, 0.035)",
-        panelBg: "rgba(23, 25, 28, 0.98)",
-        panelBgAlt: "rgba(17, 18, 20, 0.98)",
-        controlBg: "rgba(17, 18, 20, 0.95)",
-        shadow: "0 12px 26px rgba(0, 0, 0, 0.24)",
-        emptyBg: "rgba(23, 25, 28, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "cobalt":
-      return {
-        fontFamily: '"Exo 2", "Bahnschrift", "Segoe UI Variable", sans-serif',
-        text: "rgba(231, 241, 255, 0.94)",
-        textMuted: "rgba(177, 194, 221, 0.84)",
-        textSubtle: "rgba(177, 194, 221, 0.68)",
-        accent: "rgb(111, 188, 255)",
-        accentStrong: "rgb(72, 145, 255)",
-        border: "rgba(111, 188, 255, 0.28)",
-        borderSoft: "rgba(111, 188, 255, 0.14)",
-        hover: "rgba(255, 255, 255, 0.05)",
-        panelBg: "rgba(12, 19, 31, 0.98)",
-        panelBgAlt: "rgba(7, 10, 16, 0.98)",
-        controlBg: "rgba(7, 10, 16, 0.94)",
-        shadow: "0 18px 42px rgba(0, 0, 0, 0.42)",
-        emptyBg: "rgba(16, 24, 40, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "ember":
-      return {
-        fontFamily: '"Exo 2", "Bahnschrift", "Segoe UI Variable", sans-serif',
-        text: "rgba(255, 236, 225, 0.94)",
-        textMuted: "rgba(219, 187, 167, 0.84)",
-        textSubtle: "rgba(219, 187, 167, 0.68)",
-        accent: "rgb(255, 151, 94)",
-        accentStrong: "rgb(227, 102, 57)",
-        border: "rgba(255, 151, 94, 0.28)",
-        borderSoft: "rgba(255, 151, 94, 0.14)",
-        hover: "rgba(255, 255, 255, 0.05)",
-        panelBg: "rgba(30, 16, 12, 0.98)",
-        panelBgAlt: "rgba(16, 9, 7, 0.98)",
-        controlBg: "rgba(16, 9, 7, 0.94)",
-        shadow: "0 18px 42px rgba(0, 0, 0, 0.42)",
-        emptyBg: "rgba(40, 21, 16, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "glacier":
-      return {
-        fontFamily: '"Exo 2", "Bahnschrift", "Segoe UI Variable", sans-serif',
-        text: "rgba(236, 249, 252, 0.94)",
-        textMuted: "rgba(183, 209, 216, 0.84)",
-        textSubtle: "rgba(183, 209, 216, 0.68)",
-        accent: "rgb(139, 233, 255)",
-        accentStrong: "rgb(95, 189, 214)",
-        border: "rgba(139, 233, 255, 0.28)",
-        borderSoft: "rgba(139, 233, 255, 0.14)",
-        hover: "rgba(255, 255, 255, 0.05)",
-        panelBg: "rgba(16, 24, 29, 0.98)",
-        panelBgAlt: "rgba(8, 12, 15, 0.98)",
-        controlBg: "rgba(8, 12, 15, 0.94)",
-        shadow: "0 18px 42px rgba(0, 0, 0, 0.42)",
-        emptyBg: "rgba(23, 34, 39, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "mono":
-      return {
-        fontFamily: '"Exo 2", "Bahnschrift", "Segoe UI Variable", sans-serif',
-        text: "rgba(240, 240, 240, 0.94)",
-        textMuted: "rgba(184, 184, 184, 0.84)",
-        textSubtle: "rgba(184, 184, 184, 0.68)",
-        accent: "rgb(208, 208, 208)",
-        accentStrong: "rgb(153, 153, 153)",
-        border: "rgba(208, 208, 208, 0.24)",
-        borderSoft: "rgba(208, 208, 208, 0.12)",
-        hover: "rgba(255, 255, 255, 0.05)",
-        panelBg: "rgba(20, 20, 20, 0.98)",
-        panelBgAlt: "rgba(10, 10, 10, 0.98)",
-        controlBg: "rgba(10, 10, 10, 0.94)",
-        shadow: "0 18px 42px rgba(0, 0, 0, 0.42)",
-        emptyBg: "rgba(28, 28, 28, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
-    case "emerald":
-    default:
-      return {
-        fontFamily: '"Exo 2", "Bahnschrift", "Segoe UI Variable", sans-serif',
-        text: "rgba(222, 238, 230, 0.94)",
-        textMuted: "rgba(174, 201, 188, 0.84)",
-        textSubtle: "rgba(174, 201, 188, 0.68)",
-        accent: "rgb(87, 255, 173)",
-        accentStrong: "rgb(62, 201, 137)",
-        border: "rgba(87, 255, 173, 0.24)",
-        borderSoft: "rgba(87, 255, 173, 0.14)",
-        hover: "rgba(255, 255, 255, 0.05)",
-        panelBg: "rgba(9, 16, 13, 0.98)",
-        panelBgAlt: "rgba(5, 9, 7, 0.98)",
-        controlBg: "rgba(6, 9, 8, 0.94)",
-        shadow: "0 18px 42px rgba(0, 0, 0, 0.45)",
-        emptyBg: "rgba(13, 21, 18, 0.92)",
-        error: "rgba(255, 185, 185, 0.92)",
-      };
+  if (isLightAppTheme(theme)) {
+    return {
+      fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
+      text: "rgba(33, 38, 49, 0.94)",
+      textMuted: "rgba(96, 102, 114, 0.82)",
+      textSubtle: "rgba(120, 128, 142, 0.66)",
+      accent: "rgb(245, 132, 25)",
+      accentStrong: "rgb(214, 95, 18)",
+      border: "rgba(214, 220, 230, 0.7)",
+      borderSoft: "rgba(214, 220, 230, 0.38)",
+      hover: "rgba(245, 132, 25, 0.08)",
+      panelBg: "rgba(255, 255, 255, 0.98)",
+      panelBgAlt: "rgba(249, 250, 252, 0.98)",
+      controlBg: "rgba(248, 250, 253, 0.94)",
+      shadow: "0 10px 28px rgba(20, 28, 48, 0.10)",
+      emptyBg: "rgba(250, 250, 251, 0.92)",
+      error: "rgba(184, 67, 67, 0.94)",
+    };
   }
+  return {
+    fontFamily: '"IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif',
+    text: "rgba(232, 234, 238, 0.94)",
+    textMuted: "rgba(168, 174, 184, 0.84)",
+    textSubtle: "rgba(146, 152, 162, 0.66)",
+    accent: "rgb(245, 132, 25)",
+    accentStrong: "rgb(255, 158, 76)",
+    border: "rgba(255, 255, 255, 0.08)",
+    borderSoft: "rgba(255, 255, 255, 0.05)",
+    hover: "rgba(245, 132, 25, 0.10)",
+    panelBg: "rgba(24, 26, 30, 0.98)",
+    panelBgAlt: "rgba(20, 22, 26, 0.98)",
+    controlBg: "rgba(28, 30, 34, 0.94)",
+    shadow: "0 10px 28px rgba(0, 0, 0, 0.28)",
+    emptyBg: "rgba(28, 30, 34, 0.92)",
+    error: "rgba(255, 145, 145, 0.92)",
+  };
 }
 
 function popupThemeCss(theme = currentTheme) {
   const palette = getPopupThemePalette(theme);
-  const isLightTheme =
-    theme === "holaboss" || theme === "sepia" || theme === "paper";
+  const isLightTheme = isLightAppTheme(theme);
   const surfaceSoft = `color-mix(in srgb, ${palette.controlBg} 72%, ${palette.panelBgAlt} 28%)`;
   const surfaceSubtle = `color-mix(in srgb, ${palette.controlBg} 52%, ${palette.panelBgAlt} 48%)`;
   return `


### PR DESCRIPTION
## Symptom

The browser pane's URL-suggestions dropdown rendered as a dark, green-bordered panel with a heavy black drop shadow regardless of the app theme. Same visual mismatch on the downloads, history, and overflow popups. In a light app this looked like a 99% dark dropdown floating over white content, with a noticeable dark "band" of shadow below it.

## Root cause

\`getPopupThemePalette(theme)\` switched on \`holaboss / sepia / paper / slate / graphite / cobalt / ember / glacier / mono / emerald\` — none of which appear in the actual \`APP_THEMES\` set (\`holaos-light\`, \`holaos-dark\`, \`catppuccin-*\`, \`rose-pine-*\`, \`solarized-*\`, \`nord-*\`, \`one-dark-pro-*\`, \`gruvbox-*\`, \`vitesse-*\`). Every theme fell through to the \`emerald\` default:

```ts
border:  "rgba(87, 255, 173, 0.24)"    // green
panelBg: "rgba(9, 16, 13, 0.98)"       // near-black
shadow:  "0 18px 42px rgba(0, 0, 0, 0.45)"  // 42px-blur 45%-opacity shadow
```

That value reached every popup unchanged.

\`popupThemeCss\`'s \`isLightTheme\` check (\`theme === "holaboss" || theme === "sepia" || theme === "paper"\`) had the same problem — \`color-scheme: dark\` was set for everyone too.

## Fix

Replace the unreachable switch with light/dark dispatch off the theme name suffix (\`-light\` / \`-dark\`), which is the convention \`APP_THEMES\` actually uses. Two brand-aligned palettes:

- **Light**: white panels, brand-orange accent (\`rgb(245, 132, 25)\`), soft \`0 10px 28px rgba(20, 28, 48, 0.10)\` shadow
- **Dark**: neutral charcoal panels, same brand-orange accent, soft \`0 10px 28px rgba(0, 0, 0, 0.28)\` shadow

Drop ~185 lines of dead palette cases nothing ever reached.

Also clean up \`createAddressSuggestionsPopupHtml\`'s hardcoded styles:

- Drop \`color-scheme: dark\` (themeCss owns it now via the helper)
- Drop hardcoded \`.item\` / \`.title\` / \`.clock\` colors (themeCss overrides them anyway)
- Switch the inter-item border and \`.url\` color to the CSS variables themeCss already exposes (\`--popup-border-soft\`, \`--popup-text-subtle\`) so they track the theme instead of staying hardcoded.

Net diff: +42 / -199. Affects all four popups (URL suggestions, downloads, history, overflow) consistently.

## Test plan

- [ ] On \`holaos-light\`: type in URL bar → suggestions dropdown shows white panel + soft shadow + brand-orange highlights on hover. No green border. No heavy black shadow band.
- [ ] On \`holaos-dark\`: same dropdown shows charcoal panel + softer shadow, no green tint.
- [ ] Switch themes via Settings → reopen URL bar → popup picks up the new palette on next mount (popup HTML is generated lazily per ensure call).
- [ ] Downloads / history / overflow popups visually consistent with the URL suggestions popup under both light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)