### PR TITLE
chore: sync docs to Node 24 prerequisite

### DIFF
--- a/sdk/runtime-client/src/request.ts
+++ b/sdk/runtime-client/src/request.ts
@@ -1,6 +1,6 @@
 // Ported verbatim from holaOS/desktop/electron/main.ts (lines 13823-13978).
 // Two intentional changes from the original:
-//   1. Transport: node:http -> fetch. Electron renderer + Node 22 + Bun all
+//   1. Transport: node:http -> fetch. Electron renderer + Node 24 + Bun all
 //      support fetch + AbortSignal natively, so the SDK works in every host.
 //   2. Base URL: callback (`getBaseURL`) instead of an inline call to
 //      `ensureRuntimeReady()`, which was Electron-main-process-bound.

--- a/website/docs/content/docs/build/apps/troubleshooting.mdx
+++ b/website/docs/content/docs/build/apps/troubleshooting.mdx
@@ -23,7 +23,7 @@ For a packaged or standalone runtime, use the port you actually bound, usually `
 
 Most early failures happen in the desktop `predev` hook, before the app window exists.
 
-- Verify that Node.js `22+` is installed.
+- Verify that Node.js `24+` is installed.
 - Re-run `npm run desktop:install` if the desktop dependency tree is incomplete.
 - Check `desktop/.env`. `desktop/scripts/validate-dev-env.mjs` requires at least one configured remote base URL such as `HOLABOSS_BACKEND_BASE_URL`, `HOLABOSS_PROACTIVE_URL`, `HOLABOSS_CLI_PROACTIVE_URL`, or `HOLABOSS_DESKTOP_CONTROL_PLANE_BASE_URL`.
 - If the failure happens during native module rebuild, re-run `npm run desktop:install` and then `npm run desktop:typecheck`.

--- a/website/docs/content/docs/contribute/start-developing/from-source.mdx
+++ b/website/docs/content/docs/contribute/start-developing/from-source.mdx
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/holaboss-ai/holaOS-priv/main/script
 
 That installer:
 
-- installs missing `git` and Node.js `22` / `npm` when needed
+- installs missing `git` and Node.js `24` / `npm` when needed
 - clones the repository into `~/holaOS` by default
 - creates `desktop/.env` from `desktop/.env.example` if needed
 - runs `npm run desktop:install`
@@ -34,7 +34,7 @@ On Linux, the prerequisite install path may use your system package manager and 
 If you are using the manual path, make sure the machine has:
 
 - `git`
-- `node` version `22` or newer
+- `node` version `24` or newer
 - `npm`
 
 You can verify that quickly with:

--- a/website/docs/content/docs/getting-started/quick-start.mdx
+++ b/website/docs/content/docs/getting-started/quick-start.mdx
@@ -21,7 +21,7 @@ Download the `.dmg` for your platform, open it, drag holaOS into your Applicatio
 </Tab>
 <Tab value="From source">
 
-This path is for contributors who want to modify the desktop, runtime, or harness code. Requires `git`, `node` 22+, and `npm`.
+This path is for contributors who want to modify the desktop, runtime, or harness code. Requires `git`, `node` 24+, and `npm`.
 
 ```bash
 git clone https://github.com/holaboss-ai/holaOS-priv.git


### PR DESCRIPTION
## Why
- Several contributor docs and one runtime-client note still refer to Node.js 22, but the active installer and README now require Node 24+.
- This mismatch causes avoidable setup friction and false setup failures for first-time contributors.

## What changed
- Updated desktop troubleshooting docs to require Node.js `24+` for `desktop:dev` preflight failures.
- Updated `quick-start` contributor prerequisite text to `node` 24+.
- Updated source-install docs to require Node.js `24`/`24+` in both installer and manual install paths.
- Updated the runtime-client `request.ts` compatibility note to reflect Node 24.

## Validation
- Docs and comment-only change set.
- No runtime code path changed.
