### PR TITLE
feat(desktop): toast browser profile import success and close dialog

### DIFF
--- a/desktop/src/components/panes/BrowserProfileImportButton.tsx
+++ b/desktop/src/components/panes/BrowserProfileImportButton.tsx
@@ -1,10 +1,11 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Globe, Loader2, UploadCloud, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { WorkspaceIcon } from "@/components/ui/workspace-icon";
 import { cn } from "@/lib/utils";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+import { BrowserCaptureStatusToast } from "@/components/panes/useBrowserCaptureActions";
 
 const IMPORT_PROFILE_LIST_HANDLER_MISSING_MESSAGE =
   "No handler registered for 'workspace:listImportBrowserProfiles'";
@@ -127,7 +128,28 @@ export function BrowserProfileImportButton({
   const [resultWarnings, setResultWarnings] = useState<string[]>([]);
   const [lastSucceededImportSignature, setLastSucceededImportSignature] =
     useState<string | null>(null);
+  const [successToastMessage, setSuccessToastMessage] = useState("");
+  const successToastTimeoutRef = useRef<number | null>(null);
   const open = controlledOpen ?? internalOpen;
+
+  useEffect(() => {
+    return () => {
+      if (successToastTimeoutRef.current !== null) {
+        window.clearTimeout(successToastTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const showSuccessToast = (message: string) => {
+    if (successToastTimeoutRef.current !== null) {
+      window.clearTimeout(successToastTimeoutRef.current);
+    }
+    setSuccessToastMessage(message);
+    successToastTimeoutRef.current = window.setTimeout(() => {
+      setSuccessToastMessage("");
+      successToastTimeoutRef.current = null;
+    }, 2400);
+  };
 
   const setOpen = (nextOpen: boolean) => {
     if (controlledOpen === undefined) {
@@ -359,6 +381,13 @@ export function BrowserProfileImportButton({
         );
         setResultWarnings(summary.warnings);
         setLastSucceededImportSignature(currentImportSignature);
+        showSuccessToast(
+          `Copied browser profile from ${
+            selectedCopySourceWorkspace?.name || summary.sourceLabel
+          }.`,
+        );
+        setOpen(false);
+        void window.electronAPI.browser.reload();
         return;
       }
       const summary = await window.electronAPI.workspace.importBrowserProfile({
@@ -379,6 +408,9 @@ export function BrowserProfileImportButton({
       setStatusMessage(importSummaryMessage(summary));
       setResultWarnings(summary.warnings);
       setLastSucceededImportSignature(currentImportSignature);
+      showSuccessToast(`Imported ${summary.sourceLabel}.`);
+      setOpen(false);
+      void window.electronAPI.browser.reload();
     } catch (error) {
       setStatusTone("error");
       setStatusMessage(normalizeErrorMessage(error));
@@ -390,6 +422,7 @@ export function BrowserProfileImportButton({
 
   return (
     <>
+      <BrowserCaptureStatusToast message={successToastMessage} />
       <Button
         type="button"
         variant={buttonVariant}


### PR DESCRIPTION
## Summary
- Show a transient `BrowserCaptureStatusToast` after a successful browser-profile import or workspace copy
- Auto-close the import dialog and call `browser.reload()` so the embedded BrowserView picks up the imported profile immediately
- Leaves cancel/error paths unchanged so the user can still read the status banner and warnings inside the dialog

## Test plan
- [ ] Open a workspace browser, click `Import`, pick a Chrome profile, confirm — dialog closes, toast flashes, page reloads with new cookies
- [ ] Repeat with `Copy from another workspace` — same close + reload + toast
- [ ] Cancel the native Safari file picker — dialog stays open with "Browser import cancelled."
- [ ] Force an error (e.g. wrong workspace) — dialog stays open with the destructive banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)