### PR TITLE
fix(desktop): gate marketplace install on real auth status and make Cancel work mid-flow

### DIFF
--- a/desktop/src/components/marketplace/AppsGallery.tsx
+++ b/desktop/src/components/marketplace/AppsGallery.tsx
@@ -45,6 +45,7 @@ export function AppsGallery() {
     pendingAppInstall,
     clearPendingAppInstall,
     connectAndInstallApp,
+    cancelAppIntegrationConnect,
     isConnectingAppIntegration,
     refreshInstalledApps,
   } = useWorkspaceDesktop();
@@ -288,8 +289,13 @@ export function AppsGallery() {
           <button
             type="button"
             aria-label="Cancel connect account"
-            onClick={clearPendingAppInstall}
-            disabled={isConnectingAppIntegration}
+            onClick={() => {
+              if (isConnectingAppIntegration) {
+                cancelAppIntegrationConnect();
+              } else {
+                clearPendingAppInstall();
+              }
+            }}
             className="absolute inset-0 bg-scrim backdrop-blur-sm"
           />
           <div
@@ -314,8 +320,13 @@ export function AppsGallery() {
               <Button
                 variant="ghost"
                 size="sm"
-                disabled={isConnectingAppIntegration}
-                onClick={clearPendingAppInstall}
+                onClick={() => {
+                  if (isConnectingAppIntegration) {
+                    cancelAppIntegrationConnect();
+                  } else {
+                    clearPendingAppInstall();
+                  }
+                }}
               >
                 Cancel
               </Button>

--- a/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/desktop/src/components/panes/IntegrationsPane.tsx
@@ -496,6 +496,33 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
               integration.providerId.toLowerCase(),
         );
         if (newConnection) {
+          // Composio creates the row at /connect time in INITIATED state —
+          // its presence does NOT mean the user finished OAuth. Query the
+          // account's real status before finalizing.
+          let accountStatus;
+          try {
+            accountStatus =
+              await window.electronAPI.workspace.composioAccountStatus(
+                newConnection.id,
+                integration.providerId,
+              );
+          } catch {
+            continue;
+          }
+          const status = (accountStatus.status ?? "").toUpperCase();
+          if (
+            status === "FAILED" ||
+            status === "EXPIRED" ||
+            status === "INACTIVE"
+          ) {
+            setStatusMessage(
+              `Authorization for ${integration.name} ${status.toLowerCase()}. Please try again.`,
+            );
+            return;
+          }
+          if (status !== "ACTIVE") {
+            continue;
+          }
           await window.electronAPI.workspace.composioFinalize({
             connected_account_id: newConnection.id,
             provider: integration.providerId,

--- a/desktop/src/components/panes/MarketplacePane.tsx
+++ b/desktop/src/components/panes/MarketplacePane.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type View = "gallery" | "detail" | "creating" | "connect_integrations";
 
@@ -60,6 +60,11 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
     null,
   );
   const [connectStatus, setConnectStatus] = useState("");
+  const cancelConnectRef = useRef<(() => void) | null>(null);
+
+  function cancelActiveConnect() {
+    cancelConnectRef.current?.();
+  }
 
   function handleSelectKit(template: TemplateMetadataPayload) {
     setDetailTemplate(template);
@@ -85,6 +90,11 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
   }
 
   async function handleConnectProvider(provider: string) {
+    let cancelled = false;
+    cancelConnectRef.current = () => {
+      cancelled = true;
+    };
+
     setConnectingProvider(provider);
     setConnectStatus("Complete authorization in your browser...");
     try {
@@ -103,10 +113,18 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
         // tolerate snapshot failure
       }
 
+      if (cancelled) {
+        return;
+      }
+
       const link = await window.electronAPI.workspace.composioConnect({
         provider,
         owner_user_id: userId,
       });
+
+      if (cancelled) {
+        return;
+      }
 
       await window.electronAPI.ui.openExternalUrl(link.redirect_url);
 
@@ -114,6 +132,9 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
       const MAX_CONSECUTIVE_ERRORS = 20;
       for (let i = 0; i < 100; i++) {
         await new Promise((r) => setTimeout(r, 3000));
+        if (cancelled) {
+          return;
+        }
         let current;
         try {
           current =
@@ -132,16 +153,50 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
             c.toolkitSlug.toLowerCase() === provider.toLowerCase(),
         );
         if (newConnection) {
+          // Composio creates the row at /connect time in INITIATED state —
+          // its presence does NOT mean the user finished OAuth. Query the
+          // account's real status before treating it as authorized.
+          let accountStatus;
+          try {
+            accountStatus =
+              await window.electronAPI.workspace.composioAccountStatus(
+                newConnection.id,
+                provider,
+              );
+          } catch {
+            continue;
+          }
+          if (cancelled) {
+            return;
+          }
+          const status = (accountStatus.status ?? "").toUpperCase();
+          if (
+            status === "FAILED" ||
+            status === "EXPIRED" ||
+            status === "INACTIVE"
+          ) {
+            throw new Error(
+              `Authorization for ${provider} ${status.toLowerCase()}. Please try again.`,
+            );
+          }
+          if (status !== "ACTIVE") {
+            continue;
+          }
           await window.electronAPI.workspace.composioFinalize({
             connected_account_id: newConnection.id,
             provider,
             owner_user_id: userId,
             account_label: `${provider} (Managed)`,
           });
+          if (cancelled) {
+            return;
+          }
           setConnectStatus("");
-          setConnectingProvider(null);
 
           const updated = await resolveIntegrationsBeforeCreate();
+          if (cancelled) {
+            return;
+          }
           if (!updated || updated.missing_providers.length === 0) {
             clearPendingIntegrations();
             setView("creating");
@@ -150,10 +205,20 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
           return;
         }
       }
-      setConnectStatus("Connection timed out. Please try again.");
+      if (!cancelled) {
+        setConnectStatus("Connection timed out. Please try again.");
+      }
     } catch (error) {
-      setConnectStatus(error instanceof Error ? error.message : String(error));
+      if (!cancelled) {
+        setConnectStatus(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     } finally {
+      if (cancelled) {
+        setConnectStatus("");
+      }
+      cancelConnectRef.current = null;
       setConnectingProvider(null);
     }
   }
@@ -289,6 +354,7 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
                 variant="link"
                 size="sm"
                 onClick={() => {
+                  cancelActiveConnect();
                   clearPendingIntegrations();
                   setView("creating");
                 }}
@@ -315,12 +381,24 @@ export function MarketplacePane({ initialTab = "templates" }: MarketplacePanePro
                       <Button
                         type="button"
                         size="sm"
-                        disabled={connectingProvider !== null}
-                        onClick={() => void handleConnectProvider(provider)}
+                        variant={
+                          connectingProvider === provider
+                            ? "outline"
+                            : "default"
+                        }
+                        disabled={
+                          connectingProvider !== null &&
+                          connectingProvider !== provider
+                        }
+                        onClick={() => {
+                          if (connectingProvider === provider) {
+                            cancelActiveConnect();
+                          } else {
+                            void handleConnectProvider(provider);
+                          }
+                        }}
                       >
-                        {connectingProvider === provider
-                          ? "Connecting…"
-                          : "Connect"}
+                        {connectingProvider === provider ? "Cancel" : "Connect"}
                       </Button>
                     </div>
                   ))}

--- a/desktop/src/lib/workspaceDesktop.tsx
+++ b/desktop/src/lib/workspaceDesktop.tsx
@@ -128,10 +128,12 @@ interface WorkspaceDesktopContextValue {
   clearPendingAppInstall: () => void;
   connectAndInstallApp: () => Promise<void>;
   isConnectingAppIntegration: boolean;
+  cancelAppIntegrationConnect: () => void;
   connectIntegrationProvider: (params: {
     provider: string;
     appId?: string | null;
     accountLabel?: string | null;
+    signal?: AbortSignal;
   }) => Promise<{ connectionId: string }>;
   templateSourceMode: TemplateSourceMode;
   setTemplateSourceMode: (value: TemplateSourceMode) => void;
@@ -332,6 +334,11 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
   const [isResolvingIntegrations, setIsResolvingIntegrations] = useState(false);
   const [pendingAppInstall, setPendingAppInstall] = useState<{ appId: string; provider: string } | null>(null);
   const [isConnectingAppIntegration, setIsConnectingAppIntegration] = useState(false);
+  // Per-call AbortController for the in-flight app-install connect flow.
+  // A controller is created in `connectAndInstallApp`, captured here so the
+  // Cancel button can abort it. Other callers (e.g. chat pane's connect
+  // card) get their own signal — no shared mutable state to clobber.
+  const appInstallConnectControllerRef = useRef<AbortController | null>(null);
   const [firstWorkspaceStep, setFirstWorkspaceStep] = useState<FirstWorkspaceStep>("welcome");
   // Composio toolkit metadata (name + logo + categories) keyed by toolkit
   // slug. Single source of truth for app display name + icon across the
@@ -1091,14 +1098,33 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     setPendingAppInstall(null);
   }
 
+  class IntegrationConnectCancelled extends Error {
+    constructor() {
+      super("Integration connect cancelled by user");
+      this.name = "IntegrationConnectCancelled";
+    }
+  }
+
   async function connectIntegrationProvider({
     provider,
     accountLabel,
+    signal,
   }: {
     provider: string;
     appId?: string | null;
     accountLabel?: string | null;
+    signal?: AbortSignal;
   }): Promise<{ connectionId: string }> {
+    const throwIfAborted = () => {
+      if (signal?.aborted) {
+        throw new IntegrationConnectCancelled();
+      }
+    };
+
+    const COMPOSIO_POLL_INTERVAL_MS = 3000;
+    const COMPOSIO_POLL_MAX_TICKS = 100;
+    const MAX_CONSECUTIVE_ERRORS = 20;
+
     const runtimeConfig = await window.electronAPI.runtime.getConfig();
     const userId = runtimeConfig.userId ?? (resolvedUserId || "local");
 
@@ -1114,18 +1140,21 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       // tolerate snapshot failure
     }
 
+    throwIfAborted();
+
     const link = await window.electronAPI.workspace.composioConnect({
       provider,
       owner_user_id: userId,
     });
+
+    throwIfAborted();
+
     await window.electronAPI.ui.openExternalUrl(link.redirect_url);
 
-    const COMPOSIO_POLL_INTERVAL_MS = 3000;
-    const COMPOSIO_POLL_MAX_TICKS = 100;
-    const MAX_CONSECUTIVE_ERRORS = 20;
     let consecutiveErrors = 0;
     for (let tick = 0; tick < COMPOSIO_POLL_MAX_TICKS; tick++) {
       await new Promise((r) => setTimeout(r, COMPOSIO_POLL_INTERVAL_MS));
+      throwIfAborted();
       let current;
       try {
         current =
@@ -1144,13 +1173,41 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
           c.toolkitSlug.toLowerCase() === provider.toLowerCase(),
       );
       if (newConnection) {
-        await window.electronAPI.workspace.composioFinalize({
-          connected_account_id: newConnection.id,
-          provider,
-          owner_user_id: userId,
-          account_label: accountLabel ?? `${provider} (Managed)`,
-        });
-        return { connectionId: newConnection.id };
+        // Composio creates the row at /connect time in INITIATED state —
+        // its mere presence in the list is NOT proof that OAuth completed.
+        // Read the account's real status before finalizing.
+        let accountStatus;
+        try {
+          accountStatus =
+            await window.electronAPI.workspace.composioAccountStatus(
+              newConnection.id,
+              provider,
+            );
+        } catch {
+          continue;
+        }
+        throwIfAborted();
+        const status = (accountStatus.status ?? "").toUpperCase();
+        if (status === "ACTIVE") {
+          await window.electronAPI.workspace.composioFinalize({
+            connected_account_id: newConnection.id,
+            provider,
+            owner_user_id: userId,
+            account_label: accountLabel ?? `${provider} (Managed)`,
+          });
+          throwIfAborted();
+          return { connectionId: newConnection.id };
+        }
+        if (
+          status === "FAILED" ||
+          status === "EXPIRED" ||
+          status === "INACTIVE"
+        ) {
+          throw new Error(
+            `Authorization for ${provider} ${status.toLowerCase()}. Please try again.`,
+          );
+        }
+        // INITIATED / INITIATING / anything else — keep polling.
       }
     }
     throw new Error(
@@ -1160,17 +1217,48 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
     );
   }
 
+  function cancelAppIntegrationConnect() {
+    appInstallConnectControllerRef.current?.abort();
+    setPendingAppInstall(null);
+  }
+
   async function connectAndInstallApp() {
     if (!pendingAppInstall) return;
     const { appId, provider } = pendingAppInstall;
+    const controller = new AbortController();
+    appInstallConnectControllerRef.current = controller;
     setIsConnectingAppIntegration(true);
     setAppCatalogError("");
     try {
-      await connectIntegrationProvider({ provider, appId });
+      await connectIntegrationProvider({
+        provider,
+        appId,
+        signal: controller.signal,
+      });
+      // Cancel could land in the gap between connect-success and install —
+      // honor it here so the app doesn't get installed after the user
+      // clicked Cancel.
+      if (controller.signal.aborted) {
+        return;
+      }
       await doInstallApp(appId, null);
     } catch (error) {
+      // User cancelled — silent close, no error banner, no install.
+      if (
+        error instanceof IntegrationConnectCancelled ||
+        controller.signal.aborted
+      ) {
+        return;
+      }
+      // Real failure (timeout, FAILED/EXPIRED/INACTIVE, network). Close the
+      // modal so the error banner in the gallery becomes visible — otherwise
+      // the modal stays open with no progress indication and no error.
+      setPendingAppInstall(null);
       setAppCatalogError(normalizeErrorMessage(error));
     } finally {
+      if (appInstallConnectControllerRef.current === controller) {
+        appInstallConnectControllerRef.current = null;
+      }
       setIsConnectingAppIntegration(false);
     }
   }
@@ -1689,6 +1777,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
       clearPendingAppInstall,
       connectAndInstallApp,
       isConnectingAppIntegration,
+      cancelAppIntegrationConnect,
       connectIntegrationProvider,
       templateSourceMode,
       setTemplateSourceMode,


### PR DESCRIPTION
## Summary

- **Stop installing apps when auth never succeeded.** `composioConnect` creates the connected_account row in `INITIATED` state, before the user finishes OAuth. The poll was diffing connection ids only, so it treated the row's appearance as success and ran `composioFinalize` + `doInstallApp` regardless of whether the user authorized, denied, or closed the browser. Now we read `composioAccountStatus(id).status` and only finalize on `ACTIVE`; `FAILED` / `EXPIRED` / `INACTIVE` fail fast; everything else keeps polling.
- **Make Cancel actually work during the 5-minute poll.** The "Connect account" modal in `AppsGallery` and the per-provider Connect button in `MarketplacePane`'s new-workspace flow were locked for the entire poll window. Replaced the shared cancel ref with a per-call `AbortController`, wired Cancel + scrim + Back to abort the in-flight signal, and made `connectAndInstallApp` recheck `signal.aborted` between connect-success and install so a cancel landing in that gap actually stops the install.
- **Surface terminal-failure errors.** When status comes back `FAILED`/`EXPIRED`/`INACTIVE`, the modal now auto-closes so the gallery error banner becomes visible (previously it stayed mounted on top of the error with no progress affordance).

Same status-check fix applied to `IntegrationsPane.handleConnect` and `MarketplacePane.handleConnectProvider`, which had copy-pasted the same flawed poll.

## Files

- `desktop/src/lib/workspaceDesktop.tsx` — status gating in `connectIntegrationProvider`, AbortSignal plumbing, `cancelAppIntegrationConnect`, modal-close on terminal failure in `connectAndInstallApp`
- `desktop/src/components/marketplace/AppsGallery.tsx` — Cancel button + scrim call the abort path; no longer disabled while waiting
- `desktop/src/components/panes/MarketplacePane.tsx` — status gating, cancellable polling, Cancel-during-connecting button, Back interrupts the poll
- `desktop/src/components/panes/IntegrationsPane.tsx` — status gating

## Test plan

- [ ] Click Install on an app requiring OAuth → Connect → **deny / close browser**: app does NOT install; error banner appears in gallery (was: app installed silently)
- [ ] Click Install → Connect → **wait at the auth screen** → click Cancel: modal closes immediately, no install, button is re-enabled (was: Cancel disabled for ~5 min)
- [ ] Click Install → Connect → authorize successfully: app installs as before
- [ ] In new-workspace integration flow, click Connect on a provider → click Cancel during polling: returns to disabled state, no install (was: stuck)
- [ ] Create workspace flow with a template needing 2+ integrations: each provider's Connect button toggles to Cancel during its own poll; other providers' buttons stay disabled

## Known follow-ups (not in this PR)

- Dangling `INITIATED` Composio rows after Cancel are not cleaned up upstream (desktop has no Composio delete endpoint exposed). User-invisible (local integration_metadata only records ACTIVE finalized rows); needs a backend endpoint to address properly.
- Chat-pane `IntegrationConnectCard` shares `connectIntegrationProvider` but offers no Cancel UI — independent caller, not blocked by this PR's abort plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)