### PR TITLE
fix: own runtime compaction before and after prompt dispatch

### DIFF
--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -120,15 +120,33 @@ function openPiSessionManager(sessionFile: string) {
     SessionManager: {
       create: (cwd: string, sessionDir?: string) => {
         appendMessage: (message: Record<string, unknown>) => string;
+        appendCompaction: (
+          summary: string,
+          firstKeptEntryId: string,
+          tokensBefore: number,
+          details?: unknown,
+          fromHook?: boolean,
+        ) => string | undefined;
         buildSessionContext: () => {
           messages: Array<Record<string, unknown>>;
         };
+        getBranch: () => Array<Record<string, unknown>>;
+        getEntries: () => Array<Record<string, unknown>>;
         getSessionFile: () => string | undefined;
       };
       open: (sessionFile: string) => {
+        appendCompaction: (
+          summary: string,
+          firstKeptEntryId: string,
+          tokensBefore: number,
+          details?: unknown,
+          fromHook?: boolean,
+        ) => string | undefined;
         buildSessionContext: () => {
           messages: Array<Record<string, unknown>>;
         };
+        getBranch: () => Array<Record<string, unknown>>;
+        getEntries: () => Array<Record<string, unknown>>;
         getSessionFile: () => string | undefined;
       };
     };
@@ -145,9 +163,18 @@ function createPiSessionFile(params: {
     SessionManager: {
       create: (cwd: string, sessionDir?: string) => {
         appendMessage: (message: Record<string, unknown>) => string;
+        appendCompaction: (
+          summary: string,
+          firstKeptEntryId: string,
+          tokensBefore: number,
+          details?: unknown,
+          fromHook?: boolean,
+        ) => string | undefined;
         buildSessionContext: () => {
           messages: Array<Record<string, unknown>>;
         };
+        getBranch: () => Array<Record<string, unknown>>;
+        getEntries: () => Array<Record<string, unknown>>;
         getSessionFile: () => string | undefined;
       };
     };
@@ -162,6 +189,81 @@ function createPiSessionFile(params: {
     sessionManager,
     sessionFile,
   };
+}
+
+function latestPiCompactionEntry(
+  sessionFile: string,
+): Record<string, unknown> | null {
+  const branch = openPiSessionManager(sessionFile).getBranch();
+  for (let index = branch.length - 1; index >= 0; index -= 1) {
+    const entry = branch[index];
+    if (entry?.type === "compaction") {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function upsertTurnRequestSnapshotFixture(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  sessionId: string;
+  inputId: string;
+  model: string;
+  providerId: string;
+  modelId: string;
+  modelProxyProvider?: string;
+  systemPrompt?: string;
+  instructionSize?: number;
+}): void {
+  const instructionSize = Math.max(1, params.instructionSize ?? 1024);
+  params.store.upsertTurnRequestSnapshot({
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    inputId: params.inputId,
+    snapshotKind: "harness_host_request",
+    fingerprint: `snapshot-${params.inputId}`,
+    payload: {
+      schema_version: 1,
+      snapshot_kind: "harness_host_request",
+      workspace_id: params.workspaceId,
+      session_id: params.sessionId,
+      input_id: params.inputId,
+      runtime_config: {
+        provider_id: params.providerId,
+        model_id: params.modelId,
+        system_prompt: params.systemPrompt ?? "System prompt",
+        context_messages: [],
+        model_client: {
+          model_proxy_provider:
+            params.modelProxyProvider ?? "openai_compatible",
+          base_url: "https://runtime.example/api/v1/model-proxy",
+          default_headers: {
+            "X-API-Key": "snapshot-key",
+          },
+        },
+      },
+      harness_request: {
+        workspace_id: params.workspaceId,
+        session_id: params.sessionId,
+        input_id: params.inputId,
+        provider_id: params.providerId,
+        model_id: params.modelId,
+        model: params.model,
+        instruction: "x".repeat(instructionSize),
+        context: {},
+        model_client: {
+          model_proxy_provider:
+            params.modelProxyProvider ?? "openai_compatible",
+          api_key: "runtime-api-key",
+          base_url: "https://runtime.example/api/v1/model-proxy",
+          default_headers: {
+            "X-API-Key": "runtime-api-key",
+          },
+        },
+      },
+    },
+  });
 }
 
 function piUserMessage(text: string): Record<string, unknown> {
@@ -4536,5 +4638,780 @@ test("claimed input keeps existing harness session binding when run_failed omits
 
   assert.ok(binding);
   assert.equal(binding.harnessSessionId, "stale-pi-session");
+  store.close();
+});
+
+test("claimed input compacts a reused PI session before a smaller-window model run", async () => {
+  const store = makeStore("hb-claimed-input-prerun-compaction-downshift-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const workspaceDir = store.workspaceDir(workspace.id);
+  const { sessionManager, sessionFile } = createPiSessionFile({
+    workspaceDir,
+    sessionDir: path.join(workspaceDir, ".holaboss", "pi-sessions"),
+  });
+  sessionManager.appendMessage(piUserMessage("x".repeat(260_000)));
+  const assistantEntryId = sessionManager.appendMessage(
+    piAssistantMessage("previous response"),
+  );
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: sessionFile,
+  });
+  const previousInput = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "previous", model: "openai_codex/gpt-5.4" },
+  });
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: previousInput.inputId,
+    fields: { status: "DONE" },
+  });
+  store.upsertTurnResult({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: previousInput.inputId,
+    startedAt: "2026-05-11T00:00:00.000Z",
+    completedAt: "2026-05-11T00:01:00.000Z",
+    status: "completed",
+    stopReason: "completed",
+    assistantText: "previous response",
+    toolUsageSummary: {
+      total_calls: 0,
+      completed_calls: 0,
+      failed_calls: 0,
+      tool_names: [],
+      tool_ids: [],
+    },
+    permissionDenials: [],
+    promptSectionIds: [],
+    capabilityManifestFingerprint: null,
+    requestSnapshotFingerprint: null,
+    promptCacheProfile: null,
+    contextBudgetDecisions: {
+      context_usage: {
+        tokens: 650_000,
+        context_window: 1_000_000,
+        percent: 65,
+      },
+    },
+    tokenUsage: null,
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "new task", model: "openai_codex/gpt-5.5" },
+  });
+  upsertTurnRequestSnapshotFixture({
+    store,
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: queued.inputId,
+    model: "openai_codex/gpt-5.5",
+    providerId: "openai_codex",
+    modelId: "gpt-5.5",
+    instructionSize: 2_048,
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  let compactionCalls = 0;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {},
+    relayRunEventFn: async () => {},
+    resolveRuntimeModelClientFn: () => ({
+      providerId: "openai_codex",
+      configuredProviderId: "openai_codex",
+      modelId: "gpt-5.5",
+      modelToken: "openai_codex/gpt-5.5",
+      modelProxyProvider: "openai_compatible",
+      modelClient: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "runtime-api-key",
+        base_url: "https://runtime.example/api/v1/model-proxy",
+        default_headers: {
+          "X-API-Key": "runtime-api-key",
+        },
+      },
+    }),
+    runPiSessionCompactionFn: async (requestPayload) => {
+      compactionCalls += 1;
+      const snapshotSessionFile = String(requestPayload.harness_session_id);
+      openPiSessionManager(snapshotSessionFile).appendCompaction(
+        "Compacted history",
+        assistantEntryId,
+        650_000,
+        { readFiles: [], modifiedFiles: [] },
+        false,
+      );
+      return {
+        compacted: true,
+        session_file: snapshotSessionFile,
+        result: {
+          summary: "Compacted history",
+          firstKeptEntryId: assistantEntryId,
+          tokensBefore: 650_000,
+          details: { readFiles: [], modifiedFiles: [] },
+        },
+        reason: null,
+        diagnostics: {
+          context_usage: {
+            tokens: 650_000,
+            contextWindow: 1_000_000,
+            percent: 65,
+          },
+        },
+        error: null,
+      };
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      const execContext = recordValue(
+        recordValue(payload.context)?._sandbox_runtime_exec_v1,
+      );
+      assert.equal(execContext?.harness_session_id, sessionFile);
+      assert.ok(latestPiCompactionEntry(sessionFile));
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 2,
+        event_type: "run_completed",
+        payload: {
+          status: "completed",
+          harness_session_id: sessionFile,
+          context_usage: {
+            tokens: 110_000,
+            context_window: 400_000,
+            percent: 27.5,
+          },
+        },
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true,
+      };
+    },
+  });
+
+  assert.equal(compactionCalls, 1);
+  const turnResult = turnResultForInput(store, queued);
+  const preRunTelemetry = recordValue(
+    recordValue(turnResult?.contextBudgetDecisions)?.pre_run_compaction,
+  );
+  assert.equal(turnResult?.status, "completed");
+  assert.ok(preRunTelemetry);
+  assert.equal(preRunTelemetry?.initial_decision, "would_overflow");
+  assert.equal(preRunTelemetry?.final_decision, "fit");
+  assert.equal(preRunTelemetry?.trigger_reason, "model_downshift_projected_overflow");
+  assert.equal(preRunTelemetry?.compaction_attempted, true);
+  assert.equal(preRunTelemetry?.compaction_changed_branch, true);
+  assert.equal(preRunTelemetry?.reset_required, false);
+  assert.equal(preRunTelemetry?.previous_selected_model, "openai_codex/gpt-5.4");
+  assert.equal(preRunTelemetry?.target_selected_model, "openai_codex/gpt-5.5");
+  assert.ok(latestPiCompactionEntry(sessionFile));
+  store.close();
+});
+
+test("claimed input fails with session reset required when pre-run compaction cannot make the session fit", async () => {
+  const store = makeStore("hb-claimed-input-prerun-compaction-reset-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const workspaceDir = store.workspaceDir(workspace.id);
+  const { sessionManager, sessionFile } = createPiSessionFile({
+    workspaceDir,
+    sessionDir: path.join(workspaceDir, ".holaboss", "pi-sessions"),
+  });
+  sessionManager.appendMessage(piUserMessage("x".repeat(260_000)));
+  sessionManager.appendMessage(piAssistantMessage("previous response"));
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: sessionFile,
+  });
+  const previousInput = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "previous", model: "openai_codex/gpt-5.5" },
+  });
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: previousInput.inputId,
+    fields: { status: "DONE" },
+  });
+  store.upsertTurnResult({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: previousInput.inputId,
+    startedAt: "2026-05-11T00:00:00.000Z",
+    completedAt: "2026-05-11T00:01:00.000Z",
+    status: "completed",
+    stopReason: "completed",
+    assistantText: "previous response",
+    toolUsageSummary: {
+      total_calls: 0,
+      completed_calls: 0,
+      failed_calls: 0,
+      tool_names: [],
+      tool_ids: [],
+    },
+    permissionDenials: [],
+    promptSectionIds: [],
+    capabilityManifestFingerprint: null,
+    requestSnapshotFingerprint: null,
+    promptCacheProfile: null,
+    contextBudgetDecisions: {
+      context_usage: {
+        tokens: 130_100,
+        context_window: 400_000,
+        percent: 32.5,
+      },
+    },
+    tokenUsage: null,
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "new task", model: "openai_codex/gpt-5.5" },
+  });
+  upsertTurnRequestSnapshotFixture({
+    store,
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: queued.inputId,
+    model: "openai_codex/gpt-5.5",
+    providerId: "openai_codex",
+    modelId: "gpt-5.5",
+    instructionSize: 1_024,
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  let runnerCalled = false;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {},
+    relayRunEventFn: async () => {},
+    resolveRuntimeModelClientFn: () => ({
+      providerId: "openai_codex",
+      configuredProviderId: "openai_codex",
+      modelId: "gpt-5.5",
+      modelToken: "openai_codex/gpt-5.5",
+      modelProxyProvider: "openai_compatible",
+      modelClient: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "runtime-api-key",
+        base_url: "https://runtime.example/api/v1/model-proxy",
+        default_headers: {
+          "X-API-Key": "runtime-api-key",
+        },
+      },
+    }),
+    runPiSessionCompactionFn: async (requestPayload) => ({
+      compacted: false,
+      session_file: String(requestPayload.harness_session_id),
+      result: null,
+      reason: "already_compacted",
+      diagnostics: {
+        context_usage: {
+          tokens: 130_100,
+          contextWindow: 400_000,
+          percent: 32.5,
+        },
+      },
+      error: null,
+    }),
+    executeRunnerRequestFn: async () => {
+      runnerCalled = true;
+      throw new Error("runner should not be invoked");
+    },
+  });
+
+  assert.equal(runnerCalled, false);
+  const updated = store.getInput({
+    workspaceId: workspace.id,
+    inputId: queued.inputId,
+  });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
+  const terminalPayload = events.at(-1)?.payload ?? null;
+  const preRunTelemetry = recordValue(
+    recordValue(turnResult?.contextBudgetDecisions)?.pre_run_compaction,
+  );
+  assert.equal(updated?.status, "FAILED");
+  assert.equal(turnResult?.status, "failed");
+  assert.equal(turnResult?.stopReason, "session_reset_required");
+  assert.equal(recordValue(terminalPayload)?.error_type, "SessionResetRequiredError");
+  assert.ok(
+    String(recordValue(terminalPayload)?.message ?? "").includes(
+      "session reset required",
+    ),
+  );
+  assert.ok(preRunTelemetry);
+  assert.equal(preRunTelemetry?.initial_decision, "threshold_exceeded");
+  assert.equal(preRunTelemetry?.final_decision, "reset_required");
+  assert.equal(preRunTelemetry?.compaction_attempted, true);
+  assert.equal(preRunTelemetry?.compaction_changed_branch, false);
+  assert.equal(preRunTelemetry?.reset_required, true);
+  store.close();
+});
+
+test("claimed input retries once after a provider context overflow and succeeds after runtime compaction", async () => {
+  const store = makeStore("hb-claimed-input-overflow-recovery-success-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const workspaceDir = store.workspaceDir(workspace.id);
+  const { sessionManager, sessionFile } = createPiSessionFile({
+    workspaceDir,
+    sessionDir: path.join(workspaceDir, ".holaboss", "pi-sessions"),
+  });
+  sessionManager.appendMessage(piUserMessage("x".repeat(80_000)));
+  const assistantEntryId = sessionManager.appendMessage(
+    piAssistantMessage("previous response"),
+  );
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: sessionFile,
+  });
+  const previousInput = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "previous", model: "openai_codex/gpt-5.5" },
+  });
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: previousInput.inputId,
+    fields: { status: "DONE" },
+  });
+  store.upsertTurnResult({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: previousInput.inputId,
+    startedAt: "2026-05-11T00:00:00.000Z",
+    completedAt: "2026-05-11T00:01:00.000Z",
+    status: "completed",
+    stopReason: "completed",
+    assistantText: "previous response",
+    toolUsageSummary: {
+      total_calls: 0,
+      completed_calls: 0,
+      failed_calls: 0,
+      tool_names: [],
+      tool_ids: [],
+    },
+    permissionDenials: [],
+    promptSectionIds: [],
+    capabilityManifestFingerprint: null,
+    requestSnapshotFingerprint: null,
+    promptCacheProfile: null,
+    contextBudgetDecisions: {
+      context_usage: {
+        tokens: 100_000,
+        context_window: 400_000,
+        percent: 25,
+      },
+    },
+    tokenUsage: null,
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "new task", model: "openai_codex/gpt-5.5" },
+  });
+  upsertTurnRequestSnapshotFixture({
+    store,
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: queued.inputId,
+    model: "openai_codex/gpt-5.5",
+    providerId: "openai_codex",
+    modelId: "gpt-5.5",
+    instructionSize: 1_024,
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  let compactionCalls = 0;
+  let runnerCalls = 0;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {},
+    relayRunEventFn: async () => {},
+    resolveRuntimeModelClientFn: () => ({
+      providerId: "openai_codex",
+      configuredProviderId: "openai_codex",
+      modelId: "gpt-5.5",
+      modelToken: "openai_codex/gpt-5.5",
+      modelProxyProvider: "openai_compatible",
+      modelClient: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "runtime-api-key",
+        base_url: "https://runtime.example/api/v1/model-proxy",
+        default_headers: {
+          "X-API-Key": "runtime-api-key",
+        },
+      },
+    }),
+    runPiSessionCompactionFn: async (requestPayload) => {
+      compactionCalls += 1;
+      const snapshotSessionFile = String(requestPayload.harness_session_id);
+      openPiSessionManager(snapshotSessionFile).appendCompaction(
+        "Overflow recovery compaction",
+        assistantEntryId,
+        100_000,
+        { readFiles: [], modifiedFiles: [] },
+        false,
+      );
+      return {
+        compacted: true,
+        session_file: snapshotSessionFile,
+        result: {
+          summary: "Overflow recovery compaction",
+          firstKeptEntryId: assistantEntryId,
+          tokensBefore: 100_000,
+          details: { readFiles: [], modifiedFiles: [] },
+        },
+        reason: null,
+        diagnostics: {
+          context_usage: {
+            tokens: 100_000,
+            contextWindow: 400_000,
+            percent: 25,
+          },
+        },
+        error: null,
+      };
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      runnerCalls += 1;
+      if (runnerCalls === 1) {
+        assert.equal(latestPiCompactionEntry(sessionFile), null);
+        await options.onEvent?.({
+          session_id: String(payload.session_id),
+          input_id: String(payload.input_id),
+          sequence: 1,
+          event_type: "run_started",
+          payload: {},
+        });
+        await options.onEvent?.({
+          session_id: String(payload.session_id),
+          input_id: String(payload.input_id),
+          sequence: 2,
+          event_type: "run_failed",
+          payload: {
+            type: "ProviderError",
+            message: "Your input exceeds the context window of this model.",
+            harness_session_id: sessionFile,
+          },
+        });
+        return {
+          events: [],
+          skippedLines: [],
+          stderr: "",
+          returnCode: 0,
+          sawTerminal: true,
+        };
+      }
+      assert.ok(latestPiCompactionEntry(sessionFile));
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 2,
+        event_type: "run_completed",
+        payload: {
+          status: "completed",
+          harness_session_id: sessionFile,
+          context_usage: {
+            tokens: 80_000,
+            context_window: 400_000,
+            percent: 20,
+          },
+        },
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true,
+      };
+    },
+  });
+
+  assert.equal(compactionCalls, 1);
+  assert.equal(runnerCalls, 2);
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
+  const overflowRecovery = recordValue(
+    recordValue(turnResult?.contextBudgetDecisions)?.overflow_recovery,
+  );
+  assert.equal(turnResult?.status, "completed");
+  assert.deepEqual(
+    events.map((event) => event.eventType),
+    ["run_started", "run_started", "run_completed"],
+  );
+  assert.equal(events.some((event) => event.eventType === "run_failed"), false);
+  assert.ok(overflowRecovery);
+  assert.equal(overflowRecovery?.trigger_reason, "provider_context_overflow");
+  assert.equal(overflowRecovery?.initial_error_type, "ProviderError");
+  assert.equal(
+    overflowRecovery?.initial_error_message,
+    "Your input exceeds the context window of this model.",
+  );
+  assert.equal(overflowRecovery?.compaction_attempted, true);
+  assert.equal(overflowRecovery?.compaction_changed_branch, true);
+  assert.equal(overflowRecovery?.retry_attempted, true);
+  assert.equal(overflowRecovery?.recovered, true);
+  assert.equal(overflowRecovery?.reset_required, false);
+  store.close();
+});
+
+test("claimed input fails with session reset required when overflow persists after runtime recovery retry", async () => {
+  const store = makeStore("hb-claimed-input-overflow-recovery-reset-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const workspaceDir = store.workspaceDir(workspace.id);
+  const { sessionManager, sessionFile } = createPiSessionFile({
+    workspaceDir,
+    sessionDir: path.join(workspaceDir, ".holaboss", "pi-sessions"),
+  });
+  sessionManager.appendMessage(piUserMessage("x".repeat(80_000)));
+  const assistantEntryId = sessionManager.appendMessage(
+    piAssistantMessage("previous response"),
+  );
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: sessionFile,
+  });
+  const previousInput = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "previous", model: "openai_codex/gpt-5.5" },
+  });
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: previousInput.inputId,
+    fields: { status: "DONE" },
+  });
+  store.upsertTurnResult({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: previousInput.inputId,
+    startedAt: "2026-05-11T00:00:00.000Z",
+    completedAt: "2026-05-11T00:01:00.000Z",
+    status: "completed",
+    stopReason: "completed",
+    assistantText: "previous response",
+    toolUsageSummary: {
+      total_calls: 0,
+      completed_calls: 0,
+      failed_calls: 0,
+      tool_names: [],
+      tool_ids: [],
+    },
+    permissionDenials: [],
+    promptSectionIds: [],
+    capabilityManifestFingerprint: null,
+    requestSnapshotFingerprint: null,
+    promptCacheProfile: null,
+    contextBudgetDecisions: {
+      context_usage: {
+        tokens: 100_000,
+        context_window: 400_000,
+        percent: 25,
+      },
+    },
+    tokenUsage: null,
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "new task", model: "openai_codex/gpt-5.5" },
+  });
+  upsertTurnRequestSnapshotFixture({
+    store,
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: queued.inputId,
+    model: "openai_codex/gpt-5.5",
+    providerId: "openai_codex",
+    modelId: "gpt-5.5",
+    instructionSize: 1_024,
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  let compactionCalls = 0;
+  let runnerCalls = 0;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {},
+    relayRunEventFn: async () => {},
+    resolveRuntimeModelClientFn: () => ({
+      providerId: "openai_codex",
+      configuredProviderId: "openai_codex",
+      modelId: "gpt-5.5",
+      modelToken: "openai_codex/gpt-5.5",
+      modelProxyProvider: "openai_compatible",
+      modelClient: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "runtime-api-key",
+        base_url: "https://runtime.example/api/v1/model-proxy",
+        default_headers: {
+          "X-API-Key": "runtime-api-key",
+        },
+      },
+    }),
+    runPiSessionCompactionFn: async (requestPayload) => {
+      compactionCalls += 1;
+      const snapshotSessionFile = String(requestPayload.harness_session_id);
+      openPiSessionManager(snapshotSessionFile).appendCompaction(
+        "Overflow recovery compaction",
+        assistantEntryId,
+        100_000,
+        { readFiles: [], modifiedFiles: [] },
+        false,
+      );
+      return {
+        compacted: true,
+        session_file: snapshotSessionFile,
+        result: {
+          summary: "Overflow recovery compaction",
+          firstKeptEntryId: assistantEntryId,
+          tokensBefore: 100_000,
+          details: { readFiles: [], modifiedFiles: [] },
+        },
+        reason: null,
+        diagnostics: {
+          context_usage: {
+            tokens: 100_000,
+            contextWindow: 400_000,
+            percent: 25,
+          },
+        },
+        error: null,
+      };
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      runnerCalls += 1;
+      if (runnerCalls === 2) {
+        assert.ok(latestPiCompactionEntry(sessionFile));
+      }
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 2,
+        event_type: "run_failed",
+        payload: {
+          type: "ProviderError",
+          message: "context_length_exceeded: Your input exceeds the context window of this model.",
+          harness_session_id: sessionFile,
+        },
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true,
+      };
+    },
+  });
+
+  assert.equal(compactionCalls, 1);
+  assert.equal(runnerCalls, 2);
+  const updated = store.getInput({
+    workspaceId: workspace.id,
+    inputId: queued.inputId,
+  });
+  const events = outputEventsForInput(store, queued);
+  const turnResult = turnResultForInput(store, queued);
+  const terminalPayload = events.at(-1)?.payload ?? null;
+  const overflowRecovery = recordValue(
+    recordValue(turnResult?.contextBudgetDecisions)?.overflow_recovery,
+  );
+  assert.equal(updated?.status, "FAILED");
+  assert.equal(turnResult?.status, "failed");
+  assert.equal(turnResult?.stopReason, "session_reset_required");
+  assert.equal(recordValue(terminalPayload)?.error_type, "SessionResetRequiredError");
+  assert.ok(
+    String(recordValue(terminalPayload)?.message ?? "").includes(
+      "session reset required",
+    ),
+  );
+  assert.ok(overflowRecovery);
+  assert.equal(overflowRecovery?.trigger_reason, "provider_context_overflow");
+  assert.equal(overflowRecovery?.compaction_attempted, true);
+  assert.equal(overflowRecovery?.compaction_changed_branch, true);
+  assert.equal(overflowRecovery?.retry_attempted, true);
+  assert.equal(overflowRecovery?.recovered, false);
+  assert.equal(overflowRecovery?.reset_required, true);
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -25,6 +25,7 @@ import type {
   BackendAgentRunEventType,
   BackendAgentRunStartRequest,
 } from "./backend-agent-runs-contract.js";
