### PR TITLE
fix(desktop): show native notifications when window is unfocused

### DIFF
--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -20844,11 +20844,13 @@ function desktopStatusItemIconPath(): string {
 }
 
 function shouldShowNativeDesktopNotification(): boolean {
-  return Boolean(
-    mainWindow &&
-      !mainWindow.isDestroyed() &&
-      mainWindow.isMinimized(),
-  );
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return false;
+  }
+  if (mainWindow.isMinimized() || !mainWindow.isVisible()) {
+    return true;
+  }
+  return !mainWindow.isFocused();
 }
 
 function normalizedNativeNotificationText(value: string, maxLength: number): string {
@@ -20960,7 +20962,7 @@ function showNativeDesktopNotification(
       title,
       body,
       force: payload.force,
-      detail: "Main window is visible and not minimized.",
+      detail: "Main window is visible, focused, and not minimized.",
     });
     return Promise.resolve(false);
   }
@@ -20973,13 +20975,7 @@ function showNativeDesktopNotification(
     });
     return Promise.resolve(false);
   }
-  if (shouldUseMacDevelopmentNotificationFallback()) {
-    return showMacDevelopmentNotificationFallback({
-      title,
-      body,
-      force: payload.force,
-    });
-  }
+  const useDevFallback = shouldUseMacDevelopmentNotificationFallback();
 
   return new Promise<boolean>((resolve) => {
     logNativeDesktopNotificationEvent("show_requested", {
@@ -21001,6 +20997,28 @@ function showNativeDesktopNotification(
       settled = true;
       resolve(value);
     };
+    const fallbackThenSettle = (detail: string) => {
+      if (settled) {
+        return;
+      }
+      if (!useDevFallback) {
+        settle(false);
+        return;
+      }
+      logNativeDesktopNotificationEvent("dev_fallback_attempt", {
+        title,
+        body,
+        force: payload.force,
+        detail,
+      });
+      void showMacDevelopmentNotificationFallback({
+        title,
+        body,
+        force: payload.force,
+      }).then((shown) => {
+        settle(shown);
+      });
+    };
     const showTimeout = setTimeout(() => {
       logNativeDesktopNotificationEvent("show_timeout", {
         title,
@@ -21008,7 +21026,7 @@ function showNativeDesktopNotification(
         force: payload.force,
         detail: "Notification did not emit show within 1500ms.",
       });
-      settle(false);
+      fallbackThenSettle("native_show_timeout");
     }, 1500);
     notification.on("show", () => {
       clearTimeout(showTimeout);
@@ -21021,18 +21039,19 @@ function showNativeDesktopNotification(
     });
     notification.on("failed", (_event, error) => {
       clearTimeout(showTimeout);
+      const detail =
+        typeof error === "string"
+          ? error
+          : error && typeof error === "object" && "message" in error
+            ? String((error as { message?: unknown }).message ?? "unknown")
+            : String(error ?? "unknown");
       logNativeDesktopNotificationEvent("failed", {
         title,
         body,
         force: payload.force,
-        detail:
-          typeof error === "string"
-            ? error
-            : error && typeof error === "object" && "message" in error
-              ? String((error as { message?: unknown }).message ?? "unknown")
-              : String(error ?? "unknown"),
+        detail,
       });
-      settle(false);
+      fallbackThenSettle(`native_failed:${detail}`);
     });
     notification.on("click", () => {
       logNativeDesktopNotificationEvent("clicked", {


### PR DESCRIPTION
## Summary

- macOS native notifications were never appearing in practice. `runtime.log` showed every non-force call rejected with `Main window is visible and not minimized.` while the user was just in another app.
- The renderer fires notifications when the window is "away" (minimized **or** unfocused), but `shouldShowNativeDesktopNotification` in `electron/main.ts` only checked `isMinimized()`. Now it also covers unfocused and hidden windows so main matches the renderer's intent.
- On macOS dev mode the code was short-circuiting straight to the `osascript` fallback, which is attributed to Script Editor and silently no-ops when Script Editor notifications are disabled in System Settings (the default). It now tries Electron's native `Notification` first and only falls back to osascript on `failed` / 1500ms timeout. Adds a `dev_fallback_attempt` log event so the runtime log distinguishes "native worked" from "had to fall back".

## Test plan

- [ ] `npm run desktop:dev`, leave the holaOS window open but focus another app, trigger any cronjob or workspace notification.
- [ ] Verify a native macOS banner appears (grouped under Electron in dev).
- [ ] If it doesn't, check `~/.holaboss-desktop/runtime.log` for `event=shown` vs `event=dev_fallback_attempt` — if you see `dev_fallback_attempt` then `dev_fallback_shown` but no banner, the cause is System Settings → Notifications → Electron / Script Editor being disabled, not code.
- [ ] Minimize the window — notifications should still fire (regression check).
- [ ] Bring the window back to focus — notifications should be suppressed in favor of the in-app toast (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)