### PR TITLE
fix(desktop): focus_chat fills width, rail drag reveals explorer

### DIFF
--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -54,6 +54,7 @@ import { holabossLogoUrl } from "@/lib/assetPaths";
 import { type ExplorerAttachmentDragPayload } from "@/lib/attachmentDrag";
 import { CHAT_LAYOUT } from "@/lib/chatLayout";
 import { useEscapeToClose } from "@/lib/useEscapeToClose";
+import { cn } from "@/lib/utils";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
 import {
   pushRendererSentryActivity,
@@ -109,6 +110,8 @@ const THEMES = [
 ] as const;
 const MIN_EXPLORER_PANEL_WIDTH = 220;
 const MAX_EXPLORER_PANEL_WIDTH = 480;
+const EXPLORER_REVEAL_SNAP_THRESHOLD = 90;
+const EXPLORER_DRAG_ACTIVATION_DELTA = 4;
 const MIN_FILES_PANE_WIDTH = MIN_EXPLORER_PANEL_WIDTH;
 const MIN_BROWSER_PANE_WIDTH = 120;
 const MAX_UTILITY_PANE_WIDTH = 720;
@@ -1702,10 +1705,14 @@ function AppShellContent() {
     startWidth: number;
     startX: number;
   } | null>(null);
-  const explorerPanelResizeStateRef = useRef<{
-    startWidth: number;
+  const explorerRevealDragStateRef = useRef<{
     startX: number;
+    startWidth: number;
+    activated: boolean;
   } | null>(null);
+  const [explorerRevealDragWidth, setExplorerRevealDragWidth] = useState<
+    number | null
+  >(null);
 
   filesPaneWidthRef.current = filesPaneWidth;
   browserPaneWidthRef.current = browserPaneWidth;
@@ -5521,58 +5528,98 @@ function AppShellContent() {
     };
   }, [clampSpaceAgentPaneWidth]);
 
-  const startExplorerPanelResize = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      explorerPanelResizeStateRef.current = {
-        startWidth: filesPaneWidth,
+  const beginExplorerDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>, startWidth: number) => {
+      // Stage the drag without mutating layout yet. We commit to dragging
+      // only after the pointer moves past EXPLORER_DRAG_ACTIVATION_DELTA so
+      // a bare click on the handle is a true no-op.
+      explorerRevealDragStateRef.current = {
         startX: event.clientX,
+        startWidth,
+        activated: false,
       };
       try {
         event.currentTarget.setPointerCapture(event.pointerId);
       } catch {
         // BrowserView resizing falls back to the window listeners below.
       }
-      setIsUtilityPaneResizing(true);
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
       event.preventDefault();
     },
