### PR TITLE
feat(desktop/analytics): cross-surface Umami event coverage

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,9 +1,28 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import {
+  identifyUmamiUser,
+  trackUmamiEvent,
+} from "@/lib/analytics/umami";
 import { installRendererAuthCacheListeners } from "@/lib/app-sdk-client";
+import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { TooltipProvider } from "./components/ui/tooltip";
+
+function UmamiIdentity() {
+  const { data } = useDesktopAuthSession();
+  const userId = data?.user?.id ?? null;
+  const previousUserIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    identifyUmamiUser(userId);
+    if (userId && previousUserIdRef.current === null) {
+      trackUmamiEvent("signin_completed", { user_id: userId });
+    }
+    previousUserIdRef.current = userId;
+  }, [userId]);
+  return null;
+}
 
 function createDesktopQueryClient(): QueryClient {
   return new QueryClient({
@@ -46,6 +65,7 @@ function App() {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
+          <UmamiIdentity />
           <AppShell />
         </TooltipProvider>
       </QueryClientProvider>

--- a/desktop/src/components/billing/BillingSettingsPanel.tsx
+++ b/desktop/src/components/billing/BillingSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   AlertCircle,
   ArrowDownLeft,
@@ -22,6 +22,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { trackUmamiEvent } from "@/lib/analytics/umami";
 import { useDesktopBilling } from "@/lib/billing/useDesktopBilling";
 
 // ============================================================================
@@ -382,6 +383,10 @@ function openBillingLink(url: string | null | undefined) {
 export function BillingSettingsPanel() {
   const { overview, usage, links, isLoading, error, refresh } =
     useDesktopBilling();
+
+  useEffect(() => {
+    trackUmamiEvent("billing_page_viewed", { surface: "desktop" });
+  }, []);
 
   const showExpirationBanner = Boolean(overview?.expiresAt);
   const usageItems = usage?.items ?? [];

--- a/desktop/src/components/onboarding/FirstWorkspacePane.tsx
+++ b/desktop/src/components/onboarding/FirstWorkspacePane.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { firstWorkspacePaneSectionClassName } from "@/components/layout/firstWorkspacePaneLayout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { trackUmamiEvent } from "@/lib/analytics/umami";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { holabossLogoUrl } from "@/lib/assetPaths";
 import {
@@ -131,6 +132,13 @@ export function FirstWorkspacePane({
     setBrowserBootstrapMode("fresh");
   }, [setTemplateSourceMode, setBrowserBootstrapMode]);
 
+  useEffect(() => {
+    trackUmamiEvent("onboarding_step_viewed", {
+      step,
+      variant: isPanelVariant ? "panel" : "full",
+    });
+  }, [step, isPanelVariant]);
+
   const trimmedName = newWorkspaceName.trim();
   const sectionClassName = firstWorkspacePaneSectionClassName("configure");
   const defaultRoot = runtimeStatus?.sandboxRoot?.trim() || "";
@@ -182,7 +190,13 @@ export function FirstWorkspacePane({
   }
 
   function handleCreate() {
+    trackUmamiEvent("first_workspace_create_started", {
+      folder_choice: folderChoice,
+    });
     void createWorkspace().then(() => {
+      trackUmamiEvent("first_workspace_created", {
+        folder_choice: folderChoice,
+      });
       if (isPanelVariant) {
         onClose?.();
       }

--- a/desktop/src/components/panes/ChatPane/index.tsx
+++ b/desktop/src/components/panes/ChatPane/index.tsx
@@ -98,6 +98,7 @@ import {
 import { getExplorerAttachmentClipboardEntry } from "@/lib/appClipboard";
 import { CHAT_LAYOUT, chatScrollMaskImage } from "@/lib/chatLayout";
 import { ProviderBrandIcon } from "@/lib/providerBrandIcon";
+import { trackUmamiEvent } from "@/lib/analytics/umami";
 import {
   DEFAULT_RUNTIME_MODEL,
   useDesktopAuthSession,
@@ -5625,6 +5626,9 @@ export function ChatPane({
       if (targetSessionId) {
         draftParentSessionIdRef.current = null;
         setActiveSession(targetSessionId);
+        trackUmamiEvent("agent_session_started", {
+          workspace_id: selectedWorkspace.id,
+        });
       }
     }
     if (!targetSessionId) {
@@ -5655,6 +5659,13 @@ export function ChatPane({
     let optimisticUserMessageId = "";
 
     setIsSubmittingMessage(true);
+    trackUmamiEvent("agent_message_sent", {
+      workspace_id: selectedWorkspace?.id ?? null,
+      has_attachments: pendingAttachments.length > 0,
+      attachment_count: pendingAttachments.length,
+      message_length: trimmed.length,
+      queued_onto_active_run: queueOntoActiveRun,
+    });
 
     appendStreamTelemetry({
       streamId: activeStreamIdRef.current || "-",
@@ -7093,6 +7104,18 @@ export function ChatPane({
   const showLowBalanceWarning =
     usesHostedManagedCredits && isLowBalance && !isOutOfCredits;
   const showOutOfCreditsWarning = usesHostedManagedCredits && isOutOfCredits;
+  const creditWarningSeverity = showOutOfCreditsWarning
+    ? "out"
+    : showLowBalanceWarning
+      ? "low"
+      : null;
+  useEffect(() => {
+    if (creditWarningSeverity) {
+      trackUmamiEvent("credit_warning_shown", {
+        severity: creditWarningSeverity,
+      });
+    }
+  }, [creditWarningSeverity]);
   const chatPaneSentryState = useMemo(
     () => ({
       workspace_id: selectedWorkspaceId || null,
@@ -7481,7 +7504,13 @@ export function ChatPane({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => openExternalUrl(billingLinks?.addCreditsUrl)}
+                  onClick={() => {
+                    trackUmamiEvent("credit_topup_clicked", {
+                      location: "chat_warning",
+                      severity: creditWarningSeverity,
+                    });
+                    openExternalUrl(billingLinks?.addCreditsUrl);
+                  }}
                   className="rounded-full border-primary bg-primary/10 text-primary hover:bg-primary/16"
                 >
                   Add credits
@@ -7491,9 +7520,12 @@ export function ChatPane({
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() =>
-                      openExternalUrl(billingLinks?.billingPageUrl)
-                    }
+                    onClick={() => {
+                      trackUmamiEvent("billing_page_clicked", {
+                        location: "chat_warning",
+                      });
+                      openExternalUrl(billingLinks?.billingPageUrl);
+                    }}
                     className="rounded-full"
                   >
                     Manage on web

--- a/desktop/src/lib/analytics/device-id.ts
+++ b/desktop/src/lib/analytics/device-id.ts
@@ -1,0 +1,66 @@
+const DEVICE_ID_KEY = "hb_device_id";
+const FIRST_LAUNCH_KEY = "hb_has_launched";
+const LAST_LAUNCH_AT_KEY = "hb_last_launched_at";
+// Collapse HMR reloads, auth-induced renderer refreshes, and multi-window
+// re-mounts into one "launch" per ~5 minutes.
+const LAUNCH_THROTTLE_MS = 5 * 60 * 1000;
+
+function safeStorage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getDeviceId(): string {
+  const storage = safeStorage();
+  if (!storage) {
+    return "";
+  }
+  const existing = storage.getItem(DEVICE_ID_KEY);
+  if (existing) {
+    return existing;
+  }
+  const fresh =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `dev-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  try {
+    storage.setItem(DEVICE_ID_KEY, fresh);
+  } catch {
+    // localStorage quota / private mode — fall through with the in-memory id
+  }
+  return fresh;
+}
+
+export interface LaunchRecord {
+  isFirstLaunch: boolean;
+}
+
+/**
+ * Returns a record on a real launch, or null when throttled (recent launch
+ * already counted). Always advances the bookkeeping atomically.
+ */
+export function recordLaunch(): LaunchRecord | null {
+  const storage = safeStorage();
+  if (!storage) {
+    return { isFirstLaunch: true };
+  }
+  const now = Date.now();
+  const lastRaw = storage.getItem(LAST_LAUNCH_AT_KEY);
+  const last = lastRaw ? Number.parseInt(lastRaw, 10) : 0;
+  if (Number.isFinite(last) && now - last < LAUNCH_THROTTLE_MS) {
+    return null;
+  }
+  const everLaunched = storage.getItem(FIRST_LAUNCH_KEY) === "1";
+  try {
+    storage.setItem(LAST_LAUNCH_AT_KEY, String(now));
+    if (!everLaunched) {
+      storage.setItem(FIRST_LAUNCH_KEY, "1");
+    }
+  } catch {
+    // ignore — at worst we'll fire an extra event
+  }
+  return { isFirstLaunch: !everLaunched };
+}

--- a/desktop/src/lib/analytics/umami.ts
+++ b/desktop/src/lib/analytics/umami.ts
@@ -1,0 +1,88 @@
+import { getDeviceId } from "./device-id";
+
+const UMAMI_HOST = "https://cloud.umami.is";
+const UMAMI_WEBSITE_ID = "fcd99465-5997-4653-a519-bc9911c9609b";
+// Umami uses `hostname` to bucket events; pin to a stable virtual host so
+// desktop traffic shows up under one origin in the dashboard regardless of
+// whether the renderer is on file:// (packaged) or localhost (dev).
+const HOSTNAME = "desktop.holaos.ai";
+
+type EventData = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+interface SendBody {
+  type: "event";
+  payload: {
+    website: string;
+    hostname: string;
+    language: string;
+    screen: string;
+    url: string;
+    referrer: string;
+    name?: string;
+    data?: EventData;
+  };
+}
+
+let cachedUserId: string | null = null;
+
+function basePayload(): SendBody["payload"] {
+  const width = typeof window !== "undefined" ? window.screen?.width ?? 0 : 0;
+  const height = typeof window !== "undefined" ? window.screen?.height ?? 0 : 0;
+  const language =
+    typeof navigator !== "undefined" ? navigator.language || "en" : "en";
+  const url =
+    typeof window !== "undefined" ? window.location?.pathname || "/" : "/";
+  return {
+    website: UMAMI_WEBSITE_ID,
+    hostname: HOSTNAME,
+    language,
+    screen: `${width}x${height}`,
+    url,
+    referrer: "",
+  };
+}
+
+async function send(body: SendBody): Promise<void> {
+  try {
+    await fetch(`${UMAMI_HOST}/api/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      credentials: "omit",
+      keepalive: true,
+    });
+  } catch {
+    // Analytics must never break the app
+  }
+}
+
+export function trackUmamiEvent(name: string, data?: EventData): void {
+  const enriched: EventData = {
+    surface: "desktop",
+    device_id: getDeviceId(),
+    ...(cachedUserId ? { user_id: cachedUserId } : {}),
+    ...data,
+  };
+  void send({
+    type: "event",
+    payload: {
+      ...basePayload(),
+      name,
+      data: enriched,
+    },
+  });
+}
+
+export function identifyUmamiUser(userId: string | null): void {
+  if (userId === cachedUserId) {
+    return;
+  }
+  cachedUserId = userId;
+  if (!userId) {
+    return;
+  }
+  trackUmamiEvent("identify", { user_id: userId });
+}

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { trackUmamiEvent } from "@/lib/analytics/umami";
 import { getMarketplaceAppSdkClient } from "@/lib/app-sdk-client";
 import { type AuthSession, useDesktopAuthSession } from "@/lib/auth/authClient";
 import { hydrateInstalledWorkspaceApps, type WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
@@ -750,6 +751,10 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     setIsCreatingWorkspace(true);
     setWorkspaceCreatePhase("creating_workspace");
     setWorkspaceErrorMessage("");
+    trackUmamiEvent("workspace_create_phase_changed", {
+      phase: "creating_workspace",
+      template_mode: templateSourceMode,
+    });
     try {
       const trimmedWorkspaceName = newWorkspaceName.trim() || "Desktop Workspace";
       const customWorkspacePath = selectedWorkspaceFolder?.rootPath?.trim() || "";
@@ -815,6 +820,9 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
         const sourceWorkspaceId = browserBootstrapSourceWorkspaceId.trim();
         if (sourceWorkspaceId) {
           setWorkspaceCreatePhase("copying_browser_profile");
+          trackUmamiEvent("workspace_create_phase_changed", {
+            phase: "copying_browser_profile",
+          });
           try {
             await window.electronAPI.workspace.copyBrowserWorkspaceProfile({
               sourceWorkspaceId,
@@ -826,6 +834,9 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
         }
       } else if (browserBootstrapMode === "import_browser") {
         setWorkspaceCreatePhase("importing_browser_profile");
+        trackUmamiEvent("workspace_create_phase_changed", {
+          phase: "importing_browser_profile",
+        });
         try {
           await window.electronAPI.workspace.importBrowserProfile({
             workspaceId: createdWorkspaceId,
@@ -845,6 +856,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       }
 
       setWorkspaceCreatePhase("finalizing");
+      trackUmamiEvent("workspace_create_phase_changed", { phase: "finalizing" });
       // Keep the creating view alive for one more task so panel-based creation
       // can hand off cleanly to the newly selected workspace without flashing
       // the configuration screen again before the panel closes.
@@ -852,7 +864,12 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
         window.setTimeout(resolve, 0);
       });
     } catch (error) {
-      setWorkspaceErrorMessage(normalizeErrorMessage(error));
+      const message = normalizeErrorMessage(error);
+      setWorkspaceErrorMessage(message);
+      trackUmamiEvent("workspace_create_failed", {
+        template_mode: templateSourceMode,
+        error_message: message,
+      });
     } finally {
       setIsCreatingWorkspace(false);
       setWorkspaceCreatePhase("creating_workspace");
@@ -976,6 +993,11 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       return;
     }
     setAppCatalogError("");
+    trackUmamiEvent("app_install_clicked", {
+      app_id: appId,
+      workspace_id: selectedWorkspaceId,
+      source: appCatalogSource,
+    });
 
     // Check if this app requires an integration that isn't connected yet
     const provider = providerForApp(appId);
@@ -1048,8 +1070,18 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
         }
       }
       await refreshInstalledApps();
+      trackUmamiEvent("app_install_succeeded", {
+        app_id: appId,
+        workspace_id: selectedWorkspaceId,
+      });
     } catch (error) {
-      setAppCatalogError(normalizeErrorMessage(error));
+      const message = normalizeErrorMessage(error);
+      setAppCatalogError(message);
+      trackUmamiEvent("app_install_failed", {
+        app_id: appId,
+        workspace_id: selectedWorkspaceId,
+        error_message: message,
+      });
     } finally {
       setInstallingAppId(null);
     }

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import "@holaboss/editor/styles.css";
+import { recordLaunch } from "./lib/analytics/device-id";
+import { trackUmamiEvent } from "./lib/analytics/umami";
 import {
   enrichRendererSentryEvent,
   pushRendererSentryActivity,
@@ -51,6 +53,15 @@ document.addEventListener("visibilitychange", () => {
 const platform = window.electronAPI?.platform;
 if (platform) {
   document.documentElement.dataset.platform = platform;
+}
+
+const launch = recordLaunch();
+if (launch) {
+  trackUmamiEvent("desktop_launched", {
+    is_first_launch: launch.isFirstLaunch,
+    platform: platform ?? null,
+    electron_version: window.electronAPI?.versions?.electron ?? null,
+  });
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -64,4 +64,12 @@ if (launch) {
   });
 }
 
+const sessionStartedAt = Date.now();
+window.addEventListener("beforeunload", () => {
+  trackUmamiEvent("desktop_quit", {
+    session_duration_ms: Date.now() - sessionStartedAt,
+    platform: platform ?? null,
+  });
+});
+
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary

Instruments the desktop renderer with Umami events that pair with the matching server / web changes in `holaboss-frontend` to form the **landing → download → launch → register** funnel and follow-on activation / monetization funnels.

Events are sent over plain `fetch('/api/send')` so no third-party script is loaded into the renderer — CSP is untouched.

## Events added

**Launch & identity**
- `desktop_launched` — fires on renderer mount with a **5-min throttle** so HMR reloads, auth-induced refreshes, and multi-window re-mounts collapse into one launch. Carries `device_id`, `is_first_launch`, `platform`.
- `desktop_quit` — on `beforeunload`, carries `session_duration_ms`.
- `identify` + `signin_completed` — fired from a top-level `<UmamiIdentity />` on `null → userId` session transition.

**Onboarding**
- `onboarding_step_viewed` — `welcome` / `name` / `folder` step changes in `FirstWorkspacePane`.
- `first_workspace_create_started` / `first_workspace_created` — surrounding `createWorkspace()`.

**Workspace lifecycle (provider-level, covers all create entry points)**
- `workspace_create_phase_changed` — `creating_workspace` → `copying_browser_profile` → `importing_browser_profile` → `finalizing`.
- `workspace_create_failed` — in the catch block, carries `template_mode` + `error_message`.

**Agent activation**
- `agent_session_started` — when a new workspace session is created in `ChatPane.sendMessage`.
- `agent_message_sent` — at the moment a message actually submits, carries `workspace_id`, `has_attachments`, `attachment_count`, `message_length`, `queued_onto_active_run`.

**Marketplace**
- `app_install_clicked` / `app_install_succeeded` / `app_install_failed` — around `installAppFromCatalog` in `workspaceDesktop.tsx`.

**Billing / monetization**
- `billing_page_viewed` — on `BillingSettingsPanel` mount.
- `credit_warning_shown` — when the low-balance / out-of-credits chat banner appears (`severity: low | out`).
- `credit_topup_clicked` / `billing_page_clicked` — banner CTA clicks.

## Identity stitching

Each desktop event carries a stable per-install `hb_device_id` (UUID in localStorage). When a user signs in, `umami.identify(userId)` runs so prior anonymous events on the same renderer are tied to the user. The companion server-side `registration_completed` event (Better-Auth `databaseHooks.user.create.after`, in the frontend repo) is the ground-truth join key.

## Test plan

- [ ] First-time launch: see `desktop_launched` with `is_first_launch: true` in Umami → events.
- [ ] Reload renderer twice within 5 minutes: only one `desktop_launched` (throttle).
- [ ] Sign in: `signin_completed` + `identify` appear; subsequent events carry `user_id`.
- [ ] Create workspace: `workspace_create_phase_changed` fires per phase; `first_workspace_created` lands.
- [ ] Install an app: `app_install_clicked` → `app_install_succeeded`.
- [ ] Send a chat message: `agent_session_started` (first time) + `agent_message_sent`.
- [ ] Hit zero credits: `credit_warning_shown { severity: "out" }` + `credit_topup_clicked` on CTA.
- [ ] Quit app: `desktop_quit` with `session_duration_ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)