+import { resolveRuntimeModelClient } from "./agent-runtime-config.js";
 import { resolveProductRuntimeConfig } from "./runtime-config.js";
 import {
   normalizeHarnessId,
@@ -40,11 +41,16 @@ import {
 import type { MemoryServiceLike } from "./memory.js";
 import { createBackgroundTaskMemoryModelClient } from "./background-task-model.js";
 import {
+  evaluatePreRunSessionCompaction,
   enqueueSessionCheckpointJob,
+  forceCompactSessionWithSnapshotMerge,
   normalizePiContextUsage,
   shouldQueueSessionCheckpoint,
   waitForSessionCheckpointCompletion,
+  type PiCompactionCommandResult,
+  type PreRunSessionCompactionDecision,
   type PiContextUsage,
+  type SessionCheckpointSessionOps,
 } from "./session-checkpoint.js";
 import type { TurnMemoryWritebackModelContext } from "./turn-memory-writeback.js";
 import { runEvolveTasks } from "./evolve-tasks.js";
@@ -99,6 +105,34 @@ const PI_SESSION_MANAGER_MODULE_PATH = path.join(
   "session-manager.js",
 );
 const PI_SESSION_DIR_RELATIVE = path.join(".holaboss", "pi-sessions");
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /prompt is too long/i,
+  /request_too_large/i,
+  /input is too long for requested model/i,
+  /exceeds the context window/i,
+  /input token count.*exceeds the maximum/i,
+  /maximum prompt length is \d+/i,
+  /reduce the length of the messages/i,
+  /maximum context length is \d+ tokens/i,
+  /exceeds the limit of \d+/i,
+  /exceeds the available context size/i,
+  /greater than the context length/i,
+  /context window exceeds limit/i,
+  /exceeded model token limit/i,
+  /too large for model with \d+ maximum context length/i,
+  /model_context_window_exceeded/i,
+  /prompt too long; exceeded (?:max )?context length/i,
+  /context[_ ]length[_ ]exceeded/i,
+  /too many tokens/i,
+  /token limit exceeded/i,
+  /^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i,
+];
+const NON_CONTEXT_OVERFLOW_PATTERNS = [
+  /throttling error/i,
+  /service unavailable/i,
+  /rate limit/i,
+  /too many requests/i,
+];
 
 interface SessionInputAttachment {
   id: string;
@@ -169,6 +203,34 @@ interface TurnContextBudgetTelemetry {
   browserFindCalls: number;
   browserScreenshotCalls: number;
   browserPageTextChars: number;
+}
+
+interface PreRunCompactionTelemetryRecord {
+  initial_decision: PreRunSessionCompactionDecision["decision"];
+  final_decision: PreRunSessionCompactionDecision["decision"];
+  trigger_reason: string | null;
+  previous_selected_model: string | null;
+  target_selected_model: string | null;
+  previous_context_window: number | null;
+  target_context_window: number | null;
+  before_session_tokens: number | null;
+  after_session_tokens: number | null;
+  estimated_request_tokens: number | null;
+  projected_total_tokens: number | null;
+  compaction_attempted: boolean;
+  compaction_changed_branch: boolean;
+  reset_required: boolean;
+}
+
+interface OverflowRecoveryTelemetryRecord {
+  trigger_reason: string | null;
+  initial_error_type: string | null;
+  initial_error_message: string | null;
+  compaction_attempted: boolean;
+  compaction_changed_branch: boolean;
+  retry_attempted: boolean;
+  recovered: boolean;
+  reset_required: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1449,6 +1511,133 @@ function contextUsagePayload(contextUsage: PiContextUsage | null): Record<string
   };
 }
 
+function latestPriorTurnCompactionContext(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  sessionId: string;
+  currentInputId: string;
+}): {
+  previousSelectedModel: string | null;
+  previousContextUsage: PiContextUsage | null;
+} {
+  const recentTurns = params.store.listTurnResults({
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    limit: 10,
+    offset: 0,
+  });
+  for (const turn of recentTurns) {
+    if (turn.inputId === params.currentInputId) {
+      continue;
+    }
+    const previousInput = params.store.getInput({
+      workspaceId: params.workspaceId,
+      inputId: turn.inputId,
+    });
+    const contextBudgetDecisions = isRecord(turn.contextBudgetDecisions)
+      ? turn.contextBudgetDecisions
+      : null;
+    return {
+      previousSelectedModel:
+        typeof previousInput?.payload.model === "string"
+          ? previousInput.payload.model.trim() || null
+          : null,
+      previousContextUsage: normalizePiContextUsage(
+        contextBudgetDecisions?.context_usage,
+      ),
+    };
+  }
+  return {
+    previousSelectedModel: null,
+    previousContextUsage: null,
+  };
+}
+
+function preRunCompactionPayload(
+  value: PreRunCompactionTelemetryRecord | null,
+): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  return {
+    ...value,
+  };
+}
+
+function overflowRecoveryPayload(
+  value: OverflowRecoveryTelemetryRecord | null,
+): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  return {
+    ...value,
+  };
+}
+
+function contextOverflowFailureText(payload: Record<string, unknown>): string {
+  const candidates = [
+    optionalString(payload.message),
+    optionalString(payload.error_message),
+    optionalString(payload.type),
+  ].filter((value): value is string => Boolean(value));
+  try {
+    const serialized = JSON.stringify(payload);
+    if (serialized) {
+      candidates.push(serialized);
+    }
+  } catch {
+    // Ignore serialization failures and fall back to the direct fields.
+  }
+  return candidates.join("\n");
+}
+
+function isContextOverflowFailurePayload(
+  payload: Record<string, unknown> | null,
+): boolean {
+  if (!payload) {
+    return false;
+  }
+  const text = contextOverflowFailureText(payload);
+  if (!text) {
+    return false;
+  }
+  if (NON_CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text))) {
+    return false;
+  }
+  return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function runnerEventWithSequenceOffset(
+  event: RunnerEvent,
+  sequenceOffset: number,
+): RunnerEvent {
+  if (!Number.isFinite(sequenceOffset) || sequenceOffset <= 0) {
+    return event;
+  }
+  const baseSequence =
+    typeof event.sequence === "number" && Number.isFinite(event.sequence)
+      ? event.sequence
+      : 0;
+  return {
+    ...event,
+    sequence: baseSequence + sequenceOffset,
+  };
+}
+
+class SessionResetRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionResetRequiredError";
+  }
+}
+
+function executorFailureStopReason(error: unknown): string {
+  return error instanceof SessionResetRequiredError
+    ? "session_reset_required"
+    : "executor_error";
+}
+
 function promptCacheStableCandidate(promptCacheProfile: Record<string, unknown> | null): boolean {
   if (!promptCacheProfile) {
     return false;
@@ -1565,6 +1754,8 @@ function buildContextBudgetObservabilityPayload(params: {
   telemetry: TurnContextBudgetTelemetry;
   toolCallCount: number;
   checkpointQueued: boolean;
+  preRunCompaction?: PreRunCompactionTelemetryRecord | null;
+  overflowRecovery?: OverflowRecoveryTelemetryRecord | null;
 }): Record<string, unknown> {
   const inputTokens =
     firstFiniteUsageNumber(params.tokenUsage, ["input_tokens", "prompt_tokens"]);
@@ -1614,6 +1805,12 @@ function buildContextBudgetObservabilityPayload(params: {
     reason_codes: [],
     context_usage: contextUsagePayload(params.contextUsage),
     model_context_window: params.contextUsage?.contextWindow ?? null,
+    ...(params.preRunCompaction
+      ? { pre_run_compaction: preRunCompactionPayload(params.preRunCompaction) }
+      : {}),
+    ...(params.overflowRecovery
+      ? { overflow_recovery: overflowRecoveryPayload(params.overflowRecovery) }
+      : {}),
     input_budget_total: null,
     metrics: {
       status,
@@ -1659,6 +1856,8 @@ function buildMergedContextBudgetPayload(params: {
   toolReplayTrimmed: boolean;
   retrievalClipped?: boolean;
   checkpointQueued: boolean;
+  preRunCompaction?: PreRunCompactionTelemetryRecord | null;
+  overflowRecovery?: OverflowRecoveryTelemetryRecord | null;
 }): Record<string, unknown> {
   return {
     ...buildContextBudgetObservabilityPayload({
@@ -1672,6 +1871,8 @@ function buildMergedContextBudgetPayload(params: {
       telemetry: params.telemetry,
       toolCallCount: params.toolCallCount,
       checkpointQueued: params.checkpointQueued,
+      preRunCompaction: params.preRunCompaction,
+      overflowRecovery: params.overflowRecovery,
     }),
     ...buildContextBudgetDecisions({
       promptCacheProfile: params.promptCacheProfile,
@@ -3149,10 +3350,15 @@ export async function processClaimedInput(params: {
   onEvolveTaskError?: (taskName: string, error: unknown) => void;
   executeRunnerRequestFn?: typeof executeRunnerRequest;
   resolveProductRuntimeConfigFn?: typeof resolveProductRuntimeConfig;
+  resolveRuntimeModelClientFn?: typeof resolveRuntimeModelClient;
   registerRunStartedFn?: typeof registerWorkspaceAgentRunStarted;
   relayRunEventFn?: typeof registerWorkspaceAgentRunEvent;
   enqueueSessionCheckpointJobFn?: typeof enqueueSessionCheckpointJob;
   waitForSessionCheckpointCompletionFn?: typeof waitForSessionCheckpointCompletion;
+  runPiSessionCompactionFn?: (
+    requestPayload: Record<string, unknown>,
+  ) => Promise<PiCompactionCommandResult>;
+  sessionCheckpointSessionOps?: SessionCheckpointSessionOps;
   captureRuntimeExceptionFn?: typeof captureRuntimeException;
   abortSignal?: AbortSignal;
 }): Promise<void> {
@@ -3614,6 +3820,8 @@ export async function processClaimedInput(params: {
     let requestSnapshotFingerprint: string | null = null;
     let promptCacheProfile: Record<string, unknown> | null = null;
     let toolReplayTrimmed = false;
+    let preRunCompaction: PreRunCompactionTelemetryRecord | null = null;
+    let overflowRecovery: OverflowRecoveryTelemetryRecord | null = null;
     const toolCallsById = new Map<
       string,
       {
@@ -3731,418 +3939,579 @@ export async function processClaimedInput(params: {
     };
 
     try {
+      const snapshotRecord = store.getTurnRequestSnapshot({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+      });
+      const snapshotPayload = isRecord(snapshotRecord?.payload)
+        ? snapshotRecord.payload
+        : null;
+      const { previousSelectedModel, previousContextUsage } =
+        latestPriorTurnCompactionContext({
+          store,
+          workspaceId: record.workspaceId,
+          sessionId: record.sessionId,
+          currentInputId: record.inputId,
+        });
+      const initialPreRunDecision = evaluatePreRunSessionCompaction({
+        liveSessionFile: checkpointHarnessSessionId,
+        snapshotPayload,
+        selectedModel,
+        previousSelectedModel,
+        previousContextUsage,
+      });
+      if (initialPreRunDecision.decision !== "fit") {
+        const initialPreRunCompaction: PreRunCompactionTelemetryRecord = {
+          initial_decision: initialPreRunDecision.decision,
+          final_decision: initialPreRunDecision.decision,
+          trigger_reason: initialPreRunDecision.reason,
+          previous_selected_model: initialPreRunDecision.previousSelectedModel,
+          target_selected_model: initialPreRunDecision.targetSelectedModel,
+          previous_context_window: initialPreRunDecision.previousContextWindow,
+          target_context_window: initialPreRunDecision.targetContextWindow,
+          before_session_tokens: initialPreRunDecision.currentSessionTokens,
+          after_session_tokens: null,
+          estimated_request_tokens: initialPreRunDecision.estimatedRequestTokens,
+          projected_total_tokens: initialPreRunDecision.projectedTotalTokens,
+          compaction_attempted: true,
+          compaction_changed_branch: false,
+          reset_required: false,
+        };
+        preRunCompaction = initialPreRunCompaction;
+        const liveSessionState =
+          params.sessionCheckpointSessionOps?.currentLeafCheckpointState(
+            checkpointHarnessSessionId,
+          ) ?? currentPiSessionLeafState(checkpointHarnessSessionId);
+        const compactionResult = await forceCompactSessionWithSnapshotMerge({
+          store,
+          workspaceId: record.workspaceId,
+          sessionId: record.sessionId,
+          inputId: record.inputId,
+          harnessSessionId: checkpointHarnessSessionId,
+          baseLeafId: liveSessionState.leafId,
+          baseLatestCompactionId: liveSessionState.latestCompactionId,
+          runPiSessionCompactionFn: params.runPiSessionCompactionFn,
+          resolveRuntimeModelClientFn: params.resolveRuntimeModelClientFn,
+          sessionOps: params.sessionCheckpointSessionOps,
+        });
+        const finalPreRunDecision = evaluatePreRunSessionCompaction({
+          liveSessionFile: checkpointHarnessSessionId,
+          snapshotPayload,
+          selectedModel,
+          previousSelectedModel,
+          previousContextUsage: null,
+        });
+        const currentPreRunCompaction =
+          preRunCompaction ?? initialPreRunCompaction;
+        preRunCompaction = {
+          ...currentPreRunCompaction,
+          final_decision: finalPreRunDecision.decision,
+          after_session_tokens: finalPreRunDecision.currentSessionTokens,
+          estimated_request_tokens:
+            finalPreRunDecision.estimatedRequestTokens ??
+            currentPreRunCompaction.estimated_request_tokens,
+          projected_total_tokens:
+            finalPreRunDecision.projectedTotalTokens ??
+            currentPreRunCompaction.projected_total_tokens,
+          compaction_changed_branch: compactionResult.merged,
+        };
+        if (finalPreRunDecision.decision !== "fit") {
+          preRunCompaction = {
+            ...preRunCompaction,
+            final_decision: "reset_required",
+            reset_required: true,
+          };
+          throw new SessionResetRequiredError(
+            `pre-run session compaction could not make the next prompt fit ${selectedModel ?? "the selected model"}; session reset required`,
+          );
+        }
+      }
       const executeRunner =
         params.executeRunnerRequestFn ?? executeRunnerRequest;
-      const execution = await executeRunner(payload, {
-        signal: executionAbortController.signal,
-        onHeartbeat: () => {
-          renewClaimLease("heartbeat");
-        },
-        onEvent: async (event) => {
-          if (!renewClaimLease("event")) {
-            return;
+      let terminalEventToRelay:
+        | {
+            eventType: "run_completed" | "run_failed";
+            sequence: number;
+            payload: Record<string, unknown>;
+            createdAt: string;
           }
-          const sequence =
-            typeof event.sequence === "number" ? event.sequence : 0;
-          lastSequence = Math.max(lastSequence, sequence);
-          let eventPayload = payloadForEvent(event);
-          if (useEphemeralHarnessSession) {
-            eventPayload = sanitizeEphemeralHarnessSessionPayload({
-              payload: eventPayload,
-              liveSessionFile: ephemeralPiFollowupRun?.liveSessionFile ?? null,
-            });
-          }
-          const eventTimestamp = eventTimestampOrNow(event);
-          const eventType =
-            typeof event.event_type === "string" ? event.event_type : "unknown";
-          updateTurnContextBudgetTelemetryFromEvent(
-            contextBudgetTelemetry,
-            eventType,
-            eventPayload,
-          );
-          recentRunnerEvents.push(
-            summarizeRunnerEventForSentry({
-              sequence,
-              eventType,
-              timestamp: eventTimestamp,
-              payload: eventPayload,
-            }),
-          );
-          if (recentRunnerEvents.length > CLAIMED_INPUT_SENTRY_RECENT_EVENT_LIMIT) {
-            recentRunnerEvents.splice(
-              0,
-              recentRunnerEvents.length - CLAIMED_INPUT_SENTRY_RECENT_EVENT_LIMIT,
+        | null = null;
+      let runnerSequenceOffset = 0;
+
+      for (let runnerAttempt = 1; runnerAttempt <= 2; runnerAttempt += 1) {
+        const execution = await executeRunner(payload, {
+          signal: executionAbortController.signal,
+          onHeartbeat: () => {
+            renewClaimLease("heartbeat");
+          },
+          onEvent: async (rawEvent) => {
+            if (!renewClaimLease("event")) {
+              return;
+            }
+            const event = runnerEventWithSequenceOffset(
+              rawEvent,
+              runnerSequenceOffset,
             );
-          }
+            const sequence =
+              typeof event.sequence === "number" ? event.sequence : 0;
+            lastSequence = Math.max(lastSequence, sequence);
+            let eventPayload = payloadForEvent(event);
+            if (useEphemeralHarnessSession) {
+              eventPayload = sanitizeEphemeralHarnessSessionPayload({
+                payload: eventPayload,
+                liveSessionFile: ephemeralPiFollowupRun?.liveSessionFile ?? null,
+              });
+            }
+            const eventTimestamp = eventTimestampOrNow(event);
+            const eventType =
+              typeof event.event_type === "string"
+                ? event.event_type
+                : "unknown";
+            updateTurnContextBudgetTelemetryFromEvent(
+              contextBudgetTelemetry,
+              eventType,
+              eventPayload,
+            );
+            recentRunnerEvents.push(
+              summarizeRunnerEventForSentry({
+                sequence,
+                eventType,
+                timestamp: eventTimestamp,
+                payload: eventPayload,
+              }),
+            );
+            if (
+              recentRunnerEvents.length > CLAIMED_INPUT_SENTRY_RECENT_EVENT_LIMIT
+            ) {
+              recentRunnerEvents.splice(
+                0,
+                recentRunnerEvents.length -
+                  CLAIMED_INPUT_SENTRY_RECENT_EVENT_LIMIT,
+              );
+            }
+            const terminalHarnessSessionId = nonEmptyString(
+              eventPayload.harness_session_id,
+            );
+            if (terminalHarnessSessionId) {
+              checkpointHarnessSessionId = terminalHarnessSessionId;
+            }
+            if (eventType === "pi_native_event") {
+              capturedPiAssistantMessage =
+                assistantMessageFromPiNativeEventPayload(eventPayload) ??
+                capturedPiAssistantMessage;
+            }
+            if (eventType === "run_completed" || eventType === "run_failed") {
+              deferredTerminalEvent = {
+                eventType,
+                payload: eventPayload,
+                createdAt: eventTimestamp,
+              };
+            } else {
+              store.appendOutputEvent({
+                workspaceId: record.workspaceId,
+                sessionId: record.sessionId,
+                inputId: record.inputId,
+                sequence,
+                eventType,
+                payload: eventPayload,
+                createdAt: eventTimestamp,
+              });
+            }
+            maybePersistHarnessSessionId({
+              store,
+              workspaceId: record.workspaceId,
+              sessionId: record.sessionId,
+              harness,
+              eventType,
+              payload: eventPayload,
+              allowBindingPersistence: !useEphemeralHarnessSession,
+            });
+            if (
+              event.event_type === "output_delta" &&
+              typeof eventPayload.delta === "string"
+            ) {
+              assistantParts.push(eventPayload.delta);
+              if (
+                pendingOutputDeltaPayload &&
+                canMergeOutputDeltaRelayPayload(
+                  pendingOutputDeltaPayload,
+                  eventPayload,
+                ) &&
+                String(pendingOutputDeltaPayload.delta ?? "").length +
+                  eventPayload.delta.length <=
+                  BACKEND_OUTPUT_DELTA_RELAY_FLUSH_CHARS
+              ) {
+                pendingOutputDeltaPayload = mergeOutputDeltaRelayPayload(
+                  pendingOutputDeltaPayload,
+                  eventPayload,
+                );
+              } else {
+                await flushPendingOutputDelta();
+                pendingOutputDeltaPayload = { ...eventPayload };
+              }
+              pendingOutputDeltaSequence = Math.max(sequence, 1);
+              pendingOutputDeltaTimestamp = eventTimestamp;
+            }
+            if (event.event_type === "run_started") {
+              promptSectionIds = stringList(eventPayload.prompt_section_ids);
+              capabilityManifestFingerprint =
+                typeof eventPayload.capability_manifest_fingerprint ===
+                  "string" && eventPayload.capability_manifest_fingerprint.trim()
+                  ? eventPayload.capability_manifest_fingerprint.trim()
+                  : capabilityManifestFingerprint;
+              requestSnapshotFingerprint =
+                typeof eventPayload.request_snapshot_fingerprint === "string" &&
+                eventPayload.request_snapshot_fingerprint.trim()
+                  ? eventPayload.request_snapshot_fingerprint.trim()
+                  : requestSnapshotFingerprint;
+              promptCacheProfile =
+                jsonRecord(eventPayload.prompt_cache_profile) ??
+                promptCacheProfile;
+            }
+            if (event.event_type === "tool_call") {
+              const callId =
+                typeof eventPayload.call_id === "string" &&
+                eventPayload.call_id.trim()
+                  ? eventPayload.call_id.trim()
+                  : `sequence:${sequence}`;
+              const existingCall = toolCallsById.get(callId);
+              const toolName =
+                typeof eventPayload.tool_name === "string" &&
+                eventPayload.tool_name.trim()
+                  ? eventPayload.tool_name.trim()
+                  : (existingCall?.toolName ?? "unknown");
+              const toolId =
+                typeof eventPayload.tool_id === "string" &&
+                eventPayload.tool_id.trim()
+                  ? eventPayload.tool_id.trim()
+                  : (existingCall?.toolId ?? null);
+              const completed =
+                eventPayload.phase === "completed" ||
+                existingCall?.completed === true;
+              const errored =
+                eventPayload.error === true || existingCall?.error === true;
+              const browserUsage =
+                browserUsageFromToolResult(eventPayload.result) ??
+                existingCall?.browserUsage ??
+                null;
+              toolCallsById.set(callId, {
+                toolName,
+                toolId,
+                completed,
+                error: errored,
+                browserUsage,
+              });
+              if (eventPayload.phase === "completed") {
+                toolReplayTrimmed =
+                  toolReplayTrimmed ||
+                  toolReplayTrimmedFromToolResult(eventPayload.result);
+              }
+              const denial = permissionDenialFromEventPayload(eventPayload);
+              if (denial) {
+                permissionDenials.push(denial);
+              }
+            }
+            if (
+              event.event_type === "skill_invocation" ||
+              event.event_type === "tool_call"
+            ) {
+              const callId =
+                typeof eventPayload.call_id === "string" &&
+                eventPayload.call_id.trim()
+                  ? eventPayload.call_id.trim()
+                  : `sequence:${sequence}`;
+              const toolName = optionalString(eventPayload.tool_name);
+              const isSkillInvocation =
+                event.event_type === "skill_invocation" ||
+                (toolName !== null && toolName.toLowerCase() === "skill");
+              if (isSkillInvocation) {
+                const existingInvocation = skillInvocationsById.get(callId);
+                const toolArgs = jsonRecord(eventPayload.tool_args);
+                const skillName =
+                  optionalString(eventPayload.skill_name) ??
+                  optionalString(eventPayload.requested_name) ??
+                  optionalString(toolArgs?.name) ??
+                  existingInvocation?.skillName ??
+                  "unknown";
+                const skillId =
+                  optionalString(eventPayload.skill_id) ??
+                  existingInvocation?.skillId ??
+                  null;
+                const completed =
+                  eventPayload.phase === "completed" ||
+                  existingInvocation?.completed === true;
+                const error =
+                  eventPayload.error === true ||
+                  existingInvocation?.error === true;
+                skillInvocationsById.set(callId, {
+                  skillName,
+                  skillId,
+                  completed,
+                  error,
+                });
+              }
+            }
+            if (event.event_type === "skill_invocation") {
+              const scope = optionalString(eventPayload.widening_scope);
+              if (scope) {
+                wideningAudit.scope = scope;
+              }
+              if (
+                typeof eventPayload.workspace_boundary_override === "boolean"
+              ) {
+                wideningAudit.workspaceBoundaryOverride =
+                  eventPayload.workspace_boundary_override;
+              }
+              for (const toolName of stringList(eventPayload.managed_tools)) {
+                wideningAudit.managedTools.add(toolName);
+              }
+              const grantedTools = stringList(eventPayload.granted_tools);
+              for (const toolName of grantedTools) {
+                wideningAudit.grantedTools.add(toolName);
+              }
+              for (const toolName of stringList(
+                eventPayload.active_granted_tools,
+              )) {
+                wideningAudit.activeGrantedTools.add(toolName);
+              }
+              for (const commandId of stringList(eventPayload.managed_commands)) {
+                wideningAudit.managedCommands.add(commandId);
+              }
+              const grantedCommands = stringList(eventPayload.granted_commands);
+              for (const commandId of grantedCommands) {
+                wideningAudit.grantedCommands.add(commandId);
+              }
+              for (const commandId of stringList(
+                eventPayload.active_granted_commands,
+              )) {
+                wideningAudit.activeGrantedCommands.add(commandId);
+              }
+              if (
+                eventPayload.phase === "completed" &&
+                (grantedTools.length > 0 || grantedCommands.length > 0)
+              ) {
+                wideningAudit.activationCount += 1;
+              }
+            }
+            if (
+              event.event_type === "tool_call" &&
+              isSkillPolicyDeniedPayload(eventPayload)
+            ) {
+              wideningAudit.deniedCalls += 1;
+              const toolName = optionalString(eventPayload.tool_name);
+              if (toolName) {
+                wideningAudit.deniedToolNames.add(toolName);
+              }
+            }
+            if (event.event_type === "run_completed") {
+              terminalStatus = terminalStatusForCompletedPayload(
+                eventPayload,
+                harnessSupportsWaitingUser,
+              );
+              completedAt = eventTimestamp;
+              stopReason = stopReasonForTerminalEvent({
+                eventType: "run_completed",
+                payload: eventPayload,
+                terminalStatus,
+              });
+              tokenUsage = tokenUsageFromPayload(eventPayload) ?? tokenUsage;
+              contextUsage =
+                contextUsageFromPayload(eventPayload) ?? contextUsage;
+            }
+            if (event.event_type === "run_failed") {
+              terminalStatus = "ERROR";
+              lastError = eventPayload;
+              completedAt = eventTimestamp;
+              stopReason = stopReasonForTerminalEvent({
+                eventType: "run_failed",
+                payload: eventPayload,
+                terminalStatus,
+              });
+              tokenUsage = tokenUsageFromPayload(eventPayload) ?? tokenUsage;
+              contextUsage =
+                contextUsageFromPayload(eventPayload) ?? contextUsage;
+            }
+            if (event.event_type === "tool_call") {
+              await flushPendingOutputDelta();
+              await relayBackendRunEvent({
+                eventType: "tool_call",
+                payload: eventPayload,
+                timestamp: eventTimestamp,
+                preferredSequence: Math.max(sequence, 1),
+              });
+            }
+            if (event.event_type === "skill_invocation") {
+              await flushPendingOutputDelta();
+              await relayBackendRunEvent({
+                eventType: "skill_invocation",
+                payload: eventPayload,
+                timestamp: eventTimestamp,
+                preferredSequence: Math.max(sequence, 1),
+              });
+            }
+          },
+        });
+        if (claimOwnershipLost || !claimStillOwned()) {
+          return;
+        }
+        await flushPendingOutputDelta();
+
+        const persistedTerminalEvent = latestPersistedTerminalOutputEvent({
+          store,
+          workspaceId: record.workspaceId,
+          sessionId: record.sessionId,
+          inputId: record.inputId,
+        });
+
+        if (persistedTerminalEvent) {
+          const persistedPayload = persistedTerminalEvent.payload;
           const terminalHarnessSessionId = nonEmptyString(
-            eventPayload.harness_session_id,
+            persistedPayload.harness_session_id,
           );
           if (terminalHarnessSessionId) {
             checkpointHarnessSessionId = terminalHarnessSessionId;
           }
-          if (eventType === "pi_native_event") {
-            capturedPiAssistantMessage =
-              assistantMessageFromPiNativeEventPayload(eventPayload) ??
-              capturedPiAssistantMessage;
-          }
-          if (eventType === "run_completed" || eventType === "run_failed") {
-            deferredTerminalEvent = {
-              eventType,
-              payload: eventPayload,
-              createdAt: eventTimestamp,
-            };
-          } else {
-            store.appendOutputEvent({
-              workspaceId: record.workspaceId,
-              sessionId: record.sessionId,
-              inputId: record.inputId,
-              sequence,
-              eventType,
-              payload: eventPayload,
-              createdAt: eventTimestamp,
-            });
-          }
-          maybePersistHarnessSessionId({
-            store,
-            workspaceId: record.workspaceId,
-            sessionId: record.sessionId,
-            harness,
-            eventType,
-            payload: eventPayload,
-            allowBindingPersistence: !useEphemeralHarnessSession,
-          });
-          if (
-            event.event_type === "output_delta" &&
-            typeof eventPayload.delta === "string"
-          ) {
-            assistantParts.push(eventPayload.delta);
-            if (
-              pendingOutputDeltaPayload &&
-              canMergeOutputDeltaRelayPayload(
-                pendingOutputDeltaPayload,
-                eventPayload,
-              ) &&
-              String(pendingOutputDeltaPayload.delta ?? "").length +
-                eventPayload.delta.length <=
-                BACKEND_OUTPUT_DELTA_RELAY_FLUSH_CHARS
-            ) {
-              pendingOutputDeltaPayload = mergeOutputDeltaRelayPayload(
-                pendingOutputDeltaPayload,
-                eventPayload,
-              );
-            } else {
-              await flushPendingOutputDelta();
-              pendingOutputDeltaPayload = { ...eventPayload };
-            }
-            pendingOutputDeltaSequence = Math.max(sequence, 1);
-            pendingOutputDeltaTimestamp = eventTimestamp;
-          }
-          if (event.event_type === "run_started") {
-            promptSectionIds = stringList(eventPayload.prompt_section_ids);
-            capabilityManifestFingerprint =
-              typeof eventPayload.capability_manifest_fingerprint ===
-                "string" && eventPayload.capability_manifest_fingerprint.trim()
-                ? eventPayload.capability_manifest_fingerprint.trim()
-                : capabilityManifestFingerprint;
-            requestSnapshotFingerprint =
-              typeof eventPayload.request_snapshot_fingerprint === "string" &&
-              eventPayload.request_snapshot_fingerprint.trim()
-                ? eventPayload.request_snapshot_fingerprint.trim()
-                : requestSnapshotFingerprint;
-            promptCacheProfile =
-              jsonRecord(eventPayload.prompt_cache_profile) ??
-              promptCacheProfile;
-          }
-          if (event.event_type === "tool_call") {
-            const callId =
-              typeof eventPayload.call_id === "string" &&
-              eventPayload.call_id.trim()
-                ? eventPayload.call_id.trim()
-                : `sequence:${sequence}`;
-            const existingCall = toolCallsById.get(callId);
-            const toolName =
-              typeof eventPayload.tool_name === "string" &&
-              eventPayload.tool_name.trim()
-                ? eventPayload.tool_name.trim()
-                : (existingCall?.toolName ?? "unknown");
-            const toolId =
-              typeof eventPayload.tool_id === "string" &&
-              eventPayload.tool_id.trim()
-                ? eventPayload.tool_id.trim()
-                : (existingCall?.toolId ?? null);
-            const completed =
-              eventPayload.phase === "completed" ||
-              existingCall?.completed === true;
-            const errored =
-              eventPayload.error === true || existingCall?.error === true;
-            const browserUsage =
-              browserUsageFromToolResult(eventPayload.result) ??
-              existingCall?.browserUsage ??
-              null;
-            toolCallsById.set(callId, {
-              toolName,
-              toolId,
-              completed,
-              error: errored,
-              browserUsage,
-            });
-            if (eventPayload.phase === "completed") {
-              toolReplayTrimmed =
-                toolReplayTrimmed ||
-                toolReplayTrimmedFromToolResult(eventPayload.result);
-            }
-            const denial = permissionDenialFromEventPayload(eventPayload);
-            if (denial) {
-              permissionDenials.push(denial);
-            }
-          }
-          if (
-            event.event_type === "skill_invocation" ||
-            event.event_type === "tool_call"
-          ) {
-            const callId =
-              typeof eventPayload.call_id === "string" &&
-              eventPayload.call_id.trim()
-                ? eventPayload.call_id.trim()
-                : `sequence:${sequence}`;
-            const toolName = optionalString(eventPayload.tool_name);
-            const isSkillInvocation =
-              event.event_type === "skill_invocation" ||
-              (toolName !== null && toolName.toLowerCase() === "skill");
-            if (isSkillInvocation) {
-              const existingInvocation = skillInvocationsById.get(callId);
-              const toolArgs = jsonRecord(eventPayload.tool_args);
-              const skillName =
-                optionalString(eventPayload.skill_name) ??
-                optionalString(eventPayload.requested_name) ??
-                optionalString(toolArgs?.name) ??
-                existingInvocation?.skillName ??
-                "unknown";
-              const skillId =
-                optionalString(eventPayload.skill_id) ??
-                existingInvocation?.skillId ??
-                null;
-              const completed =
-                eventPayload.phase === "completed" ||
-                existingInvocation?.completed === true;
-              const error =
-                eventPayload.error === true ||
-                existingInvocation?.error === true;
-              skillInvocationsById.set(callId, {
-                skillName,
-                skillId,
-                completed,
-                error,
-              });
-            }
-          }
-          if (event.event_type === "skill_invocation") {
-            const scope = optionalString(eventPayload.widening_scope);
-            if (scope) {
-              wideningAudit.scope = scope;
-            }
-            if (typeof eventPayload.workspace_boundary_override === "boolean") {
-              wideningAudit.workspaceBoundaryOverride =
-                eventPayload.workspace_boundary_override;
-            }
-            for (const toolName of stringList(eventPayload.managed_tools)) {
-              wideningAudit.managedTools.add(toolName);
-            }
-            const grantedTools = stringList(eventPayload.granted_tools);
-            for (const toolName of grantedTools) {
-              wideningAudit.grantedTools.add(toolName);
-            }
-            for (const toolName of stringList(
-              eventPayload.active_granted_tools,
-            )) {
-              wideningAudit.activeGrantedTools.add(toolName);
-            }
-            for (const commandId of stringList(eventPayload.managed_commands)) {
-              wideningAudit.managedCommands.add(commandId);
-            }
-            const grantedCommands = stringList(eventPayload.granted_commands);
-            for (const commandId of grantedCommands) {
-              wideningAudit.grantedCommands.add(commandId);
-            }
-            for (const commandId of stringList(
-              eventPayload.active_granted_commands,
-            )) {
-              wideningAudit.activeGrantedCommands.add(commandId);
-            }
-            if (
-              eventPayload.phase === "completed" &&
-              (grantedTools.length > 0 || grantedCommands.length > 0)
-            ) {
-              wideningAudit.activationCount += 1;
-            }
-          }
-          if (
-            event.event_type === "tool_call" &&
-            isSkillPolicyDeniedPayload(eventPayload)
-          ) {
-            wideningAudit.deniedCalls += 1;
-            const toolName = optionalString(eventPayload.tool_name);
-            if (toolName) {
-              wideningAudit.deniedToolNames.add(toolName);
-            }
-          }
-          if (event.event_type === "run_completed") {
+          deferredTerminalEvent = null;
+          if (persistedTerminalEvent.eventType === "run_completed") {
             terminalStatus = terminalStatusForCompletedPayload(
-              eventPayload,
+              persistedPayload,
               harnessSupportsWaitingUser,
             );
-            completedAt = eventTimestamp;
+            lastError = null;
+            completedAt = persistedTerminalEvent.createdAt;
             stopReason = stopReasonForTerminalEvent({
               eventType: "run_completed",
-              payload: eventPayload,
+              payload: persistedPayload,
               terminalStatus,
             });
-            tokenUsage = tokenUsageFromPayload(eventPayload) ?? tokenUsage;
-            contextUsage = contextUsageFromPayload(eventPayload) ?? contextUsage;
-          }
-          if (event.event_type === "run_failed") {
+            tokenUsage = tokenUsageFromPayload(persistedPayload) ?? tokenUsage;
+            contextUsage =
+              contextUsageFromPayload(persistedPayload) ?? contextUsage;
+          } else {
             terminalStatus = "ERROR";
-            lastError = eventPayload;
-            completedAt = eventTimestamp;
+            lastError = persistedPayload;
+            completedAt = persistedTerminalEvent.createdAt;
             stopReason = stopReasonForTerminalEvent({
               eventType: "run_failed",
-              payload: eventPayload,
+              payload: persistedPayload,
               terminalStatus,
             });
-            tokenUsage = tokenUsageFromPayload(eventPayload) ?? tokenUsage;
-            contextUsage = contextUsageFromPayload(eventPayload) ?? contextUsage;
-            if (!terminalFailureCaptured) {
-              terminalFailureCaptured = true;
-              captureClaimedInputFailure(
-                terminalFailureKindFromPayload(eventPayload),
-                optionalString(eventPayload.message) ??
-                  optionalString(eventPayload.type) ??
-                  "runner emitted run_failed",
-                {
-                  failure_source: "terminal_event",
-                  terminal_status: "ERROR",
-                  terminal_stop_reason: stopReason,
-                  terminal_payload: sanitizeRuntimeSentryValue(eventPayload),
-                  event_sequence: sequence,
-                  event_timestamp: eventTimestamp,
-                },
-              );
-            }
+            tokenUsage = tokenUsageFromPayload(persistedPayload) ?? tokenUsage;
+            contextUsage =
+              contextUsageFromPayload(persistedPayload) ?? contextUsage;
           }
-          if (event.event_type === "tool_call") {
-            await flushPendingOutputDelta();
-            await relayBackendRunEvent({
-              eventType: "tool_call",
-              payload: eventPayload,
-              timestamp: eventTimestamp,
-              preferredSequence: Math.max(sequence, 1),
+        } else if (execution.aborted && !execution.sawTerminal) {
+          if (execution.abortReason === "user_requested_pause") {
+            const pausedAt = new Date().toISOString();
+            const completed = buildRunCompletedEvent({
+              sessionId: record.sessionId,
+              inputId: record.inputId,
+              sequence: lastSequence + 1,
+              payload: {
+                status: "paused",
+                stop_reason: "paused",
+                message: "Run paused by user request",
+              },
+            });
+            const completedPayload = payloadForEvent(completed);
+            lastSequence = Math.max(
+              lastSequence,
+              typeof completed.sequence === "number"
+                ? completed.sequence
+                : lastSequence + 1,
+            );
+            deferredTerminalEvent = {
+              eventType: "run_completed",
+              payload: completedPayload,
+              createdAt: pausedAt,
+            };
+            terminalStatus = "PAUSED";
+            lastError = null;
+            completedAt = pausedAt;
+            stopReason = stopReasonForTerminalEvent({
+              eventType: "run_completed",
+              payload: completedPayload,
+              terminalStatus,
+            });
+          } else {
+            const failedAt = new Date().toISOString();
+            const failure = buildRunFailedEvent({
+              sessionId: record.sessionId,
+              inputId: record.inputId,
+              sequence: lastSequence + 1,
+              message:
+                execution.abortReason === "claim_expired"
+                  ? "claimed input lease expired before the runner emitted a terminal event"
+                  : execution.stderr.trim() ||
+                    (execution.abortReason
+                      ? `runner aborted before terminal event: ${execution.abortReason}`
+                      : "runner aborted before terminal event"),
+              errorType: "RuntimeError",
+            });
+            const failurePayload = payloadForEvent(failure);
+            lastSequence = Math.max(
+              lastSequence,
+              typeof failure.sequence === "number"
+                ? failure.sequence
+                : lastSequence + 1,
+            );
+            deferredTerminalEvent = {
+              eventType: "run_failed",
+              payload: failurePayload,
+              createdAt: failedAt,
+            };
+            captureClaimedInputFailure(
+              execution.abortReason === "claim_expired"
+                ? "claim_expired"
+                : "runner_aborted",
+              String(
+                failurePayload.message ?? "runner aborted before terminal event",
+              ),
+              {
+                failure_source: "synthetic_terminal_event",
+                terminal_status: "ERROR",
+                terminal_stop_reason: stopReasonForTerminalEvent({
+                  eventType: "run_failed",
+                  payload: failurePayload,
+                  terminalStatus: "ERROR",
+                }),
+                terminal_payload: sanitizeRuntimeSentryValue(failurePayload),
+                abort_reason: execution.abortReason,
+                return_code: execution.returnCode,
+                stderr: execution.stderr,
+                saw_terminal: execution.sawTerminal,
+                skipped_lines: execution.skippedLines.slice(0, 5),
+              },
+            );
+            terminalFailureCaptured = true;
+            terminalStatus = "ERROR";
+            lastError = failurePayload;
+            completedAt = failedAt;
+            stopReason = stopReasonForTerminalEvent({
+              eventType: "run_failed",
+              payload: failurePayload,
+              terminalStatus,
             });
           }
-          if (event.event_type === "skill_invocation") {
-            await flushPendingOutputDelta();
-            await relayBackendRunEvent({
-              eventType: "skill_invocation",
-              payload: eventPayload,
-              timestamp: eventTimestamp,
-              preferredSequence: Math.max(sequence, 1),
-            });
-          }
-        },
-      });
-      if (claimOwnershipLost || !claimStillOwned()) {
-        return;
-      }
-      await flushPendingOutputDelta();
-
-      const persistedTerminalEvent = latestPersistedTerminalOutputEvent({
-        store,
-        workspaceId: record.workspaceId,
-        sessionId: record.sessionId,
-        inputId: record.inputId,
-      });
-
-      if (persistedTerminalEvent) {
-        const persistedPayload = persistedTerminalEvent.payload;
-        const terminalHarnessSessionId = nonEmptyString(
-          persistedPayload.harness_session_id,
-        );
-        if (terminalHarnessSessionId) {
-          checkpointHarnessSessionId = terminalHarnessSessionId;
-        }
-        deferredTerminalEvent = null;
-        if (persistedTerminalEvent.eventType === "run_completed") {
-          terminalStatus = terminalStatusForCompletedPayload(
-            persistedPayload,
-            harnessSupportsWaitingUser,
-          );
-          lastError = null;
-          completedAt = persistedTerminalEvent.createdAt;
-          stopReason = stopReasonForTerminalEvent({
-            eventType: "run_completed",
-            payload: persistedPayload,
-            terminalStatus,
-          });
-          tokenUsage = tokenUsageFromPayload(persistedPayload) ?? tokenUsage;
-          contextUsage = contextUsageFromPayload(persistedPayload) ?? contextUsage;
-        } else {
-          terminalStatus = "ERROR";
-          lastError = persistedPayload;
-          completedAt = persistedTerminalEvent.createdAt;
-          stopReason = stopReasonForTerminalEvent({
-            eventType: "run_failed",
-            payload: persistedPayload,
-            terminalStatus,
-          });
-          tokenUsage = tokenUsageFromPayload(persistedPayload) ?? tokenUsage;
-          contextUsage = contextUsageFromPayload(persistedPayload) ?? contextUsage;
-        }
-      } else if (execution.aborted && !execution.sawTerminal) {
-        if (execution.abortReason === "user_requested_pause") {
-          const pausedAt = new Date().toISOString();
-          const completed = buildRunCompletedEvent({
-            sessionId: record.sessionId,
-            inputId: record.inputId,
-            sequence: lastSequence + 1,
-            payload: {
-              status: "paused",
-              stop_reason: "paused",
-              message: "Run paused by user request",
-            },
-          });
-          const completedPayload = payloadForEvent(completed);
-          lastSequence = Math.max(
-            lastSequence,
-            typeof completed.sequence === "number"
-              ? completed.sequence
-              : lastSequence + 1,
-          );
-          deferredTerminalEvent = {
-            eventType: "run_completed",
-            payload: completedPayload,
-            createdAt: pausedAt,
-          };
-          terminalStatus = "PAUSED";
-          lastError = null;
-          completedAt = pausedAt;
-          stopReason = stopReasonForTerminalEvent({
-            eventType: "run_completed",
-            payload: completedPayload,
-            terminalStatus,
-          });
-        } else {
-          const failedAt = new Date().toISOString();
+        } else if (!execution.sawTerminal) {
+          const details =
+            execution.skippedLines.length > 0
+              ? execution.skippedLines.slice(0, 3).join("; ")
+              : "";
+          const suffix = details ? ` (skipped output: ${details})` : "";
           const failure = buildRunFailedEvent({
             sessionId: record.sessionId,
             inputId: record.inputId,
             sequence: lastSequence + 1,
             message:
-              execution.abortReason === "claim_expired"
-                ? "claimed input lease expired before the runner emitted a terminal event"
-                : execution.stderr.trim() ||
-                  (execution.abortReason
-                    ? `runner aborted before terminal event: ${execution.abortReason}`
-                    : "runner aborted before terminal event"),
-            errorType: "RuntimeError",
+              execution.returnCode !== 0
+                ? execution.stderr.trim() ||
+                  `runner command failed with exit_code=${execution.returnCode}`
+                : `runner ended before terminal event${suffix}`,
+            errorType:
+              execution.returnCode !== 0
+                ? "RunnerCommandError"
+                : "RuntimeError",
           });
           const failurePayload = payloadForEvent(failure);
           lastSequence = Math.max(
@@ -4154,13 +4523,17 @@ export async function processClaimedInput(params: {
           deferredTerminalEvent = {
             eventType: "run_failed",
             payload: failurePayload,
-            createdAt: failedAt,
+            createdAt: new Date().toISOString(),
           };
           captureClaimedInputFailure(
-            execution.abortReason === "claim_expired"
-              ? "claim_expired"
-              : "runner_aborted",
-            String(failurePayload.message ?? "runner aborted before terminal event"),
+            execution.returnCode !== 0
+              ? execution.stderr.trim() === "runner command timed out"
+                ? "runner_timeout"
+                : execution.stderr.includes("became idle")
+                  ? "runner_idle_timeout"
+                  : "runner_command_error"
+              : "runner_missing_terminal",
+            String(failurePayload.message ?? "runner ended before terminal event"),
             {
               failure_source: "synthetic_terminal_event",
               terminal_status: "ERROR",
@@ -4170,101 +4543,146 @@ export async function processClaimedInput(params: {
                 terminalStatus: "ERROR",
               }),
               terminal_payload: sanitizeRuntimeSentryValue(failurePayload),
-              abort_reason: execution.abortReason,
               return_code: execution.returnCode,
               stderr: execution.stderr,
               saw_terminal: execution.sawTerminal,
               skipped_lines: execution.skippedLines.slice(0, 5),
             },
           );
+          terminalFailureCaptured = true;
           terminalStatus = "ERROR";
           lastError = failurePayload;
-          completedAt = failedAt;
+          completedAt = new Date().toISOString();
           stopReason = stopReasonForTerminalEvent({
             eventType: "run_failed",
             payload: failurePayload,
             terminalStatus,
           });
         }
-      } else if (!execution.sawTerminal) {
-        const details =
-          execution.skippedLines.length > 0
-            ? execution.skippedLines.slice(0, 3).join("; ")
-            : "";
-        const suffix = details ? ` (skipped output: ${details})` : "";
-        const failure = buildRunFailedEvent({
-          sessionId: record.sessionId,
-          inputId: record.inputId,
-          sequence: lastSequence + 1,
-          message:
-            execution.returnCode !== 0
-              ? execution.stderr.trim() ||
-                `runner command failed with exit_code=${execution.returnCode}`
-              : `runner ended before terminal event${suffix}`,
-          errorType:
-            execution.returnCode !== 0 ? "RunnerCommandError" : "RuntimeError",
-        });
-        const failurePayload = payloadForEvent(failure);
-        lastSequence = Math.max(
-          lastSequence,
-          typeof failure.sequence === "number"
-            ? failure.sequence
-            : lastSequence + 1,
-        );
-        deferredTerminalEvent = {
-          eventType: "run_failed",
-          payload: failurePayload,
-          createdAt: new Date().toISOString(),
-        };
-        captureClaimedInputFailure(
-          execution.returnCode !== 0
-            ? execution.stderr.trim() === "runner command timed out"
-              ? "runner_timeout"
-              : execution.stderr.includes("became idle")
-                ? "runner_idle_timeout"
-                : "runner_command_error"
-            : "runner_missing_terminal",
-          String(failurePayload.message ?? "runner ended before terminal event"),
-          {
-            failure_source: "synthetic_terminal_event",
-            terminal_status: "ERROR",
-            terminal_stop_reason: stopReasonForTerminalEvent({
-              eventType: "run_failed",
-              payload: failurePayload,
-              terminalStatus: "ERROR",
-            }),
-            terminal_payload: sanitizeRuntimeSentryValue(failurePayload),
-            return_code: execution.returnCode,
-            stderr: execution.stderr,
-            saw_terminal: execution.sawTerminal,
-            skipped_lines: execution.skippedLines.slice(0, 5),
-          },
-        );
-        terminalStatus = "ERROR";
-        lastError = failurePayload;
-        completedAt = new Date().toISOString();
-        stopReason = stopReasonForTerminalEvent({
-          eventType: "run_failed",
-          payload: failurePayload,
-          terminalStatus,
-        });
-      }
 
-      let terminalEventToRelay = persistedTerminalEvent
-        ? {
-            eventType: persistedTerminalEvent.eventType,
-            sequence: persistedTerminalEvent.sequence,
-            payload: persistedTerminalEvent.payload,
-            createdAt: persistedTerminalEvent.createdAt,
-          }
-        : deferredTerminalEvent
+        terminalEventToRelay = persistedTerminalEvent
           ? {
-              eventType: deferredTerminalEvent.eventType,
-              sequence: lastSequence + 1,
-              payload: deferredTerminalEvent.payload,
-              createdAt: deferredTerminalEvent.createdAt,
+              eventType:
+                persistedTerminalEvent.eventType === "run_completed"
+                  ? "run_completed"
+                  : "run_failed",
+              sequence: persistedTerminalEvent.sequence,
+              payload: persistedTerminalEvent.payload,
+              createdAt: persistedTerminalEvent.createdAt,
             }
-          : null;
+          : deferredTerminalEvent
+            ? {
+                eventType: deferredTerminalEvent.eventType,
+                sequence: lastSequence + 1,
+                payload: deferredTerminalEvent.payload,
+                createdAt: deferredTerminalEvent.createdAt,
+              }
+            : null;
+
+        const terminalFailurePayload =
+          terminalEventToRelay?.eventType === "run_failed"
+            ? terminalEventToRelay.payload
+            : null;
+        if (isContextOverflowFailurePayload(terminalFailurePayload)) {
+          if (runnerAttempt >= 2) {
+            overflowRecovery = {
+              ...(overflowRecovery ?? {
+                trigger_reason: "provider_context_overflow",
+                initial_error_type:
+                  optionalString(terminalFailurePayload?.type) ?? null,
+                initial_error_message:
+                  optionalString(terminalFailurePayload?.message) ?? null,
+                compaction_attempted: false,
+                compaction_changed_branch: false,
+                retry_attempted: true,
+                recovered: false,
+                reset_required: false,
+              }),
+              retry_attempted: true,
+              recovered: false,
+              reset_required: true,
+            };
+            throw new SessionResetRequiredError(
+              `overflow recovery could not make the next prompt fit ${selectedModel ?? "the selected model"}; session reset required`,
+            );
+          }
+          overflowRecovery = {
+            trigger_reason: "provider_context_overflow",
+            initial_error_type: optionalString(terminalFailurePayload?.type),
+            initial_error_message: optionalString(
+              terminalFailurePayload?.message,
+            ),
+            compaction_attempted: true,
+            compaction_changed_branch: false,
+            retry_attempted: false,
+            recovered: false,
+            reset_required: false,
+          };
+          const liveSessionState =
+            params.sessionCheckpointSessionOps?.currentLeafCheckpointState(
+              checkpointHarnessSessionId,
+            ) ?? currentPiSessionLeafState(checkpointHarnessSessionId);
+          const compactionResult = await forceCompactSessionWithSnapshotMerge({
+            store,
+            workspaceId: record.workspaceId,
+            sessionId: record.sessionId,
+            inputId: record.inputId,
+            harnessSessionId: checkpointHarnessSessionId,
+            baseLeafId: liveSessionState.leafId,
+            baseLatestCompactionId: liveSessionState.latestCompactionId,
+            runPiSessionCompactionFn: params.runPiSessionCompactionFn,
+            resolveRuntimeModelClientFn: params.resolveRuntimeModelClientFn,
+            sessionOps: params.sessionCheckpointSessionOps,
+          });
+          overflowRecovery = {
+            ...overflowRecovery,
+            compaction_changed_branch: compactionResult.merged,
+            retry_attempted: compactionResult.merged,
+          };
+          if (!compactionResult.merged) {
+            overflowRecovery = {
+              ...overflowRecovery,
+              reset_required: true,
+            };
+            throw new SessionResetRequiredError(
+              `overflow recovery compaction could not make the next prompt fit ${selectedModel ?? "the selected model"}; session reset required`,
+            );
+          }
+          runnerSequenceOffset = Math.max(runnerSequenceOffset, lastSequence);
+          assistantParts.length = 0;
+          capturedPiAssistantMessage = null;
+          terminalStatus = "IDLE";
+          lastError = null;
+          completedAt = null;
+          stopReason = null;
+          tokenUsage = null;
+          contextUsage = null;
+          promptSectionIds = [];
+          capabilityManifestFingerprint = null;
+          requestSnapshotFingerprint = null;
+          promptCacheProfile = null;
+          toolReplayTrimmed = false;
+          deferredTerminalEvent = null;
+          pendingOutputDeltaPayload = null;
+          pendingOutputDeltaSequence = 0;
+          pendingOutputDeltaTimestamp = null;
+          toolCallsById.clear();
+          skillInvocationsById.clear();
+          permissionDenials.length = 0;
+          continue;
+        }
+        if (
+          runnerAttempt > 1 &&
+          overflowRecovery?.retry_attempted &&
+          terminalEventToRelay?.eventType === "run_completed"
+        ) {
+          overflowRecovery = {
+            ...overflowRecovery,
+            recovered: true,
+          };
+        }
+        break;
+      }
       const assistantText = assistantParts.join("").trim();
       if (
         useEphemeralHarnessSession &&
@@ -4407,6 +4825,8 @@ export async function processClaimedInput(params: {
         toolCallCount: toolCallsById.size,
         toolReplayTrimmed,
         checkpointQueued: Boolean(checkpointJob),
+        preRunCompaction,
+        overflowRecovery,
       });
       if (deferredTerminalEvent) {
         deferredTerminalEvent.payload.context_budget_decisions =
@@ -4426,6 +4846,28 @@ export async function processClaimedInput(params: {
           createdAt: deferredTerminalEvent.createdAt,
         };
         deferredTerminalEvent = null;
+      }
+      if (
+        terminalEventToRelay?.eventType === "run_failed" &&
+        !terminalFailureCaptured
+      ) {
+        terminalFailureCaptured = true;
+        captureClaimedInputFailure(
+          terminalFailureKindFromPayload(terminalEventToRelay.payload),
+          optionalString(terminalEventToRelay.payload.message) ??
+            optionalString(terminalEventToRelay.payload.type) ??
+            "runner emitted run_failed",
+          {
+            failure_source: "terminal_event",
+            terminal_status: "ERROR",
+            terminal_stop_reason: stopReason,
+            terminal_payload: sanitizeRuntimeSentryValue(
+              terminalEventToRelay.payload,
+            ),
+            event_sequence: terminalEventToRelay.sequence,
+            event_timestamp: terminalEventToRelay.createdAt,
+          },
+        );
       }
 
       store.updateInput({
@@ -4635,6 +5077,7 @@ export async function processClaimedInput(params: {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
+      const errorStopReason = executorFailureStopReason(error);
       store.updateInput({
         workspaceId: record.workspaceId,
         inputId: record.inputId,
@@ -4652,11 +5095,16 @@ export async function processClaimedInput(params: {
         eventType: "run_failed",
         payload: {
           message,
+          ...(errorStopReason === "session_reset_required" &&
+          error instanceof Error &&
+          error.name
+            ? { error_type: error.name }
+            : {}),
           context_budget_decisions: buildMergedContextBudgetPayload({
             startedAt: turnStartedAt,
             completedAt: new Date().toISOString(),
             terminalStatus: "ERROR",
-            stopReason: "executor_error",
+            stopReason: errorStopReason,
             tokenUsage: null,
             contextUsage,
             promptCacheProfile,
@@ -4664,6 +5112,8 @@ export async function processClaimedInput(params: {
             toolCallCount: toolCallsById.size,
             toolReplayTrimmed,
             checkpointQueued: false,
+            preRunCompaction,
+            overflowRecovery,
           }),
         },
       });
@@ -4675,7 +5125,12 @@ export async function processClaimedInput(params: {
         currentWorkerId: null,
         leaseUntil: null,
         heartbeatAt: null,
-        lastError: { message },
+        lastError:
+          errorStopReason === "session_reset_required" &&
+          error instanceof Error &&
+          error.name
+            ? { message, error_type: error.name }
+            : { message },
       });
       const errorCompletedAt = new Date().toISOString();
       const turnResult = persistTurnResult({
@@ -4684,7 +5139,7 @@ export async function processClaimedInput(params: {
         startedAt: turnStartedAt,
         completedAt: errorCompletedAt,
         terminalStatus: "ERROR",
-        stopReason: "executor_error",
+        stopReason: errorStopReason,
         assistantText: "",
         toolUsageSummary: summarizeToolCalls(new Map()),
         permissionDenials: [],
@@ -4696,7 +5151,7 @@ export async function processClaimedInput(params: {
           startedAt: turnStartedAt,
           completedAt: errorCompletedAt,
           terminalStatus: "ERROR",
-          stopReason: "executor_error",
+          stopReason: errorStopReason,
           tokenUsage: null,
           contextUsage,
           promptCacheProfile,
@@ -4704,6 +5159,8 @@ export async function processClaimedInput(params: {
           toolCallCount: toolCallsById.size,
           toolReplayTrimmed,
           checkpointQueued: false,
+          preRunCompaction,
+          overflowRecovery,
         }),
         tokenUsage: null,
       });

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -14,6 +14,8 @@ import { captureRuntimeException } from "./runtime-sentry.js";
 export const SESSION_CHECKPOINT_JOB_TYPE = "session_checkpoint";
 const PI_COMPACTION_CONTEXT_RESERVE_RATIO = 0.7;
 const SESSION_CHECKPOINT_WAIT_POLL_INTERVAL_MS = 100;
+const DEFAULT_PRE_RUN_CONTEXT_WINDOW = 65_536;
+const ESTIMATED_BYTES_PER_TOKEN = 2;
 
 export interface PiContextUsage {
   tokens: number | null;
@@ -30,7 +32,7 @@ interface SessionCheckpointJobPayload {
   context_usage: PiContextUsage;
 }
 
-interface PiCompactionCommandResult {
+export interface PiCompactionCommandResult {
   compacted: boolean;
   session_file: string;
   result?: Record<string, unknown> | null;
@@ -62,7 +64,7 @@ interface SessionCheckpointResultRecord {
   compaction?: SessionCheckpointCompactionRecord | null;
 }
 
-interface SessionCheckpointCompactionRecord {
+export interface SessionCheckpointCompactionRecord {
   session_file: string | null;
   reason: string | null;
   diagnostics: Record<string, unknown> | null;
@@ -90,6 +92,9 @@ interface PiSessionManagerInstance {
   getLeafId(): string | null;
   getEntries(): PiSessionBranchEntry[];
   getSessionFile(): string | undefined;
+  buildSessionContext?(): {
+    messages?: unknown[];
+  };
   appendCompaction(
     summary: string,
     firstKeptEntryId: string,
@@ -121,6 +126,34 @@ export interface SessionCheckpointSessionOps {
     liveSessionFile: string;
     snapshotSessionFile: string;
   }): boolean;
+}
+
+export interface PreRunSessionCompactionDecision {
+  decision: "fit" | "threshold_exceeded" | "would_overflow" | "reset_required";
+  reason: string | null;
+  previousSelectedModel: string | null;
+  targetSelectedModel: string | null;
+  previousContextWindow: number | null;
+  targetContextWindow: number | null;
+  currentSessionTokens: number | null;
+  estimatedRequestTokens: number | null;
+  projectedTotalTokens: number | null;
+  modelDownshift: boolean;
+}
+
+export interface ForceSessionCompactionResult {
+  outcome:
+    | "not_compacted"
+    | "binding_changed"
+    | "session_missing"
+    | "merge_guard_failed"
+    | "merge_failed"
+    | "merged_without_boundary";
+  detail?: string | null;
+  reason?: string | null;
+  merged: boolean;
+  boundaryWritten: boolean;
+  compaction: SessionCheckpointCompactionRecord | null;
 }
 
 const require = createRequire(import.meta.url);
@@ -191,6 +224,34 @@ function finiteNumberOrNull(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function jsonByteLength(value: unknown): number {
+  try {
+    const text = JSON.stringify(value);
+    return typeof text === "string" ? Buffer.byteLength(text, "utf8") : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function estimateJsonTokens(value: unknown): number | null {
+  const bytes = jsonByteLength(value);
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return null;
+  }
+  return Math.ceil(bytes / ESTIMATED_BYTES_PER_TOKEN);
+}
+
+function maxFiniteNumber(...values: Array<number | null | undefined>): number | null {
+  let max: number | null = null;
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      continue;
+    }
+    max = max === null ? value : Math.max(max, value);
+  }
+  return max;
+}
+
 function runtimeRootDir(): string {
   const configured = (process.env.HOLABOSS_RUNTIME_ROOT ?? "").trim();
   if (configured) {
@@ -239,6 +300,140 @@ function currentLeafCheckpointState(sessionFile: string): {
   };
 }
 
+function checkpointSnapshotRuntimeConfig(
+  snapshotPayload: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  return snapshotPayload && isRecord(snapshotPayload.runtime_config)
+    ? snapshotPayload.runtime_config
+    : null;
+}
+
+function checkpointModelProxyProvider(
+  snapshotPayload: Record<string, unknown> | null | undefined,
+): string | null {
+  const runtimeConfig = checkpointSnapshotRuntimeConfig(snapshotPayload);
+  const modelClient = runtimeConfig && isRecord(runtimeConfig.model_client)
+    ? runtimeConfig.model_client
+    : null;
+  return nonEmptyString(modelClient?.model_proxy_provider);
+}
+
+function normalizeHarnessModelId(modelId: string): string {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.startsWith("openai/")) {
+    return normalized.slice("openai/".length);
+  }
+  if (normalized.startsWith("holaboss_model_proxy/")) {
+    return normalized.slice("holaboss_model_proxy/".length);
+  }
+  return normalized;
+}
+
+function selectedModelParts(
+  selectedModel: string | null,
+): { providerId: string; modelId: string } | null {
+  const normalized = nonEmptyString(selectedModel);
+  if (!normalized) {
+    return null;
+  }
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === normalized.length - 1) {
+    return null;
+  }
+  return {
+    providerId: normalized.slice(0, slashIndex),
+    modelId: normalized.slice(slashIndex + 1),
+  };
+}
+
+function isOpenAiGpt5Model(modelId: string): boolean {
+  return /^gpt-5(?:[.-]|$)/.test(modelId);
+}
+
+function targetModelContextWindow(params: {
+  snapshotPayload: Record<string, unknown> | null;
+  selectedModel: string | null;
+  fallbackContextWindow?: number | null;
+}): number {
+  const selectedFromSnapshot = params.snapshotPayload
+    ? checkpointSelectedModel({
+        snapshotPayload: params.snapshotPayload,
+        harnessRequest: isRecord(params.snapshotPayload.harness_request)
+          ? params.snapshotPayload.harness_request
+          : {},
+      })
+    : null;
+  const selectedParts =
+    selectedFromSnapshot ??
+    selectedModelParts(params.selectedModel);
+  const modelProxyProvider = checkpointModelProxyProvider(params.snapshotPayload);
+  if (selectedParts) {
+    const providerId = selectedParts.providerId.trim().toLowerCase();
+    const normalizedModelId = normalizeHarnessModelId(selectedParts.modelId);
+    const openAiCompat =
+      modelProxyProvider?.trim().toLowerCase() === "openai_compatible";
+    if (openAiCompat && providerId === "openai_codex") {
+      switch (normalizedModelId) {
+        case "gpt-5.5":
+        case "gpt-5.3-codex":
+          return 400_000;
+        case "gpt-5.4":
+        case "gpt-5.4-pro":
+          return 1_000_000;
+        default:
+          break;
+      }
+    }
+    if (
+      openAiCompat &&
+      isOpenAiGpt5Model(normalizedModelId) &&
+      (providerId === "openai_direct" ||
+        providerId === "openai" ||
+        providerId === "holaboss_model_proxy" ||
+        providerId === "holaboss")
+    ) {
+      switch (normalizedModelId) {
+        case "gpt-5.4":
+        case "gpt-5.4-pro":
+          return 1_000_000;
+        case "gpt-5.4-mini":
+          return 1_050_000;
+        case "gpt-5.5":
+        case "gpt-5.2":
+          return 400_000;
+        default:
+          break;
+      }
+    }
+  }
+  const fallback = finiteNumberOrNull(params.fallbackContextWindow);
+  if (fallback !== null && fallback > 0) {
+    return fallback;
+  }
+  return DEFAULT_PRE_RUN_CONTEXT_WINDOW;
+}
+
+function estimateSessionContextTokens(sessionFile: string): number | null {
+  const sessionManager = openSessionManager(sessionFile);
+  const sessionContext = sessionManager.buildSessionContext?.();
+  const messages = Array.isArray(sessionContext?.messages)
+    ? sessionContext.messages
+    : null;
+  return messages ? estimateJsonTokens(messages) : null;
+}
+
+function estimateSnapshotRequestTokens(
+  snapshotPayload: Record<string, unknown> | null | undefined,
+): number | null {
+  if (!snapshotPayload || !isRecord(snapshotPayload.harness_request)) {
+    return null;
+  }
+  return estimateJsonTokens(snapshotPayload.harness_request);
+}
+
 function normalizePiContextUsage(value: unknown): PiContextUsage | null {
   if (!isRecord(value)) {
     return null;
@@ -265,6 +460,18 @@ function normalizePiContextUsage(value: unknown): PiContextUsage | null {
     contextWindow,
     percent,
   };
+}
+
+export function sessionCheckpointThresholdTokens(
+  contextWindow: number,
+): number | null {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return null;
+  }
+  const reserveTokens = Math.ceil(
+    contextWindow * PI_COMPACTION_CONTEXT_RESERVE_RATIO,
+  );
+  return Math.max(0, contextWindow - reserveTokens);
 }
 
 function recordSessionCheckpointResult(params: {
@@ -312,10 +519,70 @@ export function shouldQueueSessionCheckpoint(contextUsage: PiContextUsage | null
   ) {
     return false;
   }
-  const reserveTokens = Math.ceil(
-    contextUsage.contextWindow * PI_COMPACTION_CONTEXT_RESERVE_RATIO,
+  const thresholdTokens = sessionCheckpointThresholdTokens(
+    contextUsage.contextWindow,
   );
-  return contextUsage.tokens > contextUsage.contextWindow - reserveTokens;
+  return thresholdTokens !== null && contextUsage.tokens > thresholdTokens;
+}
+
+export function evaluatePreRunSessionCompaction(params: {
+  liveSessionFile: string;
+  snapshotPayload: Record<string, unknown> | null;
+  selectedModel: string | null;
+  previousSelectedModel: string | null;
+  previousContextUsage: PiContextUsage | null;
+}): PreRunSessionCompactionDecision {
+  const previousContextWindow =
+    finiteNumberOrNull(params.previousContextUsage?.contextWindow) ?? null;
+  const targetContextWindow = targetModelContextWindow({
+    snapshotPayload: params.snapshotPayload,
+    selectedModel: params.selectedModel,
+    fallbackContextWindow: previousContextWindow,
+  });
+  const currentSessionTokens = maxFiniteNumber(
+    finiteNumberOrNull(params.previousContextUsage?.tokens),
+    estimateSessionContextTokens(params.liveSessionFile),
+  );
+  const estimatedRequestTokens = estimateSnapshotRequestTokens(params.snapshotPayload);
+  const projectedTotalTokens =
+    currentSessionTokens !== null && estimatedRequestTokens !== null
+      ? currentSessionTokens + estimatedRequestTokens
+      : currentSessionTokens;
+  const thresholdTokens = sessionCheckpointThresholdTokens(targetContextWindow);
+  const modelDownshift =
+    previousContextWindow !== null && targetContextWindow < previousContextWindow;
+  let decision: PreRunSessionCompactionDecision["decision"] = "fit";
+  let reason: string | null = null;
+  if (
+    projectedTotalTokens !== null &&
+    projectedTotalTokens > targetContextWindow
+  ) {
+    decision = "would_overflow";
+    reason = modelDownshift
+      ? "model_downshift_projected_overflow"
+      : "projected_overflow";
+  } else if (
+    thresholdTokens !== null &&
+    currentSessionTokens !== null &&
+    currentSessionTokens > thresholdTokens
+  ) {
+    decision = "threshold_exceeded";
+    reason = modelDownshift
+      ? "model_downshift_above_threshold"
+      : "above_threshold";
+  }
+  return {
+    decision,
+    reason,
+    previousSelectedModel: nonEmptyString(params.previousSelectedModel),
+    targetSelectedModel: nonEmptyString(params.selectedModel),
+    previousContextWindow,
+    targetContextWindow,
+    currentSessionTokens,
+    estimatedRequestTokens,
+    projectedTotalTokens,
+    modelDownshift,
+  };
 }
 
 export function listInFlightSessionCheckpointJobs(params: {
@@ -743,8 +1010,177 @@ function withResolvedCheckpointModelClient(params: {
       ...resolved.modelClient,
       default_headers:
         Object.keys(mergedHeaders).length > 0 ? mergedHeaders : null,
-    },
+      },
   };
+}
+
+const sessionCompactionLocks = new Map<string, Promise<void>>();
+
+async function withSessionCompactionLock<T>(
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const prior = sessionCompactionLocks.get(key) ?? Promise.resolve();
+  let releaseCurrent: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  sessionCompactionLocks.set(
+    key,
+    prior.then(
+      () => current,
+      () => current,
+    ),
+  );
+  await prior.catch(() => {});
+  try {
+    return await operation();
+  } finally {
+    if (releaseCurrent) {
+      releaseCurrent();
+    }
+    if (sessionCompactionLocks.get(key) === current) {
+      sessionCompactionLocks.delete(key);
+    }
+  }
+}
+
+function sessionCompactionLockKey(params: {
+  workspaceId: string;
+  sessionId: string;
+}): string {
+  return `${params.workspaceId}:${params.sessionId}`;
+}
+
+export async function forceCompactSessionWithSnapshotMerge(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  sessionId: string;
+  inputId: string;
+  harnessSessionId: string;
+  baseLeafId: string | null;
+  baseLatestCompactionId: string | null;
+  runPiSessionCompactionFn?: (
+    requestPayload: Record<string, unknown>,
+  ) => Promise<PiCompactionCommandResult>;
+  resolveRuntimeModelClientFn?: ResolveRuntimeModelClientFn;
+  sessionOps?: SessionCheckpointSessionOps;
+}): Promise<ForceSessionCompactionResult> {
+  return await withSessionCompactionLock(
+    sessionCompactionLockKey({
+      workspaceId: params.workspaceId,
+      sessionId: params.sessionId,
+    }),
+    async () => {
+      const sessionOps = params.sessionOps ?? defaultSessionCheckpointSessionOps;
+      const snapshot = params.store.getTurnRequestSnapshot({
+        workspaceId: params.workspaceId,
+        inputId: params.inputId,
+      });
+      if (!snapshot) {
+        throw new Error(`turn request snapshot not found for ${params.inputId}`);
+      }
+      const snapshotPayload = requiredRecord(
+        snapshot.payload,
+        "turn request snapshot payload",
+      );
+      const harnessRequest = withResolvedCheckpointModelClient({
+        snapshotPayload,
+        harnessRequest: requiredRecord(
+          snapshotPayload.harness_request,
+          "turn request snapshot harness_request",
+        ),
+        workspaceId: params.workspaceId,
+        sessionId: params.sessionId,
+        inputId: params.inputId,
+        resolveRuntimeModelClientFn: params.resolveRuntimeModelClientFn,
+      });
+      const liveSessionPath = params.harnessSessionId;
+      const compactedSessionPath = snapshotSessionPath(liveSessionPath);
+      fs.copyFileSync(liveSessionPath, compactedSessionPath);
+      try {
+        const result = await (params.runPiSessionCompactionFn ?? runPiSessionCompaction)(
+          {
+            ...harnessRequest,
+            force_compaction: true,
+            harness_session_id: compactedSessionPath,
+            persisted_harness_session_id: compactedSessionPath,
+            timeout_seconds: 0,
+          },
+        );
+        const compaction = summarizeCheckpointCompactionResult(result);
+        if (!result.compacted) {
+          return {
+            outcome: "not_compacted",
+            reason: result.reason ?? null,
+            merged: false,
+            boundaryWritten: false,
+            compaction,
+          };
+        }
+        const latestHarnessSessionId =
+          params.store.getBinding({
+            workspaceId: params.workspaceId,
+            sessionId: params.sessionId,
+          })?.harnessSessionId ?? null;
+        if (latestHarnessSessionId !== params.harnessSessionId) {
+          return {
+            outcome: "binding_changed",
+            detail: "live binding changed before checkpoint merge",
+            merged: false,
+            boundaryWritten: false,
+            compaction,
+          };
+        }
+        if (!fs.existsSync(liveSessionPath)) {
+          return {
+            outcome: "session_missing",
+            detail: "live harness session file disappeared before checkpoint merge",
+            merged: false,
+            boundaryWritten: false,
+            compaction,
+          };
+        }
+        if (
+          !sessionOps.canMergeCheckpointIntoLiveSession({
+            sessionFile: liveSessionPath,
+            baseLeafId: params.baseLeafId,
+            baseLatestCompactionId: params.baseLatestCompactionId,
+          })
+        ) {
+          return {
+            outcome: "merge_guard_failed",
+            detail: "live session changed before checkpoint merge",
+            merged: false,
+            boundaryWritten: false,
+            compaction,
+          };
+        }
+        const merged = sessionOps.appendSnapshotCompactionToLiveSession({
+          liveSessionFile: liveSessionPath,
+          snapshotSessionFile: result.session_file || compactedSessionPath,
+        });
+        if (!merged) {
+          return {
+            outcome: "merge_failed",
+            detail:
+              "snapshot compaction could not be appended to the live session branch",
+            merged: false,
+            boundaryWritten: false,
+            compaction,
+          };
+        }
+        return {
+          outcome: "merged_without_boundary",
+          merged: true,
+          boundaryWritten: false,
+          compaction,
+        };
+      } finally {
+        maybeDeleteFile(compactedSessionPath);
+      }
+    },
+  );
 }
 
 export async function processSessionCheckpointJob(params: {
@@ -821,113 +1257,31 @@ export async function processSessionCheckpointJob(params: {
     return;
   }
 
-  const snapshot = params.store.getTurnRequestSnapshot({
-    workspaceId: params.record.workspaceId,
-    inputId: params.record.inputId,
-  });
-  if (!snapshot) {
-    throw new Error(`turn request snapshot not found for ${params.record.inputId}`);
-  }
-  const snapshotPayload = requiredRecord(snapshot.payload, "turn request snapshot payload");
-  const harnessRequest = withResolvedCheckpointModelClient({
-    snapshotPayload,
-    harnessRequest: requiredRecord(
-      snapshotPayload.harness_request,
-      "turn request snapshot harness_request",
-    ),
-    workspaceId: params.record.workspaceId,
-    sessionId: params.record.sessionId,
-    inputId: params.record.inputId,
-    resolveRuntimeModelClientFn: params.resolveRuntimeModelClientFn,
-  });
-  const liveSessionPath = payload.base_harness_session_id;
-  const compactedSessionPath = snapshotSessionPath(liveSessionPath);
-  fs.copyFileSync(liveSessionPath, compactedSessionPath);
-
   try {
-    const result = await (params.runPiSessionCompactionFn ?? runPiSessionCompaction)({
-      ...harnessRequest,
-      force_compaction: true,
-      harness_session_id: compactedSessionPath,
-      persisted_harness_session_id: compactedSessionPath,
-      timeout_seconds: 0,
-    });
-    const compaction = summarizeCheckpointCompactionResult(result);
-    if (!result.compacted) {
-      maybeDeleteFile(compactedSessionPath);
-      recordSessionCheckpointResult({
-        store: params.store,
-        record: params.record,
-        outcome: "not_compacted",
-        reason: result.reason ?? null,
-        compaction,
-      });
-      return;
-    }
-
-    const latestHarnessSessionId =
-      params.store.getBinding({
-        workspaceId: params.record.workspaceId,
-        sessionId: params.record.sessionId,
-      })?.harnessSessionId ?? null;
-    if (latestHarnessSessionId !== payload.base_harness_session_id) {
-      maybeDeleteFile(compactedSessionPath);
-      recordSessionCheckpointResult({
-        store: params.store,
-        record: params.record,
-        outcome: "binding_changed",
-        detail: "live binding changed before checkpoint merge",
-      });
-      return;
-    }
-    if (!fs.existsSync(liveSessionPath)) {
-      maybeDeleteFile(compactedSessionPath);
-      recordSessionCheckpointResult({
-        store: params.store,
-        record: params.record,
-        outcome: "session_missing",
-        detail: "live harness session file disappeared before checkpoint merge",
-      });
-      return;
-    }
-    if (!sessionOps.canMergeCheckpointIntoLiveSession({
-      sessionFile: liveSessionPath,
+    const compactionResult = await forceCompactSessionWithSnapshotMerge({
+      store: params.store,
+      workspaceId: params.record.workspaceId,
+      sessionId: params.record.sessionId,
+      inputId: params.record.inputId,
+      harnessSessionId: payload.base_harness_session_id,
       baseLeafId: payload.base_leaf_id,
       baseLatestCompactionId: payload.base_latest_compaction_id,
-    })) {
-      maybeDeleteFile(compactedSessionPath);
-      recordSessionCheckpointResult({
-        store: params.store,
-        record: params.record,
-        outcome: "merge_guard_failed",
-        detail: "live session changed before checkpoint merge",
-      });
-      return;
-    }
-    const merged = sessionOps.appendSnapshotCompactionToLiveSession({
-      liveSessionFile: liveSessionPath,
-      snapshotSessionFile: result.session_file || compactedSessionPath,
+      runPiSessionCompactionFn: params.runPiSessionCompactionFn,
+      resolveRuntimeModelClientFn: params.resolveRuntimeModelClientFn,
+      sessionOps,
     });
-    maybeDeleteFile(compactedSessionPath);
-    if (!merged) {
-      recordSessionCheckpointResult({
-        store: params.store,
-        record: params.record,
-        outcome: "merge_failed",
-        detail: "snapshot compaction could not be appended to the live session branch",
-      });
-      return;
-    }
     recordSessionCheckpointResult({
       store: params.store,
       record: params.record,
-      outcome: "merged_without_boundary",
-      merged: true,
-      boundaryWritten: false,
-      compaction,
+      outcome: compactionResult.outcome,
+      detail: compactionResult.detail ?? null,
+      reason: compactionResult.reason ?? null,
+      merged: compactionResult.merged,
+      boundaryWritten: compactionResult.boundaryWritten,
+      compaction: compactionResult.compaction,
     });
+    return;
   } catch (error) {
-    maybeDeleteFile(compactedSessionPath);
     const compaction = summarizeCheckpointCompactionResult(
       compactionResultFromError(error),
     );


### PR DESCRIPTION
## Context

This change moves context compaction correctness into the runtime so smaller-window model switches do not rely on PI's heuristics alone.

The main goals are:
- add a runtime-owned pre-run compaction gate before provider submission
- reuse the same snapshot-merge compaction algorithm for pre-run and post-run paths
- add a runtime-owned overflow recovery retry when a provider still returns `context_length_exceeded`

## What Changed

- extracted the forced PI session compaction flow into a shared runtime path that both pre-run and post-run logic use
- added a model-aware pre-run detector that evaluates:
  - target selected model and context window
  - previous selected model for downshift detection
  - previous context usage
  - current live session estimate
  - current turn request snapshot
- added synchronous pre-run compaction when the detector returns `threshold_exceeded` or `would_overflow`
- re-evaluate the session after compaction and surface `session_reset_required` when the session still cannot safely fit the target model
- added runtime-owned overflow recovery that compacts once and retries once after a provider overflow, then escalates to `session_reset_required` if recovery still fails
- serialized pre-run and post-run compaction through the same session-level lock
- added telemetry for `pre_run_compaction` and `overflow_recovery`

## Why

Previously, a long-lived session could be safe for `gpt-5.4` but later fail on `gpt-5.5` because PI's stale-compaction heuristic could skip pre-run compaction after a model downshift.

This change makes the runtime responsible for both:
- proactively detecting obvious overflow risk before the provider call
- recovering deterministically if the provider still becomes the first source of truth for overflow

## Validation

- `cd runtime/api-server && node --import tsx --test src/session-checkpoint.test.ts src/claimed-input-executor.test.ts`
- `cd runtime/api-server && npm run typecheck`

## Live Testing

Validated against the live desktop runtime in workspace `T6`:
- pre-run compaction path that compacted and then returned `session_reset_required` when the compacted session still exceeded the target safety threshold
- pre-run compaction path that compacted, re-evaluated to `fit`, and proceeded to the provider call
- runtime-owned overflow recovery path exercised in the live T6 store with an injected first-attempt `context_length_exceeded`, followed by compaction and a successful retry

## Impact

- no Supabase or migration changes
- no desktop UI changes
