### PR TITLE
fix: improve Windows CI diagnostics and restore chat history correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,16 @@ jobs:
             sdk/app-sdk/package-lock.json
             desktop/package-lock.json
 
-      - name: Prepare desktop (build SDK + install desktop deps)
+      - name: Install app SDK dependencies
+        run: npm install --prefix sdk/app-sdk
+
+      - name: Build app SDK
+        run: npm --prefix sdk/app-sdk run build
+
+      - name: Install desktop dependencies
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-        run: npm run desktop:prepare
+        run: npm install --prefix desktop
 
       - name: Desktop typecheck
         run: npm run desktop:typecheck
@@ -319,10 +325,16 @@ jobs:
             --url-prefix "~/" \
             runtime/api-server/dist
 
-      - name: Prepare desktop (build SDK + install desktop deps)
+      - name: Install app SDK dependencies
+        run: npm install --prefix sdk/app-sdk
+
+      - name: Build app SDK
+        run: npm --prefix sdk/app-sdk run build
+
+      - name: Install desktop dependencies
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-        run: npm run desktop:prepare
+        run: npm install --prefix desktop
 
       - name: Require mac signing and notarization credentials
         run: |
@@ -734,10 +746,16 @@ jobs:
 
           Write-Host "Azure Trusted Signing authorization validated with a signed probe executable."
 
-      - name: Prepare desktop (build SDK + install desktop deps)
+      - name: Install app SDK dependencies
+        run: npm install --prefix sdk/app-sdk
+
+      - name: Build app SDK
+        run: npm --prefix sdk/app-sdk run build
+
+      - name: Install desktop dependencies
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-        run: npm run desktop:prepare
+        run: npm install --prefix desktop
 
       - name: Build Windows desktop installer
         id: build_windows_installer

--- a/desktop/src/components/panes/ChatPane.restore-output-history.test.mjs
+++ b/desktop/src/components/panes/ChatPane.restore-output-history.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.join(__dirname, "ChatPane", "index.tsx");
+
+test("chat pane only replays terminal failure copy when restored assistant output is still empty", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(
+    source,
+    /assistantHistoryStateFromOutputEvents[\s\S]*const hasAssistantOutput = \(\) =>[\s\S]*outputText\.trim\(\)\.length > 0[\s\S]*segments\.some/,
+  );
+  assert.match(
+    source,
+    /assistantHistoryStateFromOutputEvents[\s\S]*event\.event_type === "output_delta"[\s\S]*outputText = `\$\{outputText\}\$\{delta\}`;/,
+  );
+  assert.match(
+    source,
+    /assistantHistoryStateFromOutputEvents[\s\S]*event\.event_type === "run_failed"[\s\S]*if \(!hasAssistantOutput\(\)\) \{\s*flushExecutionSegment\(\);[\s\S]*outputText = failureText;/,
+  );
+});

--- a/desktop/src/components/panes/ChatPane/index.tsx
+++ b/desktop/src/components/panes/ChatPane/index.tsx
@@ -2368,7 +2368,7 @@ function assistantHistoryStateFromOutputEvents(
     outputTone = "default";
   };
 
-  const hasAssistantOutput =
+  const hasAssistantOutput = () =>
     outputText.trim().length > 0 ||
     segments.some(
       (segment) => segment.kind === "output" && segment.text.trim().length > 0,
@@ -2483,7 +2483,7 @@ function assistantHistoryStateFromOutputEvents(
       );
       failureText = runFailedDetail(eventPayload);
       terminalCreatedAt = event.created_at;
-      if (!hasAssistantOutput) {
+      if (!hasAssistantOutput()) {
         flushExecutionSegment();
         outputText = failureText;
         outputTone = "error";


### PR DESCRIPTION
## Context

This branch does two targeted fixes:

- splits the desktop prepare path in CI so Windows failures land on the exact subcommand instead of a single opaque desktop:prepare exit
- fixes chat history replay on desktop so restored assistant turns are not replaced by stale terminal failure copy after relaunch on Windows workspaces like T1

## Changes

- split desktop workflow preparation into explicit app SDK install, app SDK build, and desktop dependency install steps
- keep ELECTRON_SKIP_BINARY_DOWNLOAD=1 scoped to the desktop dependency install step
- make ssistantHistoryStateFromOutputEvents re-evaluate whether assistant output already exists before applying un_failed fallback text
- add a focused regression test for restored output history fallback behavior

## Validation

- git diff --check
- 
ode --test desktop/src/components/panes/ChatPane.restore-output-history.test.mjs
- 
pm --prefix desktop run typecheck

## Notes

- the broad desktop/src/components/panes/ChatPane.test.mjs source-pattern suite already has unrelated failing assertions on this branch, so validation for the chat restore fix uses the focused regression test above
- no Supabase migrations or branch database changes