### PR TITLE
feat(editor): grid picker for slash-menu table command

### DIFF
--- a/packages/editor/src/extensions/SlashMenuList.tsx
+++ b/packages/editor/src/extensions/SlashMenuList.tsx
@@ -26,6 +26,21 @@ import {
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
+export interface SlashItemCommandCtx {
+  editor: Editor;
+  range: Range;
+  /** Populated when the item has a `picker` and the user committed via it. */
+  picker?: { rows: number; cols: number };
+}
+
+export type SlashItemPicker = {
+  kind: "grid";
+  maxRows: number;
+  maxCols: number;
+  initialRows: number;
+  initialCols: number;
+};
+
 export interface SlashItem {
   /** Stable id, used as React key. */
   id: string;
@@ -42,7 +57,9 @@ export interface SlashItem {
   /** Optional keyboard shortcut hint shown at the right. */
   shortcut?: string;
   /** Action invoked when this item is selected. */
-  command: (ctx: { editor: Editor; range: Range }) => void;
+  command: (ctx: SlashItemCommandCtx) => void;
+  /** Optional grid picker shown beside the menu when this item is active. */
+  picker?: SlashItemPicker;
 }
 
 export interface SlashMenuListProps {
@@ -63,6 +80,8 @@ export interface SlashMenuListHandle {
 export const SlashMenuList = forwardRef<SlashMenuListHandle, SlashMenuListProps>(
   function SlashMenuList({ items, command }, ref) {
     const [activeIndex, setActiveIndex] = useState(0);
+    const [pickerMode, setPickerMode] = useState(false);
+    const [pickerDims, setPickerDims] = useState({ rows: 0, cols: 0 });
     const containerRef = useRef<HTMLDivElement>(null);
     const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
@@ -82,22 +101,91 @@ export const SlashMenuList = forwardRef<SlashMenuListHandle, SlashMenuListProps>
       setActiveIndex(0);
     }, [items]);
 
+    const activeItem = items[activeIndex];
+    const activePicker = activeItem?.picker ?? null;
+
+    useEffect(() => {
+      setPickerMode(false);
+      if (activePicker) {
+        setPickerDims({
+          rows: activePicker.initialRows,
+          cols: activePicker.initialCols,
+        });
+      }
+    }, [
+      activeIndex,
+      activePicker?.kind,
+      activePicker?.initialRows,
+      activePicker?.initialCols,
+    ]);
+
     // Keep the active item visible inside the scroll container.
     useLayoutEffect(() => {
       const el = itemRefs.current[activeIndex];
       el?.scrollIntoView({ block: "nearest" });
     }, [activeIndex]);
 
-    const select = (index: number) => {
+    const commit = (index: number, picker?: { rows: number; cols: number }) => {
       const item = items[index];
       if (!item) return;
-      command(item);
+      if (item.picker && picker && picker.rows > 0 && picker.cols > 0) {
+        const wrapped: SlashItem = {
+          ...item,
+          command: (ctx) => item.command({ ...ctx, picker }),
+        };
+        command(wrapped);
+      } else {
+        command(item);
+      }
     };
 
     useImperativeHandle(
       ref,
       (): SlashMenuListHandle => ({
         onKeyDown: (event) => {
+          if (event.key === "Escape" && pickerMode) {
+            event.preventDefault();
+            setPickerMode(false);
+            return true;
+          }
+          if (pickerMode && activePicker) {
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setPickerDims((d) => ({ ...d, rows: Math.max(1, d.rows - 1) }));
+              return true;
+            }
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setPickerDims((d) => ({
+                ...d,
+                rows: Math.min(activePicker.maxRows, d.rows + 1),
+              }));
+              return true;
+            }
+            if (event.key === "ArrowLeft") {
+              event.preventDefault();
+              if (pickerDims.cols <= 1) {
+                setPickerMode(false);
+              } else {
+                setPickerDims((d) => ({ ...d, cols: d.cols - 1 }));
+              }
+              return true;
+            }
+            if (event.key === "ArrowRight") {
+              event.preventDefault();
+              setPickerDims((d) => ({
+                ...d,
+                cols: Math.min(activePicker.maxCols, d.cols + 1),
+              }));
+              return true;
+            }
+            if (event.key === "Enter" || event.key === "Tab") {
+              event.preventDefault();
+              commit(activeIndex, pickerDims);
+              return true;
+            }
+            return false;
+          }
           if (event.key === "ArrowUp") {
             event.preventDefault();
             setActiveIndex((i) => (i + items.length - 1) % Math.max(items.length, 1));
@@ -108,74 +196,161 @@ export const SlashMenuList = forwardRef<SlashMenuListHandle, SlashMenuListProps>
             setActiveIndex((i) => (i + 1) % Math.max(items.length, 1));
             return true;
           }
+          if (event.key === "ArrowRight" && activePicker) {
+            event.preventDefault();
+            if (pickerDims.rows === 0 || pickerDims.cols === 0) {
+              setPickerDims({
+                rows: activePicker.initialRows,
+                cols: activePicker.initialCols,
+              });
+            }
+            setPickerMode(true);
+            return true;
+          }
           if (event.key === "Enter" || event.key === "Tab") {
             event.preventDefault();
-            select(activeIndex);
+            commit(activeIndex);
             return true;
           }
           return false;
         },
       }),
-      [activeIndex, items],
+      [activeIndex, activePicker, items, pickerDims, pickerMode],
     );
 
     if (items.length === 0) {
       return (
-        <div ref={containerRef} className="hb-slash hb-slash--empty">
-          <div className="hb-slash__empty-title">No matches</div>
-          <div className="hb-slash__empty-hint">Try a different word.</div>
+        <div className="hb-slash-shell">
+          <div ref={containerRef} className="hb-slash hb-slash--empty">
+            <div className="hb-slash__empty-title">No matches</div>
+            <div className="hb-slash__empty-hint">Try a different word.</div>
+          </div>
         </div>
       );
     }
 
     let runningIndex = 0;
     return (
-      <div ref={containerRef} className="hb-slash" role="listbox">
-        {groups.map((group) => (
-          <div key={group.section} className="hb-slash__group">
-            <div className="hb-slash__section">{group.section}</div>
-            {group.items.map((item) => {
-              const index = runningIndex++;
-              const Icon = item.icon;
-              const active = index === activeIndex;
-              return (
-                <button
-                  key={item.id}
-                  ref={(el) => {
-                    itemRefs.current[index] = el;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={active}
-                  data-active={active || undefined}
-                  className="hb-slash__item"
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    select(index);
-                  }}
-                >
-                  <span className="hb-slash__icon-wrap" aria-hidden="true">
-                    <Icon className="hb-slash__icon" />
-                  </span>
-                  <span className="hb-slash__body">
-                    <span className="hb-slash__title">{item.title}</span>
-                    {item.subtitle ? (
-                      <span className="hb-slash__subtitle">{item.subtitle}</span>
+      <div className="hb-slash-shell">
+        <div ref={containerRef} className="hb-slash" role="listbox">
+          {groups.map((group) => (
+            <div key={group.section} className="hb-slash__group">
+              <div className="hb-slash__section">{group.section}</div>
+              {group.items.map((item) => {
+                const index = runningIndex++;
+                const Icon = item.icon;
+                const active = index === activeIndex;
+                return (
+                  <button
+                    key={item.id}
+                    ref={(el) => {
+                      itemRefs.current[index] = el;
+                    }}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    data-active={active || undefined}
+                    className="hb-slash__item"
+                    onMouseEnter={() => {
+                      setActiveIndex(index);
+                      setPickerMode(false);
+                    }}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      commit(index);
+                    }}
+                  >
+                    <span className="hb-slash__icon-wrap" aria-hidden="true">
+                      <Icon className="hb-slash__icon" />
+                    </span>
+                    <span className="hb-slash__body">
+                      <span className="hb-slash__title">{item.title}</span>
+                      {item.subtitle ? (
+                        <span className="hb-slash__subtitle">{item.subtitle}</span>
+                      ) : null}
+                    </span>
+                    {item.shortcut ? (
+                      <span className="hb-slash__shortcut">{item.shortcut}</span>
                     ) : null}
-                  </span>
-                  {item.shortcut ? (
-                    <span className="hb-slash__shortcut">{item.shortcut}</span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        ))}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+        {activePicker ? (
+          <GridPicker
+            maxRows={activePicker.maxRows}
+            maxCols={activePicker.maxCols}
+            rows={pickerDims.rows}
+            cols={pickerDims.cols}
+            onHover={(rows, cols) => setPickerDims({ rows, cols })}
+            onCommit={(rows, cols) => commit(activeIndex, { rows, cols })}
+          />
+        ) : null}
       </div>
     );
   },
 );
+
+interface GridPickerProps {
+  maxRows: number;
+  maxCols: number;
+  rows: number;
+  cols: number;
+  onHover: (rows: number, cols: number) => void;
+  onCommit: (rows: number, cols: number) => void;
+}
+
+function GridPicker({
+  maxRows,
+  maxCols,
+  rows,
+  cols,
+  onHover,
+  onCommit,
+}: GridPickerProps) {
+  const cells = useMemo(() => {
+    const out: Array<{ row: number; col: number }> = [];
+    for (let r = 1; r <= maxRows; r += 1) {
+      for (let c = 1; c <= maxCols; c += 1) {
+        out.push({ row: r, col: c });
+      }
+    }
+    return out;
+  }, [maxRows, maxCols]);
+
+  return (
+    <div className="hb-slash-picker" role="group" aria-label="Table size">
+      <div className="hb-slash-picker__label">
+        {rows > 0 && cols > 0 ? `${cols} × ${rows}` : "Choose size"}
+      </div>
+      <div
+        className="hb-slash-picker__grid"
+        style={{ gridTemplateColumns: `repeat(${maxCols}, 1fr)` }}
+        onMouseLeave={() => onHover(0, 0)}
+      >
+        {cells.map(({ row, col }) => {
+          const selected = row <= rows && col <= cols;
+          return (
+            <button
+              key={`${row}-${col}`}
+              type="button"
+              className="hb-slash-picker__cell"
+              data-selected={selected || undefined}
+              aria-label={`${col} columns by ${row} rows`}
+              onMouseEnter={() => onHover(row, col)}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onCommit(row, col);
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 // Default command catalogue. Order matters — items appear in this order
 // within their section. Sections render in the order their first item
@@ -284,16 +459,26 @@ export function defaultSlashItems(): SlashItem[] {
       id: "table",
       section: "Other",
       title: "Table",
-      subtitle: "3×3 grid, columns resize",
+      subtitle: "Pick a grid size, columns resize after",
       keywords: ["table", "grid", "rows", "cols"],
       icon: IconTable,
-      command: ({ editor, range }) =>
+      picker: {
+        kind: "grid",
+        maxRows: 8,
+        maxCols: 10,
+        initialRows: 3,
+        initialCols: 3,
+      },
+      command: ({ editor, range, picker }) => {
+        const rows = picker?.rows ?? 3;
+        const cols = picker?.cols ?? 3;
         editor
           .chain()
           .focus(undefined, { scrollIntoView: false })
           .deleteRange(range)
-          .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-          .run(),
+          .insertTable({ rows, cols, withHeaderRow: true })
+          .run();
+      },
     },
     {
       id: "divider",

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -482,6 +482,72 @@
   background: color-mix(in oklab, currentColor 5%, transparent);
 }
 
+.hb-slash-shell {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  width: max-content;
+  max-width: 100%;
+}
+
+.hb-slash-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.5rem;
+  border-radius: var(--hb-radius);
+  background: var(--hb-popup-bg, #ffffff);
+  color: var(--hb-popup-fg, #0f172a);
+  border: 1px solid var(--hb-popup-border, rgba(15, 23, 42, 0.1));
+  box-shadow: var(--hb-shadow-popup);
+  animation: hb-pop-in 100ms ease-out;
+}
+@media (prefers-color-scheme: dark) {
+  .hb-slash-picker {
+    background: var(--hb-popup-bg, #18181b);
+    color: var(--hb-popup-fg, #fafafa);
+    border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+  }
+}
+.dark .hb-slash-picker {
+  background: var(--hb-popup-bg, #18181b);
+  color: var(--hb-popup-fg, #fafafa);
+  border-color: var(--hb-popup-border, rgba(255, 255, 255, 0.08));
+}
+
+.hb-slash-picker__label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, currentColor 55%, transparent);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.hb-slash-picker__grid {
+  display: grid;
+  gap: 3px;
+}
+
+.hb-slash-picker__cell {
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border-radius: 2px;
+  border: 1px solid color-mix(in oklab, currentColor 18%, transparent);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 60ms ease, border-color 60ms ease;
+}
+.hb-slash-picker__cell:hover {
+  border-color: color-mix(in oklab, currentColor 35%, transparent);
+}
+.hb-slash-picker__cell[data-selected] {
+  background: color-mix(in oklab, var(--hb-accent, #f58419) 22%, transparent);
+  border-color: color-mix(in oklab, var(--hb-accent, #f58419) 55%, transparent);
+}
+
 /* Tippy strips its wrapper styling so our menus own the visual chrome.
  * We DON'T import tippy.css — own classes cover what we need. */
 .tippy-box[data-theme~="hb-slash"] {


### PR DESCRIPTION
## Summary

Replaces the hardcoded 3×3 `/table` insertion with a Notion-style grid picker rendered beside the slash menu when the **Table** item is active.

- Mouse: hover cells → live `C × R` label, click commits at that size.
- Keyboard: `→` opens the picker; arrows move the selection; `Enter` / `Tab` commits; `Esc` or `←` at col 1 exits back to the list. Pressing `Enter` directly on **Table** without opening the picker still inserts the default 3×3.
- Default grid bounds: 10 cols × 8 rows, initial 3×3 (matches old default).

Generalises `SlashItem` with an optional `picker: { kind: "grid"; maxRows; maxCols; initialRows; initialCols }` config and an extended command ctx (`picker?: { rows; cols }`), so other slash commands can adopt the same affordance later.

## Test plan

- [ ] `/` → **Table** → click cell `5 × 3` → table inserted as 5 cols × 3 rows
- [ ] `/` → **Table** → press `Enter` immediately → default 3×3 inserted (regression)
- [ ] `/` → **Table** → `→` → arrows move cell, `Enter` commits at current size
- [ ] `Esc` while in picker mode returns to list nav; pressing `Enter` on a non-Table item still works
- [ ] Other items (Heading, List, Quote, Code block, Divider) unchanged
- [ ] Light + dark themes look correct; picker label reads `C × R` clearly
- [ ] Popup width hugs content tightly (no large empty gutter on the right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)