-    [filesPaneWidth],
+    [],
+  );
+
+  const startExplorerRevealDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      beginExplorerDrag(event, 0);
+    },
+    [beginExplorerDrag],
+  );
+
+  const startExplorerPanelResize = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      beginExplorerDrag(event, filesPaneWidth);
+    },
+    [beginExplorerDrag, filesPaneWidth],
   );
 
   useEffect(() => {
     const handlePointerMove = (event: PointerEvent) => {
-      const resizeState = explorerPanelResizeStateRef.current;
-      if (!resizeState) {
+      const state = explorerRevealDragStateRef.current;
+      if (!state) return;
+      const delta = event.clientX - state.startX;
+      if (
+        !state.activated &&
+        Math.abs(delta) < EXPLORER_DRAG_ACTIVATION_DELTA
+      ) {
         return;
       }
-
-      setFilesPaneWidth(
-        clampExplorerPanelWidth(
-          resizeState.startWidth + (event.clientX - resizeState.startX),
+      if (!state.activated) {
+        state.activated = true;
+        setIsUtilityPaneResizing(true);
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+        if (state.startWidth === 0) {
+          setSpaceWorkspacePanelCollapsed(false);
+        }
+      }
+      setExplorerRevealDragWidth(
+        Math.max(
+          0,
+          Math.min(MAX_EXPLORER_PANEL_WIDTH, state.startWidth + delta),
         ),
       );
     };
 
-    const stopResize = () => {
-      if (!explorerPanelResizeStateRef.current) {
+    const stopDrag = () => {
+      const state = explorerRevealDragStateRef.current;
+      if (!state) return;
+      explorerRevealDragStateRef.current = null;
+      // Bare click — never activated. Leave layout untouched.
+      if (!state.activated) {
         return;
       }
-
-      explorerPanelResizeStateRef.current = null;
       setIsUtilityPaneResizing(false);
       document.body.style.removeProperty("cursor");
       document.body.style.removeProperty("user-select");
+      setExplorerRevealDragWidth((current) => {
+        if (current === null) return null;
+        if (current < EXPLORER_REVEAL_SNAP_THRESHOLD) {
+          setSpaceWorkspacePanelCollapsed(true);
+        } else {
+          setFilesPaneWidth(clampExplorerPanelWidth(current));
+          setSpaceWorkspacePanelCollapsed(false);
+        }
+        return null;
+      });
     };
 
     window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", stopResize);
-    window.addEventListener("pointercancel", stopResize);
+    window.addEventListener("pointerup", stopDrag);
+    window.addEventListener("pointercancel", stopDrag);
     return () => {
       window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", stopResize);
-      window.removeEventListener("pointercancel", stopResize);
-      stopResize();
+      window.removeEventListener("pointerup", stopDrag);
+      window.removeEventListener("pointercancel", stopDrag);
     };
   }, [clampExplorerPanelWidth]);
 
@@ -5813,14 +5860,38 @@ function AppShellContent() {
                   >
                     <section
                       id="space-workspace-panel"
-                      className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-border bg-card shadow-md backdrop-blur-sm"
+                      className={cn(
+                        "flex min-h-0 min-w-0 overflow-hidden rounded-xl border border-border bg-card shadow-md backdrop-blur-sm",
+                        effectiveSpaceWorkspacePanelCollapsed &&
+                          explorerRevealDragWidth === null
+                          ? "flex-none"
+                          : "flex-1 basis-0",
+                        !isUtilityPaneResizing &&
+                          explorerRevealDragWidth === null &&
+                          "transition-[flex-grow,flex-basis] duration-200 ease-out",
+                      )}
                     >
                       <div
-                        className="shrink-0 overflow-hidden border-r border-border bg-card"
+                        className="relative shrink-0 border-r border-border bg-card"
                         style={{
                           width: `${SPACE_EXPLORER_RAIL_WIDTH}px`,
                         }}
                       >
+                        {effectiveSpaceWorkspacePanelCollapsed &&
+                        explorerRevealDragWidth === null ? (
+                          <div
+                            role="separator"
+                            aria-label="Drag to reveal explorer panel"
+                            aria-orientation="vertical"
+                            onPointerDown={startExplorerRevealDrag}
+                            onDoubleClick={() => {
+                              setSpaceWorkspacePanelCollapsed(false);
+                            }}
+                            className="group absolute inset-y-0 -right-1 z-20 flex w-2 cursor-col-resize touch-none items-center justify-center"
+                          >
+                            <div className="pointer-events-none absolute left-1/2 top-1/2 h-14 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/8 opacity-0 transition duration-150 group-hover:opacity-100" />
+                          </div>
+                        ) : null}
                         <nav
                           aria-label="Space explorer mode"
                           className="flex h-full min-h-0 flex-col items-center gap-1 px-1.5 py-2"
@@ -5894,16 +5965,25 @@ function AppShellContent() {
                       </div>
 
                       <div
-                        className="relative shrink-0 overflow-hidden transition-[width] duration-200 ease-out"
+                        className={cn(
+                          "relative shrink-0 [overflow:clip] [contain:layout_paint] [will-change:width]",
+                          explorerRevealDragWidth === null &&
+                            "transition-[width] duration-200 ease-out",
+                          effectiveSpaceWorkspacePanelCollapsed &&
+                            explorerRevealDragWidth === null &&
+                            "hidden",
+                        )}
                         style={{
-                          width: effectiveSpaceWorkspacePanelCollapsed
-                            ? 0
-                            : `${filesPaneWidth}px`,
-                          willChange: "width",
-                          contain: "layout paint",
+                          width:
+                            explorerRevealDragWidth !== null
+                              ? `${explorerRevealDragWidth}px`
+                              : effectiveSpaceWorkspacePanelCollapsed
+                                ? 0
+                                : `${filesPaneWidth}px`,
                         }}
                       >
-                        {effectiveSpaceWorkspacePanelCollapsed ? null : (
+                        {effectiveSpaceWorkspacePanelCollapsed ||
+                        explorerRevealDragWidth !== null ? null : (
                           <div
                             role="separator"
                             aria-label="Resize explorer panel"
@@ -5995,8 +6075,12 @@ function AppShellContent() {
                       </div>
 
                       <div
-                        className="min-h-0 min-w-0 flex-1 overflow-hidden"
-                        style={{ minWidth: 0 }}
+                        className={cn(
+                          "min-h-0 min-w-0 flex-1 overflow-hidden",
+                          effectiveSpaceWorkspacePanelCollapsed &&
+                            explorerRevealDragWidth === null &&
+                            "hidden",
+                        )}
                       >
                         {spaceDisplayContent}
                       </div>
@@ -6024,23 +6108,29 @@ function AppShellContent() {
                     ) : null}
 
                     <div
-                      className={`min-h-0 shrink-0 overflow-hidden rounded-xl ${
-                        isUtilityPaneResizing
-                          ? ""
-                          : "transition-[width] duration-200 ease-out"
-                      }`}
-                      style={{
-                        // Explicit pixel width in every state so the browser
-                        // interpolates `width` smoothly; toggling flex-1 ↔
-                        // width:Xpx caused the choppy collapse animation.
-                        width: spaceLayoutDerivedWidths
-                          ? `${spaceLayoutDerivedWidths.agentWidth}px`
-                          : `${spaceAgentPaneWidth}px`,
-                        minWidth: spaceBrowserFullscreen
-                          ? 0
-                          : `${MIN_AGENT_CONTENT_WIDTH}px`,
-                        contain: "layout style",
-                      }}
+                      className={cn(
+                        "min-h-0 overflow-hidden rounded-xl [contain:layout_style]",
+                        effectiveSpaceWorkspacePanelCollapsed &&
+                          explorerRevealDragWidth === null
+                          ? "min-w-0 flex-1 basis-0"
+                          : "flex-none",
+                        !isUtilityPaneResizing &&
+                          explorerRevealDragWidth === null &&
+                          "transition-[width,flex-grow,flex-basis] duration-200 ease-out",
+                      )}
+                      style={
+                        effectiveSpaceWorkspacePanelCollapsed &&
+                        explorerRevealDragWidth === null
+                          ? undefined
+                          : {
+                              width: spaceLayoutDerivedWidths
+                                ? `${spaceLayoutDerivedWidths.agentWidth}px`
+                                : `${spaceAgentPaneWidth}px`,
+                              minWidth: spaceBrowserFullscreen
+                                ? 0
+                                : `${MIN_AGENT_CONTENT_WIDTH}px`,
+                            }
+                      }
                       aria-hidden={spaceBrowserFullscreen}
                     >
                       {agentContent}

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -677,7 +677,11 @@ test("claimed input persists runner events, assistant text, and idle state on su
     output_tokens: 34,
   });
   const snapshot = turnRequestSnapshotForInput(store, queued);
-  assert.equal(snapshot, null);
+  assert.ok(snapshot);
+  assert.equal(snapshot?.snapshotKind, "harness_host_request");
+  assert.equal(snapshot?.workspaceId, workspace.id);
+  assert.equal(snapshot?.sessionId, queued.sessionId);
+  assert.equal(snapshot?.inputId, queued.inputId);
 
   store.close();
 });


### PR DESCRIPTION
## Summary

In **focus_chat** mode the chat pane previously left the display pane (between the rail and the chat) at \`flex-1\` — when the user resized the window horizontally, this surfaced a wide empty column with mismatched rounded corners next to the rail. The actual chat sat too far to the right.

Two related changes:

1. **focus_chat layout** — the workspace section now collapses to rail-only width (\`flex-none\`) and the chat pane flexes to fill the remaining space (\`flex-1 basis-0\`). The display content wrapper unmounts via \`hidden\` while collapsed, so there is no half-rendered second column to leak during a resize.

2. **Drag to reveal / drag to collapse** — the rail's right edge is now a drag handle in collapsed state. Pulling it to the right grows the explorer column live (no width transition during drag, 1:1 cursor tracking). On release: width below 90px snaps back to collapsed, otherwise commits as the new \`filesPaneWidth\`. The expanded-state resize handle uses the same pipeline, so dragging it inward past the snap threshold collapses the panel symmetrically.

Both handles activate only after a 4px pointer move, so a bare click on the handle is a true no-op — the previous version briefly uncollapsed then snapped back on a stray click.

The rail icons (Files / Browser / Apps) continue to open the explorer on click, and a double-click on the rail edge still uncollapses as a quick affordance.

Implementation also moves conditional layout from inline \`style\` props to \`cn()\` + Tailwind classes per project convention; live drag width remains an inline style because it is a continuous numeric value.

## Test plan

- [ ] Switch to focus_chat; chat fills the area between rail and right edge — no empty column
- [ ] Resize window horizontally in focus_chat; rail stays put, chat grows / shrinks, no ghost column appears
- [ ] Click a rail icon (Files / Browser / Apps) — explorer expands, displays files
- [ ] In collapsed state, grab rail's right edge and drag right — explorer reveals smoothly under cursor
- [ ] Release < 90px from rail — panel snaps back to collapsed
- [ ] Release ≥ 90px — panel commits at drag width, chat resizes to its fixed width
- [ ] In expanded state, grab explorer's right separator and drag left below MIN — panel allowed to keep shrinking, < 90px on release snaps to collapsed
- [ ] Single click on either drag handle — layout does not change (no jitter)
- [ ] Double-click rail right edge while collapsed — uncollapses
- [ ] Switching between focus_chat and split via the layout-mode picker animates smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)