### PR TITLE
fix: bundle app-builder-sdk assets for packaged runtime

### DIFF
--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -126,6 +126,10 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   );
   assert.match(
     prompt.systemPrompt,
+    /Do not route an MCP-backed task through the browser just because browser tools are available; use browser tools for that system only when the user explicitly asks for browser use, the task explicitly requires UI interaction, independent visual verification is required, or the MCP route is blocked\./
+  );
+  assert.match(
+    prompt.systemPrompt,
     /Treat explicit user requirements and verification targets as completion criteria, not optional detail\./
   );
   assert.match(
@@ -135,6 +139,10 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   assert.match(
     prompt.systemPrompt,
     /Do not cross it unless the user explicitly asks\./
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /If a surfaced path returns `ENOENT` or `Path not found`, stop guessing paths outside the active workspace\./
   );
   assert.match(
     prompt.systemPrompt,
@@ -179,7 +187,7 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   assert.doesNotMatch(prompt.systemPrompt, /Connected MCP tools available now:/);
   assert.doesNotMatch(prompt.systemPrompt, /Skills available now:/);
   assert.doesNotMatch(prompt.systemPrompt, /Connected MCP access: available\./);
-  assert.ok(prompt.systemPrompt.length < 4600);
+  assert.ok(prompt.systemPrompt.length < 4800);
   assert.equal(prompt.contextMessages.length, 1);
   assert.match(prompt.contextMessages.join("\n\n"), /Capability availability snapshot:/);
   assert.match(prompt.contextMessages.join("\n\n"), /Inspect tools: available \(\d+ enabled\)\./);
@@ -374,7 +382,7 @@ test("composeAgentPrompt uses a conversational main-session prompt for workspace
   assert.match(prompt.systemPrompt, /missing web, browser, terminal, or other execution-heavy capabilities on the main session as a routing signal to delegate/i);
   assert.match(prompt.systemPrompt, /When the ideal direct tool or integration is missing, do not stop there/i);
   assert.match(prompt.systemPrompt, /try another viable route with available tools/i);
-  assert.match(prompt.systemPrompt, /Prefer surfaced MCP\/app tools over opening the web app, browser exploration, or web research when they can satisfy the request, including when the user supplies a URL for that system; use browser\/web around an MCP-backed system only for UI verification, requested independent confirmation, or after the MCP path is blocked\./);
+  assert.match(prompt.systemPrompt, /Prefer surfaced MCP\/app tools over opening the web app, browser exploration, or web research when they can satisfy the request, including when the user supplies a URL for that system; use browser\/web around an MCP-backed system only when the user explicitly asks for browser use, for UI verification, for requested independent confirmation, or after the MCP path is blocked\./);
   assert.match(prompt.systemPrompt, /Do not answer with a capability-apology or manual fallback first when `holaboss_delegate_task` is available/i);
   assert.match(prompt.systemPrompt, /trust the current run and retry the tool when appropriate/i);
   assert.match(prompt.systemPrompt, /Treat prior tool failures, subagent failures, and access or integration blockers as observations about earlier attempts, not static truth about the current run\./);
@@ -486,6 +494,14 @@ test("composeAgentPrompt requires subagent outputs to stay self-contained", () =
   assert.match(
     prompt.systemPrompt,
     /When surfaced MCP\/app tools match the task or a provided system URL, use them first instead of defaulting to bash, file inspection, or browser exploration\./,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /Treat browser use as a last resort\./,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /only use the browser when the user explicitly asks for it, the task inherently requires UI interaction, independent visual verification is required, or non-browser routes are blocked\./,
   );
   assert.match(
     prompt.systemPrompt,
@@ -1272,7 +1288,15 @@ test("composeBaseAgentPrompt requires proactive fallback when partial retrieval 
   );
   assert.match(
     prompt.systemPrompt,
-    /When browser tools are available, use them for UI-specific verification and prefer DOM-grounded actions and extraction\./
+    /When browser tools are available, treat them as a fallback UI surface, not the default route\./
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /Use them only when the user explicitly asks for browser use, the task inherently requires UI interaction, visual confirmation matters, or non-browser routes are blocked\./
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /When you do use them, prefer DOM-grounded actions and extraction\./
   );
   assert.match(
     prompt.systemPrompt,
@@ -1281,5 +1305,40 @@ test("composeBaseAgentPrompt requires proactive fallback when partial retrieval 
   assert.match(
     prompt.systemPrompt,
     /Use screenshots only when visual confirmation matters\./
+  );
+});
+
+test("composeBaseAgentPrompt keeps connected MCP server routes ahead of browser fallback when tool refs are absent", () => {
+  const capabilityManifest = buildAgentCapabilityManifest({
+    harnessId: "pi",
+    sessionKind: "subagent",
+    browserToolsAvailable: true,
+    browserToolIds: ["browser_get_state"],
+    defaultTools: ["read"],
+    extraTools: ["browser_get_state"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    resolvedMcpServerIds: ["notion"],
+  });
+
+  const prompt = composeBaseAgentPrompt("", {
+    defaultTools: ["read"],
+    extraTools: ["browser_get_state"],
+    workspaceSkillIds: [],
+    resolvedMcpToolRefs: [],
+    resolvedMcpServerIds: ["notion"],
+    sessionKind: "subagent",
+    sessionMode: "code",
+    harnessId: "pi",
+    capabilityManifest,
+  });
+
+  assert.match(
+    prompt.systemPrompt,
+    /If connected MCP access exists without tool names listed here, do not assume MCP is unavailable; use surfaced MCP tools when relevant\./,
+  );
+  assert.match(
+    prompt.systemPrompt,
+    /If browser tools are also available, do not default to browser exploration for the same connected system; keep MCP as the first route unless the user explicitly asks for browser use, the task explicitly requires UI interaction, or the MCP path is blocked\./,
   );
 });

--- a/runtime/api-server/src/agent-runtime-prompt.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.ts
@@ -218,6 +218,7 @@ function sessionPolicyPromptSection(request: ComposeBaseAgentPromptRequest): str
         "Do not rely on intermediate tool steps, hidden reasoning, or `see above` references for essential context.",
         "When the task finds multiple items, options, or takeaways, include the actual items in the final output or deliverable instead of only a one-line lead summary.",
         "When surfaced MCP/app tools match the task or a provided system URL, use them first instead of defaulting to bash, file inspection, or browser exploration.",
+        "Treat browser use as a last resort. Prefer the narrowest non-browser route that can complete the task, and only use the browser when the user explicitly asks for it, the task inherently requires UI interaction, independent visual verification is required, or non-browser routes are blocked.",
         "In workspace tasks, treat requests to `install`, `add`, or `use` an app as workspace-app requests by default, not native desktop-app installs, unless the task or user explicitly asks for the OS client.",
         "Do not inspect workspace files or app config just to prove an integration exists when the current surfaced capability set already exposes the relevant tools; invoke the relevant surfaced tool first, then inspect config only if the direct route fails or the user explicitly asked for environment inspection.",
         "If the task is blocked by a recoverable user action such as login, authorization, MFA, CAPTCHA, permission, account selection, confirmation, credentials, or missing context, use the `question` tool with the exact unblock request instead of finishing with a limitation.",
@@ -809,10 +810,11 @@ export function buildBaseAgentPromptSections(
     "Treat explicit user requirements and verification targets as completion criteria, not optional detail.",
     "If evidence is incomplete, keep retrieving or say what remains unverified; do not claim side effects happened without proof in this turn.",
     "Treat deleting files, wiping directories, `replace_existing`, or blanking a non-empty file as destructive; do them only when the user explicitly asked.",
-    "Treat local git as an internal recovery tool. Do not surface git chatter unless the user asks, and do not use destructive history operations unless explicitly requested.",
+    "Treat local git as an internal recovery tool. Do not surface git chatter or use destructive history operations unless explicitly requested.",
     "Treat the active workspace root as the default boundary. Do not cross it unless the user explicitly asks.",
+    "If a surfaced path returns `ENOENT` or `Path not found`, stop guessing paths outside the active workspace.",
     "Use tools, not hidden state. The newest user message is primary.",
-    "Resume unfinished work only when the newest message asks to continue it; otherwise answer the new message directly.",
+    "Resume unfinished work only when the newest message asks to continue it.",
     "Ask for missing identity details instead of guessing.",
     "Use `AGENTS.md` as the durable workspace ledger for stable instructions, procedures, facts, conventions, decisions, and recurring blockers; use local skills for situational workflows."
   ];
@@ -825,7 +827,7 @@ export function buildBaseAgentPromptSections(
   }
   if (capabilityManifest?.browser_tools.length) {
     executionLines.push(
-      "When browser tools are available, use them for UI-specific verification and prefer DOM-grounded actions and extraction. If a required fact may be rendered in attributes, custom elements, or hydration data instead of visible text, inspect those page-local DOM sources before concluding it is unavailable. Use screenshots only when visual confirmation matters."
+      "When browser tools are available, treat them as a fallback UI surface, not the default route. Use them only when the user explicitly asks for browser use, the task inherently requires UI interaction, visual confirmation matters, or non-browser routes are blocked. When you do use them, prefer DOM-grounded actions and extraction. If a required fact may be rendered in attributes, custom elements, or hydration data instead of visible text, inspect those page-local DOM sources before concluding it is unavailable. Use screenshots only when visual confirmation matters."
     );
   }
   if (request.workspaceSkillIds.length > 0) {
@@ -833,14 +835,16 @@ export function buildBaseAgentPromptSections(
   }
   if (request.resolvedMcpToolRefs.length > 0) {
     executionLines.push(
-      "Use MCP tools directly, and prefer surfaced MCP/app tools over browser work, web search, bash, or file inspection when they match the target system, including its URLs."
+      "Use MCP tools directly, and prefer surfaced MCP/app tools over browser work, web search, bash, or file inspection when they match the target system, including its URLs.",
+      "Do not route an MCP-backed task through the browser just because browser tools are available; use browser tools for that system only when the user explicitly asks for browser use, the task explicitly requires UI interaction, independent visual verification is required, or the MCP route is blocked."
     );
   } else if (
     (request.resolvedMcpServerIds?.length ?? 0) > 0 ||
     (request.capabilityManifest?.context.mcp_server_ids?.length ?? 0) > 0
   ) {
     executionLines.push(
-      "If connected MCP access exists without tool names listed here, do not assume MCP is unavailable; use surfaced MCP tools when relevant."
+      "If connected MCP access exists without tool names listed here, do not assume MCP is unavailable; use surfaced MCP tools when relevant.",
+      "If browser tools are also available, do not default to browser exploration for the same connected system; keep MCP as the first route unless the user explicitly asks for browser use, the task explicitly requires UI interaction, or the MCP path is blocked."
     );
   }
   if (hasScratchpadTools(request)) {
@@ -917,6 +921,7 @@ export function buildMainSessionPromptSections(
     "Treat explicit user requirements, verification targets, and deliverable shape as completion criteria for delegated work, not optional detail.",
     "Do not report work as done, verified, or already satisfied unless direct inspection or grounded child results confirm it.",
     "Treat the active workspace root as the default boundary. Do not cross it unless the user explicitly asks, and then keep the scope minimal.",
+    "If a surfaced file, skill, or reference path returns `ENOENT` or `Path not found`, stop guessing repo roots or absolute paths outside the workspace. Re-anchor on the workspace or the surfaced skill directory; if still missing, treat it as a missing packaged reference.",
     "Use coordination tools instead of hidden state. The newest user message is primary.",
     "Resume unfinished work only when the newest message clearly asks to continue it; otherwise respond to the new message directly.",
     "Ask for missing identity details instead of guessing.",
@@ -977,7 +982,7 @@ export function buildMainSessionPromptSections(
   if (request.resolvedMcpToolRefs.length > 0) {
     conversationLines.push(
       "Use relevant MCP tools directly instead of only describing them.",
-      "Prefer surfaced MCP/app tools over opening the web app, browser exploration, or web research when they can satisfy the request, including when the user supplies a URL for that system; use browser/web around an MCP-backed system only for UI verification, requested independent confirmation, or after the MCP path is blocked."
+      "Prefer surfaced MCP/app tools over opening the web app, browser exploration, or web research when they can satisfy the request, including when the user supplies a URL for that system; use browser/web around an MCP-backed system only when the user explicitly asks for browser use, for UI verification, for requested independent confirmation, or after the MCP path is blocked."
     );
   } else if (
     (request.resolvedMcpServerIds?.length ?? 0) > 0 ||

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -7072,92 +7072,95 @@ test("app install, list, build-status, and setup routes preserve local payload s
       }
     }
   });
-
-  const created = await app.inject({
-    method: "POST",
-    url: "/api/v1/workspaces",
-    payload: {
-      name: "Workspace Apps",
-      harness: "pi",
-      status: "active"
-    }
-  });
-  const workspace = created.json().workspace as { id: string };
-
-  const install = await app.inject({
-    method: "POST",
-    url: "/api/v1/apps/install",
-    payload: {
-      app_id: "demo-app",
-      workspace_id: workspace.id,
-      files: [
-        {
-          path: "app.runtime.yaml",
-          content_base64: Buffer.from(
-            [
-              "app_id: demo-app",
-              "mcp:",
-              "  port: 4100",
-              "lifecycle:",
-              "  start: npm run dev"
-            ].join("\n"),
-            "utf8"
-          ).toString("base64")
-        }
-      ]
-    }
-  });
-  assert.equal(install.statusCode, 200);
-  assert.deepEqual(install.json(), {
-    app_id: "demo-app",
-    status: "enabled",
-    detail: "App installed and running",
-    ready: true,
-    error: null
-  });
-  assert.equal(lifecycleCalls.length, 1);
-
-  const listed = await app.inject({
-    method: "GET",
-    url: `/api/v1/apps?workspace_id=${workspace.id}`
-  });
-  assert.equal(listed.statusCode, 200);
-  assert.deepEqual(listed.json(), {
-    apps: [
-      {
-        app_id: "demo-app",
-        config_path: "apps/demo-app/app.runtime.yaml",
-        lifecycle: { start: "npm run dev" },
-        build_status: "running",
-        ready: true,
-        error: null
+  try {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspaces",
+      payload: {
+        name: "Workspace Apps",
+        harness: "pi",
+        status: "active"
       }
-    ],
-    count: 1
-  });
+    });
+    const workspace = created.json().workspace as { id: string };
 
-  const buildStatus = await app.inject({
-    method: "GET",
-    url: `/api/v1/apps/demo-app/build-status?workspace_id=${workspace.id}`
-  });
-  assert.equal(buildStatus.statusCode, 200);
-  assert.equal(buildStatus.json().status, "running");
+    const install = await app.inject({
+      method: "POST",
+      url: "/api/v1/apps/install",
+      payload: {
+        app_id: "demo-app",
+        workspace_id: workspace.id,
+        files: [
+          {
+            path: "app.runtime.yaml",
+            content_base64: Buffer.from(
+              [
+                "app_id: demo-app",
+                "mcp:",
+                "  port: 4100",
+                "lifecycle:",
+                "  start: npm run dev"
+              ].join("\n"),
+              "utf8"
+            ).toString("base64")
+          }
+        ]
+      }
+    });
+    assert.equal(install.statusCode, 200);
+    assert.deepEqual(install.json(), {
+      app_id: "demo-app",
+      status: "enabled",
+      detail: "App installed and running",
+      ready: true,
+      error: null
+    });
+    assert.equal(lifecycleCalls.length, 1);
 
-  const setup = await app.inject({
-    method: "POST",
-    url: "/api/v1/apps/demo-app/setup",
-    payload: { workspace_id: workspace.id }
-  });
-  assert.equal(setup.statusCode, 200);
-  assert.deepEqual(setup.json(), {
-    app_id: "demo-app",
-    status: "no_setup_command",
-    detail: "No lifecycle.setup defined",
-    ports: {}
-  });
+    const listed = await app.inject({
+      method: "GET",
+      url: `/api/v1/apps?workspace_id=${workspace.id}`
+    });
+    assert.equal(listed.statusCode, 200);
+    assert.deepEqual(listed.json(), {
+      apps: [
+        {
+          app_id: "demo-app",
+          name: null,
+          config_path: "apps/demo-app/app.runtime.yaml",
+          lifecycle: { start: "npm run dev" },
+          build_status: "running",
+          ready: true,
+          error: null,
+          integrations: []
+        }
+      ],
+      count: 1
+    });
 
-  await app.close();
-  store.close();
+    const buildStatus = await app.inject({
+      method: "GET",
+      url: `/api/v1/apps/demo-app/build-status?workspace_id=${workspace.id}`
+    });
+    assert.equal(buildStatus.statusCode, 200);
+    assert.equal(buildStatus.json().status, "running");
+
+    const setup = await app.inject({
+      method: "POST",
+      url: "/api/v1/apps/demo-app/setup",
+      payload: { workspace_id: workspace.id }
+    });
+    assert.equal(setup.statusCode, 200);
+    assert.deepEqual(setup.json(), {
+      app_id: "demo-app",
+      status: "no_setup_command",
+      detail: "No lifecycle.setup defined",
+      ports: {}
+    });
+  } finally {
+    await app.close();
+    store.close();
+  }
 });
 
 test("app list and build-status infer pending when installed app has setup but no build record yet", async () => {
@@ -7198,35 +7201,38 @@ test("app list and build-status infer pending when installed app has setup but n
     "utf8"
   );
   const app = buildTestRuntimeApiServer({ store });
+  try {
+    const listed = await app.inject({
+      method: "GET",
+      url: `/api/v1/apps?workspace_id=${workspace.id}`
+    });
+    assert.equal(listed.statusCode, 200);
+    assert.deepEqual(listed.json(), {
+      apps: [
+        {
+          app_id: "demo-app",
+          name: null,
+          config_path: "apps/demo-app/app.runtime.yaml",
+          lifecycle: { setup: "npm install" },
+          build_status: "pending",
+          ready: false,
+          error: null,
+          integrations: []
+        }
+      ],
+      count: 1
+    });
 
-  const listed = await app.inject({
-    method: "GET",
-    url: `/api/v1/apps?workspace_id=${workspace.id}`
-  });
-  assert.equal(listed.statusCode, 200);
-  assert.deepEqual(listed.json(), {
-    apps: [
-      {
-        app_id: "demo-app",
-        config_path: "apps/demo-app/app.runtime.yaml",
-        lifecycle: { setup: "npm install" },
-        build_status: "pending",
-        ready: false,
-        error: null
-      }
-    ],
-    count: 1
-  });
-
-  const buildStatus = await app.inject({
-    method: "GET",
-    url: `/api/v1/apps/demo-app/build-status?workspace_id=${workspace.id}`
-  });
-  assert.equal(buildStatus.statusCode, 200);
-  assert.deepEqual(buildStatus.json(), { status: "pending" });
-
-  await app.close();
-  store.close();
+    const buildStatus = await app.inject({
+      method: "GET",
+      url: `/api/v1/apps/demo-app/build-status?workspace_id=${workspace.id}`
+    });
+    assert.equal(buildStatus.statusCode, 200);
+    assert.deepEqual(buildStatus.json(), { status: "pending" });
+  } finally {
+    await app.close();
+    store.close();
+  }
 });
 
 test("queue route persists input and runtime state without writing session history until claim", async () => {

--- a/runtime/api-server/src/workspace-skills.test.ts
+++ b/runtime/api-server/src/workspace-skills.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   invokeWorkspaceSkill,
@@ -304,4 +305,41 @@ test("resolveWorkspaceSkills captures declared granted tools and commands and in
   assert.match(invoked.text, /Only use the docs path\./);
   assert.deepEqual(invoked.granted_tools, ["bash", "deploy"]);
   assert.deepEqual(invoked.granted_commands, ["deploy-docs"]);
+});
+
+test("embedded app-builder-sdk skill only references bundled local assets", () => {
+  const sourceDir = path.dirname(fileURLToPath(import.meta.url));
+  const skillDir = path.resolve(
+    sourceDir,
+    "../../harnesses/src/embedded-skills/app-builder-sdk",
+  );
+  const skillBody = fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf8");
+
+  assert.doesNotMatch(skillBody, /docs\/pm\/app-vibe-coding\.md/);
+  assert.doesNotMatch(skillBody, /experiments\/app-builder-sdk\//);
+  assert.doesNotMatch(skillBody, /holaOS\/desktop\//);
+
+  for (const relativePath of [
+    "sdk/README.txt",
+    "sdk/app.ts",
+    "sdk/index.ts",
+    "sdk/types.ts",
+    "sdk/mcp-server.test.ts",
+    "reference/pinterest-publishing/app.ts",
+    "reference/slack-messaging/server.ts",
+    "reference/slack-messaging/app.runtime.yaml",
+    "sdk-package/package.json",
+    "sdk-package/src/index.ts",
+    "sdk-package/src/types.ts",
+    "sdk-package/reference/github-workflow/app.ts",
+    "ui-reference/components.json",
+    "ui-reference/tokens.css",
+    "ui-reference/themes/holaos.css",
+  ]) {
+    assert.equal(
+      fs.existsSync(path.join(skillDir, relativePath)),
+      true,
+      `expected embedded skill asset to exist: ${relativePath}`,
+    );
+  }
 });

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/SKILL.md
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/SKILL.md
@@ -12,7 +12,7 @@ Use this skill whenever the user wants a new holaOS app. Two shapes both ship th
 
 The SDK core (5 primitives below) is identical for both shapes. The dashboard shape adds a `src/client/` directory; that's the only structural delta.
 
-Reference doc for the product intent: `docs/pm/app-vibe-coding.md` (vibe-coding flow + the 4-layer UI constraint hierarchy below).
+All supplemental files named in this skill are bundled beside this `SKILL.md`. Treat those paths as skill-local references that are safe to use in packaged runtimes; do not guess at repo-root paths.
 
 ## When NOT to use this skill
 
@@ -36,7 +36,7 @@ Mental model:
 - `sync` = periodic upstream read that upserts records keyed by external id
 - HOW (steps / states / reversal) lives in the SDK. WHEN (scheduling, retry) lives in Holaboss automations — **the SDK never schedules**.
 
-Full type contract: `experiments/app-builder-sdk/src/types.ts`. Public exports: `experiments/app-builder-sdk/src/index.ts`.
+Full type contract: `sdk/types.ts`. Public exports: `sdk/index.ts`.
 
 ### `provider.id` MUST be the Composio toolkit slug
 
@@ -71,7 +71,7 @@ The legacy `composioToolkit` field on `ProviderRegistry` is **deprecated**. Do n
 
 The SDK's default `startMcpServer({ httpPort, ... })` ships a one-screen "headless module" placeholder on the http port. That placeholder is **only acceptable for integration-only modules** (Slack-style MCP-driven flows). The moment the user asks for a dashboard / list view / kanban / calendar / "let me see my X", **you must replace the placeholder with a real shadcn UI under `src/client/`**. The placeholder is what makes vibe-coded apps look ugly — the user has flagged it explicitly.
 
-The product constraints come from `docs/pm/app-vibe-coding.md`. Distilled, four layers from strict to loose:
+The product constraints are distilled below from the original vibe-coding design review. Treat this section as the source of truth for the UI constraints in packaged runtimes.
 
 ### L1 — shadcn registry is the ONLY component source
 
@@ -139,7 +139,7 @@ After writing the dashboard, eyeball it against an existing healthy holaOS pane 
 
 ## Pick a reference shape
 
-Copy the closest reference dir as your template; don't write from scratch. All references are at `experiments/app-builder-sdk/reference/<shape>/`.
+Copy the closest bundled reference dir as your template; don't write from scratch. All backend references are at `reference/<shape>/`.
 
 The existing references are **integration-only** (no `src/client/`). Use them for the backend skeleton (`app.ts`, `provider.ts`, `server.ts`, `app.runtime.yaml`) — they're correct. For dashboard apps, layer `src/client/` on top per the "Dashboard / workspace-pane UI" section above; no dashboard-shape reference exists yet, so model the visual after the desktop's healthy panes (marketplace / integrations) and the L1-L4 constraints.
 
@@ -216,12 +216,12 @@ After writing the 4 files into `<workspace>/apps/<app_id>/`, do these in order. 
   "private": true,
   "type": "module",
   "dependencies": {
-    "@holaboss/app-builder-sdk": "file:/absolute/path/to/holaOS/experiments/app-builder-sdk"
+    "@holaboss/app-builder-sdk": "file:/absolute/path/to/<app-builder-sdk-skill-dir>/sdk-package"
   }
 }
 ```
 
-Why absolute, not relative: the path is per-machine, so the agent must read `$HOME` or the repo root from a known constant (the runtime exposes the workspace root) and write the absolute string. Relative paths break across worktrees.
+Prefer the bundled `sdk-package` path beside this skill. Do not assume a repo checkout exists. The dependency path still needs to be absolute because the SDK package lives outside the workspace and relative paths break across worktrees.
 
 ### 2. `bun install` once in the app dir
 
@@ -244,7 +244,7 @@ env_contract:
   - "MCP_PORT"
 ```
 
-`mcp.tools` list must match what `app.derivedTools()` returns. The derivation rules from `experiments/app-builder-sdk/src/app.ts:165-238` are:
+`mcp.tools` list must match what `app.derivedTools()` returns. The derivation rules from `sdk/app.ts:165-238` are:
 - `<app_id>_connection_status` — always
 - For each resource: `<app_id>_list_<plural>`, `<app_id>_get_<resource>`, and (if `refreshEvery + fetch` declared) `<app_id>_refresh_<plural>`
 - For each action: `<app_id>_<action_name>_<resource_name>` (or `def.toolName` override), plus `<app_id>_cancel_<action>_<resource>` for reversible
@@ -355,19 +355,19 @@ Run all of these. Stop at the first failure and report the symptom verbatim, don
 
 ### Always
 
-1. `docs/pm/app-vibe-coding.md` — product intent + L1-L4 UI constraint hierarchy (the doc this skill is downstream of).
-2. `experiments/app-builder-sdk/README.md` — top-level overview
-3. `experiments/app-builder-sdk/src/index.ts` — public surface
-4. `experiments/app-builder-sdk/src/types.ts` — full type contract, including `RowOf` and the integer-id stringify note
+1. `sdk/README.txt` — top-level overview bundled for packaged runtimes
+2. `sdk/index.ts` — public surface
+3. `sdk/types.ts` — full type contract, including `RowOf` and the integer-id stringify note
+4. `sdk/app.ts` — derived tool naming, primitive wiring, and registration behavior
 
 ### For the backend shape (both integration-only and dashboard apps need this)
 
-5. `experiments/app-builder-sdk/reference/<shape>/app.ts` — copy + adapt; pick the shape that matches the user's request (messaging / publishing / workflow / event-with-time)
-6. `experiments/app-builder-sdk/reference/slack-messaging/server.ts` + `app.runtime.yaml` — copy + adapt; this is the only reference that ships a complete `server.ts`
-7. `experiments/app-builder-sdk/test/mcp-server.test.ts` — what derived tools / `connection_status` / refresh / sync_status are expected to do; useful as oracle when writing a new app's tests
+5. `reference/<shape>/app.ts` — copy + adapt; pick the shape that matches the user's request (messaging / publishing / workflow / event-with-time)
+6. `reference/slack-messaging/server.ts` + `reference/slack-messaging/app.runtime.yaml` — copy + adapt; this is the only bundled reference that ships a complete `server.ts`
+7. `sdk/mcp-server.test.ts` — what derived tools / `connection_status` / refresh / sync_status are expected to do; useful as oracle when writing a new app's tests
 
 ### For dashboard apps (additionally)
 
-8. `holaOS/desktop/components.json` — the holaOS-locked shadcn registry version. Match it in the app's own `components.json` so primitives stay aligned.
-9. `holaOS/desktop/src/styles/themes/` — the CSS variable tokens (`--background` / `--primary` / `--radius` / etc.). Use these; do not invent new ones.
-10. Any existing healthy holaOS pane (e.g. the marketplace / integrations panes under `holaOS/desktop/src/components/panes/`) — these are the visual reference for "looks like one family".
+8. `ui-reference/components.json` — the holaOS-locked shadcn registry version. Match it in the app's own `components.json` so primitives stay aligned.
+9. `ui-reference/tokens.css` and `ui-reference/themes/holaos.css` — the shared CSS variable tokens (`--background` / `--primary` / `--radius` / etc.). Use these; do not invent new ones.
+10. Compare against the current live desktop panes if available, but do not leave the workspace or guess repo-root source paths just to locate pane source files.

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/app.ts
@@ -1,0 +1,222 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "event-with-time" shape — resources that carry
+// their own start_time/end_time (distinct from automations scheduling),
+// recurring events (RRULE), RSVP as side-effect action.
+//
+// Event start_time/end_time are intrinsic event attributes (the user books
+// a meeting for March 5 at 2pm). This is NOT the "schedule this action to
+// run later" concept — that lives in Holaboss automations.
+//
+// Copy this directory as a template when building a real calendar / event
+// module; do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { GCALENDAR } from "./provider.ts"
+
+export function buildGcalendarApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "gcalendar",
+    provider: GCALENDAR,
+    description: "Google Calendar event management",
+  }, options)
+
+  app.connection()
+
+  const calendar = app.resource("calendar", {
+    schema: z.object({
+      id: z.string(),
+      summary: z.string(),
+      time_zone: z.string().optional(),
+      primary: z.boolean().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "6h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{
+        items: { id: string; summary: string; timeZone?: string; primary?: boolean }[]
+      }>("GET", "/users/me/calendarList")
+      if (r.kind === "error") throw r
+      return r.data.items.map(c => ({
+        id: c.id, summary: c.summary, time_zone: c.timeZone, primary: c.primary,
+      }))
+    },
+  })
+
+  const event = app.resource("event", {
+    schema: z.object({
+      calendar_id: calendar.ref(),
+      summary: z.string().max(1024),
+      description: z.string().optional(),
+      location: z.string().optional(),
+      start_time: z.string(),
+      end_time: z.string(),
+      time_zone: z.string().optional(),
+      recurrence: z.array(z.string()).optional(),
+      attendees: z.array(z.object({
+        email: z.string().email(),
+        optional: z.boolean().optional(),
+        responseStatus: z.string().optional(),
+      })).optional(),
+    }),
+    states: ["draft", "confirmed", "cancelled", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => `${r.summary} @ ${r.start_time}`,
+      deepLink: r => r.external_id && r.calendar_id
+        ? `https://calendar.google.com/calendar/event?eid=${r.external_id}`
+        : null,
+    },
+  })
+
+  app.action(event, "create_event", {
+    fromStates: ["draft"],
+    toState: "confirmed",
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        if (!row.external_id) return { ok: true }
+        const r = await bridge.call(
+          "DELETE",
+          `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        )
+        if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, bridge }) => {
+      if (row.external_id) return { ok: true, externalId: row.external_id }  // idempotent
+      const body: Record<string, unknown> = {
+        summary: row.summary,
+        description: row.description,
+        location: row.location,
+        start: { dateTime: row.start_time, timeZone: row.time_zone },
+        end: { dateTime: row.end_time, timeZone: row.time_zone },
+      }
+      if (row.recurrence) body.recurrence = row.recurrence
+      if (row.attendees) body.attendees = row.attendees
+
+      const r = await bridge.call<{ id: string }>(
+        "POST",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events`,
+        body,
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true, externalId: r.data.id }
+    },
+  })
+
+  app.action(event, "update_event", {
+    fromStates: ["confirmed"],
+    toState: "confirmed",
+    schema: z.object({
+      summary: z.string().max(1024).optional(),
+      description: z.string().optional(),
+      location: z.string().optional(),
+      start_time: z.string().optional(),
+      end_time: z.string().optional(),
+    }),
+    run: async ({ row, input, bridge, persist }) => {
+      const patch: Record<string, unknown> = {}
+      if (input.summary !== undefined) patch.summary = input.summary
+      if (input.description !== undefined) patch.description = input.description
+      if (input.location !== undefined) patch.location = input.location
+      if (input.start_time) patch.start = { dateTime: input.start_time, timeZone: row.time_zone }
+      if (input.end_time) patch.end = { dateTime: input.end_time, timeZone: row.time_zone }
+
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        patch,
+      )
+      if (r.kind === "error") return { fail: r }
+      await persist(input)
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "cancel_event", {
+    fromStates: ["confirmed"],
+    toState: "cancelled",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        { status: "cancelled" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "delete_event", {
+    fromStates: ["draft", "confirmed", "cancelled"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call(
+          "DELETE",
+          `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        )
+        if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "rsvp", {
+    fromStates: ["confirmed"],
+    toState: null,
+    toolName: "gcalendar_rsvp",
+    schema: z.object({
+      response: z.enum(["accepted", "declined", "tentative"]),
+      self_email: z.string().email(),
+    }),
+    run: async ({ row, input, bridge }) => {
+      const existing = row.attendees ?? []
+      const others = existing.filter(a => a.email !== input.self_email)
+      const me = existing.find(a => a.email === input.self_email) ?? { email: input.self_email }
+      const nextAttendees = [...others, { ...me, responseStatus: input.response }]
+
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        { attendees: nextAttendees },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.sync("upcoming_events", {
+    schedule: "*/15 * * * *",
+    attachTo: event,
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{
+        items: {
+          id: string
+          summary?: string
+          status: string
+          start?: { dateTime?: string; date?: string }
+          end?: { dateTime?: string; date?: string }
+        }[]
+      }>("GET", "/calendars/primary/events?singleEvents=false&maxResults=50")
+      if (r.kind === "error") return { ok: false, error: r }
+      return { ok: true, items: r.data.items }
+    },
+    upsert: { key: "id" },
+    normalize: raw => ({
+      external_id: raw.id,
+      summary: raw.summary ?? "(no title)",
+      start_time: raw.start?.dateTime ?? raw.start?.date ?? "",
+      end_time: raw.end?.dateTime ?? raw.end?.date ?? "",
+      upstream_status: raw.status,
+    }),
+  })
+
+  return { app, calendar, event }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/e2e.ts
@@ -1,0 +1,292 @@
+// Real E2E for the Google Calendar app — BDD scenarios against your live calendar.
+//
+// Zero-friction: set COMPOSIO_API_KEY and run. The script discovers your Calendar
+// connection from Composio and uses your "primary" calendar (Google's alias for
+// your own main calendar — no impact on shared calendars).
+//
+// Test events are scheduled ~1 hour out, immediately cleaned up via the Cleanup
+// feature. If a scenario fails partway, you may need to delete leftover events
+// manually (search calendar for "[E2E").
+//
+// Optional overrides:
+//   COMPOSIO_USER_ID          scope account listing to a specific user
+//   COMPOSIO_GCAL_ACCOUNT_ID  skip auto-discovery
+//   TEST_CALENDAR_ID          use this calendar instead of "primary"
+//
+// Run: bun run reference/gcalendar-events/e2e.ts
+
+import { buildGcalendarApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { GCALENDAR } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx
+Find it in backend/.env or your frontend wrangler secrets.`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID
+let ACCOUNT_ID = process.env.COMPOSIO_GCAL_ACCOUNT_ID
+const CALENDAR_ID = process.env.TEST_CALENDAR_ID ?? "primary"
+
+// ─── Auto-discover: Composio Calendar connection ───────────────────────────
+
+async function discoverCalendarConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}
+  - if "user_id required" → set COMPOSIO_USER_ID=<your holaboss user id>`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const cals = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "googlecalendar"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (cals.length === 0) {
+    throw new Error(`No active Google Calendar connection in Composio.
+  - connect Calendar via desktop UI first, OR
+  - set COMPOSIO_USER_ID to filter by user`)
+  }
+  if (cals.length > 1) {
+    console.warn(`Found ${cals.length} active Calendar connections — picking first.`)
+    console.warn(`  IDs: ${cals.map(c => c.id).join(", ")}`)
+    console.warn(`  To pick explicitly, set COMPOSIO_GCAL_ACCOUNT_ID.`)
+  }
+  return cals[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Google Calendar connection from Composio…")
+  ACCOUNT_ID = await discoverCalendarConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+// ─── Build SUT ─────────────────────────────────────────────────────────────
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: GCALENDAR, transport })
+const { app, event } = buildGcalendarApp() as unknown as { app: AppHandleInternal; event: any }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+console.log(`SUT ready. Target calendar: ${CALENDAR_ID}\nRunning scenarios…\n`)
+
+// ─── Minimal BDD harness ───────────────────────────────────────────────────
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+    toMatch(re: RegExp, label = "value") {
+      if (typeof actual !== "string" || !re.test(actual))
+        throw new Error(`${label}: expected to match ${re}, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(
+      `${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`,
+    )
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+function futureEvent(offsetMinutes = 60, durationMinutes = 30) {
+  const start = new Date(Date.now() + offsetMinutes * 60_000)
+  const end = new Date(start.getTime() + durationMinutes * 60_000)
+  return { start_time: start.toISOString(), end_time: end.toISOString() }
+}
+
+let createdEvent: { id: string; externalId?: string } | null = null
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenarios
+// ───────────────────────────────────────────────────────────────────────────
+
+feature("Create event")
+
+await scenario("draft → confirmed; event appears in calendar with externalId + dashboard card", async () => {
+  given(`a draft event on calendar '${CALENDAR_ID}'`)
+  const times = futureEvent(60, 30)
+  const row = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID,
+    summary: `[E2E ${stamp()}] create scenario`,
+    description: "Auto-created by app-builder-sdk e2e — safe to ignore.",
+    ...times,
+  }, "draft")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status initial")
+
+  when("the agent invokes create_event")
+  const result = await app._invokeAction({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the action succeeds and Google returns an event id")
+  expectOk(result, "create_event")
+  expect(result.externalId).toBeTruthy("Google event id")
+
+  then("the row transitions to 'confirmed' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("confirmed", "row.status after create")
+  expect(final?.externalId).toBe(result.externalId!, "row.externalId persisted")
+
+  then("a dashboard card is emitted with a Calendar deepLink")
+  const card = app.state().outputs.find(o => o.rowId === row.id)
+  expect(!!card).toBe(true, "dashboard card exists")
+  expect(card!.status).toBe("confirmed", "card.status")
+  expect(card!.deepLink ?? "").toMatch(/calendar\.google\.com/, "card.deepLink")
+
+  createdEvent = { id: row.id, externalId: result.externalId }
+})
+
+feature("Update event")
+
+await scenario("update_event: change summary; row stays 'confirmed'; upstream patched", async () => {
+  given("the event created above")
+  expect(!!createdEvent).toBe(true, "create scenario must succeed first")
+
+  when("the agent updates the summary")
+  const result = await app._invokeAction({
+    actionName: "update_event",
+    rowId: createdEvent!.id,
+    input: { summary: `[E2E ${stamp()}] (updated via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row stays 'confirmed'")
+  expectOk(result, "update_event")
+  expect(app._state.getRow(createdEvent!.id)?.status).toBe("confirmed", "row.status after update")
+})
+
+feature("State machine guards")
+
+await scenario("rsvp on a draft row fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft row never created on Google")
+  const times = futureEvent(60, 30)
+  const draft = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID, summary: "should never reach Google", ...times,
+  }, "draft")
+  expect(draft.externalId).toBe(undefined, "no externalId for unsent draft")
+
+  when("the agent tries to RSVP on the draft")
+  const result = await app._invokeAction({
+    actionName: "rsvp",
+    rowId: draft.id,
+    input: { response: "accepted", self_email: "test@example.com" },
+    bridge,
+  })
+
+  then("the action fails with code='invalid_state' and a state-naming message")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+    expect(result.fail.message).toMatch(/from state 'draft'/, "fail.message")
+  }
+
+  then("the row remains untouched")
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Reversible action: create + reverse")
+
+await scenario("create + reverse roundtrip — row created → reverted to draft, event deleted upstream", async () => {
+  given("a fresh draft event")
+  const times = futureEvent(120, 30)
+  const row = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID,
+    summary: `[E2E ${stamp()}] this should NEVER persist (created then reverted)`,
+    ...times,
+  }, "draft")
+
+  when("the agent invokes create_event")
+  const created = await app._invokeAction({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the create succeeds with a Google event id")
+  expectOk(created, "create_event")
+  expect(app._state.getRow(row.id)?.status).toBe("confirmed", "row.status after create")
+
+  when("the agent invokes the reverse (cancel) action")
+  const reversed = await app._invokeReverse({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the reverse succeeds and row transitions back to 'draft'")
+  expectOk(reversed, "reverse(create_event)")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status after reverse")
+})
+
+feature("Cleanup")
+
+await scenario("delete_event removes the test event from calendar; row → deleted, card reflects", async () => {
+  given("the event created in the first scenario")
+  expect(!!createdEvent).toBe(true)
+
+  when("the agent invokes delete_event")
+  const result = await app._invokeAction({
+    actionName: "delete_event", rowId: createdEvent!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_event")
+  expect(app._state.getRow(createdEvent!.id)?.status).toBe("deleted", "row.status after delete")
+
+  then("the dashboard card status reflects the deletion")
+  const card = app.state().outputs.find(o => o.rowId === createdEvent!.id)
+  expect(card?.status).toBe("deleted", "card.status")
+})
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/gcalendar-events/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const GCALENDAR: ProviderRegistry = {
+  id: "gcalendar",
+  baseUrl: "https://www.googleapis.com/calendar/v3",
+  allowedHosts: ["www.googleapis.com"],
+  whoamiPath: "/users/me/calendarList",
+  composioToolkit: "googlecalendar",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/github-workflow/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/github-workflow/app.ts
@@ -1,0 +1,173 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "workflow" shape — 6-state lifecycle
+// (draft/open/in_progress/closed/reopened/failed), reversible state
+// transitions (close↔reopen), and side-effect actions that don't mutate
+// row.status (comment, assign).
+//
+// Copy this directory as a template when building a real
+// workflow-shape app (issue tracker / CRM lead pipeline / ticket
+// system); do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { GITHUB } from "./provider.ts"
+
+export function buildGithubIssuesApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "github",
+    provider: GITHUB,
+    description: "GitHub issue triage & lifecycle",
+  }, options)
+
+  app.connection()
+
+  const repo = app.resource("repo", {
+    schema: z.object({ id: z.string(), full_name: z.string() }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "6h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{ id: number; full_name: string }[]>("GET", "/user/repos")
+      if (r.kind === "error") throw r
+      return r.data.map(x => ({ id: String(x.id), full_name: x.full_name }))
+    },
+  })
+
+  const issue = app.resource("issue", {
+    schema: z.object({
+      repo_full_name: repo.ref(),
+      title: z.string().max(256),
+      body: z.string().optional(),
+    }),
+    states: ["draft", "open", "in_progress", "closed", "reopened", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => r.title,
+      deepLink: r => r.external_id && r.repo_full_name
+        ? `https://github.com/${r.repo_full_name}/issues/${r.external_id}`
+        : null,
+    },
+  })
+
+  app.action(issue, "create", {
+    fromStates: ["draft"],
+    toState: "open",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) return { ok: true, externalId: row.external_id }   // idempotent
+      const r = await bridge.call<{ number: number; html_url: string }>(
+        "POST", `/repos/${row.repo_full_name}/issues`,
+        { title: row.title, body: row.body },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true, externalId: String(r.data.number) }
+    },
+  })
+
+  app.action(issue, "start_work", {
+    fromStates: ["open", "reopened"],
+    toState: "in_progress",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/labels`,
+        { labels: ["in-progress"] },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "close", {
+    fromStates: ["open", "in_progress", "reopened"],
+    toState: "closed",
+    reversible: {
+      toState: "reopened",
+      run: async ({ row, bridge }) => {
+        const r = await bridge.call(
+          "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+          { state: "open" },
+        )
+        if (r.kind === "error") return { fail: r }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+        { state: "closed" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "reopen", {
+    fromStates: ["closed"],
+    toState: "reopened",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+        { state: "open" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "comment", {
+    fromStates: ["open", "in_progress", "closed", "reopened"],
+    toState: null,
+    toolName: "github_comment_on_issue",
+    schema: z.object({ body: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/comments`,
+        { body: input.body },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "assign", {
+    fromStates: ["open", "in_progress", "reopened"],
+    toState: null,
+    schema: z.object({ assignees: z.array(z.string()).min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/assignees`,
+        { assignees: input.assignees },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.sync("issue_activity", {
+    schedule: "*/15 * * * *",
+    attachTo: issue,
+    fetch: async ({ bridge, db }) => {
+      const open = db.query(issue).where({ status: "open" }).all()
+      const active: { issue_id: string; raw: { reactions?: { total_count?: number }; comments?: number } }[] = []
+      for (const i of open) {
+        if (!i.external_id) continue
+        const r = await bridge.call<{ reactions?: { total_count?: number }; comments?: number }>(
+          "GET", `/repos/${i.repo_full_name}/issues/${i.external_id}`,
+        )
+        if (r.kind === "error") return { ok: false, error: r }
+        active.push({ issue_id: i.id, raw: r.data })
+      }
+      return { ok: true, items: active }
+    },
+    upsert: { key: "issue_id" },
+    normalize: raw => ({
+      reach: raw.raw.reactions?.total_count ?? 0,
+      engagement: raw.raw.comments ?? 0,
+      clicks: 0,
+    }),
+  })
+
+  return { app, issue, repo }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/github-workflow/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/github-workflow/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const GITHUB: ProviderRegistry = {
+  id: "github",
+  baseUrl: "https://api.github.com",
+  allowedHosts: ["api.github.com"],
+  whoamiPath: "/user",
+  composioToolkit: "github",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/pinterest-publishing/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/pinterest-publishing/app.ts
@@ -1,0 +1,144 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "publishing" shape — multi-step actions with
+// persisted checkpoints (upload media → create pin), reversible actions
+// (delete on cancel), and the row.external_id idempotency pattern.
+//
+// Copy this directory as a template when building a real publishing-shape
+// app; do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { PINTEREST } from "./provider.ts"
+
+export function buildPinterestApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "pinterest",
+    provider: PINTEREST,
+    description: "Pinterest pin publishing & board management",
+  }, options)
+
+  app.connection()
+
+  // ─── Board: container, read-mostly, NOT in dashboard ─────────────────────
+  const board = app.resource("board", {
+    schema: z.object({ id: z.string(), name: z.string() }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "1h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{ items: { id: string; name: string }[] }>("GET", "/boards")
+      if (r.kind === "error") throw r
+      return r.data.items
+    },
+  })
+
+  // ─── Pin: publishing-shape ───────────────────────────────────────────────
+  const pin = app.resource("pin", {
+    schema: z.object({
+      board_id: board.ref(),
+      image_url: z.string().url(),
+      title: z.string().max(100).optional(),
+      description: z.string().max(500).optional(),
+      media_id: z.string().optional(),       // checkpoint field, set after upload step
+    }),
+    states: ["draft", "scheduled", "published", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "content_plan",
+      summary: r => r.title ?? r.description?.slice(0, 50) ?? "Untitled pin",
+      deepLink: r => r.external_id ? `https://pinterest.com/pin/${r.external_id}` : null,
+    },
+  })
+
+  app.action(pin, "publish", {
+    fromStates: ["draft"],
+    toState: "published",
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        if (row.external_id) {
+          const r = await bridge.call("DELETE", `/pins/${row.external_id}`)
+          if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+        }
+        return { ok: true }
+      },
+    },
+    steps: [
+      {
+        name: "upload_media",
+        run: async ({ row, bridge, persist }) => {
+          if (row.media_id) return { ok: true }   // idempotent: already uploaded
+          const r = await bridge.call<{ id: string }>("POST", "/media", {
+            media_type: "image",
+            url: row.image_url,
+          })
+          if (r.kind === "error") return { fail: r }
+          await persist({ media_id: r.data.id })
+          return { ok: true }
+        },
+      },
+      {
+        name: "create_pin",
+        run: async ({ row, bridge }) => {
+          if (row.external_id) return { ok: true, externalId: row.external_id }
+          const r = await bridge.call<{ id: string }>("POST", "/pins", {
+            board_id: row.board_id,
+            media_source: { source_type: "image_upload", media_id: row.media_id },
+            title: row.title,
+            description: row.description,
+          })
+          if (r.kind === "error") return { fail: r }
+          return { ok: true, externalId: r.data.id }
+        },
+      },
+    ],
+  })
+
+  app.action(pin, "edit", {
+    fromStates: ["draft", "published"],
+    toState: "published",
+    schema: z.object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    run: async ({ row, input, bridge, persist }) => {
+      if (row.status === "draft") {
+        await persist(input)
+        return { ok: true }
+      }
+      const r = await bridge.call("PATCH", `/pins/${row.external_id}`, input)
+      if (r.kind === "error") return { fail: r }
+      await persist(input)
+      return { ok: true }
+    },
+  })
+
+  app.sync("pin_metrics", {
+    schedule: "0 */6 * * *",
+    attachTo: pin,
+    fetch: async ({ bridge, db }) => {
+      const pins = db.query(pin).where({ status: "published" }).recent("30d")
+      const results: { pin_id: string; raw: Record<string, number> }[] = []
+      for (const p of pins) {
+        if (!p.external_id) continue
+        const r = await bridge.call<Record<string, number>>(
+          "GET",
+          `/pins/${p.external_id}/analytics?metric_types=SAVE,PIN_CLICK,IMPRESSION,OUTBOUND_CLICK`,
+        )
+        if (r.kind === "error") return { ok: false, error: r }
+        results.push({ pin_id: p.id, raw: r.data })
+      }
+      return { ok: true, items: results }
+    },
+    upsert: { key: "pin_id" },
+    normalize: raw => ({
+      reach: raw.raw.IMPRESSION ?? 0,
+      engagement: (raw.raw.SAVE ?? 0) + (raw.raw.PIN_CLICK ?? 0),
+      clicks: raw.raw.OUTBOUND_CLICK ?? 0,
+    }),
+  })
+
+  return { app, pin, board }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/pinterest-publishing/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/pinterest-publishing/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const PINTEREST: ProviderRegistry = {
+  id: "pinterest",
+  baseUrl: "https://api.pinterest.com/v5",
+  allowedHosts: ["api.pinterest.com"],
+  whoamiPath: "/user_account",
+  composioToolkit: "pinterest",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/app.runtime.yaml
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/app.runtime.yaml
@@ -1,0 +1,45 @@
+app_id: "slack"
+name: "Slack"
+slug: "slack"
+
+lifecycle:
+  setup: "bun install"
+  start: "bun run server.ts"
+  stop: "kill $(lsof -t -i :${MCP_PORT:-3099} 2>/dev/null) 2>/dev/null || true"
+
+healthchecks:
+  mcp:
+    path: /mcp/health
+    timeout_s: 30
+
+mcp:
+  enabled: true
+  transport: http-sse
+  port: 3099
+  path: /mcp/sse
+  tools:
+    - slack_connection_status
+    - slack_list_channels
+    - slack_get_channel
+    - slack_refresh_channels
+    - slack_list_messages
+    - slack_get_message
+    - slack_send_message_message
+    - slack_schedule_send_message
+    - slack_cancel_schedule_send_message
+    - slack_edit_message_message
+    - slack_delete_message_message
+    - slack_react
+    - slack_channel_directory_sync_status
+    - slack_snapshot
+
+integration:
+  destination: "slack"
+  credential_source: "platform"
+
+env_contract:
+  - "HOLABOSS_WORKSPACE_ID"
+  - "WORKSPACE_DB_PATH"
+  - "HOLABOSS_INTEGRATION_BROKER_URL"
+  - "HOLABOSS_APP_GRANT"
+  - "MCP_PORT"

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/app.ts
@@ -1,0 +1,218 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "messaging" shape via Slack — custom state
+// alphabet (draft/scheduled/sent/edited/deleted/failed), side-effect
+// actions (react), provider quirks (body.ok pattern, DM channel
+// resolution, 60s scheduled-message cancellation window), real reverse
+// handler. Also serves as the SDK's test fixture and the most-stressed
+// example (3 real production quirks were found and fixed via real-API
+// E2E against live Slack).
+//
+// For a production Slack module: see hola-boss-apps/slack/ (legacy
+// @holaboss/bridge SDK, ~600 lines, broader tool coverage including
+// list_channels / search_messages / list_users / send_dm). To replace
+// it, write a new workspace app under <workspace>/apps/ or
+// hola-boss-apps/ that uses this reference as a template plus the full
+// v1 tool surface — NOT a job for this reference dir.
+//
+// Per-provider Slack quirks (kept as inline comments at the call sites
+// they apply to; no separate SKILL.md — that conflicts with Holaboss's
+// real skill system at runtime/harnesses/src/embedded-skills/):
+//   - Slack returns errors as HTTP 200 + { ok:false, error:"..." }, not
+//     4xx/5xx. Every action checks body.ok via `slackUnwrap` below.
+//   - chat.postMessage with channel=user_id auto-resolves to a DM
+//     channel ("D0..."); we persist the resolved channel back to the
+//     row so subsequent edit/delete/react use the right id.
+//   - chat.deleteScheduledMessage rejects with
+//     invalid_scheduled_message_id if <60s remain before post_at —
+//     schedule with sufficient lead time.
+
+import { createApp, z, type CreateAppOptions, type ProxyResult, type BridgeError } from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+
+// Slack returns its own errors in body.ok / body.error.
+type SlackBody = { ok?: boolean; error?: string; [k: string]: unknown }
+
+function slackUnwrap<T extends SlackBody>(
+  r: ProxyResult<T>,
+):
+  | { ok: true; data: T }
+  | { ok: false; fail: BridgeError | { kind: "error"; code: string; message: string } } {
+  if (r.kind === "error") return { ok: false, fail: r }
+  if (r.data.ok === false) {
+    const code = r.data.error ?? "slack_error"
+    return { ok: false, fail: { kind: "error", code, message: code } }
+  }
+  return { ok: true, data: r.data }
+}
+
+export function buildSlackApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "slack",
+    provider: SLACK,
+    description: "Slack channel messaging, edits, reactions",
+  }, options)
+
+  app.connection()
+
+  const channel = app.resource("channel", {
+    schema: z.object({
+      id: z.string(),
+      name: z.string(),
+      is_private: z.boolean().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "1h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<SlackBody & {
+        channels?: { id: string; name: string; is_private?: boolean }[]
+      }>("GET", "/conversations.list")
+      const u = slackUnwrap(r)
+      if (!u.ok) throw u.fail
+      return u.data.channels ?? []
+    },
+  })
+
+  const message = app.resource("message", {
+    schema: z.object({
+      channel_id: channel.ref(),
+      text: z.string().max(40_000),
+      thread_ts: z.string().optional(),
+      post_at: z.number().optional(),
+    }),
+    states: ["draft", "scheduled", "sent", "edited", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => (r.text ?? "").slice(0, 80),
+      deepLink: r => r.external_id && r.channel_id
+        ? `https://slack.com/archives/${r.channel_id}/p${String(r.external_id).replace(".", "")}`
+        : null,
+    },
+  })
+
+  app.action(message, "send_message", {
+    fromStates: ["draft"],
+    toState: "sent",
+    run: async ({ row, bridge, persist }) => {
+      const r = await bridge.call<SlackBody & { ts?: string; channel?: string }>(
+        "POST", "/chat.postMessage",
+        { channel: row.channel_id, text: row.text, thread_ts: row.thread_ts },
+      )
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      // Slack DM auto-resolution: when input channel is a user_id, the response
+      // carries the actual DM channel id ("D0..."). Persist it for subsequent ops.
+      if (u.data.channel && u.data.channel !== row.channel_id) {
+        await persist({ channel_id: u.data.channel })
+      }
+      return { ok: true, externalId: u.data.ts }
+    },
+  })
+
+  app.action(message, "schedule_send", {
+    fromStates: ["draft"],
+    toState: "scheduled",
+    schema: z.object({ post_at: z.number().int().positive() }),
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        // Slack-specific: this WILL fail with invalid_scheduled_message_id if
+        // less than 60 seconds remain before post_at. Schedule with sufficient
+        // lead time to give the cancel a chance. Agent should propagate the
+        // error and let the user know they hit the window.
+        const r = await bridge.call<SlackBody>("POST", "/chat.deleteScheduledMessage", {
+          channel: row.channel_id,
+          scheduled_message_id: row.external_id,
+        })
+        const u = slackUnwrap(r)
+        if (!u.ok) return { fail: u.fail }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, input, bridge, persist }) => {
+      const r = await bridge.call<SlackBody & {
+        scheduled_message_id?: string; post_at?: number; channel?: string
+      }>("POST", "/chat.scheduleMessage", {
+        channel: row.channel_id, text: row.text, post_at: input.post_at, thread_ts: row.thread_ts,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      // Persist the DM-resolved channel id. chat.scheduledMessages.list
+      // verifies the scheduled message is keyed under this channel, so the
+      // delete must use it too. (Note: cancel will only succeed if invoked
+      // more than 60 seconds before post_at — Slack's hard rule.)
+      const patch: { post_at?: number; channel_id?: string } = {}
+      if (u.data.post_at) patch.post_at = u.data.post_at
+      if (u.data.channel && u.data.channel !== row.channel_id) patch.channel_id = u.data.channel
+      if (Object.keys(patch).length) await persist(patch)
+      return { ok: true, externalId: u.data.scheduled_message_id }
+    },
+  })
+
+  app.action(message, "edit_message", {
+    fromStates: ["sent", "edited"],
+    toState: "edited",
+    schema: z.object({ text: z.string().min(1).max(40_000) }),
+    run: async ({ row, input, bridge, persist }) => {
+      const r = await bridge.call<SlackBody>("POST", "/chat.update", {
+        channel: row.channel_id, ts: row.external_id, text: input.text,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      await persist({ text: input.text })
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "delete_message", {
+    fromStates: ["draft", "scheduled", "sent", "edited"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call<SlackBody>("POST", "/chat.delete", {
+          channel: row.channel_id, ts: row.external_id,
+        })
+        const u = slackUnwrap(r)
+        // Propagate all errors (including not_found) — let the agent decide.
+        if (!u.ok) return { fail: u.fail }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "react", {
+    fromStates: ["sent", "edited"],
+    toState: null,
+    toolName: "slack_react",
+    schema: z.object({ emoji: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call<SlackBody>("POST", "/reactions.add", {
+        channel: row.channel_id, timestamp: row.external_id, name: input.emoji,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      return { ok: true }
+    },
+  })
+
+  app.sync("channel_directory", {
+    schedule: "0 * * * *",
+    attachTo: channel,
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<SlackBody & { channels?: { id: string; name: string }[] }>(
+        "GET", "/conversations.list",
+      )
+      const u = slackUnwrap(r)
+      if (!u.ok) return { ok: false, error: u.fail }
+      return { ok: true, items: u.data.channels ?? [] }
+    },
+    upsert: { key: "id" },
+    normalize: raw => ({ id: raw.id, name: raw.name }),
+  })
+
+  return { app, channel, message }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/e2e-bearer.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/e2e-bearer.ts
@@ -1,0 +1,72 @@
+// Self-host OAuth E2E — proves the SDK works with a transport you control,
+// no Composio / Holaboss backend involved. Single scenario, just enough to
+// validate the transport contract end-to-end.
+//
+// Required env:
+//   SLACK_BEARER_TOKEN   xoxb-... or xoxp-... (Slack token from your app/install)
+//   TEST_SLACK_CHANNEL   channel id
+//
+// Run: bun run reference/slack-messaging/e2e-bearer.ts
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge } from "../../src/bridge.ts"
+import { SLACK } from "./provider.ts"
+import { createBearerTokenTransport } from "../../src/bridge-transports/bearer.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+const TOKEN = process.env.SLACK_BEARER_TOKEN
+const CHANNEL = process.env.TEST_SLACK_CHANNEL
+if (!TOKEN || !CHANNEL) {
+  console.error(`Missing env. Set SLACK_BEARER_TOKEN and TEST_SLACK_CHANNEL.`)
+  process.exit(1)
+}
+
+// ─── BDD harness (tiny duplicate of e2e.ts's — keeps this file standalone) ─
+
+async function scenario(name: string, body: () => Promise<void>) {
+  console.log(`\nScenario: ${name}`)
+  const start = Date.now()
+  try { await body(); console.log(`  ✓ pass (${Date.now() - start}ms)`) }
+  catch (e) { console.error(`  ✗ FAIL:`, e instanceof Error ? e.message : e); process.exit(1) }
+}
+function given(s: string) { console.log(`  Given ${s}`) }
+function when(s: string)  { console.log(`  When  ${s}`) }
+function then(s: string)  { console.log(`  Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+
+// ─── SUT ────────────────────────────────────────────────────────────────────
+
+const transport = createBearerTokenTransport({ accessToken: TOKEN })
+const bridge = createBridge({ provider: SLACK, transport })
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e-bearer", sessionId: "e2e-bearer" })
+
+// ─── Scenario ───────────────────────────────────────────────────────────────
+
+await scenario("Self-host OAuth path: send_message succeeds with bearer transport, row → sent", async () => {
+  given("a draft message and a SDK bridge wired to a user-provided bearer token")
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL,
+    text: `[E2E-bearer ${new Date().toISOString().slice(11, 19)}] self-host OAuth proof`,
+  }, "draft")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the SDK doesn't care that no Composio / Holaboss backend is in the path — it just works")
+  expect("ok" in result).toBe(true, "result kind")
+  const externalId = "ok" in result ? result.externalId : undefined
+  expect(externalId).toBeTruthy("Slack ts returned via bearer transport")
+  expect(app._state.getRow(row.id)?.status).toBe("sent", "row.status after send")
+
+  console.log(`  Dashboard card:`, app.state().outputs.find(o => o.rowId === row.id))
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/e2e.ts
@@ -1,0 +1,318 @@
+// Real E2E for the Slack app — BDD-style scenarios against a live Slack workspace.
+//
+// Zero-friction: set COMPOSIO_API_KEY and run. The script discovers your Slack
+// connection from Composio, your own user_id via auth.test, and DMs the test
+// messages to YOURSELF (no team channels spammed).
+//
+// Optional overrides:
+//   COMPOSIO_USER_ID            scope account listing to a specific user
+//   COMPOSIO_SLACK_ACCOUNT_ID   skip auto-discovery (use this id directly)
+//   TEST_SLACK_CHANNEL          send to this channel instead of self-DM
+//
+// Run: bun run reference/slack-messaging/e2e.ts
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx
+Find it in backend/.env or your frontend wrangler secrets.`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID                    // optional
+let ACCOUNT_ID = process.env.COMPOSIO_SLACK_ACCOUNT_ID          // optional override
+let CHANNEL = process.env.TEST_SLACK_CHANNEL                    // optional override
+
+// ─── Auto-discover: Composio Slack connection ──────────────────────────────
+
+async function discoverSlackConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}
+  - if "user_id required" → set COMPOSIO_USER_ID=<your holaboss user id>`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const slacks = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "slack"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (slacks.length === 0) {
+    throw new Error(`No active Slack connection in Composio.
+  - connect Slack via desktop UI first, OR
+  - set COMPOSIO_USER_ID to filter by user`)
+  }
+  if (slacks.length > 1) {
+    console.warn(`Found ${slacks.length} active Slack connections — picking first.`)
+    console.warn(`  IDs: ${slacks.map(s => s.id).join(", ")}`)
+    console.warn(`  To pick explicitly, set COMPOSIO_SLACK_ACCOUNT_ID.`)
+  }
+  return slacks[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Slack connection from Composio…")
+  ACCOUNT_ID = await discoverSlackConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+// ─── Build SUT ─────────────────────────────────────────────────────────────
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: SLACK, transport })
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+// ─── Auto-discover: own Slack user_id for DM-to-self ───────────────────────
+
+if (!CHANNEL) {
+  console.log("Discovering your own Slack user via auth.test…")
+  const r = await bridge.call<{ ok: boolean; user_id?: string; user?: string; team?: string }>(
+    "POST", "/auth.test",
+  )
+  if (r.kind === "error" || !r.data?.user_id) {
+    throw new Error(`auth.test failed: ${JSON.stringify(r).slice(0, 300)}
+  - set TEST_SLACK_CHANNEL=C0... manually to skip self-DM`)
+  }
+  CHANNEL = r.data.user_id
+  console.log(`  → DMing @${r.data.user} (workspace ${r.data.team}, channel ${CHANNEL})`)
+}
+
+console.log(`\nSUT ready. Running scenarios…\n`)
+
+// ─── Minimal BDD harness ───────────────────────────────────────────────────
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+    toMatch(re: RegExp, label = "value") {
+      if (typeof actual !== "string" || !re.test(actual))
+        throw new Error(`${label}: expected to match ${re}, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+
+// Specialized assertion for action results — if the action failed, includes
+// the full fail.code + message in the error so we don't have to guess.
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(
+      `${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`,
+    )
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+let sentMessage: { id: string; externalId?: string } | null = null
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenarios
+// ───────────────────────────────────────────────────────────────────────────
+
+feature("Send a message")
+
+await scenario("draft → sent transitions row, returns Slack ts, emits dashboard card", async () => {
+  given(`a draft message row targeting ${CHANNEL}`)
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL!, text: `[E2E ${stamp()}] send scenario`,
+  }, "draft")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status initial")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the action succeeds and Slack returns a message ts")
+  expectOk(result, "send_message")
+  const externalId = result.externalId
+  expect(externalId).toBeTruthy("externalId (Slack ts)")
+
+  then("the row transitions to 'sent' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("sent", "row.status after send")
+  expect(final?.externalId).toBe(externalId!, "row.externalId persisted")
+
+  then("a dashboard card is emitted with a Slack deepLink")
+  const card = app.state().outputs.find(o => o.rowId === row.id)
+  expect(!!card).toBe(true, "dashboard card exists")
+  expect(card!.status).toBe("sent", "card.status")
+  expect(card!.deepLink ?? "").toMatch(/slack\.com\/archives\//, "card.deepLink")
+
+  sentMessage = { id: row.id, externalId }
+})
+
+feature("Edit and react to a sent message")
+
+await scenario("edit_message transitions sent → edited and updates upstream text", async () => {
+  given("the message sent in the previous scenario")
+  expect(!!sentMessage).toBe(true, "send scenario must succeed first")
+
+  when("the agent edits the text")
+  const result = await app._invokeAction({
+    actionName: "edit_message",
+    rowId: sentMessage!.id,
+    input: { text: `[E2E ${stamp()}] (edited via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row transitions to 'edited'")
+  expectOk(result, "edit_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("edited", "row.status after edit")
+})
+
+await scenario("react adds emoji WITHOUT mutating row.status (side-effect contract)", async () => {
+  given("the same message, now in 'edited' state")
+  expect(!!sentMessage).toBe(true)
+  const beforeStatus = app._state.getRow(sentMessage!.id)?.status
+  const beforeCardCount = app.state().outputs.filter(o => o.rowId === sentMessage!.id).length
+
+  when("the agent reacts with :rocket:")
+  const result = await app._invokeAction({
+    actionName: "react",
+    rowId: sentMessage!.id,
+    input: { emoji: "rocket" },
+    bridge,
+  })
+
+  then("the action succeeds but row.status is unchanged (toState: null)")
+  expectOk(result, "react")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe(beforeStatus!, "row.status preserved")
+
+  then("no new dashboard card is emitted (side-effect actions don't dirty the surface)")
+  const afterCardCount = app.state().outputs.filter(o => o.rowId === sentMessage!.id).length
+  expect(afterCardCount).toBe(beforeCardCount, "dashboard card count")
+})
+
+feature("State machine guards")
+
+await scenario("react on a draft row fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft row never sent to Slack")
+  const draft = app._state.insertRow("message", {
+    channel_id: CHANNEL!, text: "should never reach Slack",
+  }, "draft")
+  expect(draft.externalId).toBe(undefined, "no externalId for unsent draft")
+
+  when("the agent tries to react on the draft")
+  const result = await app._invokeAction({
+    actionName: "react", rowId: draft.id, input: { emoji: "thumbsup" }, bridge,
+  })
+
+  then("the action fails with code='invalid_state' and a state-naming message")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+    expect(result.fail.message).toMatch(/from state 'draft'/, "fail.message")
+  }
+
+  then("the row remains untouched")
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Reversible action: schedule + cancel")
+
+await scenario("schedule_send + reverse roundtrip — row scheduled → draft, upstream cancel called", async () => {
+  given("a fresh draft row scheduled 180s in the future (Slack requires >60s lead time at cancel time)")
+  const future = Math.floor(Date.now() / 1000) + 180
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL!,
+    text: `[E2E ${stamp()}] this should NEVER appear (scheduled then cancelled)`,
+  }, "draft")
+
+  when("the agent invokes schedule_send")
+  const scheduled = await app._invokeAction({
+    actionName: "schedule_send", rowId: row.id, input: { post_at: future }, bridge,
+  })
+
+  then("the action succeeds with a scheduled_message_id as externalId")
+  expectOk(scheduled, "schedule_send")
+  expect(scheduled.externalId).toBeTruthy("scheduled_message_id")
+  expect(app._state.getRow(row.id)?.status).toBe("scheduled", "row.status after schedule")
+
+  when("the agent invokes the reverse (cancel) action")
+  const reversed = await app._invokeReverse({ actionName: "schedule_send", rowId: row.id, bridge })
+
+  then("the reverse succeeds and row transitions back to 'draft'")
+  expectOk(reversed, "reverse(schedule_send)")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status after reverse")
+})
+
+feature("Cleanup")
+
+await scenario("delete_message removes the test message; row → deleted, card reflects", async () => {
+  given("the sent message from the first scenario")
+  expect(!!sentMessage).toBe(true)
+
+  when("the agent invokes delete_message")
+  const result = await app._invokeAction({
+    actionName: "delete_message", rowId: sentMessage!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("deleted", "row.status after delete")
+
+  then("the dashboard card status reflects the deletion")
+  const card = app.state().outputs.find(o => o.rowId === sentMessage!.id)
+  expect(card?.status).toBe("deleted", "card.status")
+})
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/manifest.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/manifest.ts
@@ -1,0 +1,28 @@
+// Generates app.runtime.yaml for the Slack v2 module.
+//
+// Run: bun run reference/slack-messaging/manifest.ts
+// Output: writes reference/slack-messaging/app.runtime.yaml
+
+import { writeFileSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { buildSlackApp } from "./app.ts"
+import { buildAppRuntimeManifest } from "../../src/runtime/manifest.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+const yaml = buildAppRuntimeManifest(app, {
+  name: "Slack",
+  slug: "slack",
+  lifecycle: {
+    setup: "bun install",
+    start: "bun run server.ts",
+    stop: "kill $(lsof -t -i :${MCP_PORT:-3099} 2>/dev/null) 2>/dev/null || true",
+  },
+})
+
+const here = dirname(fileURLToPath(import.meta.url))
+const out = join(here, "app.runtime.yaml")
+writeFileSync(out, yaml, "utf-8")
+console.log(`Wrote ${out}`)
+console.log(`\n${yaml}`)

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const SLACK: ProviderRegistry = {
+  id: "slack",
+  baseUrl: "https://slack.com/api",
+  allowedHosts: ["slack.com"],
+  whoamiPath: "/auth.test",
+  composioToolkit: "slack",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/run.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/run.ts
@@ -1,0 +1,79 @@
+// Interactive demo for the Slack app.
+// Walks: send_message → edit_message → react → delete_message
+// against a fake transport, printing the row, dashboard card, and audit log
+// at each step. Run with: `bun run reference/slack-messaging/run.ts`
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge, type TransportFn } from "../../src/bridge.ts"
+import { SLACK } from "./provider.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// Fake Slack — scripts replies. Real impl would call /broker/proxy.
+const replies = new Map<string, unknown>([
+  ["POST https://slack.com/api/chat.postMessage",
+    { ok: true, ts: "1700000000.111111", channel: "C0123" }],
+  ["POST https://slack.com/api/chat.update",
+    { ok: true, ts: "1700000000.111111", channel: "C0123" }],
+  ["POST https://slack.com/api/reactions.add",
+    { ok: true }],
+  ["POST https://slack.com/api/chat.delete",
+    { ok: true }],
+])
+
+const transport: TransportFn = async ({ method, url, body }) => {
+  console.log(`  → ${method} ${url}`)
+  if (body) console.log(`     body: ${JSON.stringify(body)}`)
+  const key = `${method} ${url}`
+  const body_ = replies.get(key)
+  if (!body_) throw new Error(`no scripted reply for ${key}`)
+  return { status: 200, body: body_ }
+}
+
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "demo-turn", sessionId: "demo-session" })
+const bridge = createBridge({ provider: SLACK, transport })
+
+console.log("\n=== Derived MCP tools ===")
+console.table(app.derivedTools().map(t => ({ name: t.name, category: t.category, input: t.inputShape })))
+
+console.log("\n=== Step 1: create draft row + send_message ===")
+const row = app._state.insertRow("message", {
+  channel_id: "C0123",
+  text: "Hello from the v2 SDK demo",
+}, "draft")
+console.log(`  row inserted: id=${row.id}, status=${row.status}`)
+
+const send = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+console.log("  result:", send)
+console.log("  row now:", { status: app._state.getRow(row.id)?.status, externalId: app._state.getRow(row.id)?.externalId })
+
+console.log("\n=== Step 2: edit_message ===")
+const edit = await app._invokeAction({
+  actionName: "edit_message",
+  rowId: row.id,
+  input: { text: "Hello from the v2 SDK demo (edited)" },
+  bridge,
+})
+console.log("  result:", edit, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Step 3: react (side effect — status should stay 'edited') ===")
+const react = await app._invokeAction({
+  actionName: "react", rowId: row.id, input: { emoji: "rocket" }, bridge,
+})
+console.log("  result:", react, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Step 4: delete_message ===")
+const del = await app._invokeAction({ actionName: "delete_message", rowId: row.id, bridge })
+console.log("  result:", del, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Dashboard cards (what user would see in workspace) ===")
+console.table(app.state().outputs.map(o => ({
+  status: o.status, surface: o.surface, summary: o.summary, deepLink: o.deepLink,
+})))
+
+console.log("\n=== Audit log (last 8 events) ===")
+console.table(app.state().audit.slice(-8).map(a => ({
+  event: a.event,
+  step: a.fields.step ?? a.fields.action ?? "-",
+  outcome: a.fields.outcome ?? "-",
+})))

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/server.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/slack-messaging/server.ts
@@ -1,0 +1,62 @@
+// Production entry point for the Slack v2 app module.
+//
+// What this file does (in one place):
+//   1. Builds the Slack app with a SqliteStateBackend (persists to WORKSPACE_DB_PATH)
+//   2. Wires a runtime-broker transport (reads HOLABOSS_APP_GRANT + broker URL)
+//   3. Starts the MCP server on MCP_PORT
+//   4. Handles SIGTERM / SIGINT for clean shutdown
+//
+// When the Holaboss runtime launches this app via app.runtime.yaml lifecycle.start,
+// it injects all required env vars. From the user's perspective:
+//   - Connect Slack via desktop OAuth flow (existing infrastructure)
+//   - Workspace gets a slack-v2 app entry, MCP tools become available to agent
+//   - Agent calls slack_send_message → SDK → broker → real Slack
+//
+// To generate this app's app.runtime.yaml: bun run reference/slack-messaging/manifest.ts
+
+import { buildSlackApp } from "./app.ts"
+import {
+  createBridge,
+  createRuntimeBrokerTransport,
+  SqliteStateBackend,
+  startMcpServer,
+} from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+
+const workspaceDbPath = process.env.WORKSPACE_DB_PATH
+if (!workspaceDbPath) {
+  console.error("[slack-v2] WORKSPACE_DB_PATH not set — refusing to start without persistence")
+  process.exit(1)
+}
+const mcpPort = Number(process.env.MCP_PORT ?? 3099)
+// Holaboss runtime allocates an HTTP port per app for the desktop iframe
+// surface. Headless SDK modules don't have a web UI, but the desktop still
+// tries to load the URL — startMcpServer serves a placeholder page on PORT
+// to avoid ERR_CONNECTION_REFUSED.
+const httpPort = process.env.PORT ? Number(process.env.PORT) : undefined
+
+// 1) SQLite-backed state (persists across app restarts)
+const backend = new SqliteStateBackend({ dbPath: workspaceDbPath, appId: "slack" })
+
+// 2) Build the Slack app with persistent backend
+const { app } = buildSlackApp({ backend })
+
+// 3) Production transport — reads HOLABOSS_APP_GRANT + HOLABOSS_INTEGRATION_BROKER_URL from env
+const transport = createRuntimeBrokerTransport({ provider: "slack" })
+const bridge = createBridge({ provider: SLACK, transport })
+
+// 4) Boot MCP server (+ headless web stub if PORT was injected)
+const server = await startMcpServer({ app: app as never, port: mcpPort, bridge, httpPort })
+console.log(`[slack-v2] MCP server listening on :${server.port}`)
+if (server.httpPort) console.log(`[slack-v2] Web stub on :${server.httpPort}`)
+console.log(`[slack-v2] Workspace DB: ${workspaceDbPath}`)
+console.log(`[slack-v2] Tools registered: ${app.derivedTools().length}`)
+
+// 5) Clean shutdown
+async function shutdown(signal: string) {
+  console.log(`[slack-v2] Received ${signal}, shutting down…`)
+  await server.close().catch(err => console.error("[slack-v2] MCP close failed:", err))
+  process.exit(0)
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"))
+process.on("SIGINT", () => shutdown("SIGINT"))

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/app.ts
@@ -1,0 +1,189 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate that the SDK supports messaging-shape apps with
+// integer external IDs (Telegram message_id is int — see RowOf doc in
+// types.ts for the stringify pattern). Built end-to-end by a cold
+// subagent given ONLY the SDK meta-skill + the user request "add
+// Telegram" — first time pass, 0 `as any`, 9 unit tests. Useful as a
+// "did our agent-build flow really work" artifact.
+//
+// Known: real-API E2E NOT run yet (Composio proxy path convention for
+// Telegram bot tokens is unverified — depends on whether Composio's
+// `API_KEY` auth toolkit injects the token into the URL path).
+//
+// Copy this directory as a template when building a real Telegram /
+// Discord / bot-style messaging module; do not deploy it as-is.
+//
+// Telegram — messaging app (bot API). Same shape as Slack: chats + messages,
+// custom state alphabet, side-effect react action.
+//
+// Telegram-specific contract: like Slack, errors come back as HTTP 200 with
+// { ok: false, description, error_code } in the body. SDK's BridgeClient only
+// maps HTTP status, so each action must check r.data.ok via `tgUnwrap` below.
+//
+// Telegram-specific behavior notes:
+//   - message_id is a numeric int (not a string ts like Slack). Persisted as
+//     `String(message_id)` so it fits the SDK's external_id contract.
+//   - There is NO scheduleMessage in the Bot API and NO server-side edit
+//     window beyond 48h for non-bot messages — bots can edit their own
+//     messages indefinitely. No schedule action declared.
+//   - setMessageReaction REPLACES the bot's prior reactions on that message
+//     (it doesn't append). Passing an empty array clears.
+//   - chat_id can be a numeric id OR an @channelusername. Persisted as a
+//     string for both.
+
+import { createApp, z, type CreateAppOptions, type ProxyResult, type BridgeError } from "../../src/index.ts"
+import { TELEGRAM } from "./provider.ts"
+
+type TgBody = {
+  ok?: boolean
+  description?: string
+  error_code?: number
+  result?: unknown
+  [k: string]: unknown
+}
+
+function tgUnwrap<T extends TgBody>(
+  r: ProxyResult<T>,
+):
+  | { ok: true; data: T }
+  | { ok: false; fail: BridgeError | { kind: "error"; code: string; message: string } } {
+  if (r.kind === "error") return { ok: false, fail: r }
+  if (r.data.ok === false) {
+    const description = r.data.description ?? "telegram_error"
+    const code = r.data.error_code ? `telegram_${r.data.error_code}` : "telegram_error"
+    return { ok: false, fail: { kind: "error", code, message: description } }
+  }
+  return { ok: true, data: r.data }
+}
+
+export function buildTelegramApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "telegram",
+    provider: TELEGRAM,
+    description: "Telegram bot messaging, edits, reactions",
+  }, options)
+
+  app.connection()
+
+  const chat = app.resource("chat", {
+    schema: z.object({
+      id: z.string(),
+      title: z.string().optional(),
+      type: z.string().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+  })
+
+  const message = app.resource("message", {
+    schema: z.object({
+      chat_id: chat.ref(),
+      text: z.string().min(1).max(4096),
+      reply_to_message_id: z.number().int().optional(),
+      parse_mode: z.enum(["HTML", "MarkdownV2"]).optional(),
+    }),
+    states: ["draft", "sent", "edited", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => (r.text ?? "").slice(0, 80),
+      deepLink: r => {
+        if (!r.external_id) return null
+        // Public channel/group URL only resolves when chat_id is @username.
+        const ref = String(r.chat_id ?? "")
+        if (ref.startsWith("@")) {
+          return `https://t.me/${ref.slice(1)}/${r.external_id}`
+        }
+        return null
+      },
+    },
+  })
+
+  app.action(message, "send_message", {
+    fromStates: ["draft"],
+    toState: "sent",
+    run: async ({ row, bridge }) => {
+      type SendResult = TgBody & {
+        result?: { message_id: number; chat: { id: number | string } }
+      }
+      const r = await bridge.call<SendResult>("POST", "/sendMessage", {
+        chat_id: row.chat_id,
+        text: row.text,
+        reply_to_message_id: row.reply_to_message_id,
+        parse_mode: row.parse_mode,
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      const messageId = u.data.result?.message_id
+      if (messageId === undefined) {
+        return { fail: { kind: "error", code: "telegram_missing_message_id", message: "no message_id in result" } }
+      }
+      return { ok: true, externalId: String(messageId) }
+    },
+  })
+
+  app.action(message, "edit_message", {
+    fromStates: ["sent", "edited"],
+    toState: "edited",
+    schema: z.object({ text: z.string().min(1).max(4096) }),
+    run: async ({ row, input, bridge, persist }) => {
+      if (!row.external_id) {
+        return { fail: { kind: "error", code: "missing_external_id", message: "edit requires external_id" } }
+      }
+      const r = await bridge.call<TgBody>("POST", "/editMessageText", {
+        chat_id: row.chat_id,
+        message_id: Number(row.external_id),
+        text: input.text,
+        parse_mode: row.parse_mode,
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      await persist({ text: input.text })
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "delete_message", {
+    fromStates: ["draft", "sent", "edited"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call<TgBody>("POST", "/deleteMessage", {
+          chat_id: row.chat_id,
+          message_id: Number(row.external_id),
+        })
+        const u = tgUnwrap(r)
+        // Propagate all errors — let the agent decide. Telegram returns
+        // 'message to delete not found' as ok:false; don't swallow it.
+        if (!u.ok) return { fail: u.fail }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "react", {
+    fromStates: ["sent", "edited"],
+    toState: null,
+    toolName: "telegram_react",
+    schema: z.object({ emoji: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      if (!row.external_id) {
+        return { fail: { kind: "error", code: "missing_external_id", message: "react requires external_id" } }
+      }
+      // setMessageReaction replaces prior bot reactions; pass single emoji.
+      const r = await bridge.call<TgBody>("POST", "/setMessageReaction", {
+        chat_id: row.chat_id,
+        message_id: Number(row.external_id),
+        reaction: [{ type: "emoji", emoji: input.emoji }],
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      return { ok: true }
+    },
+  })
+
+  return { app, chat, message }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/e2e.ts
@@ -1,0 +1,231 @@
+// Real E2E for the Telegram app — BDD-style scenarios against a live bot.
+//
+// Setup:
+//   1. Talk to @BotFather, /newbot, save the bot token
+//   2. Connect Telegram via desktop UI (Composio) using that bot token
+//   3. Start a chat with your bot and send it any message so it knows your chat_id
+//   4. export COMPOSIO_API_KEY=ck_...
+//      export TEST_TELEGRAM_CHAT_ID=<your numeric chat id, from getUpdates>
+//
+// Optional:
+//   COMPOSIO_USER_ID                  scope account listing to a specific user
+//   COMPOSIO_TELEGRAM_ACCOUNT_ID      skip auto-discovery
+//
+// Run: bun run reference/telegram-messaging/e2e.ts
+
+import { buildTelegramApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { TELEGRAM } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx`)
+  process.exit(1)
+}
+const CHAT_ID = process.env.TEST_TELEGRAM_CHAT_ID
+if (!CHAT_ID) {
+  console.error(`Missing env: TEST_TELEGRAM_CHAT_ID=<numeric chat id>
+  - DM your bot first, then GET /bot<token>/getUpdates to find your chat id`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID
+let ACCOUNT_ID = process.env.COMPOSIO_TELEGRAM_ACCOUNT_ID
+
+async function discoverTelegramConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const tgs = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "telegram"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (tgs.length === 0) {
+    throw new Error(`No active Telegram connection in Composio. Connect via desktop UI first.`)
+  }
+  return tgs[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Telegram connection from Composio…")
+  ACCOUNT_ID = await discoverTelegramConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: TELEGRAM, transport })
+const { app } = buildTelegramApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+console.log(`\nSUT ready (chat_id=${CHAT_ID}). Running scenarios…\n`)
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(`${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`)
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+let sentMessage: { id: string; externalId?: string } | null = null
+
+feature("Send a message")
+
+await scenario("draft → sent, returns message_id, emits dashboard card", async () => {
+  given(`a draft message row targeting chat ${CHAT_ID}`)
+  const row = app._state.insertRow("message", {
+    chat_id: CHAT_ID, text: `[E2E ${stamp()}] send scenario`,
+  }, "draft")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the action succeeds and Telegram returns a message_id")
+  expectOk(result, "send_message")
+  expect(result.externalId).toBeTruthy("externalId (Telegram message_id)")
+
+  then("the row transitions to 'sent' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("sent", "row.status after send")
+  expect(final?.externalId).toBe(result.externalId!, "row.externalId persisted")
+
+  sentMessage = { id: row.id, externalId: result.externalId }
+})
+
+feature("Edit and react")
+
+await scenario("edit_message: sent → edited and updates upstream text", async () => {
+  given("the sent message from the previous scenario")
+  expect(!!sentMessage).toBe(true, "send scenario must succeed first")
+
+  when("the agent edits the text")
+  const result = await app._invokeAction({
+    actionName: "edit_message",
+    rowId: sentMessage!.id,
+    input: { text: `[E2E ${stamp()}] (edited via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row transitions to 'edited'")
+  expectOk(result, "edit_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("edited", "row.status after edit")
+})
+
+await scenario("react: adds 👍 WITHOUT mutating row.status (side-effect contract)", async () => {
+  given("the same message, now in 'edited' state")
+  expect(!!sentMessage).toBe(true)
+  const beforeStatus = app._state.getRow(sentMessage!.id)?.status
+
+  when("the agent reacts with 👍")
+  const result = await app._invokeAction({
+    actionName: "react",
+    rowId: sentMessage!.id,
+    input: { emoji: "👍" },
+    bridge,
+  })
+
+  then("the action succeeds but row.status is unchanged (toState: null)")
+  expectOk(result, "react")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe(beforeStatus!, "row.status preserved")
+})
+
+feature("State machine guards")
+
+await scenario("react on a draft fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft never sent to Telegram")
+  const draft = app._state.insertRow("message", {
+    chat_id: CHAT_ID, text: "should never reach Telegram",
+  }, "draft")
+
+  when("the agent tries to react on the draft")
+  const result = await app._invokeAction({
+    actionName: "react", rowId: draft.id, input: { emoji: "👍" }, bridge,
+  })
+
+  then("the action fails with code='invalid_state'")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+  }
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Cleanup")
+
+await scenario("delete_message removes the test message; row → deleted", async () => {
+  given("the sent message from the first scenario")
+  expect(!!sentMessage).toBe(true)
+
+  when("the agent invokes delete_message")
+  const result = await app._invokeAction({
+    actionName: "delete_message", rowId: sentMessage!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("deleted", "row.status after delete")
+})
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/reference/telegram-messaging/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const TELEGRAM: ProviderRegistry = {
+  id: "telegram",
+  baseUrl: "https://api.telegram.org",
+  allowedHosts: ["api.telegram.org"],
+  whoamiPath: "/getMe",
+  composioToolkit: "telegram",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/README.md
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/README.md
@@ -1,0 +1,203 @@
+# @holaboss/app-builder-sdk — Holaboss app module SDK (experimental)
+
+> Distinct from `@holaboss/app-sdk` (the generated product API client) and
+> `@holaboss/bridge` (the legacy app SDK that pre-dates this redesign).
+> This package is what new Holaboss app modules are built against. The
+> existing `app-builder` skill in `runtime/harnesses/src/embedded-skills/`
+> will be updated to know about this SDK once it reaches production runtime
+> integration.
+
+A TypeScript prototype rebuilding the Holaboss app SDK around **5 orthogonal
+primitives**. The goal: let agents author apps of any shape (publishing,
+messaging, workflow, event-with-time, sync-mirror) with zero `as any`, strong
+compile-time guardrails, and no scheduling/retry concerns leaking into app code.
+
+**This is not production code.** It is a spike with passing end-to-end tests
+to validate the API surface before integrating into the real Holaboss runtime.
+
+## What's the SDK, what isn't
+
+```
+src/                      ← THE SDK — ~11 files, ~1100 lines. Touched only
+│                            by SDK maintainers; agents adding apps NEVER
+│                            modify this directory.
+├── index.ts                public exports
+├── types.ts                all type definitions
+├── app.ts                  createApp + 5 primitive registrars
+├── bridge.ts               BridgeClient + createBridge (transport contract)
+├── bridge-transports/      bearer / composio-direct / runtime-broker
+└── runtime/                internal execution: action-runner, sync-runner,
+                            state backends (in-memory + sqlite), mcp-server,
+                            manifest helper
+
+reference/<shape>-<provider>/  ← SDK REFERENCE APPS (NOT production code).
+                                  Demo + test fixtures + agent templates.
+                                  Each illustrates one app shape:
+                                    pinterest-publishing
+                                    slack-messaging
+                                    github-workflow
+                                    gcalendar-events
+                                    telegram-messaging
+                                  Read these to learn the SDK; copy them to
+                                  bootstrap a new module; do NOT ship them
+                                  unmodified.
+
+test/<area>.test.ts        ← UNIT + INTEGRATION TESTS
+```
+
+**Three places code about Holaboss apps can live**:
+
+| Location | Role | Status |
+|---|---|---|
+| `experiments/app-builder-sdk/reference/<shape>/` | **SDK reference** — demos, test fixtures, agent templates. Used to validate SDK design across shapes. | Spike phase |
+| `hola-boss-apps/<name>/` | **Production app modules** — legacy bridge-SDK-era apps shipped to users. ~20 modules. | Stable, runs in workspaces today |
+| `<workspace>/apps/<id>/` | **Workspace-installed apps** — what a user's actual workspace contains. Materialized via marketplace install or agent-build skill. | Per-workspace |
+
+Reference apps are **not** production apps. If a reference and a production app share a name (e.g. `reference/slack-messaging/` vs `hola-boss-apps/slack/`), they cover different ground — different tool names, different coverage. See each `app.ts`'s top-of-file banner for what it demonstrates.
+
+> Note on Holaboss "skills": this SDK does NOT define a per-app SKILL.md
+> convention — the real Holaboss skill system lives at
+> `runtime/harnesses/src/embedded-skills/<skill-id>/SKILL.md` (system-wide,
+> with frontmatter) and `<workspace>/skills/<skill-id>/SKILL.md`
+> (workspace-local, created via the `skill-creator` skill). Provider quirks
+> stay as code comments in `app.ts`; the existing `app-builder` skill needs
+> an update — to know about the 5-primitive v2 SDK shape — when v2 SDK
+> reaches production runtime integration.
+
+## The 5 primitives
+
+```ts
+app.connection()                      // declares provider connection
+app.resource(name, def)               // declares a typed entity with its own state alphabet
+app.action(resource, name, def)       // declares a callable that transitions states
+app.sync(name, def)                   // periodic fetch+upsert+normalize (automations-scheduled)
+app.start()                           // boot
+```
+
+Read [`src/types.ts`](./src/types.ts) for the full type surface and the
+ActionDef / SyncDef doc comments for the SDK ↔ Automations boundary.
+
+## What's verified
+
+| File | Shape | Tests |
+|---|---|---|
+| [`reference/pinterest-publishing/app.ts`](./reference/pinterest-publishing/app.ts) | publishing (multi-step + reversible) | 5 |
+| [`reference/slack-messaging/app.ts`](./reference/slack-messaging/app.ts) | messaging (custom states, side-effect react, 3 prod quirks fixed) | 11 |
+| [`reference/github-workflow/app.ts`](./reference/github-workflow/app.ts) | workflow (6-state lifecycle) | 7 |
+| [`reference/gcalendar-events/app.ts`](./reference/gcalendar-events/app.ts) | event-with-time (RSVP, recurring) | 9 |
+| [`reference/telegram-messaging/app.ts`](./reference/telegram-messaging/app.ts) | messaging (cold-subagent-built; integer IDs; no schedule) | 9 |
+| `test/sync.test.ts` | sync E2E across 3 apps | 8 |
+| `test/agent-mistakes.test.ts` | compile + runtime double-guard | 8 |
+| `test/sqlite-backend.test.ts` | SqliteStateBackend parity + persistence + isolation + integration | 4 |
+| `test/emit-context.test.ts` | emit row.id/status/external_id regression lock | 1 |
+| **Total** | **5 example apps + Iter 1 persistence** | **63 / 247 expect / 0 fail / tsc clean** |
+
+```bash
+bun install
+bun test           # 63 pass / 0 fail
+bunx tsc --noEmit  # clean
+```
+
+## Transports — the SDK is auth-mechanism agnostic
+
+The SDK never assumes Hono, Composio, OAuth, or any specific provider. The
+`BridgeClient` delegates network I/O to a `TransportFn` (`(req) => response`).
+You pick the transport that matches your deployment.
+
+Bundled options under `src/bridge-transports/`:
+
+| Transport | When to use | What you supply |
+|---|---|---|
+| `createBearerTokenTransport` | **Self-host OAuth** — you manage tokens (Auth0 / Clerk / your own auth server / manual). | `accessToken: string \| (() => Promise<string>)` |
+| `createComposioDirectTransport` | Composio managed auth, no broker hop. Good for single-tenant deploys, local dev, E2E. | `COMPOSIO_API_KEY` + `connectedAccountId` |
+| `createRuntimeBrokerTransport` | **Production** — running inside Holaboss runtime sandbox. Same `/broker/proxy` + grant model as `@holaboss/bridge`. | `provider` + env `HOLABOSS_INTEGRATION_BROKER_URL` + `HOLABOSS_APP_GRANT` (auto-resolved) |
+| Roll your own | Custom auth (Vault, mTLS, internal gateway). | Implement ~20 lines of `fetch` returning `{ status, body, headers }`. |
+
+Bundled transports never call Holaboss backend / Hono. Production runtime
+integrations are wired by the runtime team via the broker-proxy pattern; that's
+separate from this SDK.
+
+## Real E2E (single command, no Holaboss backend required)
+
+```bash
+cd experiments/app-builder-sdk
+export COMPOSIO_API_KEY=ck_...
+export COMPOSIO_SLACK_ACCOUNT_ID=ca_...   # from workspace.db, see e2e.ts header
+export TEST_SLACK_CHANNEL=C0123ABCD
+bun run reference/slack-messaging/e2e.ts
+```
+
+Sends real messages to your Slack workspace via `createComposioDirectTransport`.
+Watch Slack — message + edit + 🚀 reaction should appear within seconds.
+
+## What's in scope
+
+- HOW an action does its work (steps, checkpoint, state transitions, reverse handler)
+- Resource schema → typed callbacks (no `as any` in agent code)
+- HTTP-level error normalization via `BridgeClient`
+- Auto-derive MCP tool list from declarations
+- Auto-emit `OutputCard` to dashboard surface on every state change
+
+## What's NOT in scope (lives in automations)
+
+- WHEN actions run (cron, schedule, future-time)
+- Retry on transient failure (rate limit, network)
+- Cross-app orchestration
+- User-visible "what's scheduled" view
+
+Actions MUST be idempotent: re-invoking on a row that carries persisted
+intermediate state (e.g. `media_id` from a prior failed publish attempt) must
+safely no-op the already-completed steps. The 4 examples demonstrate the
+pattern via `row.external_id` short-circuit.
+
+## Known weaknesses (honestly listed after a cold review pass)
+
+1. **Idempotency is by convention, not by type.** Agent could write a
+   non-idempotent action; type system won't catch it. Examples demonstrate
+   the `row.external_id` short-circuit pattern. Future: optional
+   `idempotencyKey: (row) => row.external_id` hook so SDK can short-circuit
+   automatically.
+
+2. **`askUser` protocol not designed.** No way for an action mid-step to pause
+   and ask the user to choose a value. Requires runtime turn-suspend
+   coordination — single-handed SDK can't define it cleanly.
+
+3. **`app.start()` is a 1-line check.** Real implementation (start MCP SSE
+   server, register with runtime, etc.) lands when this SDK is wired into the
+   actual Holaboss runtime.
+
+4. **Reverse tool naming convention.** Defaults to
+   `<app>_cancel_<action>_<resource>`, or `<toolName>_reverse` when `toolName`
+   was overridden on the forward action. Convention not encoded in types.
+
+5. **`DbView.where()` supports scalar equality only** (string/number/boolean/
+   null). Type system enforces via `ScalarFilter<T>` — passing an array or
+   object as a where condition won't compile. Array-membership / object-deep
+   queries need a separate primitive if/when needed.
+
+6. **Sync record retention.** When a row is deleted (state="deleted") or an
+   external resource disappears from sync results, prior sync records stay in
+   `state.syncRecords` with dangling `attachedRowId`. Needs a retention
+   policy. Low priority — only matters once SyncRecord drives UI.
+
+7. **Three `as unknown` casts in `src/app.ts`** at storage boundaries (action
+   and sync registration). These widen agent-precise types to a generic
+   `Record<string, unknown>` shape so the storage arrays can be homogeneous.
+   Each is annotated with intent. **Agent code (reference/) has zero `as
+   any`.**
+
+## Origin
+
+Distilled from a multi-round design discussion (architecture review →
+stress-test by independent subagents → cold review by a third subagent →
+type-system fixes → sync execution). The design dossier lives in the parent
+workspace, not in this repo.
+
+## Next steps (if this lands)
+
+1. Wire `BridgeClient` to the real `/broker/proxy`.
+2. Replace in-memory state with SQLite (via `@holaboss/runtime-state-store`).
+3. Replace derived tool list with real MCP SSE server registration.
+4. Migrate one wrapper-shape module (e.g. `bannerbear`) as the first
+   dog-fooding test (current: ~600 lines → target: ~80 lines).
+5. Design `askUser` protocol with runtime team.

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/README.txt
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/README.txt
@@ -1,0 +1,203 @@
+# @holaboss/app-builder-sdk — Holaboss app module SDK (experimental)
+
+> Distinct from `@holaboss/app-sdk` (the generated product API client) and
+> `@holaboss/bridge` (the legacy app SDK that pre-dates this redesign).
+> This package is what new Holaboss app modules are built against. The
+> existing `app-builder` skill in `runtime/harnesses/src/embedded-skills/`
+> will be updated to know about this SDK once it reaches production runtime
+> integration.
+
+A TypeScript prototype rebuilding the Holaboss app SDK around **5 orthogonal
+primitives**. The goal: let agents author apps of any shape (publishing,
+messaging, workflow, event-with-time, sync-mirror) with zero `as any`, strong
+compile-time guardrails, and no scheduling/retry concerns leaking into app code.
+
+**This is not production code.** It is a spike with passing end-to-end tests
+to validate the API surface before integrating into the real Holaboss runtime.
+
+## What's the SDK, what isn't
+
+```
+src/                      ← THE SDK — ~11 files, ~1100 lines. Touched only
+│                            by SDK maintainers; agents adding apps NEVER
+│                            modify this directory.
+├── index.ts                public exports
+├── types.ts                all type definitions
+├── app.ts                  createApp + 5 primitive registrars
+├── bridge.ts               BridgeClient + createBridge (transport contract)
+├── bridge-transports/      bearer / composio-direct / runtime-broker
+└── runtime/                internal execution: action-runner, sync-runner,
+                            state backends (in-memory + sqlite), mcp-server,
+                            manifest helper
+
+reference/<shape>-<provider>/  ← SDK REFERENCE APPS (NOT production code).
+                                  Demo + test fixtures + agent templates.
+                                  Each illustrates one app shape:
+                                    pinterest-publishing
+                                    slack-messaging
+                                    github-workflow
+                                    gcalendar-events
+                                    telegram-messaging
+                                  Read these to learn the SDK; copy them to
+                                  bootstrap a new module; do NOT ship them
+                                  unmodified.
+
+test/<area>.test.ts        ← UNIT + INTEGRATION TESTS
+```
+
+**Three places code about Holaboss apps can live**:
+
+| Location | Role | Status |
+|---|---|---|
+| `experiments/app-builder-sdk/reference/<shape>/` | **SDK reference** — demos, test fixtures, agent templates. Used to validate SDK design across shapes. | Spike phase |
+| `hola-boss-apps/<name>/` | **Production app modules** — legacy bridge-SDK-era apps shipped to users. ~20 modules. | Stable, runs in workspaces today |
+| `<workspace>/apps/<id>/` | **Workspace-installed apps** — what a user's actual workspace contains. Materialized via marketplace install or agent-build skill. | Per-workspace |
+
+Reference apps are **not** production apps. If a reference and a production app share a name (e.g. `reference/slack-messaging/` vs `hola-boss-apps/slack/`), they cover different ground — different tool names, different coverage. See each `app.ts`'s top-of-file banner for what it demonstrates.
+
+> Note on Holaboss "skills": this SDK does NOT define a per-app SKILL.md
+> convention — the real Holaboss skill system lives at
+> `runtime/harnesses/src/embedded-skills/<skill-id>/SKILL.md` (system-wide,
+> with frontmatter) and `<workspace>/skills/<skill-id>/SKILL.md`
+> (workspace-local, created via the `skill-creator` skill). Provider quirks
+> stay as code comments in `app.ts`; the existing `app-builder` skill needs
+> an update — to know about the 5-primitive v2 SDK shape — when v2 SDK
+> reaches production runtime integration.
+
+## The 5 primitives
+
+```ts
+app.connection()                      // declares provider connection
+app.resource(name, def)               // declares a typed entity with its own state alphabet
+app.action(resource, name, def)       // declares a callable that transitions states
+app.sync(name, def)                   // periodic fetch+upsert+normalize (automations-scheduled)
+app.start()                           // boot
+```
+
+Read [`src/types.ts`](./src/types.ts) for the full type surface and the
+ActionDef / SyncDef doc comments for the SDK ↔ Automations boundary.
+
+## What's verified
+
+| File | Shape | Tests |
+|---|---|---|
+| [`reference/pinterest-publishing/app.ts`](./reference/pinterest-publishing/app.ts) | publishing (multi-step + reversible) | 5 |
+| [`reference/slack-messaging/app.ts`](./reference/slack-messaging/app.ts) | messaging (custom states, side-effect react, 3 prod quirks fixed) | 11 |
+| [`reference/github-workflow/app.ts`](./reference/github-workflow/app.ts) | workflow (6-state lifecycle) | 7 |
+| [`reference/gcalendar-events/app.ts`](./reference/gcalendar-events/app.ts) | event-with-time (RSVP, recurring) | 9 |
+| [`reference/telegram-messaging/app.ts`](./reference/telegram-messaging/app.ts) | messaging (cold-subagent-built; integer IDs; no schedule) | 9 |
+| `test/sync.test.ts` | sync E2E across 3 apps | 8 |
+| `test/agent-mistakes.test.ts` | compile + runtime double-guard | 8 |
+| `test/sqlite-backend.test.ts` | SqliteStateBackend parity + persistence + isolation + integration | 4 |
+| `test/emit-context.test.ts` | emit row.id/status/external_id regression lock | 1 |
+| **Total** | **5 example apps + Iter 1 persistence** | **63 / 247 expect / 0 fail / tsc clean** |
+
+```bash
+bun install
+bun test           # 63 pass / 0 fail
+bunx tsc --noEmit  # clean
+```
+
+## Transports — the SDK is auth-mechanism agnostic
+
+The SDK never assumes Hono, Composio, OAuth, or any specific provider. The
+`BridgeClient` delegates network I/O to a `TransportFn` (`(req) => response`).
+You pick the transport that matches your deployment.
+
+Bundled options under `src/bridge-transports/`:
+
+| Transport | When to use | What you supply |
+|---|---|---|
+| `createBearerTokenTransport` | **Self-host OAuth** — you manage tokens (Auth0 / Clerk / your own auth server / manual). | `accessToken: string \| (() => Promise<string>)` |
+| `createComposioDirectTransport` | Composio managed auth, no broker hop. Good for single-tenant deploys, local dev, E2E. | `COMPOSIO_API_KEY` + `connectedAccountId` |
+| `createRuntimeBrokerTransport` | **Production** — running inside Holaboss runtime sandbox. Same `/broker/proxy` + grant model as `@holaboss/bridge`. | `provider` + env `HOLABOSS_INTEGRATION_BROKER_URL` + `HOLABOSS_APP_GRANT` (auto-resolved) |
+| Roll your own | Custom auth (Vault, mTLS, internal gateway). | Implement ~20 lines of `fetch` returning `{ status, body, headers }`. |
+
+Bundled transports never call Holaboss backend / Hono. Production runtime
+integrations are wired by the runtime team via the broker-proxy pattern; that's
+separate from this SDK.
+
+## Real E2E (single command, no Holaboss backend required)
+
+```bash
+cd experiments/app-builder-sdk
+export COMPOSIO_API_KEY=ck_...
+export COMPOSIO_SLACK_ACCOUNT_ID=ca_...   # from workspace.db, see e2e.ts header
+export TEST_SLACK_CHANNEL=C0123ABCD
+bun run reference/slack-messaging/e2e.ts
+```
+
+Sends real messages to your Slack workspace via `createComposioDirectTransport`.
+Watch Slack — message + edit + 🚀 reaction should appear within seconds.
+
+## What's in scope
+
+- HOW an action does its work (steps, checkpoint, state transitions, reverse handler)
+- Resource schema → typed callbacks (no `as any` in agent code)
+- HTTP-level error normalization via `BridgeClient`
+- Auto-derive MCP tool list from declarations
+- Auto-emit `OutputCard` to dashboard surface on every state change
+
+## What's NOT in scope (lives in automations)
+
+- WHEN actions run (cron, schedule, future-time)
+- Retry on transient failure (rate limit, network)
+- Cross-app orchestration
+- User-visible "what's scheduled" view
+
+Actions MUST be idempotent: re-invoking on a row that carries persisted
+intermediate state (e.g. `media_id` from a prior failed publish attempt) must
+safely no-op the already-completed steps. The 4 examples demonstrate the
+pattern via `row.external_id` short-circuit.
+
+## Known weaknesses (honestly listed after a cold review pass)
+
+1. **Idempotency is by convention, not by type.** Agent could write a
+   non-idempotent action; type system won't catch it. Examples demonstrate
+   the `row.external_id` short-circuit pattern. Future: optional
+   `idempotencyKey: (row) => row.external_id` hook so SDK can short-circuit
+   automatically.
+
+2. **`askUser` protocol not designed.** No way for an action mid-step to pause
+   and ask the user to choose a value. Requires runtime turn-suspend
+   coordination — single-handed SDK can't define it cleanly.
+
+3. **`app.start()` is a 1-line check.** Real implementation (start MCP SSE
+   server, register with runtime, etc.) lands when this SDK is wired into the
+   actual Holaboss runtime.
+
+4. **Reverse tool naming convention.** Defaults to
+   `<app>_cancel_<action>_<resource>`, or `<toolName>_reverse` when `toolName`
+   was overridden on the forward action. Convention not encoded in types.
+
+5. **`DbView.where()` supports scalar equality only** (string/number/boolean/
+   null). Type system enforces via `ScalarFilter<T>` — passing an array or
+   object as a where condition won't compile. Array-membership / object-deep
+   queries need a separate primitive if/when needed.
+
+6. **Sync record retention.** When a row is deleted (state="deleted") or an
+   external resource disappears from sync results, prior sync records stay in
+   `state.syncRecords` with dangling `attachedRowId`. Needs a retention
+   policy. Low priority — only matters once SyncRecord drives UI.
+
+7. **Three `as unknown` casts in `src/app.ts`** at storage boundaries (action
+   and sync registration). These widen agent-precise types to a generic
+   `Record<string, unknown>` shape so the storage arrays can be homogeneous.
+   Each is annotated with intent. **Agent code (reference/) has zero `as
+   any`.**
+
+## Origin
+
+Distilled from a multi-round design discussion (architecture review →
+stress-test by independent subagents → cold review by a third subagent →
+type-system fixes → sync execution). The design dossier lives in the parent
+workspace, not in this repo.
+
+## Next steps (if this lands)
+
+1. Wire `BridgeClient` to the real `/broker/proxy`.
+2. Replace in-memory state with SQLite (via `@holaboss/runtime-state-store`).
+3. Replace derived tool list with real MCP SSE server registration.
+4. Migrate one wrapper-shape module (e.g. `bannerbear`) as the first
+   dog-fooding test (current: ~600 lines → target: ~80 lines).
+5. Design `askUser` protocol with runtime team.

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/bun.lock
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/bun.lock
@@ -1,0 +1,212 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@holaboss/app-sdk-v2-experiment",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.19", "", {}, "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/package.json
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@holaboss/app-builder-sdk",
+  "version": "0.0.1",
+  "description": "SDK for building Holaboss app modules — 5 orthogonal primitives (connection / resource / action / sync / start), declarative state machines, typed bridge, pluggable state backend.",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "example": "bun run reference/pinterest-publishing/run.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "zod": "^3.23.0"
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/app.ts
@@ -1,0 +1,222 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "event-with-time" shape — resources that carry
+// their own start_time/end_time (distinct from automations scheduling),
+// recurring events (RRULE), RSVP as side-effect action.
+//
+// Event start_time/end_time are intrinsic event attributes (the user books
+// a meeting for March 5 at 2pm). This is NOT the "schedule this action to
+// run later" concept — that lives in Holaboss automations.
+//
+// Copy this directory as a template when building a real calendar / event
+// module; do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { GCALENDAR } from "./provider.ts"
+
+export function buildGcalendarApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "gcalendar",
+    provider: GCALENDAR,
+    description: "Google Calendar event management",
+  }, options)
+
+  app.connection()
+
+  const calendar = app.resource("calendar", {
+    schema: z.object({
+      id: z.string(),
+      summary: z.string(),
+      time_zone: z.string().optional(),
+      primary: z.boolean().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "6h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{
+        items: { id: string; summary: string; timeZone?: string; primary?: boolean }[]
+      }>("GET", "/users/me/calendarList")
+      if (r.kind === "error") throw r
+      return r.data.items.map(c => ({
+        id: c.id, summary: c.summary, time_zone: c.timeZone, primary: c.primary,
+      }))
+    },
+  })
+
+  const event = app.resource("event", {
+    schema: z.object({
+      calendar_id: calendar.ref(),
+      summary: z.string().max(1024),
+      description: z.string().optional(),
+      location: z.string().optional(),
+      start_time: z.string(),
+      end_time: z.string(),
+      time_zone: z.string().optional(),
+      recurrence: z.array(z.string()).optional(),
+      attendees: z.array(z.object({
+        email: z.string().email(),
+        optional: z.boolean().optional(),
+        responseStatus: z.string().optional(),
+      })).optional(),
+    }),
+    states: ["draft", "confirmed", "cancelled", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => `${r.summary} @ ${r.start_time}`,
+      deepLink: r => r.external_id && r.calendar_id
+        ? `https://calendar.google.com/calendar/event?eid=${r.external_id}`
+        : null,
+    },
+  })
+
+  app.action(event, "create_event", {
+    fromStates: ["draft"],
+    toState: "confirmed",
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        if (!row.external_id) return { ok: true }
+        const r = await bridge.call(
+          "DELETE",
+          `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        )
+        if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, bridge }) => {
+      if (row.external_id) return { ok: true, externalId: row.external_id }  // idempotent
+      const body: Record<string, unknown> = {
+        summary: row.summary,
+        description: row.description,
+        location: row.location,
+        start: { dateTime: row.start_time, timeZone: row.time_zone },
+        end: { dateTime: row.end_time, timeZone: row.time_zone },
+      }
+      if (row.recurrence) body.recurrence = row.recurrence
+      if (row.attendees) body.attendees = row.attendees
+
+      const r = await bridge.call<{ id: string }>(
+        "POST",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events`,
+        body,
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true, externalId: r.data.id }
+    },
+  })
+
+  app.action(event, "update_event", {
+    fromStates: ["confirmed"],
+    toState: "confirmed",
+    schema: z.object({
+      summary: z.string().max(1024).optional(),
+      description: z.string().optional(),
+      location: z.string().optional(),
+      start_time: z.string().optional(),
+      end_time: z.string().optional(),
+    }),
+    run: async ({ row, input, bridge, persist }) => {
+      const patch: Record<string, unknown> = {}
+      if (input.summary !== undefined) patch.summary = input.summary
+      if (input.description !== undefined) patch.description = input.description
+      if (input.location !== undefined) patch.location = input.location
+      if (input.start_time) patch.start = { dateTime: input.start_time, timeZone: row.time_zone }
+      if (input.end_time) patch.end = { dateTime: input.end_time, timeZone: row.time_zone }
+
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        patch,
+      )
+      if (r.kind === "error") return { fail: r }
+      await persist(input)
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "cancel_event", {
+    fromStates: ["confirmed"],
+    toState: "cancelled",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        { status: "cancelled" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "delete_event", {
+    fromStates: ["draft", "confirmed", "cancelled"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call(
+          "DELETE",
+          `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        )
+        if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(event, "rsvp", {
+    fromStates: ["confirmed"],
+    toState: null,
+    toolName: "gcalendar_rsvp",
+    schema: z.object({
+      response: z.enum(["accepted", "declined", "tentative"]),
+      self_email: z.string().email(),
+    }),
+    run: async ({ row, input, bridge }) => {
+      const existing = row.attendees ?? []
+      const others = existing.filter(a => a.email !== input.self_email)
+      const me = existing.find(a => a.email === input.self_email) ?? { email: input.self_email }
+      const nextAttendees = [...others, { ...me, responseStatus: input.response }]
+
+      const r = await bridge.call(
+        "PATCH",
+        `/calendars/${encodeURIComponent(row.calendar_id)}/events/${row.external_id}`,
+        { attendees: nextAttendees },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.sync("upcoming_events", {
+    schedule: "*/15 * * * *",
+    attachTo: event,
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{
+        items: {
+          id: string
+          summary?: string
+          status: string
+          start?: { dateTime?: string; date?: string }
+          end?: { dateTime?: string; date?: string }
+        }[]
+      }>("GET", "/calendars/primary/events?singleEvents=false&maxResults=50")
+      if (r.kind === "error") return { ok: false, error: r }
+      return { ok: true, items: r.data.items }
+    },
+    upsert: { key: "id" },
+    normalize: raw => ({
+      external_id: raw.id,
+      summary: raw.summary ?? "(no title)",
+      start_time: raw.start?.dateTime ?? raw.start?.date ?? "",
+      end_time: raw.end?.dateTime ?? raw.end?.date ?? "",
+      upstream_status: raw.status,
+    }),
+  })
+
+  return { app, calendar, event }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/e2e.ts
@@ -1,0 +1,292 @@
+// Real E2E for the Google Calendar app — BDD scenarios against your live calendar.
+//
+// Zero-friction: set COMPOSIO_API_KEY and run. The script discovers your Calendar
+// connection from Composio and uses your "primary" calendar (Google's alias for
+// your own main calendar — no impact on shared calendars).
+//
+// Test events are scheduled ~1 hour out, immediately cleaned up via the Cleanup
+// feature. If a scenario fails partway, you may need to delete leftover events
+// manually (search calendar for "[E2E").
+//
+// Optional overrides:
+//   COMPOSIO_USER_ID          scope account listing to a specific user
+//   COMPOSIO_GCAL_ACCOUNT_ID  skip auto-discovery
+//   TEST_CALENDAR_ID          use this calendar instead of "primary"
+//
+// Run: bun run reference/gcalendar-events/e2e.ts
+
+import { buildGcalendarApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { GCALENDAR } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx
+Find it in backend/.env or your frontend wrangler secrets.`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID
+let ACCOUNT_ID = process.env.COMPOSIO_GCAL_ACCOUNT_ID
+const CALENDAR_ID = process.env.TEST_CALENDAR_ID ?? "primary"
+
+// ─── Auto-discover: Composio Calendar connection ───────────────────────────
+
+async function discoverCalendarConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}
+  - if "user_id required" → set COMPOSIO_USER_ID=<your holaboss user id>`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const cals = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "googlecalendar"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (cals.length === 0) {
+    throw new Error(`No active Google Calendar connection in Composio.
+  - connect Calendar via desktop UI first, OR
+  - set COMPOSIO_USER_ID to filter by user`)
+  }
+  if (cals.length > 1) {
+    console.warn(`Found ${cals.length} active Calendar connections — picking first.`)
+    console.warn(`  IDs: ${cals.map(c => c.id).join(", ")}`)
+    console.warn(`  To pick explicitly, set COMPOSIO_GCAL_ACCOUNT_ID.`)
+  }
+  return cals[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Google Calendar connection from Composio…")
+  ACCOUNT_ID = await discoverCalendarConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+// ─── Build SUT ─────────────────────────────────────────────────────────────
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: GCALENDAR, transport })
+const { app, event } = buildGcalendarApp() as unknown as { app: AppHandleInternal; event: any }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+console.log(`SUT ready. Target calendar: ${CALENDAR_ID}\nRunning scenarios…\n`)
+
+// ─── Minimal BDD harness ───────────────────────────────────────────────────
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+    toMatch(re: RegExp, label = "value") {
+      if (typeof actual !== "string" || !re.test(actual))
+        throw new Error(`${label}: expected to match ${re}, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(
+      `${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`,
+    )
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+function futureEvent(offsetMinutes = 60, durationMinutes = 30) {
+  const start = new Date(Date.now() + offsetMinutes * 60_000)
+  const end = new Date(start.getTime() + durationMinutes * 60_000)
+  return { start_time: start.toISOString(), end_time: end.toISOString() }
+}
+
+let createdEvent: { id: string; externalId?: string } | null = null
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenarios
+// ───────────────────────────────────────────────────────────────────────────
+
+feature("Create event")
+
+await scenario("draft → confirmed; event appears in calendar with externalId + dashboard card", async () => {
+  given(`a draft event on calendar '${CALENDAR_ID}'`)
+  const times = futureEvent(60, 30)
+  const row = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID,
+    summary: `[E2E ${stamp()}] create scenario`,
+    description: "Auto-created by app-builder-sdk e2e — safe to ignore.",
+    ...times,
+  }, "draft")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status initial")
+
+  when("the agent invokes create_event")
+  const result = await app._invokeAction({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the action succeeds and Google returns an event id")
+  expectOk(result, "create_event")
+  expect(result.externalId).toBeTruthy("Google event id")
+
+  then("the row transitions to 'confirmed' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("confirmed", "row.status after create")
+  expect(final?.externalId).toBe(result.externalId!, "row.externalId persisted")
+
+  then("a dashboard card is emitted with a Calendar deepLink")
+  const card = app.state().outputs.find(o => o.rowId === row.id)
+  expect(!!card).toBe(true, "dashboard card exists")
+  expect(card!.status).toBe("confirmed", "card.status")
+  expect(card!.deepLink ?? "").toMatch(/calendar\.google\.com/, "card.deepLink")
+
+  createdEvent = { id: row.id, externalId: result.externalId }
+})
+
+feature("Update event")
+
+await scenario("update_event: change summary; row stays 'confirmed'; upstream patched", async () => {
+  given("the event created above")
+  expect(!!createdEvent).toBe(true, "create scenario must succeed first")
+
+  when("the agent updates the summary")
+  const result = await app._invokeAction({
+    actionName: "update_event",
+    rowId: createdEvent!.id,
+    input: { summary: `[E2E ${stamp()}] (updated via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row stays 'confirmed'")
+  expectOk(result, "update_event")
+  expect(app._state.getRow(createdEvent!.id)?.status).toBe("confirmed", "row.status after update")
+})
+
+feature("State machine guards")
+
+await scenario("rsvp on a draft row fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft row never created on Google")
+  const times = futureEvent(60, 30)
+  const draft = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID, summary: "should never reach Google", ...times,
+  }, "draft")
+  expect(draft.externalId).toBe(undefined, "no externalId for unsent draft")
+
+  when("the agent tries to RSVP on the draft")
+  const result = await app._invokeAction({
+    actionName: "rsvp",
+    rowId: draft.id,
+    input: { response: "accepted", self_email: "test@example.com" },
+    bridge,
+  })
+
+  then("the action fails with code='invalid_state' and a state-naming message")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+    expect(result.fail.message).toMatch(/from state 'draft'/, "fail.message")
+  }
+
+  then("the row remains untouched")
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Reversible action: create + reverse")
+
+await scenario("create + reverse roundtrip — row created → reverted to draft, event deleted upstream", async () => {
+  given("a fresh draft event")
+  const times = futureEvent(120, 30)
+  const row = app._state.insertRow("event", {
+    calendar_id: CALENDAR_ID,
+    summary: `[E2E ${stamp()}] this should NEVER persist (created then reverted)`,
+    ...times,
+  }, "draft")
+
+  when("the agent invokes create_event")
+  const created = await app._invokeAction({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the create succeeds with a Google event id")
+  expectOk(created, "create_event")
+  expect(app._state.getRow(row.id)?.status).toBe("confirmed", "row.status after create")
+
+  when("the agent invokes the reverse (cancel) action")
+  const reversed = await app._invokeReverse({ actionName: "create_event", rowId: row.id, bridge })
+
+  then("the reverse succeeds and row transitions back to 'draft'")
+  expectOk(reversed, "reverse(create_event)")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status after reverse")
+})
+
+feature("Cleanup")
+
+await scenario("delete_event removes the test event from calendar; row → deleted, card reflects", async () => {
+  given("the event created in the first scenario")
+  expect(!!createdEvent).toBe(true)
+
+  when("the agent invokes delete_event")
+  const result = await app._invokeAction({
+    actionName: "delete_event", rowId: createdEvent!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_event")
+  expect(app._state.getRow(createdEvent!.id)?.status).toBe("deleted", "row.status after delete")
+
+  then("the dashboard card status reflects the deletion")
+  const card = app.state().outputs.find(o => o.rowId === createdEvent!.id)
+  expect(card?.status).toBe("deleted", "card.status")
+})
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/gcalendar-events/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const GCALENDAR: ProviderRegistry = {
+  id: "gcalendar",
+  baseUrl: "https://www.googleapis.com/calendar/v3",
+  allowedHosts: ["www.googleapis.com"],
+  whoamiPath: "/users/me/calendarList",
+  composioToolkit: "googlecalendar",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/github-workflow/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/github-workflow/app.ts
@@ -1,0 +1,173 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "workflow" shape — 6-state lifecycle
+// (draft/open/in_progress/closed/reopened/failed), reversible state
+// transitions (close↔reopen), and side-effect actions that don't mutate
+// row.status (comment, assign).
+//
+// Copy this directory as a template when building a real
+// workflow-shape app (issue tracker / CRM lead pipeline / ticket
+// system); do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { GITHUB } from "./provider.ts"
+
+export function buildGithubIssuesApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "github",
+    provider: GITHUB,
+    description: "GitHub issue triage & lifecycle",
+  }, options)
+
+  app.connection()
+
+  const repo = app.resource("repo", {
+    schema: z.object({ id: z.string(), full_name: z.string() }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "6h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{ id: number; full_name: string }[]>("GET", "/user/repos")
+      if (r.kind === "error") throw r
+      return r.data.map(x => ({ id: String(x.id), full_name: x.full_name }))
+    },
+  })
+
+  const issue = app.resource("issue", {
+    schema: z.object({
+      repo_full_name: repo.ref(),
+      title: z.string().max(256),
+      body: z.string().optional(),
+    }),
+    states: ["draft", "open", "in_progress", "closed", "reopened", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => r.title,
+      deepLink: r => r.external_id && r.repo_full_name
+        ? `https://github.com/${r.repo_full_name}/issues/${r.external_id}`
+        : null,
+    },
+  })
+
+  app.action(issue, "create", {
+    fromStates: ["draft"],
+    toState: "open",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) return { ok: true, externalId: row.external_id }   // idempotent
+      const r = await bridge.call<{ number: number; html_url: string }>(
+        "POST", `/repos/${row.repo_full_name}/issues`,
+        { title: row.title, body: row.body },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true, externalId: String(r.data.number) }
+    },
+  })
+
+  app.action(issue, "start_work", {
+    fromStates: ["open", "reopened"],
+    toState: "in_progress",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/labels`,
+        { labels: ["in-progress"] },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "close", {
+    fromStates: ["open", "in_progress", "reopened"],
+    toState: "closed",
+    reversible: {
+      toState: "reopened",
+      run: async ({ row, bridge }) => {
+        const r = await bridge.call(
+          "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+          { state: "open" },
+        )
+        if (r.kind === "error") return { fail: r }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+        { state: "closed" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "reopen", {
+    fromStates: ["closed"],
+    toState: "reopened",
+    run: async ({ row, bridge }) => {
+      const r = await bridge.call(
+        "PATCH", `/repos/${row.repo_full_name}/issues/${row.external_id}`,
+        { state: "open" },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "comment", {
+    fromStates: ["open", "in_progress", "closed", "reopened"],
+    toState: null,
+    toolName: "github_comment_on_issue",
+    schema: z.object({ body: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/comments`,
+        { body: input.body },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.action(issue, "assign", {
+    fromStates: ["open", "in_progress", "reopened"],
+    toState: null,
+    schema: z.object({ assignees: z.array(z.string()).min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call(
+        "POST", `/repos/${row.repo_full_name}/issues/${row.external_id}/assignees`,
+        { assignees: input.assignees },
+      )
+      if (r.kind === "error") return { fail: r }
+      return { ok: true }
+    },
+  })
+
+  app.sync("issue_activity", {
+    schedule: "*/15 * * * *",
+    attachTo: issue,
+    fetch: async ({ bridge, db }) => {
+      const open = db.query(issue).where({ status: "open" }).all()
+      const active: { issue_id: string; raw: { reactions?: { total_count?: number }; comments?: number } }[] = []
+      for (const i of open) {
+        if (!i.external_id) continue
+        const r = await bridge.call<{ reactions?: { total_count?: number }; comments?: number }>(
+          "GET", `/repos/${i.repo_full_name}/issues/${i.external_id}`,
+        )
+        if (r.kind === "error") return { ok: false, error: r }
+        active.push({ issue_id: i.id, raw: r.data })
+      }
+      return { ok: true, items: active }
+    },
+    upsert: { key: "issue_id" },
+    normalize: raw => ({
+      reach: raw.raw.reactions?.total_count ?? 0,
+      engagement: raw.raw.comments ?? 0,
+      clicks: 0,
+    }),
+  })
+
+  return { app, issue, repo }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/github-workflow/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/github-workflow/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const GITHUB: ProviderRegistry = {
+  id: "github",
+  baseUrl: "https://api.github.com",
+  allowedHosts: ["api.github.com"],
+  whoamiPath: "/user",
+  composioToolkit: "github",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/pinterest-publishing/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/pinterest-publishing/app.ts
@@ -1,0 +1,144 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "publishing" shape — multi-step actions with
+// persisted checkpoints (upload media → create pin), reversible actions
+// (delete on cancel), and the row.external_id idempotency pattern.
+//
+// Copy this directory as a template when building a real publishing-shape
+// app; do not deploy it as-is.
+
+import { createApp, z, type CreateAppOptions } from "../../src/index.ts"
+import { PINTEREST } from "./provider.ts"
+
+export function buildPinterestApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "pinterest",
+    provider: PINTEREST,
+    description: "Pinterest pin publishing & board management",
+  }, options)
+
+  app.connection()
+
+  // ─── Board: container, read-mostly, NOT in dashboard ─────────────────────
+  const board = app.resource("board", {
+    schema: z.object({ id: z.string(), name: z.string() }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "1h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<{ items: { id: string; name: string }[] }>("GET", "/boards")
+      if (r.kind === "error") throw r
+      return r.data.items
+    },
+  })
+
+  // ─── Pin: publishing-shape ───────────────────────────────────────────────
+  const pin = app.resource("pin", {
+    schema: z.object({
+      board_id: board.ref(),
+      image_url: z.string().url(),
+      title: z.string().max(100).optional(),
+      description: z.string().max(500).optional(),
+      media_id: z.string().optional(),       // checkpoint field, set after upload step
+    }),
+    states: ["draft", "scheduled", "published", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "content_plan",
+      summary: r => r.title ?? r.description?.slice(0, 50) ?? "Untitled pin",
+      deepLink: r => r.external_id ? `https://pinterest.com/pin/${r.external_id}` : null,
+    },
+  })
+
+  app.action(pin, "publish", {
+    fromStates: ["draft"],
+    toState: "published",
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        if (row.external_id) {
+          const r = await bridge.call("DELETE", `/pins/${row.external_id}`)
+          if (r.kind === "error" && r.code !== "not_found") return { fail: r }
+        }
+        return { ok: true }
+      },
+    },
+    steps: [
+      {
+        name: "upload_media",
+        run: async ({ row, bridge, persist }) => {
+          if (row.media_id) return { ok: true }   // idempotent: already uploaded
+          const r = await bridge.call<{ id: string }>("POST", "/media", {
+            media_type: "image",
+            url: row.image_url,
+          })
+          if (r.kind === "error") return { fail: r }
+          await persist({ media_id: r.data.id })
+          return { ok: true }
+        },
+      },
+      {
+        name: "create_pin",
+        run: async ({ row, bridge }) => {
+          if (row.external_id) return { ok: true, externalId: row.external_id }
+          const r = await bridge.call<{ id: string }>("POST", "/pins", {
+            board_id: row.board_id,
+            media_source: { source_type: "image_upload", media_id: row.media_id },
+            title: row.title,
+            description: row.description,
+          })
+          if (r.kind === "error") return { fail: r }
+          return { ok: true, externalId: r.data.id }
+        },
+      },
+    ],
+  })
+
+  app.action(pin, "edit", {
+    fromStates: ["draft", "published"],
+    toState: "published",
+    schema: z.object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    run: async ({ row, input, bridge, persist }) => {
+      if (row.status === "draft") {
+        await persist(input)
+        return { ok: true }
+      }
+      const r = await bridge.call("PATCH", `/pins/${row.external_id}`, input)
+      if (r.kind === "error") return { fail: r }
+      await persist(input)
+      return { ok: true }
+    },
+  })
+
+  app.sync("pin_metrics", {
+    schedule: "0 */6 * * *",
+    attachTo: pin,
+    fetch: async ({ bridge, db }) => {
+      const pins = db.query(pin).where({ status: "published" }).recent("30d")
+      const results: { pin_id: string; raw: Record<string, number> }[] = []
+      for (const p of pins) {
+        if (!p.external_id) continue
+        const r = await bridge.call<Record<string, number>>(
+          "GET",
+          `/pins/${p.external_id}/analytics?metric_types=SAVE,PIN_CLICK,IMPRESSION,OUTBOUND_CLICK`,
+        )
+        if (r.kind === "error") return { ok: false, error: r }
+        results.push({ pin_id: p.id, raw: r.data })
+      }
+      return { ok: true, items: results }
+    },
+    upsert: { key: "pin_id" },
+    normalize: raw => ({
+      reach: raw.raw.IMPRESSION ?? 0,
+      engagement: (raw.raw.SAVE ?? 0) + (raw.raw.PIN_CLICK ?? 0),
+      clicks: raw.raw.OUTBOUND_CLICK ?? 0,
+    }),
+  })
+
+  return { app, pin, board }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/pinterest-publishing/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/pinterest-publishing/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const PINTEREST: ProviderRegistry = {
+  id: "pinterest",
+  baseUrl: "https://api.pinterest.com/v5",
+  allowedHosts: ["api.pinterest.com"],
+  whoamiPath: "/user_account",
+  composioToolkit: "pinterest",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/app.runtime.yaml
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/app.runtime.yaml
@@ -1,0 +1,45 @@
+app_id: "slack"
+name: "Slack"
+slug: "slack"
+
+lifecycle:
+  setup: "bun install"
+  start: "bun run server.ts"
+  stop: "kill $(lsof -t -i :${MCP_PORT:-3099} 2>/dev/null) 2>/dev/null || true"
+
+healthchecks:
+  mcp:
+    path: /mcp/health
+    timeout_s: 30
+
+mcp:
+  enabled: true
+  transport: http-sse
+  port: 3099
+  path: /mcp/sse
+  tools:
+    - slack_connection_status
+    - slack_list_channels
+    - slack_get_channel
+    - slack_refresh_channels
+    - slack_list_messages
+    - slack_get_message
+    - slack_send_message_message
+    - slack_schedule_send_message
+    - slack_cancel_schedule_send_message
+    - slack_edit_message_message
+    - slack_delete_message_message
+    - slack_react
+    - slack_channel_directory_sync_status
+    - slack_snapshot
+
+integration:
+  destination: "slack"
+  credential_source: "platform"
+
+env_contract:
+  - "HOLABOSS_WORKSPACE_ID"
+  - "WORKSPACE_DB_PATH"
+  - "HOLABOSS_INTEGRATION_BROKER_URL"
+  - "HOLABOSS_APP_GRANT"
+  - "MCP_PORT"

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/app.ts
@@ -1,0 +1,218 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate the "messaging" shape via Slack — custom state
+// alphabet (draft/scheduled/sent/edited/deleted/failed), side-effect
+// actions (react), provider quirks (body.ok pattern, DM channel
+// resolution, 60s scheduled-message cancellation window), real reverse
+// handler. Also serves as the SDK's test fixture and the most-stressed
+// example (3 real production quirks were found and fixed via real-API
+// E2E against live Slack).
+//
+// For a production Slack module: see hola-boss-apps/slack/ (legacy
+// @holaboss/bridge SDK, ~600 lines, broader tool coverage including
+// list_channels / search_messages / list_users / send_dm). To replace
+// it, write a new workspace app under <workspace>/apps/ or
+// hola-boss-apps/ that uses this reference as a template plus the full
+// v1 tool surface — NOT a job for this reference dir.
+//
+// Per-provider Slack quirks (kept as inline comments at the call sites
+// they apply to; no separate SKILL.md — that conflicts with Holaboss's
+// real skill system at runtime/harnesses/src/embedded-skills/):
+//   - Slack returns errors as HTTP 200 + { ok:false, error:"..." }, not
+//     4xx/5xx. Every action checks body.ok via `slackUnwrap` below.
+//   - chat.postMessage with channel=user_id auto-resolves to a DM
+//     channel ("D0..."); we persist the resolved channel back to the
+//     row so subsequent edit/delete/react use the right id.
+//   - chat.deleteScheduledMessage rejects with
+//     invalid_scheduled_message_id if <60s remain before post_at —
+//     schedule with sufficient lead time.
+
+import { createApp, z, type CreateAppOptions, type ProxyResult, type BridgeError } from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+
+// Slack returns its own errors in body.ok / body.error.
+type SlackBody = { ok?: boolean; error?: string; [k: string]: unknown }
+
+function slackUnwrap<T extends SlackBody>(
+  r: ProxyResult<T>,
+):
+  | { ok: true; data: T }
+  | { ok: false; fail: BridgeError | { kind: "error"; code: string; message: string } } {
+  if (r.kind === "error") return { ok: false, fail: r }
+  if (r.data.ok === false) {
+    const code = r.data.error ?? "slack_error"
+    return { ok: false, fail: { kind: "error", code, message: code } }
+  }
+  return { ok: true, data: r.data }
+}
+
+export function buildSlackApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "slack",
+    provider: SLACK,
+    description: "Slack channel messaging, edits, reactions",
+  }, options)
+
+  app.connection()
+
+  const channel = app.resource("channel", {
+    schema: z.object({
+      id: z.string(),
+      name: z.string(),
+      is_private: z.boolean().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+    refreshEvery: "1h",
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<SlackBody & {
+        channels?: { id: string; name: string; is_private?: boolean }[]
+      }>("GET", "/conversations.list")
+      const u = slackUnwrap(r)
+      if (!u.ok) throw u.fail
+      return u.data.channels ?? []
+    },
+  })
+
+  const message = app.resource("message", {
+    schema: z.object({
+      channel_id: channel.ref(),
+      text: z.string().max(40_000),
+      thread_ts: z.string().optional(),
+      post_at: z.number().optional(),
+    }),
+    states: ["draft", "scheduled", "sent", "edited", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => (r.text ?? "").slice(0, 80),
+      deepLink: r => r.external_id && r.channel_id
+        ? `https://slack.com/archives/${r.channel_id}/p${String(r.external_id).replace(".", "")}`
+        : null,
+    },
+  })
+
+  app.action(message, "send_message", {
+    fromStates: ["draft"],
+    toState: "sent",
+    run: async ({ row, bridge, persist }) => {
+      const r = await bridge.call<SlackBody & { ts?: string; channel?: string }>(
+        "POST", "/chat.postMessage",
+        { channel: row.channel_id, text: row.text, thread_ts: row.thread_ts },
+      )
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      // Slack DM auto-resolution: when input channel is a user_id, the response
+      // carries the actual DM channel id ("D0..."). Persist it for subsequent ops.
+      if (u.data.channel && u.data.channel !== row.channel_id) {
+        await persist({ channel_id: u.data.channel })
+      }
+      return { ok: true, externalId: u.data.ts }
+    },
+  })
+
+  app.action(message, "schedule_send", {
+    fromStates: ["draft"],
+    toState: "scheduled",
+    schema: z.object({ post_at: z.number().int().positive() }),
+    reversible: {
+      toState: "draft",
+      run: async ({ row, bridge }) => {
+        // Slack-specific: this WILL fail with invalid_scheduled_message_id if
+        // less than 60 seconds remain before post_at. Schedule with sufficient
+        // lead time to give the cancel a chance. Agent should propagate the
+        // error and let the user know they hit the window.
+        const r = await bridge.call<SlackBody>("POST", "/chat.deleteScheduledMessage", {
+          channel: row.channel_id,
+          scheduled_message_id: row.external_id,
+        })
+        const u = slackUnwrap(r)
+        if (!u.ok) return { fail: u.fail }
+        return { ok: true }
+      },
+    },
+    run: async ({ row, input, bridge, persist }) => {
+      const r = await bridge.call<SlackBody & {
+        scheduled_message_id?: string; post_at?: number; channel?: string
+      }>("POST", "/chat.scheduleMessage", {
+        channel: row.channel_id, text: row.text, post_at: input.post_at, thread_ts: row.thread_ts,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      // Persist the DM-resolved channel id. chat.scheduledMessages.list
+      // verifies the scheduled message is keyed under this channel, so the
+      // delete must use it too. (Note: cancel will only succeed if invoked
+      // more than 60 seconds before post_at — Slack's hard rule.)
+      const patch: { post_at?: number; channel_id?: string } = {}
+      if (u.data.post_at) patch.post_at = u.data.post_at
+      if (u.data.channel && u.data.channel !== row.channel_id) patch.channel_id = u.data.channel
+      if (Object.keys(patch).length) await persist(patch)
+      return { ok: true, externalId: u.data.scheduled_message_id }
+    },
+  })
+
+  app.action(message, "edit_message", {
+    fromStates: ["sent", "edited"],
+    toState: "edited",
+    schema: z.object({ text: z.string().min(1).max(40_000) }),
+    run: async ({ row, input, bridge, persist }) => {
+      const r = await bridge.call<SlackBody>("POST", "/chat.update", {
+        channel: row.channel_id, ts: row.external_id, text: input.text,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      await persist({ text: input.text })
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "delete_message", {
+    fromStates: ["draft", "scheduled", "sent", "edited"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call<SlackBody>("POST", "/chat.delete", {
+          channel: row.channel_id, ts: row.external_id,
+        })
+        const u = slackUnwrap(r)
+        // Propagate all errors (including not_found) — let the agent decide.
+        if (!u.ok) return { fail: u.fail }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "react", {
+    fromStates: ["sent", "edited"],
+    toState: null,
+    toolName: "slack_react",
+    schema: z.object({ emoji: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      const r = await bridge.call<SlackBody>("POST", "/reactions.add", {
+        channel: row.channel_id, timestamp: row.external_id, name: input.emoji,
+      })
+      const u = slackUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      return { ok: true }
+    },
+  })
+
+  app.sync("channel_directory", {
+    schedule: "0 * * * *",
+    attachTo: channel,
+    fetch: async ({ bridge }) => {
+      const r = await bridge.call<SlackBody & { channels?: { id: string; name: string }[] }>(
+        "GET", "/conversations.list",
+      )
+      const u = slackUnwrap(r)
+      if (!u.ok) return { ok: false, error: u.fail }
+      return { ok: true, items: u.data.channels ?? [] }
+    },
+    upsert: { key: "id" },
+    normalize: raw => ({ id: raw.id, name: raw.name }),
+  })
+
+  return { app, channel, message }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/e2e-bearer.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/e2e-bearer.ts
@@ -1,0 +1,72 @@
+// Self-host OAuth E2E — proves the SDK works with a transport you control,
+// no Composio / Holaboss backend involved. Single scenario, just enough to
+// validate the transport contract end-to-end.
+//
+// Required env:
+//   SLACK_BEARER_TOKEN   xoxb-... or xoxp-... (Slack token from your app/install)
+//   TEST_SLACK_CHANNEL   channel id
+//
+// Run: bun run reference/slack-messaging/e2e-bearer.ts
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge } from "../../src/bridge.ts"
+import { SLACK } from "./provider.ts"
+import { createBearerTokenTransport } from "../../src/bridge-transports/bearer.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+const TOKEN = process.env.SLACK_BEARER_TOKEN
+const CHANNEL = process.env.TEST_SLACK_CHANNEL
+if (!TOKEN || !CHANNEL) {
+  console.error(`Missing env. Set SLACK_BEARER_TOKEN and TEST_SLACK_CHANNEL.`)
+  process.exit(1)
+}
+
+// ─── BDD harness (tiny duplicate of e2e.ts's — keeps this file standalone) ─
+
+async function scenario(name: string, body: () => Promise<void>) {
+  console.log(`\nScenario: ${name}`)
+  const start = Date.now()
+  try { await body(); console.log(`  ✓ pass (${Date.now() - start}ms)`) }
+  catch (e) { console.error(`  ✗ FAIL:`, e instanceof Error ? e.message : e); process.exit(1) }
+}
+function given(s: string) { console.log(`  Given ${s}`) }
+function when(s: string)  { console.log(`  When  ${s}`) }
+function then(s: string)  { console.log(`  Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+
+// ─── SUT ────────────────────────────────────────────────────────────────────
+
+const transport = createBearerTokenTransport({ accessToken: TOKEN })
+const bridge = createBridge({ provider: SLACK, transport })
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e-bearer", sessionId: "e2e-bearer" })
+
+// ─── Scenario ───────────────────────────────────────────────────────────────
+
+await scenario("Self-host OAuth path: send_message succeeds with bearer transport, row → sent", async () => {
+  given("a draft message and a SDK bridge wired to a user-provided bearer token")
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL,
+    text: `[E2E-bearer ${new Date().toISOString().slice(11, 19)}] self-host OAuth proof`,
+  }, "draft")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the SDK doesn't care that no Composio / Holaboss backend is in the path — it just works")
+  expect("ok" in result).toBe(true, "result kind")
+  const externalId = "ok" in result ? result.externalId : undefined
+  expect(externalId).toBeTruthy("Slack ts returned via bearer transport")
+  expect(app._state.getRow(row.id)?.status).toBe("sent", "row.status after send")
+
+  console.log(`  Dashboard card:`, app.state().outputs.find(o => o.rowId === row.id))
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/e2e.ts
@@ -1,0 +1,318 @@
+// Real E2E for the Slack app — BDD-style scenarios against a live Slack workspace.
+//
+// Zero-friction: set COMPOSIO_API_KEY and run. The script discovers your Slack
+// connection from Composio, your own user_id via auth.test, and DMs the test
+// messages to YOURSELF (no team channels spammed).
+//
+// Optional overrides:
+//   COMPOSIO_USER_ID            scope account listing to a specific user
+//   COMPOSIO_SLACK_ACCOUNT_ID   skip auto-discovery (use this id directly)
+//   TEST_SLACK_CHANNEL          send to this channel instead of self-DM
+//
+// Run: bun run reference/slack-messaging/e2e.ts
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx
+Find it in backend/.env or your frontend wrangler secrets.`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID                    // optional
+let ACCOUNT_ID = process.env.COMPOSIO_SLACK_ACCOUNT_ID          // optional override
+let CHANNEL = process.env.TEST_SLACK_CHANNEL                    // optional override
+
+// ─── Auto-discover: Composio Slack connection ──────────────────────────────
+
+async function discoverSlackConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}
+  - if "user_id required" → set COMPOSIO_USER_ID=<your holaboss user id>`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const slacks = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "slack"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (slacks.length === 0) {
+    throw new Error(`No active Slack connection in Composio.
+  - connect Slack via desktop UI first, OR
+  - set COMPOSIO_USER_ID to filter by user`)
+  }
+  if (slacks.length > 1) {
+    console.warn(`Found ${slacks.length} active Slack connections — picking first.`)
+    console.warn(`  IDs: ${slacks.map(s => s.id).join(", ")}`)
+    console.warn(`  To pick explicitly, set COMPOSIO_SLACK_ACCOUNT_ID.`)
+  }
+  return slacks[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Slack connection from Composio…")
+  ACCOUNT_ID = await discoverSlackConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+// ─── Build SUT ─────────────────────────────────────────────────────────────
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: SLACK, transport })
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+// ─── Auto-discover: own Slack user_id for DM-to-self ───────────────────────
+
+if (!CHANNEL) {
+  console.log("Discovering your own Slack user via auth.test…")
+  const r = await bridge.call<{ ok: boolean; user_id?: string; user?: string; team?: string }>(
+    "POST", "/auth.test",
+  )
+  if (r.kind === "error" || !r.data?.user_id) {
+    throw new Error(`auth.test failed: ${JSON.stringify(r).slice(0, 300)}
+  - set TEST_SLACK_CHANNEL=C0... manually to skip self-DM`)
+  }
+  CHANNEL = r.data.user_id
+  console.log(`  → DMing @${r.data.user} (workspace ${r.data.team}, channel ${CHANNEL})`)
+}
+
+console.log(`\nSUT ready. Running scenarios…\n`)
+
+// ─── Minimal BDD harness ───────────────────────────────────────────────────
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+    toMatch(re: RegExp, label = "value") {
+      if (typeof actual !== "string" || !re.test(actual))
+        throw new Error(`${label}: expected to match ${re}, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+
+// Specialized assertion for action results — if the action failed, includes
+// the full fail.code + message in the error so we don't have to guess.
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(
+      `${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`,
+    )
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+let sentMessage: { id: string; externalId?: string } | null = null
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenarios
+// ───────────────────────────────────────────────────────────────────────────
+
+feature("Send a message")
+
+await scenario("draft → sent transitions row, returns Slack ts, emits dashboard card", async () => {
+  given(`a draft message row targeting ${CHANNEL}`)
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL!, text: `[E2E ${stamp()}] send scenario`,
+  }, "draft")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status initial")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the action succeeds and Slack returns a message ts")
+  expectOk(result, "send_message")
+  const externalId = result.externalId
+  expect(externalId).toBeTruthy("externalId (Slack ts)")
+
+  then("the row transitions to 'sent' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("sent", "row.status after send")
+  expect(final?.externalId).toBe(externalId!, "row.externalId persisted")
+
+  then("a dashboard card is emitted with a Slack deepLink")
+  const card = app.state().outputs.find(o => o.rowId === row.id)
+  expect(!!card).toBe(true, "dashboard card exists")
+  expect(card!.status).toBe("sent", "card.status")
+  expect(card!.deepLink ?? "").toMatch(/slack\.com\/archives\//, "card.deepLink")
+
+  sentMessage = { id: row.id, externalId }
+})
+
+feature("Edit and react to a sent message")
+
+await scenario("edit_message transitions sent → edited and updates upstream text", async () => {
+  given("the message sent in the previous scenario")
+  expect(!!sentMessage).toBe(true, "send scenario must succeed first")
+
+  when("the agent edits the text")
+  const result = await app._invokeAction({
+    actionName: "edit_message",
+    rowId: sentMessage!.id,
+    input: { text: `[E2E ${stamp()}] (edited via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row transitions to 'edited'")
+  expectOk(result, "edit_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("edited", "row.status after edit")
+})
+
+await scenario("react adds emoji WITHOUT mutating row.status (side-effect contract)", async () => {
+  given("the same message, now in 'edited' state")
+  expect(!!sentMessage).toBe(true)
+  const beforeStatus = app._state.getRow(sentMessage!.id)?.status
+  const beforeCardCount = app.state().outputs.filter(o => o.rowId === sentMessage!.id).length
+
+  when("the agent reacts with :rocket:")
+  const result = await app._invokeAction({
+    actionName: "react",
+    rowId: sentMessage!.id,
+    input: { emoji: "rocket" },
+    bridge,
+  })
+
+  then("the action succeeds but row.status is unchanged (toState: null)")
+  expectOk(result, "react")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe(beforeStatus!, "row.status preserved")
+
+  then("no new dashboard card is emitted (side-effect actions don't dirty the surface)")
+  const afterCardCount = app.state().outputs.filter(o => o.rowId === sentMessage!.id).length
+  expect(afterCardCount).toBe(beforeCardCount, "dashboard card count")
+})
+
+feature("State machine guards")
+
+await scenario("react on a draft row fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft row never sent to Slack")
+  const draft = app._state.insertRow("message", {
+    channel_id: CHANNEL!, text: "should never reach Slack",
+  }, "draft")
+  expect(draft.externalId).toBe(undefined, "no externalId for unsent draft")
+
+  when("the agent tries to react on the draft")
+  const result = await app._invokeAction({
+    actionName: "react", rowId: draft.id, input: { emoji: "thumbsup" }, bridge,
+  })
+
+  then("the action fails with code='invalid_state' and a state-naming message")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+    expect(result.fail.message).toMatch(/from state 'draft'/, "fail.message")
+  }
+
+  then("the row remains untouched")
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Reversible action: schedule + cancel")
+
+await scenario("schedule_send + reverse roundtrip — row scheduled → draft, upstream cancel called", async () => {
+  given("a fresh draft row scheduled 180s in the future (Slack requires >60s lead time at cancel time)")
+  const future = Math.floor(Date.now() / 1000) + 180
+  const row = app._state.insertRow("message", {
+    channel_id: CHANNEL!,
+    text: `[E2E ${stamp()}] this should NEVER appear (scheduled then cancelled)`,
+  }, "draft")
+
+  when("the agent invokes schedule_send")
+  const scheduled = await app._invokeAction({
+    actionName: "schedule_send", rowId: row.id, input: { post_at: future }, bridge,
+  })
+
+  then("the action succeeds with a scheduled_message_id as externalId")
+  expectOk(scheduled, "schedule_send")
+  expect(scheduled.externalId).toBeTruthy("scheduled_message_id")
+  expect(app._state.getRow(row.id)?.status).toBe("scheduled", "row.status after schedule")
+
+  when("the agent invokes the reverse (cancel) action")
+  const reversed = await app._invokeReverse({ actionName: "schedule_send", rowId: row.id, bridge })
+
+  then("the reverse succeeds and row transitions back to 'draft'")
+  expectOk(reversed, "reverse(schedule_send)")
+  expect(app._state.getRow(row.id)?.status).toBe("draft", "row.status after reverse")
+})
+
+feature("Cleanup")
+
+await scenario("delete_message removes the test message; row → deleted, card reflects", async () => {
+  given("the sent message from the first scenario")
+  expect(!!sentMessage).toBe(true)
+
+  when("the agent invokes delete_message")
+  const result = await app._invokeAction({
+    actionName: "delete_message", rowId: sentMessage!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("deleted", "row.status after delete")
+
+  then("the dashboard card status reflects the deletion")
+  const card = app.state().outputs.find(o => o.rowId === sentMessage!.id)
+  expect(card?.status).toBe("deleted", "card.status")
+})
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/manifest.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/manifest.ts
@@ -1,0 +1,28 @@
+// Generates app.runtime.yaml for the Slack v2 module.
+//
+// Run: bun run reference/slack-messaging/manifest.ts
+// Output: writes reference/slack-messaging/app.runtime.yaml
+
+import { writeFileSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { buildSlackApp } from "./app.ts"
+import { buildAppRuntimeManifest } from "../../src/runtime/manifest.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+const yaml = buildAppRuntimeManifest(app, {
+  name: "Slack",
+  slug: "slack",
+  lifecycle: {
+    setup: "bun install",
+    start: "bun run server.ts",
+    stop: "kill $(lsof -t -i :${MCP_PORT:-3099} 2>/dev/null) 2>/dev/null || true",
+  },
+})
+
+const here = dirname(fileURLToPath(import.meta.url))
+const out = join(here, "app.runtime.yaml")
+writeFileSync(out, yaml, "utf-8")
+console.log(`Wrote ${out}`)
+console.log(`\n${yaml}`)

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const SLACK: ProviderRegistry = {
+  id: "slack",
+  baseUrl: "https://slack.com/api",
+  allowedHosts: ["slack.com"],
+  whoamiPath: "/auth.test",
+  composioToolkit: "slack",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/run.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/run.ts
@@ -1,0 +1,79 @@
+// Interactive demo for the Slack app.
+// Walks: send_message → edit_message → react → delete_message
+// against a fake transport, printing the row, dashboard card, and audit log
+// at each step. Run with: `bun run reference/slack-messaging/run.ts`
+
+import { buildSlackApp } from "./app.ts"
+import { createBridge, type TransportFn } from "../../src/bridge.ts"
+import { SLACK } from "./provider.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// Fake Slack — scripts replies. Real impl would call /broker/proxy.
+const replies = new Map<string, unknown>([
+  ["POST https://slack.com/api/chat.postMessage",
+    { ok: true, ts: "1700000000.111111", channel: "C0123" }],
+  ["POST https://slack.com/api/chat.update",
+    { ok: true, ts: "1700000000.111111", channel: "C0123" }],
+  ["POST https://slack.com/api/reactions.add",
+    { ok: true }],
+  ["POST https://slack.com/api/chat.delete",
+    { ok: true }],
+])
+
+const transport: TransportFn = async ({ method, url, body }) => {
+  console.log(`  → ${method} ${url}`)
+  if (body) console.log(`     body: ${JSON.stringify(body)}`)
+  const key = `${method} ${url}`
+  const body_ = replies.get(key)
+  if (!body_) throw new Error(`no scripted reply for ${key}`)
+  return { status: 200, body: body_ }
+}
+
+const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "demo-turn", sessionId: "demo-session" })
+const bridge = createBridge({ provider: SLACK, transport })
+
+console.log("\n=== Derived MCP tools ===")
+console.table(app.derivedTools().map(t => ({ name: t.name, category: t.category, input: t.inputShape })))
+
+console.log("\n=== Step 1: create draft row + send_message ===")
+const row = app._state.insertRow("message", {
+  channel_id: "C0123",
+  text: "Hello from the v2 SDK demo",
+}, "draft")
+console.log(`  row inserted: id=${row.id}, status=${row.status}`)
+
+const send = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+console.log("  result:", send)
+console.log("  row now:", { status: app._state.getRow(row.id)?.status, externalId: app._state.getRow(row.id)?.externalId })
+
+console.log("\n=== Step 2: edit_message ===")
+const edit = await app._invokeAction({
+  actionName: "edit_message",
+  rowId: row.id,
+  input: { text: "Hello from the v2 SDK demo (edited)" },
+  bridge,
+})
+console.log("  result:", edit, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Step 3: react (side effect — status should stay 'edited') ===")
+const react = await app._invokeAction({
+  actionName: "react", rowId: row.id, input: { emoji: "rocket" }, bridge,
+})
+console.log("  result:", react, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Step 4: delete_message ===")
+const del = await app._invokeAction({ actionName: "delete_message", rowId: row.id, bridge })
+console.log("  result:", del, "→ status:", app._state.getRow(row.id)?.status)
+
+console.log("\n=== Dashboard cards (what user would see in workspace) ===")
+console.table(app.state().outputs.map(o => ({
+  status: o.status, surface: o.surface, summary: o.summary, deepLink: o.deepLink,
+})))
+
+console.log("\n=== Audit log (last 8 events) ===")
+console.table(app.state().audit.slice(-8).map(a => ({
+  event: a.event,
+  step: a.fields.step ?? a.fields.action ?? "-",
+  outcome: a.fields.outcome ?? "-",
+})))

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/server.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/slack-messaging/server.ts
@@ -1,0 +1,62 @@
+// Production entry point for the Slack v2 app module.
+//
+// What this file does (in one place):
+//   1. Builds the Slack app with a SqliteStateBackend (persists to WORKSPACE_DB_PATH)
+//   2. Wires a runtime-broker transport (reads HOLABOSS_APP_GRANT + broker URL)
+//   3. Starts the MCP server on MCP_PORT
+//   4. Handles SIGTERM / SIGINT for clean shutdown
+//
+// When the Holaboss runtime launches this app via app.runtime.yaml lifecycle.start,
+// it injects all required env vars. From the user's perspective:
+//   - Connect Slack via desktop OAuth flow (existing infrastructure)
+//   - Workspace gets a slack-v2 app entry, MCP tools become available to agent
+//   - Agent calls slack_send_message → SDK → broker → real Slack
+//
+// To generate this app's app.runtime.yaml: bun run reference/slack-messaging/manifest.ts
+
+import { buildSlackApp } from "./app.ts"
+import {
+  createBridge,
+  createRuntimeBrokerTransport,
+  SqliteStateBackend,
+  startMcpServer,
+} from "../../src/index.ts"
+import { SLACK } from "./provider.ts"
+
+const workspaceDbPath = process.env.WORKSPACE_DB_PATH
+if (!workspaceDbPath) {
+  console.error("[slack-v2] WORKSPACE_DB_PATH not set — refusing to start without persistence")
+  process.exit(1)
+}
+const mcpPort = Number(process.env.MCP_PORT ?? 3099)
+// Holaboss runtime allocates an HTTP port per app for the desktop iframe
+// surface. Headless SDK modules don't have a web UI, but the desktop still
+// tries to load the URL — startMcpServer serves a placeholder page on PORT
+// to avoid ERR_CONNECTION_REFUSED.
+const httpPort = process.env.PORT ? Number(process.env.PORT) : undefined
+
+// 1) SQLite-backed state (persists across app restarts)
+const backend = new SqliteStateBackend({ dbPath: workspaceDbPath, appId: "slack" })
+
+// 2) Build the Slack app with persistent backend
+const { app } = buildSlackApp({ backend })
+
+// 3) Production transport — reads HOLABOSS_APP_GRANT + HOLABOSS_INTEGRATION_BROKER_URL from env
+const transport = createRuntimeBrokerTransport({ provider: "slack" })
+const bridge = createBridge({ provider: SLACK, transport })
+
+// 4) Boot MCP server (+ headless web stub if PORT was injected)
+const server = await startMcpServer({ app: app as never, port: mcpPort, bridge, httpPort })
+console.log(`[slack-v2] MCP server listening on :${server.port}`)
+if (server.httpPort) console.log(`[slack-v2] Web stub on :${server.httpPort}`)
+console.log(`[slack-v2] Workspace DB: ${workspaceDbPath}`)
+console.log(`[slack-v2] Tools registered: ${app.derivedTools().length}`)
+
+// 5) Clean shutdown
+async function shutdown(signal: string) {
+  console.log(`[slack-v2] Received ${signal}, shutting down…`)
+  await server.close().catch(err => console.error("[slack-v2] MCP close failed:", err))
+  process.exit(0)
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"))
+process.on("SIGINT", () => shutdown("SIGINT"))

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/app.ts
@@ -1,0 +1,189 @@
+// SDK REFERENCE — NOT a production module.
+//
+// Purpose: demonstrate that the SDK supports messaging-shape apps with
+// integer external IDs (Telegram message_id is int — see RowOf doc in
+// types.ts for the stringify pattern). Built end-to-end by a cold
+// subagent given ONLY the SDK meta-skill + the user request "add
+// Telegram" — first time pass, 0 `as any`, 9 unit tests. Useful as a
+// "did our agent-build flow really work" artifact.
+//
+// Known: real-API E2E NOT run yet (Composio proxy path convention for
+// Telegram bot tokens is unverified — depends on whether Composio's
+// `API_KEY` auth toolkit injects the token into the URL path).
+//
+// Copy this directory as a template when building a real Telegram /
+// Discord / bot-style messaging module; do not deploy it as-is.
+//
+// Telegram — messaging app (bot API). Same shape as Slack: chats + messages,
+// custom state alphabet, side-effect react action.
+//
+// Telegram-specific contract: like Slack, errors come back as HTTP 200 with
+// { ok: false, description, error_code } in the body. SDK's BridgeClient only
+// maps HTTP status, so each action must check r.data.ok via `tgUnwrap` below.
+//
+// Telegram-specific behavior notes:
+//   - message_id is a numeric int (not a string ts like Slack). Persisted as
+//     `String(message_id)` so it fits the SDK's external_id contract.
+//   - There is NO scheduleMessage in the Bot API and NO server-side edit
+//     window beyond 48h for non-bot messages — bots can edit their own
+//     messages indefinitely. No schedule action declared.
+//   - setMessageReaction REPLACES the bot's prior reactions on that message
+//     (it doesn't append). Passing an empty array clears.
+//   - chat_id can be a numeric id OR an @channelusername. Persisted as a
+//     string for both.
+
+import { createApp, z, type CreateAppOptions, type ProxyResult, type BridgeError } from "../../src/index.ts"
+import { TELEGRAM } from "./provider.ts"
+
+type TgBody = {
+  ok?: boolean
+  description?: string
+  error_code?: number
+  result?: unknown
+  [k: string]: unknown
+}
+
+function tgUnwrap<T extends TgBody>(
+  r: ProxyResult<T>,
+):
+  | { ok: true; data: T }
+  | { ok: false; fail: BridgeError | { kind: "error"; code: string; message: string } } {
+  if (r.kind === "error") return { ok: false, fail: r }
+  if (r.data.ok === false) {
+    const description = r.data.description ?? "telegram_error"
+    const code = r.data.error_code ? `telegram_${r.data.error_code}` : "telegram_error"
+    return { ok: false, fail: { kind: "error", code, message: description } }
+  }
+  return { ok: true, data: r.data }
+}
+
+export function buildTelegramApp(options: CreateAppOptions = {}) {
+  const app = createApp({
+    id: "telegram",
+    provider: TELEGRAM,
+    description: "Telegram bot messaging, edits, reactions",
+  }, options)
+
+  app.connection()
+
+  const chat = app.resource("chat", {
+    schema: z.object({
+      id: z.string(),
+      title: z.string().optional(),
+      type: z.string().optional(),
+    }),
+    states: ["cached"] as const,
+    initialState: "cached",
+    emit: { surface: "none" },
+  })
+
+  const message = app.resource("message", {
+    schema: z.object({
+      chat_id: chat.ref(),
+      text: z.string().min(1).max(4096),
+      reply_to_message_id: z.number().int().optional(),
+      parse_mode: z.enum(["HTML", "MarkdownV2"]).optional(),
+    }),
+    states: ["draft", "sent", "edited", "deleted", "failed"] as const,
+    initialState: "draft",
+    failedState: "failed",
+    emit: {
+      surface: "ops_log",
+      summary: r => (r.text ?? "").slice(0, 80),
+      deepLink: r => {
+        if (!r.external_id) return null
+        // Public channel/group URL only resolves when chat_id is @username.
+        const ref = String(r.chat_id ?? "")
+        if (ref.startsWith("@")) {
+          return `https://t.me/${ref.slice(1)}/${r.external_id}`
+        }
+        return null
+      },
+    },
+  })
+
+  app.action(message, "send_message", {
+    fromStates: ["draft"],
+    toState: "sent",
+    run: async ({ row, bridge }) => {
+      type SendResult = TgBody & {
+        result?: { message_id: number; chat: { id: number | string } }
+      }
+      const r = await bridge.call<SendResult>("POST", "/sendMessage", {
+        chat_id: row.chat_id,
+        text: row.text,
+        reply_to_message_id: row.reply_to_message_id,
+        parse_mode: row.parse_mode,
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      const messageId = u.data.result?.message_id
+      if (messageId === undefined) {
+        return { fail: { kind: "error", code: "telegram_missing_message_id", message: "no message_id in result" } }
+      }
+      return { ok: true, externalId: String(messageId) }
+    },
+  })
+
+  app.action(message, "edit_message", {
+    fromStates: ["sent", "edited"],
+    toState: "edited",
+    schema: z.object({ text: z.string().min(1).max(4096) }),
+    run: async ({ row, input, bridge, persist }) => {
+      if (!row.external_id) {
+        return { fail: { kind: "error", code: "missing_external_id", message: "edit requires external_id" } }
+      }
+      const r = await bridge.call<TgBody>("POST", "/editMessageText", {
+        chat_id: row.chat_id,
+        message_id: Number(row.external_id),
+        text: input.text,
+        parse_mode: row.parse_mode,
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      await persist({ text: input.text })
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "delete_message", {
+    fromStates: ["draft", "sent", "edited"],
+    toState: "deleted",
+    run: async ({ row, bridge }) => {
+      if (row.external_id) {
+        const r = await bridge.call<TgBody>("POST", "/deleteMessage", {
+          chat_id: row.chat_id,
+          message_id: Number(row.external_id),
+        })
+        const u = tgUnwrap(r)
+        // Propagate all errors — let the agent decide. Telegram returns
+        // 'message to delete not found' as ok:false; don't swallow it.
+        if (!u.ok) return { fail: u.fail }
+      }
+      return { ok: true }
+    },
+  })
+
+  app.action(message, "react", {
+    fromStates: ["sent", "edited"],
+    toState: null,
+    toolName: "telegram_react",
+    schema: z.object({ emoji: z.string().min(1) }),
+    run: async ({ row, input, bridge }) => {
+      if (!row.external_id) {
+        return { fail: { kind: "error", code: "missing_external_id", message: "react requires external_id" } }
+      }
+      // setMessageReaction replaces prior bot reactions; pass single emoji.
+      const r = await bridge.call<TgBody>("POST", "/setMessageReaction", {
+        chat_id: row.chat_id,
+        message_id: Number(row.external_id),
+        reaction: [{ type: "emoji", emoji: input.emoji }],
+      })
+      const u = tgUnwrap(r)
+      if (!u.ok) return { fail: u.fail }
+      return { ok: true }
+    },
+  })
+
+  return { app, chat, message }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/e2e.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/e2e.ts
@@ -1,0 +1,231 @@
+// Real E2E for the Telegram app — BDD-style scenarios against a live bot.
+//
+// Setup:
+//   1. Talk to @BotFather, /newbot, save the bot token
+//   2. Connect Telegram via desktop UI (Composio) using that bot token
+//   3. Start a chat with your bot and send it any message so it knows your chat_id
+//   4. export COMPOSIO_API_KEY=ck_...
+//      export TEST_TELEGRAM_CHAT_ID=<your numeric chat id, from getUpdates>
+//
+// Optional:
+//   COMPOSIO_USER_ID                  scope account listing to a specific user
+//   COMPOSIO_TELEGRAM_ACCOUNT_ID      skip auto-discovery
+//
+// Run: bun run reference/telegram-messaging/e2e.ts
+
+import { buildTelegramApp } from "./app.ts"
+import { createBridge, type BridgeClient } from "../../src/index.ts"
+import { TELEGRAM } from "./provider.ts"
+import { createComposioDirectTransport } from "../../src/bridge-transports/composio-direct.ts"
+import type { AppHandleInternal } from "../../src/app.ts"
+
+// ─── Env ───────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.COMPOSIO_API_KEY
+if (!API_KEY) {
+  console.error(`Missing env: COMPOSIO_API_KEY=ck_xxx`)
+  process.exit(1)
+}
+const CHAT_ID = process.env.TEST_TELEGRAM_CHAT_ID
+if (!CHAT_ID) {
+  console.error(`Missing env: TEST_TELEGRAM_CHAT_ID=<numeric chat id>
+  - DM your bot first, then GET /bot<token>/getUpdates to find your chat id`)
+  process.exit(1)
+}
+const COMPOSIO_BASE = (process.env.COMPOSIO_BASE_URL ?? "https://backend.composio.dev").replace(/\/+$/, "")
+const USER_ID = process.env.COMPOSIO_USER_ID
+let ACCOUNT_ID = process.env.COMPOSIO_TELEGRAM_ACCOUNT_ID
+
+async function discoverTelegramConnection(): Promise<string> {
+  const params = new URLSearchParams({ page: "1", page_size: "200" })
+  if (USER_ID) params.set("user_id", USER_ID)
+  const url = `${COMPOSIO_BASE}/api/v3/connected_accounts?${params}`
+  const r = await fetch(url, { headers: { "x-api-key": API_KEY! } })
+  if (!r.ok) {
+    const text = await r.text().catch(() => "")
+    throw new Error(`Composio list-accounts failed (${r.status}): ${text.slice(0, 300)}`)
+  }
+  const data = (await r.json()) as {
+    items?: Array<{ id?: string; status?: string; toolkit?: { slug?: string } }>
+  }
+  const tgs = (data.items ?? []).filter(
+    a => a.toolkit?.slug?.toLowerCase() === "telegram"
+      && (a.status ?? "").toUpperCase() === "ACTIVE",
+  )
+  if (tgs.length === 0) {
+    throw new Error(`No active Telegram connection in Composio. Connect via desktop UI first.`)
+  }
+  return tgs[0]!.id ?? ""
+}
+
+if (!ACCOUNT_ID) {
+  console.log("Discovering Telegram connection from Composio…")
+  ACCOUNT_ID = await discoverTelegramConnection()
+  console.log(`  → ${ACCOUNT_ID}`)
+}
+
+const transport = createComposioDirectTransport({ apiKey: API_KEY, connectedAccountId: ACCOUNT_ID })
+const bridge: BridgeClient = createBridge({ provider: TELEGRAM, transport })
+const { app } = buildTelegramApp() as unknown as { app: AppHandleInternal }
+app._setTurn({ turnId: "e2e", sessionId: "e2e" })
+
+console.log(`\nSUT ready (chat_id=${CHAT_ID}). Running scenarios…\n`)
+
+interface ScenarioResult { feature: string; name: string; ok: boolean; ms: number; err?: string }
+const results: ScenarioResult[] = []
+let currentFeature = ""
+function feature(name: string) { currentFeature = name; console.log(`\n━━━ Feature: ${name} ━━━`) }
+async function scenario(name: string, body: () => Promise<void>) {
+  const start = Date.now()
+  console.log(`\n  Scenario: ${name}`)
+  try {
+    await body()
+    const ms = Date.now() - start
+    results.push({ feature: currentFeature, name, ok: true, ms })
+    console.log(`  ✓ pass (${ms}ms)`)
+  } catch (e) {
+    const ms = Date.now() - start
+    const err = e instanceof Error ? e.message : String(e)
+    results.push({ feature: currentFeature, name, ok: false, ms, err })
+    console.error(`  ✗ FAIL: ${err}`)
+  }
+}
+function given(s: string) { console.log(`    Given ${s}`) }
+function when(s: string)  { console.log(`    When  ${s}`) }
+function then(s: string)  { console.log(`    Then  ${s}`) }
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T, label = "value") {
+      if (actual !== expected) throw new Error(
+        `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeTruthy(label = "value") {
+      if (!actual) throw new Error(`${label}: expected truthy, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+function expectOk(
+  result: { ok: true; externalId?: string } | { fail: { code: string; message: string } },
+  label = "action",
+): asserts result is { ok: true; externalId?: string } {
+  if ("fail" in result) {
+    throw new Error(`${label} expected ok but FAILED: code='${result.fail.code}' message='${result.fail.message}'`)
+  }
+}
+
+const stamp = () => new Date().toISOString().slice(11, 19)
+let sentMessage: { id: string; externalId?: string } | null = null
+
+feature("Send a message")
+
+await scenario("draft → sent, returns message_id, emits dashboard card", async () => {
+  given(`a draft message row targeting chat ${CHAT_ID}`)
+  const row = app._state.insertRow("message", {
+    chat_id: CHAT_ID, text: `[E2E ${stamp()}] send scenario`,
+  }, "draft")
+
+  when("the agent invokes send_message")
+  const result = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge })
+
+  then("the action succeeds and Telegram returns a message_id")
+  expectOk(result, "send_message")
+  expect(result.externalId).toBeTruthy("externalId (Telegram message_id)")
+
+  then("the row transitions to 'sent' and persists externalId")
+  const final = app._state.getRow(row.id)
+  expect(final?.status).toBe("sent", "row.status after send")
+  expect(final?.externalId).toBe(result.externalId!, "row.externalId persisted")
+
+  sentMessage = { id: row.id, externalId: result.externalId }
+})
+
+feature("Edit and react")
+
+await scenario("edit_message: sent → edited and updates upstream text", async () => {
+  given("the sent message from the previous scenario")
+  expect(!!sentMessage).toBe(true, "send scenario must succeed first")
+
+  when("the agent edits the text")
+  const result = await app._invokeAction({
+    actionName: "edit_message",
+    rowId: sentMessage!.id,
+    input: { text: `[E2E ${stamp()}] (edited via SDK)` },
+    bridge,
+  })
+
+  then("the action succeeds and row transitions to 'edited'")
+  expectOk(result, "edit_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("edited", "row.status after edit")
+})
+
+await scenario("react: adds 👍 WITHOUT mutating row.status (side-effect contract)", async () => {
+  given("the same message, now in 'edited' state")
+  expect(!!sentMessage).toBe(true)
+  const beforeStatus = app._state.getRow(sentMessage!.id)?.status
+
+  when("the agent reacts with 👍")
+  const result = await app._invokeAction({
+    actionName: "react",
+    rowId: sentMessage!.id,
+    input: { emoji: "👍" },
+    bridge,
+  })
+
+  then("the action succeeds but row.status is unchanged (toState: null)")
+  expectOk(result, "react")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe(beforeStatus!, "row.status preserved")
+})
+
+feature("State machine guards")
+
+await scenario("react on a draft fails with typed invalid_state — NO upstream call", async () => {
+  given("a fresh draft never sent to Telegram")
+  const draft = app._state.insertRow("message", {
+    chat_id: CHAT_ID, text: "should never reach Telegram",
+  }, "draft")
+
+  when("the agent tries to react on the draft")
+  const result = await app._invokeAction({
+    actionName: "react", rowId: draft.id, input: { emoji: "👍" }, bridge,
+  })
+
+  then("the action fails with code='invalid_state'")
+  expect("fail" in result).toBe(true, "result kind")
+  if ("fail" in result) {
+    expect(result.fail.code).toBe("invalid_state", "fail.code")
+  }
+  expect(app._state.getRow(draft.id)?.status).toBe("draft", "row.status unchanged")
+})
+
+feature("Cleanup")
+
+await scenario("delete_message removes the test message; row → deleted", async () => {
+  given("the sent message from the first scenario")
+  expect(!!sentMessage).toBe(true)
+
+  when("the agent invokes delete_message")
+  const result = await app._invokeAction({
+    actionName: "delete_message", rowId: sentMessage!.id, bridge,
+  })
+
+  then("the action succeeds and row transitions to 'deleted'")
+  expectOk(result, "delete_message")
+  expect(app._state.getRow(sentMessage!.id)?.status).toBe("deleted", "row.status after delete")
+})
+
+const passed = results.filter(r => r.ok).length
+const failed = results.length - passed
+const totalMs = results.reduce((sum, r) => sum + r.ms, 0)
+
+console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+console.log(`  ${passed} passed / ${failed} failed in ${totalMs}ms`)
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+
+if (failed > 0) {
+  console.log("\nFailures:")
+  for (const r of results.filter(r => !r.ok)) {
+    console.log(`  ✗ [${r.feature}] ${r.name}`)
+    console.log(`    ${r.err}`)
+  }
+  process.exit(1)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/provider.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/reference/telegram-messaging/provider.ts
@@ -1,0 +1,9 @@
+import type { ProviderRegistry } from "../../src/types.ts"
+
+export const TELEGRAM: ProviderRegistry = {
+  id: "telegram",
+  baseUrl: "https://api.telegram.org",
+  allowedHosts: ["api.telegram.org"],
+  whoamiPath: "/getMe",
+  composioToolkit: "telegram",
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/app.ts
@@ -1,0 +1,331 @@
+import type { ZodTypeAny } from "zod"
+import { z } from "zod"
+import type {
+  ActionDef,
+  AppConfig,
+  AppHandle,
+  AppState,
+  BridgeClient,
+  DerivedTool,
+  ResourceDef,
+  ResourceHandle,
+  RowOf,
+  StateBackend,
+  StateTuple,
+  SyncDef,
+  TurnContext,
+} from "./types.ts"
+import { RuntimeState } from "./runtime/state.ts"
+import { runAction } from "./runtime/action-runner.ts"
+import { runSync, type SyncRunResult } from "./runtime/sync-runner.ts"
+
+// Storage shape — homogeneous so the actions[] array can hold registrations
+// from different resources/schemas. Agent-facing type safety lives at the
+// app.action<TS, S, I>(...) call site, not at storage. The runtime operates
+// on Record<string, unknown> rows by design, so widening here is honest.
+interface RegisteredAction {
+  resource: ResourceHandle<ZodTypeAny, StateTuple>
+  name: string
+  def: ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>>
+}
+
+interface RegisteredSync {
+  name: string
+  def: SyncDef<ZodTypeAny, unknown, unknown>
+}
+
+export interface AppHandleInternal extends AppHandle {
+  _invokeAction(opts: {
+    actionName: string
+    rowId: string
+    input?: unknown
+    bridge: BridgeClient
+  }): Promise<any>
+  _invokeReverse(opts: {
+    actionName: string
+    rowId: string
+    bridge: BridgeClient
+  }): Promise<any>
+  _runSync(name: string, bridge: BridgeClient): Promise<SyncRunResult>
+  _state: StateBackend
+  _setTurn(ctx: TurnContext | null): void
+  _resources: Map<string, ResourceHandle<any, any>>
+  _actions: RegisteredAction[]
+  _syncs: RegisteredSync[]
+}
+
+/**
+ * createApp options. `backend` defaults to in-memory; production runtime
+ * should pass a SqliteStateBackend (see runtime/state-backend-sqlite.ts).
+ */
+export interface CreateAppOptions {
+  backend?: StateBackend
+}
+
+export function createApp(config: AppConfig, options: CreateAppOptions = {}): AppHandleInternal {
+  const state: StateBackend = options.backend ?? new RuntimeState()
+  const resources = new Map<string, ResourceHandle<any, any>>()
+  const actions: RegisteredAction[] = []
+  const syncs: RegisteredSync[] = []
+  let connectionCalled = false
+
+  function connection(_opts?: { whoamiPath?: string }): void {
+    connectionCalled = true
+  }
+
+  function resource<TSchema extends ZodTypeAny, States extends StateTuple>(
+    name: string,
+    def: ResourceDef<TSchema, States>,
+  ): ResourceHandle<TSchema, States> {
+    if (!(def.states as readonly string[]).includes(def.initialState)) {
+      throw new Error(
+        `[${config.id}] resource '${name}': initialState '${def.initialState}' not in states [${def.states.join(",")}]`,
+      )
+    }
+    if (def.failedState !== undefined && !(def.states as readonly string[]).includes(def.failedState)) {
+      throw new Error(
+        `[${config.id}] resource '${name}': failedState '${def.failedState}' not in states [${def.states.join(",")}]`,
+      )
+    }
+    const handle: ResourceHandle<TSchema, States> = {
+      __resource: true,
+      name,
+      states: def.states,
+      schema: def.schema,
+      def,
+      // ref() returns plain z.string() (NOT branded). Branding broke round-trip
+      // updates — provider responses come back as plain strings and couldn't
+      // satisfy the brand, forcing `as` casts at every persist call.
+      // The semantic "this is an <X> id" is documented by the field name +
+      // schema location; type-system enforcement adds more friction than value.
+      ref: () => z.string(),
+    }
+    resources.set(name, handle)
+    return handle
+  }
+
+  function action<TSchema extends ZodTypeAny, States extends StateTuple, I = {}>(
+    res: ResourceHandle<TSchema, States>,
+    name: string,
+    def: ActionDef<RowOf<TSchema>, States, I>,
+  ): void {
+    if (!def.steps && !def.run) {
+      throw new Error(`[${config.id}] action ${name}: must provide either run or steps`)
+    }
+    if (def.steps && def.run) {
+      throw new Error(`[${config.id}] action ${name}: provide either run or steps, not both`)
+    }
+    const allowed = res.def.states as readonly string[]
+    for (const s of def.fromStates) {
+      if (!allowed.includes(s as string)) {
+        throw new Error(
+          `[${config.id}] action ${name}: fromStates contains '${s}' not in resource '${res.name}' states [${allowed.join(",")}]`,
+        )
+      }
+    }
+    if (def.toState !== null && !allowed.includes(def.toState as string)) {
+      throw new Error(
+        `[${config.id}] action ${name}: toState '${def.toState}' not in resource '${res.name}' states [${allowed.join(",")}]`,
+      )
+    }
+    if (def.reversible && !allowed.includes(def.reversible.toState as string)) {
+      throw new Error(
+        `[${config.id}] action ${name}: reversible.toState '${def.reversible.toState}' not in resource '${res.name}' states`,
+      )
+    }
+    // Single intentional widening at storage boundary — runtime operates on
+    // Record<string, unknown> rows, so the precise TSchema/I types are
+    // discarded here. The agent's compile-time guarantee lives at the
+    // app.action<TSchema, States, I>(...) call above; storage doesn't need it.
+    actions.push({
+      resource: res as unknown as ResourceHandle<ZodTypeAny, StateTuple>,
+      name,
+      def: def as unknown as ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>>,
+    })
+  }
+
+  function sync<TSchema extends ZodTypeAny, RAW, N>(
+    name: string,
+    def: SyncDef<TSchema, RAW, N>,
+  ): void {
+    // Storage widens: runtime calls fetch/normalize generically. Agent-side
+    // typing was preserved at the app.sync<TSchema, RAW, N>(...) call above.
+    syncs.push({
+      name,
+      def: def as unknown as SyncDef<ZodTypeAny, unknown, unknown>,
+    })
+  }
+
+  async function start(): Promise<void> {
+    if (!connectionCalled) {
+      throw new Error(`[${config.id}] app.connection() must be called before app.start()`)
+    }
+  }
+
+  function derivedTools(): DerivedTool[] {
+    const tools: DerivedTool[] = []
+
+    if (connectionCalled) {
+      tools.push({
+        name: `${config.id}_connection_status`,
+        inputShape: "{}",
+        description: `Check ${config.id} connection state.`,
+        category: "connection",
+      })
+    }
+
+    for (const [rname, rhandle] of resources) {
+      tools.push({
+        name: `${config.id}_list_${plural(rname)}`,
+        inputShape: "{ status?, limit? }",
+        description: `List ${rname} rows.`,
+        category: "resource_query",
+      })
+      tools.push({
+        name: `${config.id}_get_${rname}`,
+        inputShape: `{ ${rname}_id }`,
+        description: `Fetch a single ${rname}.`,
+        category: "resource_query",
+      })
+      if (rhandle.def.refreshEvery) {
+        tools.push({
+          name: `${config.id}_refresh_${plural(rname)}`,
+          inputShape: "{}",
+          description: `Force-refresh ${rname} cache.`,
+          category: "resource_query",
+        })
+      }
+    }
+
+    for (const { resource: r, name, def } of actions) {
+      const toolName = def.toolName ?? `${config.id}_${name}_${r.name}`
+      tools.push({
+        name: toolName,
+        inputShape: `{ ${r.name}_id${def.schema ? ", ...extra" : ""} }`,
+        description: `${name} a ${r.name} (from ${def.fromStates.join("|")} → ${def.toState ?? "side-effect"}).`,
+        category: "action",
+      })
+      if (def.reversible) {
+        const reverseToolName = def.toolName
+          ? `${def.toolName}_reverse`
+          : `${config.id}_cancel_${name}_${r.name}`
+        tools.push({
+          name: reverseToolName,
+          inputShape: `{ ${r.name}_id }`,
+          description: `Reverse ${name} on a ${r.name} (→ ${def.reversible.toState}).`,
+          category: "reverse_action",
+        })
+      }
+    }
+
+    for (const { name } of syncs) {
+      tools.push({
+        name: `${config.id}_${name}_sync_status`,
+        inputShape: "{}",
+        description: `Status of ${name} sync.`,
+        category: "sync",
+      })
+    }
+
+    tools.push({
+      name: `${config.id}_snapshot`,
+      inputShape: "{}",
+      description: `Compact situational read of ${config.id}.`,
+      category: "snapshot",
+    })
+
+    return tools
+  }
+
+  function getStateSnapshot(): AppState {
+    const snap = state.snapshot()
+    snap.derivedTools = derivedTools()
+    return snap
+  }
+
+  return {
+    config,
+    connection,
+    resource,
+    action,
+    sync,
+    start,
+    derivedTools,
+    state: getStateSnapshot,
+    _state: state,
+    _resources: resources,
+    _actions: actions,
+    _syncs: syncs,
+    _setTurn: (ctx) => state.setTurnContext(ctx),
+    async _invokeAction({ actionName, rowId, input, bridge }) {
+      const reg = actions.find(a => a.name === actionName)
+      if (!reg) throw new Error(`action ${actionName} not registered`)
+      return runAction({
+        appId: config.id,
+        resourceName: reg.resource.name,
+        resourceDef: reg.resource.def,
+        actionName: reg.name,
+        actionDef: reg.def,
+        rowId,
+        input: (input ?? {}) as Record<string, unknown>,
+        bridge,
+        state,
+      })
+    },
+    async _invokeReverse({ actionName, rowId, bridge }) {
+      const reg = actions.find(a => a.name === actionName)
+      if (!reg) throw new Error(`action ${actionName} not registered`)
+      if (!reg.def.reversible) {
+        throw new Error(`action ${actionName} is not reversible`)
+      }
+      const row = state.getRow(rowId)
+      if (!row) throw new Error(`row ${rowId} not found`)
+      if (row.status !== reg.def.toState) {
+        return {
+          fail: {
+            code: "invalid_state",
+            message: `cannot reverse ${actionName}: row is in '${row.status}', expected '${reg.def.toState}'`,
+          },
+        }
+      }
+      const reverseDef: ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>> = {
+        fromStates: [reg.def.toState as string],
+        toState: reg.def.reversible.toState,
+        run: reg.def.reversible.run,
+      }
+      // Pass a resourceDef WITHOUT failedState: if reverse fails, the row
+      // stays in its current state (the forward action's toState) because
+      // upstream reality hasn't changed — the thing we tried to undo is still
+      // in effect. The error is recorded via errorMessage + notification.
+      const reverseResourceDef = { ...reg.resource.def, failedState: undefined }
+      return runAction({
+        appId: config.id,
+        resourceName: reg.resource.name,
+        resourceDef: reverseResourceDef,
+        actionName: `cancel_${reg.name}`,
+        actionDef: reverseDef,
+        rowId,
+        input: {},
+        bridge,
+        state,
+      })
+    },
+    async _runSync(name, bridge) {
+      const reg = syncs.find(s => s.name === name)
+      if (!reg) throw new Error(`sync ${name} not registered`)
+      return runSync({
+        appId: config.id,
+        syncName: reg.name,
+        syncDef: reg.def,
+        bridge,
+        state,
+      })
+    },
+  }
+}
+
+function plural(name: string): string {
+  if (name.endsWith("s") || name.endsWith("x") || name.endsWith("ch")) return `${name}es`
+  if (name.endsWith("y")) return `${name.slice(0, -1)}ies`
+  return `${name}s`
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/bearer.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/bearer.ts
@@ -1,0 +1,59 @@
+// Generic OAuth bearer-token transport.
+//
+// Use this when YOU manage OAuth — your own auth server, Auth0, Clerk, manual
+// token issuance, anything. The SDK doesn't care where the token comes from;
+// it only cares that this transport produces requests with a valid Bearer
+// header.
+//
+// Token refresh is NOT this transport's job. Either:
+//   - pass a sync `accessToken: string` (the SDK will not retry on 401)
+//   - pass an async getter `accessToken: () => Promise<string>` that returns
+//     a currently-valid token (your OAuth client handles refresh internally)
+//
+// On 401/403 the SDK's BridgeClient surfaces a typed `not_connected` error
+// with reauthUrl hint based on the provider registry; YOU are responsible for
+// driving the user back through OAuth.
+
+import type { TransportFn } from "../bridge.ts"
+
+export interface BearerTokenOpts {
+  /** Either a static token or a function that returns a currently-valid token. */
+  accessToken: string | (() => string | Promise<string>)
+  /** Extra headers to merge into every request (e.g. User-Agent). */
+  defaultHeaders?: Record<string, string>
+  fetchImpl?: typeof fetch
+}
+
+export function createBearerTokenTransport(opts: BearerTokenOpts): TransportFn {
+  const fetchImpl = opts.fetchImpl ?? fetch
+
+  return async ({ method, url, body }) => {
+    const token = typeof opts.accessToken === "function"
+      ? await opts.accessToken()
+      : opts.accessToken
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      ...opts.defaultHeaders,
+    }
+    if (body !== undefined) headers["Content-Type"] = "application/json"
+
+    const r = await fetchImpl(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    let parsed: unknown = null
+    const text = await r.text()
+    if (text) {
+      try { parsed = JSON.parse(text) } catch { parsed = { _raw: text } }
+    }
+
+    const respHeaders: Record<string, string> = {}
+    r.headers.forEach((v, k) => { respHeaders[k] = v })
+
+    return { status: r.status, body: parsed, headers: respHeaders }
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/composio-direct.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/composio-direct.ts
@@ -1,0 +1,68 @@
+// Composio direct transport — talks to Composio's REST API without going
+// through any Holaboss backend (no Hono, no cookie, no runtime, no grant).
+//
+// Use this when you hold the Composio API key directly (single-tenant deploy,
+// E2E test scripts, local development). For multi-tenant production where
+// Composio API key must NOT be exposed to the caller, use a different
+// transport that brokers through your backend.
+//
+// Auth: COMPOSIO_API_KEY header (your Holaboss-deployment key).
+// Identity: connected_account_id (per-provider, per-user, set up via OAuth flow).
+
+import type { TransportFn } from "../bridge.ts"
+
+export interface ComposioDirectOpts {
+  /** Composio API base URL. Default: https://backend.composio.dev */
+  composioBaseUrl?: string
+  /** COMPOSIO_API_KEY for your deployment. */
+  apiKey: string
+  /**
+   * Composio connected_account_id for the target provider.
+   * Set up via Composio OAuth flow (e.g. via desktop UI), then read from
+   * workspace.db integration_connections.account_external_id.
+   */
+  connectedAccountId: string
+  fetchImpl?: typeof fetch
+}
+
+export function createComposioDirectTransport(opts: ComposioDirectOpts): TransportFn {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const base = (opts.composioBaseUrl ?? "https://backend.composio.dev").replace(/\/+$/, "")
+
+  return async ({ method, url, body }) => {
+    const r = await fetchImpl(`${base}/api/v3/tools/execute/proxy`, {
+      method: "POST",
+      headers: {
+        "x-api-key": opts.apiKey,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        connected_account_id: opts.connectedAccountId,
+        endpoint: url,           // Composio expects absolute URL
+        method,
+        ...(body !== undefined ? { body } : {}),
+      }),
+    })
+
+    // Composio wraps successful provider responses as { data, status, headers }.
+    // Non-2xx from Composio means Composio itself errored (auth / quota / etc.)
+    if (!r.ok) {
+      const text = await r.text().catch(() => "")
+      let parsed: unknown = null
+      try { parsed = text ? JSON.parse(text) : null } catch { parsed = { _raw: text } }
+      return { status: r.status, body: parsed, headers: {} }
+    }
+
+    const payload = (await r.json()) as {
+      data?: unknown
+      status?: number
+      headers?: Record<string, string>
+    }
+    return {
+      status: payload.status ?? r.status,
+      body: payload.data ?? null,
+      headers: payload.headers ?? {},
+    }
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/runtime-broker.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge-transports/runtime-broker.ts
@@ -1,0 +1,130 @@
+// Runtime-broker transport — production path inside the Holaboss runtime.
+//
+// Uses the same `/broker/proxy` endpoint + grant-based auth as the legacy
+// `@holaboss/bridge` SDK, so this SDK's apps slot into existing sandbox
+// integration infrastructure with no runtime-side changes.
+//
+// The runtime injects two env vars when launching an SDK app:
+//   - HOLABOSS_INTEGRATION_BROKER_URL   in-sandbox runtime URL
+//   - HOLABOSS_APP_GRANT                grant:<workspaceId>:<appId>:<nonce>
+//
+// On broker-level errors (grant invalid, binding missing, connection inactive,
+// token unavailable) the transport returns the HTTP status as-is, so
+// BridgeClient can map them to typed BridgeError codes (`not_connected`,
+// `validation_failed`, etc.).
+//
+// On broker success the response is `{ data, status, headers }` where `status`
+// is the UPSTREAM provider's status (might be Slack's 200 + body.ok:false, a
+// 429 from Twitter, etc.) — this transport faithfully passes it through so
+// provider-specific handling stays in the app code.
+
+import type { TransportFn } from "../bridge.ts"
+
+export interface RuntimeBrokerOpts {
+  /** Provider id (e.g. "slack", "twitter"). Required — broker uses it to
+   *  look up the integration binding for the grant's workspace+app. */
+  provider: string
+  /** Broker URL. Defaults to HOLABOSS_INTEGRATION_BROKER_URL env. */
+  brokerUrl?: string
+  /** App grant token. Defaults to HOLABOSS_APP_GRANT env. */
+  grant?: string
+  fetchImpl?: typeof fetch
+}
+
+export function createRuntimeBrokerTransport(opts: RuntimeBrokerOpts): TransportFn {
+  const brokerUrl = (opts.brokerUrl ?? process.env.HOLABOSS_INTEGRATION_BROKER_URL ?? "")
+    .replace(/\/+$/, "")
+  const grant = opts.grant ?? process.env.HOLABOSS_APP_GRANT ?? ""
+
+  if (!brokerUrl) {
+    throw new Error(
+      "runtime-broker transport: HOLABOSS_INTEGRATION_BROKER_URL not set and no brokerUrl override provided",
+    )
+  }
+  if (!grant) {
+    throw new Error(
+      "runtime-broker transport: HOLABOSS_APP_GRANT not set and no grant override provided",
+    )
+  }
+  if (!opts.provider) {
+    throw new Error("runtime-broker transport: provider is required")
+  }
+
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const provider = opts.provider
+
+  return async ({ method, url, body }) => {
+    const r = await fetchImpl(`${brokerUrl}/broker/proxy`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        grant,
+        provider,
+        request: {
+          method,
+          endpoint: url,
+          ...(body !== undefined ? { body } : {}),
+        },
+      }),
+    })
+
+    // Broker-level failure (HTTP non-2xx from /broker/proxy itself).
+    // Body shape from integration-broker.ts: { error: <code>, message: <text> }
+    // SDK BridgeClient maps the status to typed error codes.
+    if (!r.ok) {
+      const text = await r.text().catch(() => "")
+      let parsed: unknown = null
+      try { parsed = text ? JSON.parse(text) : null } catch { parsed = { _raw: text } }
+
+      // Recast Hono-upstream auth failures to 401 so bridge.ts maps them to
+      // `not_connected` and the agent surfaces "please re-login to Holaboss"
+      // instead of a generic upstream 5xx. The cookie-crash signature is a 5xx
+      // from runtime's ComposioService wrapping Hono's response — the error
+      // string "Composio proxy via Hono failed: ..." is stable across the
+      // crash and the auth-rejection paths (see runtime/api-server/src/
+      // composio-service.ts).
+      if (isHonoAuthFailure(r.status, parsed)) {
+        return {
+          status: 401,
+          body: {
+            error: "holaboss_session_invalid",
+            message:
+              "Holaboss session is invalid or expired. Log in to Holaboss in the desktop app, " +
+              "then restart desktop so the runtime picks up a fresh auth cookie.",
+            broker_status: r.status,
+            broker_body: parsed,
+          },
+          headers: {},
+        }
+      }
+      return { status: r.status, body: parsed, headers: {} }
+    }
+
+    // Broker succeeded — unwrap the provider response envelope.
+    const payload = (await r.json()) as {
+      data?: unknown
+      status?: number
+      headers?: Record<string, string>
+    }
+    return {
+      status: payload.status ?? r.status,
+      body: payload.data ?? null,
+      headers: payload.headers ?? {},
+    }
+  }
+}
+
+function isHonoAuthFailure(brokerStatus: number, body: unknown): boolean {
+  if (brokerStatus < 400) return false
+  if (!body || typeof body !== "object") return false
+  const r = body as Record<string, unknown>
+  const candidate =
+    (typeof r.detail === "string" ? r.detail : null) ??
+    (typeof r.message === "string" ? r.message : null) ??
+    (typeof r.error === "string" ? r.error : null)
+  if (!candidate) return false
+  return /Composio proxy via Hono failed/i.test(candidate)
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/bridge.ts
@@ -1,0 +1,104 @@
+import type {
+  BridgeClient,
+  BridgeError,
+  HttpMethod,
+  ProviderRegistry,
+  ProxyResult,
+} from "./types.ts"
+
+// In real SDK, this hits /broker/proxy via fetch. For the experiment we
+// allow tests to inject a mock transport so we can simulate provider errors
+// deterministically.
+
+export type TransportFn = (req: {
+  method: HttpMethod
+  url: string
+  body?: unknown
+}) => Promise<{ status: number; body: unknown; headers?: Record<string, string> }>
+
+export function createBridge(opts: {
+  provider: ProviderRegistry
+  transport: TransportFn
+}): BridgeClient {
+  const { provider, transport } = opts
+
+  return {
+    async call<T>(method: HttpMethod, path: string, body?: unknown): Promise<ProxyResult<T>> {
+      // Resolve path → absolute URL using provider.baseUrl
+      const url = path.startsWith("http") ? path : `${provider.baseUrl}${path}`
+
+      // Host allowlist check — endpoint shape errors fail BEFORE network
+      const host = new URL(url).host
+      if (!provider.allowedHosts.includes(host)) {
+        return makeError("validation_failed", `host ${host} not allowed for ${provider.id}`)
+      }
+
+      let resp
+      try {
+        resp = await transport({ method, url, body })
+      } catch (e) {
+        return makeError("upstream_error", e instanceof Error ? e.message : String(e))
+      }
+
+      if (resp.status >= 200 && resp.status < 300) {
+        return { kind: "ok", data: resp.body as T, status: resp.status }
+      }
+
+      const retryAfter = resp.headers?.["retry-after"]
+        ? Number(resp.headers["retry-after"])
+        : undefined
+
+      if (resp.status === 429) {
+        return makeError("rate_limited", extractMessage(resp.body) ?? "rate limit", {
+          upstreamStatus: 429,
+          upstreamBody: resp.body,
+          retryAfter,
+        })
+      }
+      if (resp.status === 401 || resp.status === 403) {
+        return makeError(
+          "not_connected",
+          extractMessage(resp.body) ?? `auth failed (${resp.status})`,
+          {
+            upstreamStatus: resp.status,
+            upstreamBody: resp.body,
+            reauthUrl: `/integrations/${provider.id}/connect`,
+          },
+        )
+      }
+      if (resp.status === 404) {
+        return makeError("not_found", extractMessage(resp.body) ?? "not found", {
+          upstreamStatus: 404,
+          upstreamBody: resp.body,
+        })
+      }
+      if (resp.status >= 400 && resp.status < 500) {
+        return makeError(
+          "validation_failed",
+          extractMessage(resp.body) ?? `client error ${resp.status}`,
+          { upstreamStatus: resp.status, upstreamBody: resp.body },
+        )
+      }
+      return makeError("upstream_error", `upstream ${resp.status}`, {
+        upstreamStatus: resp.status,
+        upstreamBody: resp.body,
+      })
+    },
+  }
+}
+
+function makeError(
+  code: BridgeError["code"],
+  message: string,
+  extra: Partial<BridgeError> = {},
+): BridgeError {
+  return { kind: "error", code, message, ...extra }
+}
+
+function extractMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined
+  const r = body as Record<string, unknown>
+  if (typeof r.message === "string") return r.message
+  if (typeof r.error === "string") return r.error
+  return undefined
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/index.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/index.ts
@@ -1,0 +1,48 @@
+// Public API surface for @holaboss/app-builder-sdk.
+
+// Core
+export { createApp } from "./app.ts"
+export type { CreateAppOptions } from "./app.ts"
+export { createBridge } from "./bridge.ts"
+export type { TransportFn } from "./bridge.ts"
+export { z } from "zod"
+
+// State backends
+export { SqliteStateBackend } from "./runtime/state-backend-sqlite.ts"
+export type { SqliteStateBackendOpts } from "./runtime/state-backend-sqlite.ts"
+
+// MCP server (production boot)
+export { startMcpServer } from "./runtime/mcp-server.ts"
+export type { StartMcpServerOpts, StartedMcpServer } from "./runtime/mcp-server.ts"
+
+// Bridge transports (pick the one that matches your deployment)
+export { createBearerTokenTransport } from "./bridge-transports/bearer.ts"
+export type { BearerTokenOpts } from "./bridge-transports/bearer.ts"
+export { createComposioDirectTransport } from "./bridge-transports/composio-direct.ts"
+export type { ComposioDirectOpts } from "./bridge-transports/composio-direct.ts"
+export { createRuntimeBrokerTransport } from "./bridge-transports/runtime-broker.ts"
+export type { RuntimeBrokerOpts } from "./bridge-transports/runtime-broker.ts"
+
+export type {
+  AppHandle,
+  AppConfig,
+  AppState,
+  BridgeClient,
+  BridgeError,
+  BridgeErrorCode,
+  DerivedTool,
+  StateBackend,
+  ProxyResult,
+  ProviderRegistry,
+  ResourceDef,
+  ResourceHandle,
+  StateTuple,
+  ActionDef,
+  ReversibleDef,
+  Step,
+  StepContext,
+  StepResult,
+  SyncDef,
+  TurnContext,
+  HttpMethod,
+} from "./types.ts"

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/action-runner.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/action-runner.ts
@@ -1,0 +1,186 @@
+// Executes an action against a row.
+// Runtime layer treats row data as Record<string, unknown>; agent-facing
+// callbacks receive the inferred row type (handled by app.ts type signatures).
+
+import type {
+  ActionDef,
+  BridgeClient,
+  EmitConfig,
+  ResourceDef,
+  StateBackend,
+  Step,
+  StepResult,
+} from "../types.ts"
+import type { ZodTypeAny } from "zod"
+
+interface RunOpts {
+  resourceName: string
+  resourceDef: ResourceDef<ZodTypeAny, any>
+  actionName: string
+  actionDef: ActionDef<Record<string, unknown>, any, any>
+  rowId: string
+  input: Record<string, unknown>
+  bridge: BridgeClient
+  state: StateBackend
+  appId: string
+}
+
+export async function runAction(
+  opts: RunOpts,
+): Promise<{ ok: true; externalId?: string } | { fail: { code: string; message: string } }> {
+  const {
+    resourceName, resourceDef, actionName, actionDef,
+    rowId, input, bridge, state, appId,
+  } = opts
+
+  const row = state.getRow(rowId)
+  if (!row) return { fail: { code: "not_found", message: `row ${rowId} not found` } }
+
+  if (!(actionDef.fromStates as readonly string[]).includes(row.status)) {
+    return {
+      fail: {
+        code: "invalid_state",
+        message: `action ${actionName} not allowed from state '${row.status}' (allowed: ${actionDef.fromStates.join("|")})`,
+      },
+    }
+  }
+
+  state.pushAudit("action.start", {
+    app: appId, resource: resourceName, action: actionName,
+    row_id: rowId, turn_id: row.createdInTurn, input,
+  })
+
+  const startTime = Date.now()
+  const steps: Step<Record<string, unknown>, Record<string, unknown>>[] =
+    actionDef.steps ?? (actionDef.run ? [{ name: actionName, run: actionDef.run }] : [])
+
+  if (steps.length === 0) {
+    return { fail: { code: "config_error", message: "action has no run or steps" } }
+  }
+
+  const persist = async (patch: Record<string, unknown>) => {
+    const merged = { ...(state.getRow(rowId)!.data as object), ...patch }
+    state.updateRow(rowId, { data: merged as Record<string, unknown> })
+  }
+  const log = (msg: string, extra?: Record<string, unknown>) =>
+    state.pushAudit("step.complete", { app: appId, msg, extra })
+
+  let externalId: string | undefined
+
+  for (const step of steps) {
+    const currentRow = state.getRow(rowId)!
+    const ctx = {
+      row: {
+        ...(currentRow.data as object),
+        id: rowId,
+        status: currentRow.status,
+        external_id: currentRow.externalId,
+      } as Record<string, unknown>,
+      input,
+      bridge,
+      persist,
+      log,
+    }
+
+    const stepStart = Date.now()
+    let result: StepResult
+    try {
+      result = await step.run(ctx)
+    } catch (e) {
+      result = {
+        fail: {
+          kind: "error",
+          code: "unhandled_exception",
+          message: e instanceof Error ? e.message : String(e),
+        },
+      }
+    }
+    const stepDur = Date.now() - stepStart
+
+    if ("fail" in result) {
+      state.pushAudit("step.complete", {
+        app: appId, step: step.name, outcome: "fail",
+        duration_ms: stepDur, error: result.fail,
+      })
+
+      const patch: Partial<typeof row> = { errorMessage: result.fail.message }
+      if (resourceDef.failedState !== undefined) {
+        patch.status = resourceDef.failedState as string
+      }
+      state.updateRow(rowId, patch)
+
+      if (resourceDef.failedState !== undefined) {
+        syncOutput(
+          state, resourceName, rowId, resourceDef.emit,
+          resourceDef.failedState as string,
+          state.getRow(rowId)!.data,
+          state.getRow(rowId)!.externalId,
+        )
+      }
+
+      const isAuth = (result.fail as { code: string }).code === "not_connected"
+      state.pushNotification({
+        level: "error",
+        summary: `${appId} ${actionName} failed at step ${step.name}: ${result.fail.message}`,
+        agentHint: isAuth
+          ? `Connection expired; ask user to reconnect.`
+          : `Step ${step.name} failed; retry policy may apply.`,
+        ref: { kind: resourceName, id: rowId },
+      })
+
+      state.pushAudit("action.end", {
+        app: appId, action: actionName, outcome: "fail",
+        total_duration_ms: Date.now() - startTime,
+      })
+      return {
+        fail: { code: (result.fail as { code: string }).code ?? "step_failed", message: result.fail.message },
+      }
+    }
+
+    if (result.externalId) externalId = result.externalId
+    state.pushAudit("step.complete", {
+      app: appId, step: step.name, outcome: "ok", duration_ms: stepDur,
+    })
+  }
+
+  if (actionDef.toState !== null) {
+    state.updateRow(rowId, {
+      status: actionDef.toState as string,
+      ...(externalId ? { externalId } : {}),
+    })
+    const finalRow = state.getRow(rowId)!
+    syncOutput(
+      state, resourceName, rowId, resourceDef.emit,
+      actionDef.toState as string,
+      finalRow.data,
+      finalRow.externalId,
+    )
+  }
+
+  state.pushAudit("action.end", {
+    app: appId, action: actionName, outcome: "ok",
+    external_id: externalId,
+    total_duration_ms: Date.now() - startTime,
+  })
+
+  return { ok: true, externalId }
+}
+
+function syncOutput(
+  state: StateBackend,
+  resourceName: string,
+  rowId: string,
+  emit: EmitConfig<any> | undefined,
+  status: string,
+  rowData: Record<string, unknown>,
+  externalId?: string,
+): void {
+  if (!emit || emit.surface === "none") return
+  const enriched = { ...rowData, id: rowId, status, external_id: externalId }
+  const summary = emit.summary?.(enriched) ?? null
+  const deepLink = emit.deepLink?.(enriched) ?? null
+  state.upsertOutput({
+    resourceName, rowId, surface: emit.surface,
+    status, summary, deepLink,
+  })
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/db-view.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/db-view.ts
@@ -1,0 +1,70 @@
+// DbView implementation — backend-agnostic query over rows.
+
+import type { DbView, ResourceHandle, RowOf, StateBackend, StateTuple } from "../types.ts"
+import type { ZodTypeAny } from "zod"
+
+export function createDbView(state: StateBackend): DbView {
+  return {
+    query<TSchema extends ZodTypeAny, States extends StateTuple>(
+      resource: ResourceHandle<TSchema, States>,
+    ) {
+      const allRows = () =>
+        state.rowsByResource(resource.name).map(r => ({
+          ...r.data,
+          id: r.id,
+          status: r.status,
+          external_id: r.externalId,
+        }) as RowOf<TSchema>)
+
+      function applyWhere(cond: Record<string, unknown>) {
+        const rows = allRows().filter(r => {
+          for (const [k, v] of Object.entries(cond)) {
+            // Scalar equality only — DbView's where() type restricts callers
+            // at compile time (ScalarFilter). This runtime check exists for
+            // untyped JS callers that bypass the type.
+            const got = (r as Record<string, unknown>)[k]
+            if (got !== v) return false
+          }
+          return true
+        })
+
+        return {
+          all: () => rows,
+          recent: (window: string) => {
+            const ms = parseWindow(window)
+            const cutoff = Date.now() - ms
+            // recency by createdAt — need original RowRecord, not the merged view
+            const ids = new Set(rows.map(r => r.id))
+            return state.rowsByResource(resource.name)
+              .filter(rr => ids.has(rr.id) && Date.parse(rr.createdAt) >= cutoff)
+              .map(rr => ({
+                ...rr.data,
+                id: rr.id,
+                status: rr.status,
+                external_id: rr.externalId,
+              }) as RowOf<TSchema>)
+          },
+        }
+      }
+
+      return {
+        where: applyWhere,
+        all: allRows,
+      }
+    },
+  }
+}
+
+function parseWindow(window: string): number {
+  // "30d" / "6h" / "15m"
+  const m = window.match(/^(\d+)([dhms])$/)
+  if (!m) throw new Error(`bad window: ${window}`)
+  const n = parseInt(m[1]!, 10)
+  switch (m[2]) {
+    case "d": return n * 86_400_000
+    case "h": return n * 3_600_000
+    case "m": return n * 60_000
+    case "s": return n * 1000
+    default:  return 0
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/manifest.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/manifest.ts
@@ -1,0 +1,91 @@
+// Generates an app.runtime.yaml document from an SDK app's declaration.
+//
+// The Holaboss runtime reads app.runtime.yaml for lifecycle (setup/start/stop),
+// healthchecks, MCP descriptor (port + tool list), env contract, and
+// integrations. With this helper, an SDK app doesn't hand-write boilerplate
+// — the manifest is derived from what the app already declared.
+
+import type { AppHandleInternal } from "../app.ts"
+
+export interface ManifestOpts {
+  /** Display name for marketplace / UI. Defaults to app.id with title-case. */
+  name?: string
+  /** Manifest slug. Defaults to app.id. */
+  slug?: string
+  /** npm/bun setup + start commands. Defaults to sensible bun pattern. */
+  lifecycle?: { setup?: string; start?: string; stop?: string }
+  /** MCP port the entry point will listen on. Default 3099 (matches existing convention). */
+  mcpPort?: number
+  /** Optional UI port (Express server) — omit if the app has no UI. */
+  uiPort?: number
+  /** Extra env vars beyond the SDK's defaults. */
+  extraEnv?: string[]
+}
+
+export function buildAppRuntimeManifest(app: AppHandleInternal, opts: ManifestOpts = {}): string {
+  const cfg = app.config
+  const name = opts.name ?? titleCase(cfg.id)
+  const slug = opts.slug ?? cfg.id
+  const mcpPort = opts.mcpPort ?? 3099
+  const lifecycle = {
+    setup: opts.lifecycle?.setup ?? "bun install",
+    start: opts.lifecycle?.start ?? `MCP_PORT=${mcpPort} bun run server.ts`,
+    stop: opts.lifecycle?.stop ?? `kill $(lsof -t -i :\${MCP_PORT:-${mcpPort}} 2>/dev/null) 2>/dev/null || true`,
+  }
+  const baseEnv = [
+    "HOLABOSS_WORKSPACE_ID",
+    "WORKSPACE_DB_PATH",
+    "HOLABOSS_INTEGRATION_BROKER_URL",
+    "HOLABOSS_APP_GRANT",
+    "MCP_PORT",
+  ]
+  const env = [...new Set([...baseEnv, ...(opts.extraEnv ?? [])])]
+
+  const toolNames = app.derivedTools().map(t => t.name)
+
+  // Produce yaml manually — no yaml dep needed, structure is rigid.
+  const lines: string[] = []
+  lines.push(`app_id: "${cfg.id}"`)
+  lines.push(`name: "${name}"`)
+  lines.push(`slug: "${slug}"`)
+  lines.push(``)
+  lines.push(`lifecycle:`)
+  lines.push(`  setup: "${escapeYaml(lifecycle.setup)}"`)
+  lines.push(`  start: "${escapeYaml(lifecycle.start)}"`)
+  lines.push(`  stop: "${escapeYaml(lifecycle.stop)}"`)
+  lines.push(``)
+  lines.push(`healthchecks:`)
+  lines.push(`  mcp:`)
+  lines.push(`    path: /mcp/health`)
+  lines.push(`    timeout_s: 30`)
+  lines.push(``)
+  lines.push(`mcp:`)
+  lines.push(`  enabled: true`)
+  lines.push(`  transport: http-sse`)
+  lines.push(`  port: ${mcpPort}`)
+  lines.push(`  path: /mcp/sse`)
+  lines.push(`  tools:`)
+  for (const t of toolNames) lines.push(`    - ${t}`)
+  if (opts.uiPort !== undefined) {
+    lines.push(``)
+    lines.push(`ui:`)
+    lines.push(`  port: ${opts.uiPort}`)
+  }
+  lines.push(``)
+  lines.push(`integration:`)
+  lines.push(`  destination: "${cfg.provider.composioToolkit ?? cfg.id}"`)
+  lines.push(`  credential_source: "platform"`)
+  lines.push(``)
+  lines.push(`env_contract:`)
+  for (const e of env) lines.push(`  - "${e}"`)
+  lines.push(``)
+  return lines.join("\n")
+}
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1).replace(/[_-]/g, " ")
+}
+
+function escapeYaml(s: string): string {
+  return s.replace(/"/g, '\\"')
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/mcp-server.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/mcp-server.ts
@@ -1,0 +1,484 @@
+// MCP server boot — exposes SDK app's derived tools as a real MCP server
+// over HTTP/SSE (matches the convention used by all hola-boss-apps modules).
+//
+// Pattern follows _template/src/server/mcp.ts:
+//   GET  /mcp/health    → { status: "ok" }
+//   GET  /mcp/sse       → establishes SSE transport (one per agent session)
+//   POST /mcp/messages  → routes JSON-RPC messages to the right SSE transport
+//
+// Tools registered automatically from the app:
+//   - <app>_create_<resource>           creates a row in initialState
+//   - <app>_list_<resource>s            lists rows of that resource
+//   - <app>_get_<resource>              fetches one by id
+//   - <app>_<action>_<resource>         invokes a registered action
+//   - <app>_cancel_<action>_<resource>  invokes a reversible action's reverse
+//   - <app>_connection_status           probes provider whoami via bridge
+//   - <app>_refresh_<plural>            (for resources with refreshEvery+fetch)
+//   - <app>_<sync>_sync_status          reads last sync run from audit
+//   - <app>_snapshot                    compact situational read
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
+import { createServer, type Server as HttpServer } from "node:http"
+import { z, type ZodObject, type ZodRawShape } from "zod"
+import type { AppHandleInternal } from "../app.ts"
+import type { BridgeClient } from "../types.ts"
+
+export interface StartMcpServerOpts {
+  app: AppHandleInternal
+  /** Port to listen on. Use 0 for an OS-assigned port (returned via `port`). */
+  port: number
+  /** Bridge used when actions/syncs need to call upstream. Production should
+   *  pass a runtime-broker transport; tests can pass a mock transport. */
+  bridge: BridgeClient
+  /** Optional MCP server display name. Defaults to `<app.id> Module`. */
+  serverName?: string
+  /** Optional MCP server version. */
+  serverVersion?: string
+  /** Optional web-surface port. Holaboss desktop renders an iframe at this URL
+   *  for hola-boss-apps-style modules. SDK apps are headless, but the desktop
+   *  still tries to load the URL — this option binds a tiny HTTP server that
+   *  serves a placeholder page so the iframe gets a 200 instead of
+   *  ERR_CONNECTION_REFUSED. Wire from `process.env.PORT` in production. */
+  httpPort?: number
+}
+
+export interface StartedMcpServer {
+  /** Actual port the MCP server is listening on (resolved after 0 → OS-assigned). */
+  port: number
+  /** Actual port the web-surface stub is listening on (if httpPort was set). */
+  httpPort?: number
+  /** Stop both servers gracefully. */
+  close: () => Promise<void>
+}
+
+export async function startMcpServer(opts: StartMcpServerOpts): Promise<StartedMcpServer> {
+  const { app, bridge } = opts
+  const serverName = opts.serverName ?? `${app.config.id} Module`
+  const serverVersion = opts.serverVersion ?? "1.0.0"
+
+  // Per-session transports (MCP allows multiple concurrent SSE clients).
+  const transports = new Map<string, SSEServerTransport>()
+
+  function buildServer(): McpServer {
+    const server = new McpServer({ name: serverName, version: serverVersion })
+    registerTools(server, app, bridge)
+    return server
+  }
+
+  const httpServer = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${opts.port}`)
+
+    if (url.pathname === "/mcp/health") {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ status: "ok", app_id: app.config.id }))
+      return
+    }
+
+    if (url.pathname === "/mcp/sse" && req.method === "GET") {
+      const transport = new SSEServerTransport("/mcp/messages", res)
+      transports.set(transport.sessionId, transport)
+      const server = buildServer()
+      await server.connect(transport)
+      return
+    }
+
+    if (url.pathname === "/mcp/messages" && req.method === "POST") {
+      const sessionId = url.searchParams.get("sessionId")
+      const transport = sessionId ? transports.get(sessionId) : undefined
+      if (!transport) {
+        res.writeHead(400)
+        res.end("Unknown session")
+        return
+      }
+      await transport.handlePostMessage(req, res)
+      return
+    }
+
+    res.writeHead(404)
+    res.end("Not found")
+  })
+
+  await new Promise<void>((resolve) => httpServer.listen(opts.port, () => resolve()))
+  const addr = httpServer.address()
+  const actualPort = typeof addr === "object" && addr ? addr.port : opts.port
+
+  let webStub: HttpServer | undefined
+  let actualHttpPort: number | undefined
+  if (opts.httpPort !== undefined) {
+    webStub = createWebStub(app.config.id, actualPort)
+    await new Promise<void>((resolve) => webStub!.listen(opts.httpPort, () => resolve()))
+    const sAddr = webStub.address()
+    actualHttpPort = typeof sAddr === "object" && sAddr ? sAddr.port : opts.httpPort
+  }
+
+  return {
+    port: actualPort,
+    httpPort: actualHttpPort,
+    close: () => Promise.all([
+      new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      ),
+      webStub
+        ? new Promise<void>((resolve, reject) =>
+            webStub!.close((err) => (err ? reject(err) : resolve())),
+          )
+        : Promise.resolve(),
+    ]).then(() => undefined),
+  }
+}
+
+// Headless-module placeholder for the desktop's iframe surface.
+function createWebStub(appId: string, mcpPort: number): HttpServer {
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(appId)} — headless module</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    :root { color-scheme: light dark }
+    body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+           margin: 0; padding: 32px; max-width: 640px }
+    h1 { font-size: 18px; margin: 0 0 8px; font-weight: 600 }
+    p  { margin: 6px 0; opacity: .8 }
+    code { font: 12px ui-monospace, SF Mono, Menlo, monospace;
+           background: color-mix(in srgb, currentColor 8%, transparent);
+           padding: 1px 6px; border-radius: 4px }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(appId)}</h1>
+  <p>This module was built with <code>@holaboss/app-builder-sdk</code> and is headless — it exposes only an MCP server, no web UI.</p>
+  <p>Drive it from agent chat. The MCP server is on <code>:${mcpPort}/mcp/sse</code>.</p>
+</body>
+</html>`
+  return createServer((req, res) => {
+    if (req.url === "/health" || req.url === "/healthz") {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ status: "ok", surface: "headless_stub", app_id: appId }))
+      return
+    }
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
+    res.end(html)
+  })
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!))
+}
+
+// ─── Tool registration ─────────────────────────────────────────────────────
+
+function registerTools(mcp: McpServer, app: AppHandleInternal, bridge: BridgeClient): void {
+  const appId = app.config.id
+
+  // Connection — probe provider.whoamiPath via bridge.
+  mcp.registerTool(
+    `${appId}_connection_status`,
+    {
+      title: "Connection status",
+      description: `Check whether ${appId} is connected and ready to call (probes the provider's whoami endpoint).`,
+      inputSchema: {},
+    },
+    async () => textResult(await probeConnection(app, bridge)),
+  )
+
+  // Per-resource: create / list / get / (refresh if refreshEvery + fetch declared)
+  for (const [resourceName, resource] of app._resources) {
+    const inputShapeForCreate = extractShape(resource.schema)
+
+    if (resource.def.refreshEvery && resource.def.fetch) {
+      mcp.registerTool(
+        `${appId}_refresh_${plural(resourceName)}`,
+        {
+          title: `Refresh ${resourceName} cache`,
+          description: `Re-pull ${resourceName} list from upstream and upsert into local cache.`,
+          inputSchema: {},
+        },
+        async () => textResult(await refreshResource(app, resource, bridge)),
+      )
+    }
+
+    mcp.registerTool(
+      `${appId}_create_${resourceName}`,
+      {
+        title: `Create ${resourceName} draft`,
+        description: `Create a new ${resourceName} row in '${resource.def.initialState}' state. ` +
+          `No upstream call yet — use an action tool to act on the row.`,
+        inputSchema: inputShapeForCreate,
+      },
+      async (input) => {
+        const row = app._state.insertRow(resourceName, input as Record<string, unknown>, resource.def.initialState)
+        return textResult(rowAsView(row))
+      },
+    )
+
+    mcp.registerTool(
+      `${appId}_list_${plural(resourceName)}`,
+      {
+        title: `List ${resourceName} rows`,
+        description: `List all ${resourceName} rows tracked by this app, with status and ids.`,
+        inputSchema: {},
+      },
+      async () => {
+        const rows = app._state.rowsByResource(resourceName).map(rowAsView)
+        return textResult({ rows, count: rows.length })
+      },
+    )
+
+    mcp.registerTool(
+      `${appId}_get_${resourceName}`,
+      {
+        title: `Get ${resourceName} by id`,
+        description: `Fetch a single ${resourceName} row by its id.`,
+        inputSchema: { id: z.string() },
+      },
+      async (input) => {
+        const row = app._state.getRow((input as { id: string }).id)
+        if (!row) return errResult("not_found", `${resourceName} not found`)
+        return textResult(rowAsView(row))
+      },
+    )
+  }
+
+  // Per-action: invoke + (if reversible) cancel
+  for (const reg of app._actions) {
+    const toolName = reg.def.toolName ?? `${appId}_${reg.name}_${reg.resource.name}`
+    const rowIdKey = `${reg.resource.name}_id`
+
+    // Action input shape: <resource>_id + (action.schema's fields if defined)
+    const extraShape = extractShape(reg.def.schema)
+    const inputShape: ZodRawShape = { [rowIdKey]: z.string(), ...extraShape }
+
+    mcp.registerTool(
+      toolName,
+      {
+        title: `${reg.name} ${reg.resource.name}`,
+        description:
+          `${reg.name} a ${reg.resource.name} ` +
+          `(from ${reg.def.fromStates.join("|")} → ${reg.def.toState ?? "side-effect"})`,
+        inputSchema: inputShape,
+      },
+      async (input) => {
+        const i = input as Record<string, unknown>
+        const rowId = i[rowIdKey] as string
+        const actionInput: Record<string, unknown> = { ...i }
+        delete actionInput[rowIdKey]
+        const result = await app._invokeAction({
+          actionName: reg.name, rowId, input: actionInput, bridge,
+        })
+        return "fail" in result
+          ? errResult(result.fail.code, result.fail.message)
+          : textResult(result)
+      },
+    )
+
+    if (reg.def.reversible) {
+      const reverseToolName = reg.def.toolName
+        ? `${reg.def.toolName}_reverse`
+        : `${appId}_cancel_${reg.name}_${reg.resource.name}`
+      mcp.registerTool(
+        reverseToolName,
+        {
+          title: `Cancel ${reg.name} ${reg.resource.name}`,
+          description:
+            `Reverse a ${reg.name} on a ${reg.resource.name} ` +
+            `(brings row back to '${reg.def.reversible.toState}')`,
+          inputSchema: { [rowIdKey]: z.string() },
+        },
+        async (input) => {
+          const rowId = (input as Record<string, string>)[rowIdKey]
+          const result = await app._invokeReverse({
+            actionName: reg.name, rowId: rowId!, bridge,
+          })
+          return "fail" in result
+            ? errResult(result.fail.code, result.fail.message)
+            : textResult(result)
+        },
+      )
+    }
+  }
+
+  // Snapshot
+  mcp.registerTool(
+    `${appId}_snapshot`,
+    {
+      title: `${appId} snapshot`,
+      description: `Compact situational read of this app: row counts by status, recent failures, last sync time.`,
+      inputSchema: {},
+    },
+    async () => textResult(buildSnapshot(app)),
+  )
+
+  // Sync status — read last sync.start/sync.end from audit + record count.
+  for (const sync of app._syncs) {
+    mcp.registerTool(
+      `${appId}_${sync.name}_sync_status`,
+      {
+        title: `${sync.name} sync status`,
+        description: `Last-run status of the ${sync.name} sync (started_at, outcome, fetched, upserted, error).`,
+        inputSchema: {},
+      },
+      async () => textResult(readSyncStatus(app, sync.name)),
+    )
+  }
+}
+
+// ─── Tool handlers extracted for clarity / unit reuse ──────────────────────
+
+async function probeConnection(app: AppHandleInternal, bridge: BridgeClient) {
+  const appId = app.config.id
+  const whoamiPath = app.config.provider.whoamiPath
+  if (!whoamiPath) {
+    return {
+      app_id: appId,
+      connected: null,
+      reason: "no_probe_defined",
+      message: `provider '${app.config.provider.id}' has no whoamiPath — connection cannot be verified`,
+    }
+  }
+  const r = await bridge.call("GET", whoamiPath)
+  if (r.kind === "ok") {
+    return { app_id: appId, connected: true as const, identity: r.data }
+  }
+  return {
+    app_id: appId,
+    connected: false as const,
+    reason: r.code,
+    message: r.message,
+    upstream_status: r.upstreamStatus,
+    reauth_url: r.reauthUrl,
+  }
+}
+
+async function refreshResource(
+  app: AppHandleInternal,
+  resource: { name: string; schema: unknown; def: { fetch?: (ctx: { bridge: BridgeClient }) => Promise<unknown[]>; initialState: string } },
+  bridge: BridgeClient,
+) {
+  const fetchFn = resource.def.fetch
+  if (!fetchFn) {
+    return { ok: false, error: { code: "no_fetch_defined", message: `${resource.name} has refreshEvery but no fetch()` } }
+  }
+  let items: unknown[]
+  try {
+    items = await fetchFn({ bridge })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { ok: false, error: { code: "fetch_threw", message: msg } }
+  }
+  const existing = app._state.rowsByResource(resource.name)
+  const initialState = resource.def.initialState
+  let inserted = 0
+  let updated = 0
+  for (const raw of items) {
+    if (!raw || typeof raw !== "object") continue
+    const data = raw as Record<string, unknown>
+    const key = data.id !== undefined ? String(data.id) : null
+    const match = key ? existing.find(r => String(r.data.id ?? "") === key) : undefined
+    if (match) {
+      app._state.updateRow(match.id, { data, status: initialState })
+      updated++
+    } else {
+      app._state.insertRow(resource.name, data, initialState)
+      inserted++
+    }
+  }
+  return { ok: true, fetched: items.length, inserted, updated }
+}
+
+function readSyncStatus(app: AppHandleInternal, syncName: string) {
+  const snap = app._state.snapshot()
+  const matching = snap.audit.filter(e =>
+    (e.event === "sync.start" || e.event === "sync.end") && e.fields.sync === syncName,
+  )
+  const lastStart = [...matching].reverse().find(e => e.event === "sync.start")
+  const lastEnd = [...matching].reverse().find(e => e.event === "sync.end")
+  const sync = app._syncs.find(s => s.name === syncName)
+  const recordsTotal = snap.syncRecords.filter(r => r.syncName === syncName).length
+
+  if (!lastEnd && !lastStart) {
+    return {
+      sync_name: syncName,
+      schedule: sync?.def.schedule ?? null,
+      has_ever_run: false,
+      records_total: recordsTotal,
+    }
+  }
+  const endFields = (lastEnd?.fields ?? {}) as Record<string, unknown>
+  return {
+    sync_name: syncName,
+    schedule: sync?.def.schedule ?? null,
+    has_ever_run: true,
+    started_at: lastStart?.at,
+    ended_at: lastEnd?.at,
+    outcome: endFields.outcome ?? null,
+    fetched: endFields.fetched ?? null,
+    upserted: endFields.upserted ?? null,
+    total_ms: endFields.total_ms ?? null,
+    error: endFields.error ?? null,
+    records_total: recordsTotal,
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function extractShape(schema: unknown): ZodRawShape {
+  if (schema && typeof schema === "object" && "shape" in schema) {
+    return (schema as ZodObject<ZodRawShape>).shape
+  }
+  return {}
+}
+
+function plural(name: string): string {
+  if (name.endsWith("s") || name.endsWith("x") || name.endsWith("ch")) return `${name}es`
+  if (name.endsWith("y")) return `${name.slice(0, -1)}ies`
+  return `${name}s`
+}
+
+function rowAsView(row: { id: string; status: string; data: Record<string, unknown>; externalId?: string; errorMessage?: string }) {
+  return {
+    id: row.id,
+    status: row.status,
+    ...row.data,
+    ...(row.externalId ? { external_id: row.externalId } : {}),
+    ...(row.errorMessage ? { error_message: row.errorMessage } : {}),
+  }
+}
+
+function buildSnapshot(app: AppHandleInternal) {
+  const state = app.state()
+  const counts: Record<string, Record<string, number>> = {}
+  for (const row of state.rows) {
+    counts[row.resource] = counts[row.resource] ?? {}
+    counts[row.resource]![row.status] = (counts[row.resource]![row.status] ?? 0) + 1
+  }
+  const recentFailures = state.notifications
+    .filter(n => n.level === "error")
+    .slice(-5)
+    .map(n => ({ at: n.at, summary: n.summary }))
+  return {
+    app_id: app.config.id,
+    rows_by_resource: counts,
+    recent_failures: recentFailures,
+    total_outputs: state.outputs.length,
+    total_sync_records: state.syncRecords.length,
+  }
+}
+
+function textResult(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    structuredContent: data && typeof data === "object" && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : undefined,
+  }
+}
+
+function errResult(code: string, message: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ code, message }, null, 2) }],
+    isError: true as const,
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/state-backend-sqlite.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/state-backend-sqlite.ts
@@ -1,0 +1,325 @@
+// SQLite-backed StateBackend — production implementation.
+//
+// Uses bun:sqlite to open the workspace shared DB (WORKSPACE_DB_PATH) and
+// keeps all SDK state in app-owned tables prefixed with the app id.
+//
+// This iteration intentionally does NOT bridge to @holaboss/runtime-state-store's
+// `outputs` / `runtime_notifications` tables — those mappings come in a follow-up
+// iteration. For now, outputs and notifications are persisted in app-owned
+// tables; once we wire to state-store, those tables can be backfilled or
+// migrated.
+
+import { Database } from "bun:sqlite"
+import { randomUUID } from "node:crypto"
+import type {
+  AppState,
+  AuditEntry,
+  NotificationEntry,
+  OutputCard,
+  RowRecord,
+  StateBackend,
+  SyncRecord,
+  TurnContext,
+} from "../types.ts"
+
+export interface SqliteStateBackendOpts {
+  /** Filesystem path to the workspace SQLite database. */
+  dbPath: string
+  /** App id — used as table prefix so multiple SDK apps share workspace.db cleanly. */
+  appId: string
+}
+
+export class SqliteStateBackend implements StateBackend {
+  private db: Database
+  private appId: string
+  private turnContext: TurnContext | null = null
+
+  // Pre-compiled statements
+  private stmts: {
+    insertRow: ReturnType<Database["prepare"]>
+    updateRow: ReturnType<Database["prepare"]>
+    getRow: ReturnType<Database["prepare"]>
+    rowsByResource: ReturnType<Database["prepare"]>
+    listAllRows: ReturnType<Database["prepare"]>
+    insertAudit: ReturnType<Database["prepare"]>
+    listAudit: ReturnType<Database["prepare"]>
+    upsertOutput: ReturnType<Database["prepare"]>
+    listOutputs: ReturnType<Database["prepare"]>
+    insertNotification: ReturnType<Database["prepare"]>
+    listNotifications: ReturnType<Database["prepare"]>
+    upsertSyncRecord: ReturnType<Database["prepare"]>
+    listSyncRecords: ReturnType<Database["prepare"]>
+  }
+
+  constructor(opts: SqliteStateBackendOpts) {
+    this.appId = opts.appId
+    this.db = new Database(opts.dbPath)
+    this.db.exec("PRAGMA journal_mode = WAL")
+    this.createTables()
+    this.stmts = this.prepareStatements()
+  }
+
+  setTurnContext(ctx: TurnContext | null): void {
+    this.turnContext = ctx
+  }
+
+  insertRow(resource: string, data: Record<string, unknown>, status: string): RowRecord {
+    const id = `r_${randomUUID().slice(0, 12)}`
+    const now = new Date().toISOString()
+    this.stmts.insertRow.run(
+      id, resource, status, JSON.stringify(data),
+      null, null, null,
+      this.turnContext?.turnId ?? null,
+      this.turnContext?.sessionId ?? null,
+      now, now,
+    )
+    return {
+      id, resource, status, data,
+      createdInTurn: this.turnContext?.turnId,
+      sessionId: this.turnContext?.sessionId,
+      createdAt: now, updatedAt: now,
+    }
+  }
+
+  updateRow(id: string, patch: Partial<RowRecord>): RowRecord {
+    const existing = this.getRow(id)
+    if (!existing) throw new Error(`row ${id} not found`)
+    const merged: RowRecord = {
+      ...existing,
+      ...patch,
+      data: patch.data ?? existing.data,
+      updatedAt: new Date().toISOString(),
+    }
+    this.stmts.updateRow.run(
+      merged.resource, merged.status, JSON.stringify(merged.data),
+      merged.externalId ?? null,
+      merged.errorMessage ?? null,
+      merged.scheduledAt ?? null,
+      merged.createdInTurn ?? null,
+      merged.sessionId ?? null,
+      merged.updatedAt,
+      id,
+    )
+    return merged
+  }
+
+  getRow(id: string): RowRecord | undefined {
+    const row = this.stmts.getRow.get(id) as RawRowRow | undefined
+    return row ? this.rowFromRaw(row) : undefined
+  }
+
+  rowsByResource(resource: string): RowRecord[] {
+    const rows = this.stmts.rowsByResource.all(resource) as RawRowRow[]
+    return rows.map(r => this.rowFromRaw(r))
+  }
+
+  pushAudit(event: AuditEntry["event"], fields: Record<string, unknown>): void {
+    this.stmts.insertAudit.run(new Date().toISOString(), event, JSON.stringify(fields))
+  }
+
+  upsertOutput(card: Omit<OutputCard, "updatedAt">): void {
+    this.stmts.upsertOutput.run(
+      card.resourceName, card.rowId,
+      card.surface, card.status,
+      card.summary ?? null,
+      card.deepLink ?? null,
+      new Date().toISOString(),
+    )
+  }
+
+  pushNotification(n: Omit<NotificationEntry, "at">): void {
+    this.stmts.insertNotification.run(
+      new Date().toISOString(),
+      n.level, n.summary,
+      n.agentHint ?? null,
+      n.ref?.kind ?? null,
+      n.ref?.id ?? null,
+    )
+  }
+
+  upsertSyncRecord(rec: Omit<SyncRecord, "syncedAt">): void {
+    this.stmts.upsertSyncRecord.run(
+      rec.syncName, rec.key, rec.attachedRowId,
+      JSON.stringify(rec.raw), JSON.stringify(rec.normalized),
+      new Date().toISOString(),
+    )
+  }
+
+  snapshot(): AppState {
+    const rows = (this.stmts.listAllRows.all() as RawRowRow[]).map(r => this.rowFromRaw(r))
+    const audit = (this.stmts.listAudit.all() as RawAuditRow[]).map(a => ({
+      at: a.at, event: a.event as AuditEntry["event"],
+      fields: JSON.parse(a.fields_json),
+    }))
+    const outputs = (this.stmts.listOutputs.all() as RawOutputRow[]).map(o => ({
+      resourceName: o.resource_name, rowId: o.row_id, surface: o.surface,
+      status: o.status, summary: o.summary, deepLink: o.deep_link, updatedAt: o.updated_at,
+    }))
+    const notifications = (this.stmts.listNotifications.all() as RawNotifRow[]).map(n => ({
+      at: n.at,
+      level: n.level as NotificationEntry["level"],
+      summary: n.summary,
+      agentHint: n.agent_hint ?? undefined,
+      ref: n.ref_kind && n.ref_id ? { kind: n.ref_kind, id: n.ref_id } : undefined,
+    }))
+    const syncRecords = (this.stmts.listSyncRecords.all() as RawSyncRow[]).map(s => ({
+      syncName: s.sync_name, key: s.key, attachedRowId: s.attached_row_id ?? "",
+      raw: JSON.parse(s.raw_json), normalized: JSON.parse(s.normalized_json),
+      syncedAt: s.synced_at,
+    }))
+    return { rows, audit, outputs, notifications, syncRecords, derivedTools: [] }
+  }
+
+  /** Test-only: close the underlying DB. */
+  close(): void {
+    this.db.close()
+  }
+
+  // ─── private ──────────────────────────────────────────────────────────────
+
+  private t(suffix: string) { return `${this.appId}__${suffix}` }
+
+  private createTables(): void {
+    const rows = this.t("rows")
+    const audit = this.t("audit")
+    const outputs = this.t("outputs")
+    const notif = this.t("notifications")
+    const sync = this.t("sync_records")
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ${rows} (
+        id TEXT PRIMARY KEY,
+        resource TEXT NOT NULL,
+        status TEXT NOT NULL,
+        data_json TEXT NOT NULL,
+        external_id TEXT,
+        error_message TEXT,
+        scheduled_at TEXT,
+        created_in_turn TEXT,
+        session_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_${rows}_resource ON ${rows}(resource);
+
+      CREATE TABLE IF NOT EXISTS ${audit} (
+        rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+        at TEXT NOT NULL,
+        event TEXT NOT NULL,
+        fields_json TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS ${outputs} (
+        resource_name TEXT NOT NULL,
+        row_id TEXT NOT NULL,
+        surface TEXT NOT NULL,
+        status TEXT NOT NULL,
+        summary TEXT,
+        deep_link TEXT,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (resource_name, row_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ${notif} (
+        rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+        at TEXT NOT NULL,
+        level TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        agent_hint TEXT,
+        ref_kind TEXT,
+        ref_id TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS ${sync} (
+        sync_name TEXT NOT NULL,
+        key TEXT NOT NULL,
+        attached_row_id TEXT,
+        raw_json TEXT NOT NULL,
+        normalized_json TEXT NOT NULL,
+        synced_at TEXT NOT NULL,
+        PRIMARY KEY (sync_name, key)
+      );
+    `)
+  }
+
+  private prepareStatements() {
+    const rows = this.t("rows")
+    const audit = this.t("audit")
+    const outputs = this.t("outputs")
+    const notif = this.t("notifications")
+    const sync = this.t("sync_records")
+    return {
+      insertRow: this.db.prepare(`
+        INSERT INTO ${rows} (id, resource, status, data_json, external_id, error_message, scheduled_at, created_in_turn, session_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      updateRow: this.db.prepare(`
+        UPDATE ${rows} SET resource = ?, status = ?, data_json = ?, external_id = ?, error_message = ?, scheduled_at = ?, created_in_turn = ?, session_id = ?, updated_at = ?
+        WHERE id = ?
+      `),
+      getRow: this.db.prepare(`SELECT * FROM ${rows} WHERE id = ?`),
+      rowsByResource: this.db.prepare(`SELECT * FROM ${rows} WHERE resource = ? ORDER BY created_at`),
+      listAllRows: this.db.prepare(`SELECT * FROM ${rows} ORDER BY created_at`),
+      insertAudit: this.db.prepare(`INSERT INTO ${audit} (at, event, fields_json) VALUES (?, ?, ?)`),
+      listAudit: this.db.prepare(`SELECT * FROM ${audit} ORDER BY rowid`),
+      upsertOutput: this.db.prepare(`
+        INSERT INTO ${outputs} (resource_name, row_id, surface, status, summary, deep_link, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(resource_name, row_id) DO UPDATE SET
+          surface = excluded.surface,
+          status = excluded.status,
+          summary = excluded.summary,
+          deep_link = excluded.deep_link,
+          updated_at = excluded.updated_at
+      `),
+      listOutputs: this.db.prepare(`SELECT * FROM ${outputs} ORDER BY updated_at`),
+      insertNotification: this.db.prepare(`
+        INSERT INTO ${notif} (at, level, summary, agent_hint, ref_kind, ref_id) VALUES (?, ?, ?, ?, ?, ?)
+      `),
+      listNotifications: this.db.prepare(`SELECT * FROM ${notif} ORDER BY rowid`),
+      upsertSyncRecord: this.db.prepare(`
+        INSERT INTO ${sync} (sync_name, key, attached_row_id, raw_json, normalized_json, synced_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(sync_name, key) DO UPDATE SET
+          attached_row_id = excluded.attached_row_id,
+          raw_json = excluded.raw_json,
+          normalized_json = excluded.normalized_json,
+          synced_at = excluded.synced_at
+      `),
+      listSyncRecords: this.db.prepare(`SELECT * FROM ${sync} ORDER BY synced_at`),
+    }
+  }
+
+  private rowFromRaw(r: RawRowRow): RowRecord {
+    return {
+      id: r.id, resource: r.resource, status: r.status,
+      data: JSON.parse(r.data_json),
+      externalId: r.external_id ?? undefined,
+      errorMessage: r.error_message ?? undefined,
+      scheduledAt: r.scheduled_at ?? undefined,
+      createdInTurn: r.created_in_turn ?? undefined,
+      sessionId: r.session_id ?? undefined,
+      createdAt: r.created_at, updatedAt: r.updated_at,
+    }
+  }
+}
+
+// Raw row shapes from SQLite
+interface RawRowRow {
+  id: string; resource: string; status: string; data_json: string
+  external_id: string | null; error_message: string | null; scheduled_at: string | null
+  created_in_turn: string | null; session_id: string | null
+  created_at: string; updated_at: string
+}
+interface RawAuditRow { at: string; event: string; fields_json: string }
+interface RawOutputRow {
+  resource_name: string; row_id: string; surface: string; status: string
+  summary: string | null; deep_link: string | null; updated_at: string
+}
+interface RawNotifRow {
+  at: string; level: string; summary: string
+  agent_hint: string | null; ref_kind: string | null; ref_id: string | null
+}
+interface RawSyncRow {
+  sync_name: string; key: string; attached_row_id: string | null
+  raw_json: string; normalized_json: string; synced_at: string
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/state.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/state.ts
@@ -1,0 +1,110 @@
+// In-memory implementation of StateBackend.
+//
+// Used by default in tests and dev. Production runtime should inject
+// SqliteStateBackend (see state-backend-sqlite.ts) which persists to
+// workspace.db + Holaboss runtime state-store.
+
+import type {
+  AppState,
+  AuditEntry,
+  NotificationEntry,
+  OutputCard,
+  RowRecord,
+  StateBackend,
+  SyncRecord,
+  TurnContext,
+} from "../types.ts"
+
+/**
+ * In-memory StateBackend. Public fields (rows / audit / outputs / etc.)
+ * are exposed for test inspection convenience — production callers should
+ * go through the StateBackend interface methods.
+ *
+ * Name kept as `RuntimeState` for backward compatibility with existing
+ * test code accessing `app._state` properties directly.
+ */
+export class RuntimeState implements StateBackend {
+  rows: RowRecord[] = []
+  audit: AuditEntry[] = []
+  outputs: OutputCard[] = []
+  notifications: NotificationEntry[] = []
+  syncRecords: SyncRecord[] = []
+  turnContext: TurnContext | null = null
+
+  setTurnContext(ctx: TurnContext | null) {
+    this.turnContext = ctx
+  }
+
+  insertRow(
+    resource: string,
+    data: Record<string, unknown>,
+    status: string,
+  ): RowRecord {
+    const id = randId()
+    const now = new Date().toISOString()
+    const row: RowRecord = {
+      id, resource, status, data,
+      createdInTurn: this.turnContext?.turnId,
+      sessionId: this.turnContext?.sessionId,
+      createdAt: now, updatedAt: now,
+    }
+    this.rows.push(row)
+    return row
+  }
+
+  updateRow(id: string, patch: Partial<RowRecord>): RowRecord {
+    const r = this.rows.find(x => x.id === id)
+    if (!r) throw new Error(`row ${id} not found`)
+    Object.assign(r, patch, { updatedAt: new Date().toISOString() })
+    return r
+  }
+
+  getRow(id: string): RowRecord | undefined {
+    return this.rows.find(x => x.id === id)
+  }
+
+  rowsByResource(resource: string): RowRecord[] {
+    return this.rows.filter(r => r.resource === resource)
+  }
+
+  pushAudit(event: AuditEntry["event"], fields: Record<string, unknown>) {
+    this.audit.push({ at: new Date().toISOString(), event, fields })
+  }
+
+  upsertOutput(card: Omit<OutputCard, "updatedAt">) {
+    const idx = this.outputs.findIndex(
+      o => o.resourceName === card.resourceName && o.rowId === card.rowId,
+    )
+    const updated: OutputCard = { ...card, updatedAt: new Date().toISOString() }
+    if (idx >= 0) this.outputs[idx] = updated
+    else this.outputs.push(updated)
+  }
+
+  pushNotification(n: Omit<NotificationEntry, "at">) {
+    this.notifications.push({ ...n, at: new Date().toISOString() })
+  }
+
+  upsertSyncRecord(rec: Omit<SyncRecord, "syncedAt">) {
+    const idx = this.syncRecords.findIndex(
+      s => s.syncName === rec.syncName && s.key === rec.key,
+    )
+    const updated: SyncRecord = { ...rec, syncedAt: new Date().toISOString() }
+    if (idx >= 0) this.syncRecords[idx] = updated
+    else this.syncRecords.push(updated)
+  }
+
+  snapshot(): AppState {
+    return {
+      rows: [...this.rows],
+      audit: [...this.audit],
+      outputs: [...this.outputs],
+      notifications: [...this.notifications],
+      syncRecords: [...this.syncRecords],
+      derivedTools: [],
+    }
+  }
+}
+
+function randId() {
+  return `r_${Math.random().toString(36).slice(2, 10)}`
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/sync-runner.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/runtime/sync-runner.ts
@@ -1,0 +1,104 @@
+// Executes a registered sync.
+// SDK does NOT schedule — automations or tests call runSync().
+//
+// fetch() MUST return { ok: true, items } | { ok: false, error }. The runner
+// distinguishes "upstream returned 0 items" (ok: true, items: []) from
+// "upstream failed" (ok: false) — the latter triggers app.notify and reports
+// failure to the caller so automations can retry intelligently.
+
+import type { BridgeClient, ResourceHandle, StateBackend, SyncDef } from "../types.ts"
+import { createDbView } from "./db-view.ts"
+
+interface RunSyncOpts {
+  appId: string
+  syncName: string
+  syncDef: SyncDef<any, any, any>
+  bridge: BridgeClient
+  state: StateBackend
+}
+
+export interface SyncRunResult {
+  ok: boolean
+  fetched: number
+  upserted: number
+  error?: { code: string; message: string }
+}
+
+export async function runSync(opts: RunSyncOpts): Promise<SyncRunResult> {
+  const { appId, syncName, syncDef, bridge, state } = opts
+  const startTime = Date.now()
+
+  state.pushAudit("sync.start", { app: appId, sync: syncName })
+
+  const db = createDbView(state)
+  let fetchResult
+  try {
+    fetchResult = await syncDef.fetch({ bridge, db })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    state.pushAudit("sync.end", {
+      app: appId, sync: syncName, outcome: "fail",
+      total_ms: Date.now() - startTime, error: msg,
+    })
+    state.pushNotification({
+      level: "warning",
+      summary: `${appId} sync '${syncName}' threw: ${msg}`,
+      agentHint: "Sync will retry on next automation tick.",
+    })
+    return { ok: false, fetched: 0, upserted: 0, error: { code: "fetch_threw", message: msg } }
+  }
+
+  if (!fetchResult.ok) {
+    const err = fetchResult.error
+    state.pushAudit("sync.end", {
+      app: appId, sync: syncName, outcome: "fail",
+      total_ms: Date.now() - startTime, error: err,
+    })
+    const isAuth = err.code === "not_connected"
+    state.pushNotification({
+      level: "error",
+      summary: `${appId} sync '${syncName}' upstream failed: ${err.message}`,
+      agentHint: isAuth
+        ? "Connection expired; ask user to reconnect."
+        : "Sync will retry on next automation tick.",
+    })
+    return { ok: false, fetched: 0, upserted: 0, error: { code: err.code, message: err.message } }
+  }
+
+  const rawList = fetchResult.items
+  const keyField = syncDef.upsert.key
+  let upserted = 0
+  for (const raw of rawList) {
+    if (!raw || typeof raw !== "object") continue
+    const r = raw as Record<string, unknown>
+    const key = String(r[keyField] ?? "")
+    if (!key) continue
+
+    let normalized: Record<string, unknown> = {}
+    try {
+      normalized = syncDef.normalize(raw) as Record<string, unknown>
+    } catch {
+      continue
+    }
+
+    let attachedRowId = ""
+    if (syncDef.attachTo) {
+      const attachResource = syncDef.attachTo as ResourceHandle<any, any>
+      const matched = state.rowsByResource(attachResource.name).find(
+        rr => rr.id === key || rr.externalId === key,
+      )
+      attachedRowId = matched?.id ?? ""
+    }
+
+    state.upsertSyncRecord({ syncName, attachedRowId, key, raw: r, normalized })
+    upserted++
+  }
+
+  state.pushAudit("sync.end", {
+    app: appId, sync: syncName, outcome: "ok",
+    fetched: rawList.length, upserted,
+    total_ms: Date.now() - startTime,
+  })
+
+  return { ok: true, fetched: rawList.length, upserted }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/types.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/src/types.ts
@@ -1,0 +1,367 @@
+import type { ZodSchema, ZodTypeAny, z } from "zod"
+
+// ─── Bridge ────────────────────────────────────────────────────────────────
+
+export type BridgeErrorCode =
+  | "not_connected"
+  | "rate_limited"
+  | "not_found"
+  | "validation_failed"
+  | "upstream_error"
+
+export interface BridgeError {
+  kind: "error"
+  code: BridgeErrorCode
+  message: string
+  upstreamStatus?: number
+  upstreamBody?: unknown
+  retryAfter?: number
+  reauthUrl?: string
+}
+
+export type ProxyResult<T = unknown> =
+  | { kind: "ok"; data: T; status: number }
+  | BridgeError
+
+export interface BridgeClient {
+  call<T = unknown>(method: HttpMethod, path: string, body?: unknown): Promise<ProxyResult<T>>
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
+// ─── Transport contract ────────────────────────────────────────────────────
+//
+// The SDK is transport-agnostic. BridgeClient delegates the actual network
+// I/O to a TransportFn — the SDK never assumes Hono, Composio, OAuth, or any
+// specific authentication mechanism.
+//
+// Bundled transport adapters live under src/bridge-transports/:
+//   - bearer.ts            — self-host OAuth (bring your own access token)
+//   - composio-direct.ts   — Composio managed auth, no Holaboss backend in path
+//
+// You can write your own: a TransportFn is just (req) => Promise<response>.
+// Put your auth headers / proxy / vault token resolution there. The SDK only
+// cares that the response shape comes back populated.
+
+// ─── Provider Registry ─────────────────────────────────────────────────────
+
+export interface ProviderRegistry {
+  /**
+   * Canonical Composio toolkit slug. Same value flows through yaml
+   * `integration.destination`, `pending_integrations[].provider_id`,
+   * Hono `/composio/connect` body.provider (= Composio `toolkit_slug`),
+   * `integration_connections.provider_id`,
+   * `integration_bindings.integration_key`, and broker
+   * `createRuntimeBrokerTransport({ provider })`. Must match Composio's
+   * catalog exactly (e.g. `"discordbot"` for Discord bot, NOT `"discord"`).
+   */
+  id: string
+  baseUrl: string
+  allowedHosts: string[]
+  whoamiPath?: string
+  /**
+   * @deprecated Use `id` instead. The runtime does NOT consult this field;
+   * only `manifest.ts` falls back to it when generating `integration.destination`,
+   * which causes confusion when authors set `id` and `composioToolkit` to
+   * different values. Set `id` to the Composio toolkit slug and leave this
+   * unset.
+   */
+  composioToolkit?: string
+}
+
+// ─── Type helpers: schema → row type vending ───────────────────────────────
+//
+// The agent declares schema once (z.object({...})). All callbacks
+// (step.run / emit / db.query) receive a row typed as the inferred shape
+// PLUS system fields { id, status, external_id }. No more `as any` chasing.
+
+export type Infer<TSchema extends ZodTypeAny> = z.infer<TSchema>
+
+/**
+ * Row shape exposed to step.run / emit / db callbacks.
+ *
+ * external_id is intentionally typed as `string` (not string | number).
+ * Many provider APIs return integer IDs (Telegram message_id, GitHub issue
+ * number, Reddit post id). Stringify them on persist; cast back at the
+ * upstream call site:
+ *
+ *     // Telegram example:
+ *     return { ok: true, externalId: String(r.data.message_id) }
+ *     // ...later:
+ *     await bridge.call("POST", "/editMessageText", {
+ *       message_id: Number(row.external_id), ...
+ *     })
+ */
+export type RowOf<TSchema extends ZodTypeAny> = Infer<TSchema> & {
+  id: string
+  status: string
+  external_id?: string
+}
+
+// ─── Resource ──────────────────────────────────────────────────────────────
+
+export type StateTuple = readonly [string, ...string[]]
+
+export interface EmitConfig<TRow> {
+  surface: string                            // "content_plan" | "ops_log" | "none" | <agent-defined>
+  summary?: (row: TRow) => string | null
+  deepLink?: (row: TRow) => string | null
+}
+
+export interface ResourceDef<TSchema extends ZodTypeAny, States extends StateTuple> {
+  schema: TSchema
+  states: States
+  initialState: States[number]
+  /** Where to put row when an action on it fails. Optional — if absent, status preserved on failure. */
+  failedState?: States[number]
+  emit?: EmitConfig<RowOf<TSchema>>
+  refreshEvery?: string
+  fetch?: (ctx: { bridge: BridgeClient }) => Promise<Infer<TSchema>[]>
+}
+
+export interface ResourceHandle<TSchema extends ZodTypeAny = ZodTypeAny, States extends StateTuple = StateTuple> {
+  __resource: true
+  name: string
+  states: States
+  schema: TSchema
+  def: ResourceDef<TSchema, States>
+  /** Foreign-key reference. Returns a branded zod string schema. */
+  ref(): ZodSchema<string>
+}
+
+// ─── Action ────────────────────────────────────────────────────────────────
+
+export type StepResult<TOut = {}> =
+  | { ok: true; data?: TOut; externalId?: string }
+  | { fail: BridgeError | { kind: "error"; code: string; message: string } }
+
+export interface StepContext<TRow, TInput> {
+  row: TRow
+  input: TInput
+  bridge: BridgeClient
+  persist: (patch: Partial<TRow>) => Promise<void>
+  log: (msg: string, extra?: Record<string, unknown>) => void
+}
+
+export interface Step<TRow, TInput, TOut = {}> {
+  name: string
+  run: (ctx: StepContext<TRow, TInput>) => Promise<StepResult<TOut>>
+}
+
+export interface ReversibleDef<TRow, States extends StateTuple> {
+  toState: States[number]
+  run: (ctx: StepContext<TRow, {}>) => Promise<StepResult>
+}
+
+/**
+ * SDK boundary: ActionDef describes HOW to do something — its inputs, steps,
+ * state transitions, and reversal path. WHEN to do it (now / in 5h / every
+ * Monday) is NOT an SDK concern; that lives in the Holaboss automations
+ * subsystem. The SDK therefore intentionally has NO `schedulable` flag and NO
+ * retry policy — re-invocation on failure is the caller's choice.
+ *
+ * Actions MUST be idempotent: re-running an action on a row that already
+ * carries persisted intermediate state (e.g. media_id from a prior failed
+ * publish attempt) must safely no-op the already-done steps. Use row.external_id
+ * and row.<persisted_field> to detect "already done".
+ */
+export interface ActionDef<TRow, States extends StateTuple, I = {}> {
+  fromStates: readonly States[number][]
+  /**
+   * State to put the row in on success.
+   * `null` = side-effect action; row.status is NOT changed, NO output is re-emitted.
+   */
+  toState: States[number] | null
+  schema?: ZodSchema<I>
+  /** Override the auto-derived tool name. Default: `<app>_<action>_<resource>`.
+   *  If overridden, the reverse tool becomes `<toolName>_reverse`. */
+  toolName?: string
+  reversible?: ReversibleDef<TRow, States>
+  // exactly one of:
+  run?: (ctx: StepContext<TRow, I>) => Promise<StepResult>
+  steps?: Step<TRow, I>[]
+}
+
+// ─── Sync ──────────────────────────────────────────────────────────────────
+//
+// A sync is just a special background action that automations triggers on a
+// `schedule` hint. The SDK provides the execution machinery (DbView, upsert,
+// normalize); the SDK does NOT internally schedule.
+//
+// fetch() MUST return an explicit ok/error union — the SDK distinguishes
+// "upstream succeeded with 0 items" from "upstream failed". Returning an empty
+// array on failure (the old pattern) would silently mask outages from
+// dashboards and automations retry logic.
+
+export type SyncFetchResult<TRaw> =
+  | { ok: true; items: TRaw[] }
+  | { ok: false; error: BridgeError | { kind: "error"; code: string; message: string } }
+
+export interface SyncDef<TSchema extends ZodTypeAny, TRaw, TNormalized> {
+  /** Hint to automations (cron expression). SDK does not enforce. */
+  schedule: string
+  /** The resource these metrics attach to (for deep_link / aggregation). */
+  attachTo?: ResourceHandle<TSchema, any>
+  fetch: (ctx: { bridge: BridgeClient; db: DbView }) => Promise<SyncFetchResult<TRaw>>
+  upsert: { key: keyof TRaw & string }
+  normalize: (raw: TRaw) => TNormalized
+}
+
+// ─── DbView ────────────────────────────────────────────────────────────────
+//
+// where() supports scalar-equality filtering only. Arrays / objects are
+// excluded at the type level because the runtime uses === comparison and
+// can't meaningfully match deeply.
+
+type ScalarValue = string | number | boolean | null | undefined
+type ScalarKeys<T> = {
+  [K in keyof T]-?: T[K] extends ScalarValue ? K : never
+}[keyof T]
+type ScalarFilter<T> = Partial<Pick<T, ScalarKeys<T>>>
+
+export interface DbView {
+  query<TSchema extends ZodTypeAny, States extends StateTuple>(
+    resource: ResourceHandle<TSchema, States>,
+  ): {
+    where: (cond: ScalarFilter<RowOf<TSchema> & { status: States[number] }>) => {
+      recent: (window: string) => RowOf<TSchema>[]
+      all: () => RowOf<TSchema>[]
+    }
+    all: () => RowOf<TSchema>[]
+  }
+}
+
+// ─── App ───────────────────────────────────────────────────────────────────
+
+export interface AppConfig {
+  id: string
+  provider: ProviderRegistry
+  description?: string
+}
+
+export interface DerivedTool {
+  name: string
+  inputShape: string
+  description: string
+  category: "connection" | "resource_query" | "action" | "reverse_action" | "sync" | "snapshot"
+}
+
+export interface AppHandle {
+  config: AppConfig
+  connection(opts?: { whoamiPath?: string }): void
+  resource<TSchema extends ZodTypeAny, States extends StateTuple>(
+    name: string,
+    def: ResourceDef<TSchema, States>,
+  ): ResourceHandle<TSchema, States>
+  action<TSchema extends ZodTypeAny, States extends StateTuple, I = {}>(
+    resource: ResourceHandle<TSchema, States>,
+    name: string,
+    def: ActionDef<RowOf<TSchema>, States, I>,
+  ): void
+  sync<TSchema extends ZodTypeAny, RAW, N>(
+    name: string,
+    def: SyncDef<TSchema, RAW, N>,
+  ): void
+  start(): Promise<void>
+  derivedTools(): DerivedTool[]
+  state(): AppState
+}
+
+// ─── Internal runtime state ────────────────────────────────────────────────
+
+export interface RowRecord {
+  id: string
+  resource: string
+  status: string
+  data: Record<string, unknown>
+  externalId?: string
+  errorMessage?: string
+  scheduledAt?: string
+  createdInTurn?: string
+  sessionId?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AuditEntry {
+  at: string
+  event: "action.start" | "step.complete" | "action.retry" | "action.end" | "tool.call" | "sync.start" | "sync.end"
+  fields: Record<string, unknown>
+}
+
+export interface OutputCard {
+  resourceName: string
+  rowId: string
+  surface: string
+  status: string
+  summary: string | null
+  deepLink: string | null
+  updatedAt: string
+}
+
+export interface NotificationEntry {
+  at: string
+  level: "info" | "warning" | "error"
+  summary: string
+  agentHint?: string
+  ref?: { kind: string; id: string }
+}
+
+export interface SyncRecord {
+  syncName: string
+  attachedRowId: string                       // the row from the attachTo resource
+  key: string
+  raw: Record<string, unknown>
+  normalized: Record<string, unknown>
+  syncedAt: string
+}
+
+export interface AppState {
+  rows: RowRecord[]
+  audit: AuditEntry[]
+  outputs: OutputCard[]
+  notifications: NotificationEntry[]
+  syncRecords: SyncRecord[]
+  derivedTools: DerivedTool[]
+}
+
+// ─── State backend contract ────────────────────────────────────────────────
+//
+// All persistence (rows, audit, outputs, notifications, sync records) goes
+// through this interface. The SDK ships two implementations:
+//   - InMemoryStateBackend (the default) — testing + dev
+//   - SqliteStateBackend (in `runtime/state-backend-sqlite.ts`) — production
+//     deploy, persists to workspace.db + Holaboss runtime state-store
+//
+// createApp() accepts an optional `backend?: StateBackend` so production
+// runtime can inject SQLite without breaking unit tests' in-memory shape.
+
+export interface StateBackend {
+  setTurnContext(ctx: TurnContext | null): void
+
+  // Row CRUD (per-resource rows)
+  insertRow(resource: string, data: Record<string, unknown>, status: string): RowRecord
+  updateRow(id: string, patch: Partial<RowRecord>): RowRecord
+  getRow(id: string): RowRecord | undefined
+  rowsByResource(resource: string): RowRecord[]
+
+  // Audit log
+  pushAudit(event: AuditEntry["event"], fields: Record<string, unknown>): void
+
+  // Dashboard outputs
+  upsertOutput(card: Omit<OutputCard, "updatedAt">): void
+
+  // Notifications (push to user / agent next turn)
+  pushNotification(n: Omit<NotificationEntry, "at">): void
+
+  // Sync records (periodic data pulls)
+  upsertSyncRecord(rec: Omit<SyncRecord, "syncedAt">): void
+
+  // Snapshot for tests / inspection
+  snapshot(): AppState
+}
+
+export interface TurnContext {
+  turnId: string
+  sessionId: string
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/agent-mistakes.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/agent-mistakes.test.ts
@@ -1,0 +1,110 @@
+// This file proves the agent-error-prevention story is real, on TWO levels:
+// - Compile-time: each @ts-expect-error block proves tsc catches the wrong code.
+//   If tsc finds no error to suppress, the file fails to compile.
+// - Runtime: even if untyped JS slips through, app.action validators throw.
+// Both fire together for these tests.
+
+import { describe, test, expect } from "bun:test"
+import { createApp, z } from "../src/index.ts"
+import { SLACK } from "../reference/slack-messaging/provider.ts"
+
+function freshApp() {
+  const app = createApp({ id: "slack", provider: SLACK })
+  app.connection()
+  const message = app.resource("message", {
+    schema: z.object({ text: z.string() }),
+    states: ["draft", "sent", "edited", "deleted"] as const,
+    initialState: "draft",
+  })
+  return { app, message }
+}
+
+describe("Type system catches agent mistakes at compile time", () => {
+  test("correct usage compiles AND runs", () => {
+    const { app, message } = freshApp()
+    expect(() => {
+      app.action(message, "send", {
+        fromStates: ["draft"],
+        toState: "sent",
+        run: async () => ({ ok: true }),
+      })
+    }).not.toThrow()
+  })
+
+  test("toState outside resource alphabet — caught at compile + runtime", () => {
+    const { app, message } = freshApp()
+    expect(() => {
+      app.action(message, "bad1", {
+        fromStates: ["draft"],
+        // @ts-expect-error 'published' is not in message.states
+        toState: "published",
+        run: async () => ({ ok: true }),
+      })
+    }).toThrow(/toState.*not in/)
+  })
+
+  test("fromStates typo — caught at compile + runtime", () => {
+    const { app, message } = freshApp()
+    expect(() => {
+      app.action(message, "bad2", {
+        // @ts-expect-error 'darft' is a typo
+        fromStates: ["darft"],
+        toState: "sent",
+        run: async () => ({ ok: true }),
+      })
+    }).toThrow(/fromStates.*not in/)
+  })
+
+  test("reversible.toState outside alphabet — caught at compile + runtime", () => {
+    const { app, message } = freshApp()
+    expect(() => {
+      app.action(message, "bad3", {
+        fromStates: ["draft"],
+        toState: "sent",
+        reversible: {
+          // @ts-expect-error 'cancelled' not declared
+          toState: "cancelled",
+          run: async () => ({ ok: true }),
+        },
+        run: async () => ({ ok: true }),
+      })
+    }).toThrow(/reversible.*not in/)
+  })
+
+  test("reversible: true (boolean) — caught at compile + runtime", () => {
+    const { app, message } = freshApp()
+    expect(() => {
+      app.action(message, "bad4", {
+        fromStates: ["draft"],
+        toState: "sent",
+        // @ts-expect-error reversible must be a ReversibleDef object, not boolean
+        reversible: true,
+        run: async () => ({ ok: true }),
+      })
+    }).toThrow()
+  })
+
+  test("invalid initialState — caught at runtime (and compile, if literal)", () => {
+    const app = createApp({ id: "x", provider: SLACK })
+    app.connection()
+    expect(() => {
+      app.resource("foo", {
+        schema: z.object({}),
+        states: ["a", "b"] as const,
+        // @ts-expect-error 'z' not in states
+        initialState: "z",
+      })
+    }).toThrow(/initialState/)
+  })
+
+  test("ResourceHandle.ref() — usable as zod string schema", () => {
+    const { message } = freshApp()
+    const channelLike = message.ref()
+    expect(channelLike.parse("C123")).toBe("C123")
+  })
+
+  test("start() requires connection() first — runtime guard", async () => {
+    const bare = createApp({ id: "y", provider: SLACK })
+    await expect(bare.start()).rejects.toThrow(/connection/)
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/emit-context.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/emit-context.test.ts
@@ -1,0 +1,56 @@
+// Locks in the syncOutput fix: emit.summary / emit.deepLink callbacks receive
+// row with id, status, and external_id populated — not just the schema fields.
+
+import { describe, test, expect } from "bun:test"
+import { createApp, z, createBridge, type TransportFn } from "../src/index.ts"
+import { PINTEREST } from "../reference/pinterest-publishing/provider.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+const transport: TransportFn = async () => ({ status: 200, body: { id: "extern_42" } })
+const bridge = () => createBridge({ provider: PINTEREST, transport })
+
+function appWithIdInSummary() {
+  const app = createApp({ id: "test", provider: PINTEREST })
+  app.connection()
+
+  const thing = app.resource("thing", {
+    schema: z.object({ name: z.string() }),
+    states: ["draft", "active"] as const,
+    initialState: "draft",
+    emit: {
+      surface: "content_plan",
+      // ★ THIS is the regression check: row.id / row.status / row.external_id
+      // MUST be defined when emit callbacks fire. Old action-runner only spread
+      // rowData + external_id, leaving id and status undefined.
+      summary: r => `${r.id}|${r.status}|${r.name}|${r.external_id ?? "no-ext"}`,
+      deepLink: r => `https://x.test/${r.id}/${r.external_id ?? "none"}`,
+    },
+  })
+
+  app.action(thing, "activate", {
+    fromStates: ["draft"],
+    toState: "active",
+    run: async ({ bridge }) => {
+      const r = await bridge.call<{ id: string }>("POST", "/things")
+      if (r.kind === "error") return { fail: r }
+      return { ok: true, externalId: r.data.id }
+    },
+  })
+
+  return app as unknown as AppHandleInternal
+}
+
+describe("emit callbacks receive complete row (id, status, external_id)", () => {
+  test("after action.toState transition: emit row has id + status + external_id", async () => {
+    const app = appWithIdInSummary()
+    const row = app._state.insertRow("thing", { name: "widget" }, "draft")
+
+    await app._invokeAction({ actionName: "activate", rowId: row.id, bridge: bridge() })
+
+    const card = app.state().outputs.find(o => o.rowId === row.id)!
+    expect(card.summary).toBe(`${row.id}|active|widget|extern_42`)
+    expect(card.deepLink).toBe(`https://x.test/${row.id}/extern_42`)
+
+    // Before fix: would have been "undefined|undefined|widget|extern_42"
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/gcalendar.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/gcalendar.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { GCALENDAR } from "../reference/gcalendar-events/provider.ts"
+import { buildGcalendarApp } from "../reference/gcalendar-events/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+function bridge() {
+  return createBridge({ provider: GCALENDAR, transport })
+}
+function setup() {
+  calls = []
+  scriptedResponses = []
+  const built = buildGcalendarApp() as unknown as {
+    app: AppHandleInternal
+    event: any
+    calendar: any
+  }
+  built.app._setTurn({ turnId: "turn_1", sessionId: "sess_1" })
+  return built
+}
+
+describe("Google Calendar — event lifecycle", () => {
+  test("create_event: draft → confirmed, externalId persisted", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      {
+        calendar_id: "primary",
+        summary: "Team standup",
+        start_time: "2026-06-01T14:00:00-07:00",
+        end_time: "2026-06-01T14:30:00-07:00",
+        time_zone: "America/Los_Angeles",
+      },
+      "draft",
+    )
+    scriptedResponses.push({
+      status: 200,
+      body: { id: "evt_abc", htmlLink: "https://calendar.google.com/..." },
+    })
+
+    const r = await app._invokeAction({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect(r).toEqual({ ok: true, externalId: "evt_abc" })
+
+    const final = app._state.getRow(row.id)!
+    expect(final.status).toBe("confirmed")
+    expect(final.externalId).toBe("evt_abc")
+
+    // The action body should carry intrinsic event timing — proves the
+    // start_time/end_time live with the event, not the SDK scheduler.
+    expect(calls[0].method).toBe("POST")
+    expect(calls[0].url).toContain("/calendars/primary/events")
+    expect(calls[0].body.start.dateTime).toBe("2026-06-01T14:00:00-07:00")
+    expect(calls[0].body.end.dateTime).toBe("2026-06-01T14:30:00-07:00")
+
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card!.surface).toBe("ops_log")
+    expect(card!.status).toBe("confirmed")
+    expect(card!.summary).toContain("Team standup")
+    expect(card!.deepLink).toContain("eid=evt_abc")
+  })
+
+  test("recurring event: one row, RRULE forwarded to upstream", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      {
+        calendar_id: "primary",
+        summary: "Weekly 1:1",
+        start_time: "2026-06-01T10:00:00-07:00",
+        end_time: "2026-06-01T10:30:00-07:00",
+        recurrence: ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+      },
+      "draft",
+    )
+    scriptedResponses.push({ status: 200, body: { id: "evt_recur", htmlLink: "..." } })
+
+    await app._invokeAction({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+
+    expect(calls[0].body.recurrence).toEqual(["RRULE:FREQ=WEEKLY;BYDAY=MO"])
+    // One row, not N — occurrences stay upstream-only.
+    expect(app._state.snapshot().rows.filter(r => r.resource === "event")).toHaveLength(1)
+  })
+
+  test("create_event is idempotent: replaying with same row skips upstream POST", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      {
+        calendar_id: "primary",
+        summary: "Once",
+        start_time: "2026-06-01T14:00:00-07:00",
+        end_time: "2026-06-01T15:00:00-07:00",
+      },
+      "draft",
+    )
+    scriptedResponses.push({ status: 200, body: { id: "evt_once", htmlLink: "..." } })
+
+    const r1 = await app._invokeAction({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((r1 as any).externalId).toBe("evt_once")
+    expect(calls).toHaveLength(1)
+
+    // Simulate automations retry: put the row back into draft (as a
+    // hypothetical caller-driven re-run) and replay. The action MUST notice
+    // external_id is already set and refuse to double-POST.
+    app._state.updateRow(row.id, { status: "draft" })
+
+    const r2 = await app._invokeAction({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((r2 as any).ok).toBe(true)
+    expect((r2 as any).externalId).toBe("evt_once")
+    // No new upstream call.
+    expect(calls).toHaveLength(1)
+    expect(app._state.getRow(row.id)!.status).toBe("confirmed")
+  })
+
+  test("cancel_event: confirmed → cancelled (soft, body.status=cancelled)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      { calendar_id: "primary", summary: "x", start_time: "t1", end_time: "t2" },
+      "confirmed",
+    )
+    app._state.updateRow(row.id, { externalId: "evt_xyz" })
+
+    scriptedResponses.push({ status: 200, body: { id: "evt_xyz", status: "cancelled" } })
+    const r = await app._invokeAction({
+      actionName: "cancel_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("cancelled")
+    expect(calls[0].method).toBe("PATCH")
+    expect(calls[0].body).toEqual({ status: "cancelled" })
+  })
+
+  test("rsvp: side effect, does NOT change event.status, merges attendees", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      {
+        calendar_id: "primary",
+        summary: "Big meeting",
+        start_time: "t1",
+        end_time: "t2",
+        attendees: [
+          { email: "host@example.com" },
+          { email: "me@example.com" },
+        ],
+      },
+      "confirmed",
+    )
+    app._state.updateRow(row.id, { externalId: "evt_invited" })
+    app._state.upsertOutput({
+      resourceName: "event",
+      rowId: row.id,
+      surface: "ops_log",
+      status: "confirmed",
+      summary: "Big meeting",
+      deepLink: null,
+    })
+
+    scriptedResponses.push({ status: 200, body: { id: "evt_invited" } })
+    const r = await app._invokeAction({
+      actionName: "rsvp",
+      rowId: row.id,
+      input: { response: "accepted", self_email: "me@example.com" },
+      bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("confirmed") // unchanged
+
+    const sentAttendees = calls[0].body.attendees as Array<any>
+    const me = sentAttendees.find(a => a.email === "me@example.com")
+    const host = sentAttendees.find(a => a.email === "host@example.com")
+    expect(me.responseStatus).toBe("accepted")
+    expect(host).toBeDefined()
+    expect(host.responseStatus).toBeUndefined()
+
+    // Dashboard card untouched
+    const cards = app.state().outputs.filter(o => o.rowId === row.id)
+    expect(cards).toHaveLength(1)
+    expect(cards[0].status).toBe("confirmed")
+  })
+
+  test("invalid state: cancel_event on a draft is rejected", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      { calendar_id: "primary", summary: "x", start_time: "t1", end_time: "t2" },
+      "draft",
+    )
+    const r = await app._invokeAction({
+      actionName: "cancel_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((r as any).fail.code).toBe("invalid_state")
+    expect((r as any).fail.message).toContain("from state 'draft'")
+  })
+
+  test("auth error on create_event lands row in 'failed' with reauth hint", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      { calendar_id: "primary", summary: "x", start_time: "t1", end_time: "t2" },
+      "draft",
+    )
+    scriptedResponses.push({
+      status: 401,
+      body: { error: "Invalid Credentials" },
+    })
+    const r = await app._invokeAction({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((r as any).fail.code).toBe("not_connected")
+    expect(app._state.getRow(row.id)!.status).toBe("failed")
+    expect(app.state().notifications[0].agentHint).toContain("reconnect")
+  })
+
+  test("create_event reversible: confirmed → draft + DELETE upstream", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow(
+      "event",
+      { calendar_id: "primary", summary: "x", start_time: "t1", end_time: "t2" },
+      "draft",
+    )
+    scriptedResponses.push({ status: 200, body: { id: "evt_kill", htmlLink: "..." } })
+    await app._invokeAction({ actionName: "create_event", rowId: row.id, bridge: bridge() })
+
+    scriptedResponses.push({ status: 204, body: null })
+    const rev = await app._invokeReverse({
+      actionName: "create_event",
+      rowId: row.id,
+      bridge: bridge(),
+    })
+    expect((rev as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("draft")
+    expect(calls.at(-1)?.method).toBe("DELETE")
+    expect(calls.at(-1)?.url).toContain("evt_kill")
+  })
+
+  test("derived tools include create/update/cancel/delete/rsvp + reverse + sync", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name)
+    expect(names).toContain("gcalendar_connection_status")
+    expect(names).toContain("gcalendar_create_event_event")
+    expect(names).toContain("gcalendar_cancel_create_event_event") // reversible
+    expect(names).toContain("gcalendar_update_event_event")
+    expect(names).toContain("gcalendar_cancel_event_event")
+    expect(names).toContain("gcalendar_delete_event_event")
+    expect(names).toContain("gcalendar_rsvp") // toolName override
+    expect(names).toContain("gcalendar_list_events")
+    expect(names).toContain("gcalendar_list_calendars")
+    expect(names).toContain("gcalendar_refresh_calendars")
+    expect(names).toContain("gcalendar_upcoming_events_sync_status")
+    expect(names).toContain("gcalendar_snapshot")
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/github-issues.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/github-issues.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { GITHUB } from "../reference/github-workflow/provider.ts"
+import { buildGithubIssuesApp } from "../reference/github-workflow/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+function bridge() {
+  return createBridge({ provider: GITHUB, transport })
+}
+function setup() {
+  calls = []
+  scriptedResponses = []
+  const built = buildGithubIssuesApp() as unknown as { app: AppHandleInternal; issue: any; repo: any }
+  built.app._setTurn({ turnId: "turn_1", sessionId: "sess_1" })
+  return built
+}
+
+describe("GitHub Issues — full workflow lifecycle", () => {
+  test("full issue lifecycle: draft → open → in_progress → closed → reopened", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("issue", {
+      repo_full_name: "holaboss/holaboss", title: "Bug X", body: "details",
+    }, "draft")
+
+    // 1. create: draft → open
+    scriptedResponses.push({ status: 201, body: { number: 42, html_url: "..." } })
+    const r1 = await app._invokeAction({ actionName: "create", rowId: row.id, bridge: bridge() })
+    expect((r1 as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("open")
+    expect(app._state.getRow(row.id)!.externalId).toBe("42")
+
+    // 2. start_work: open → in_progress
+    scriptedResponses.push({ status: 200, body: [] })
+    const r2 = await app._invokeAction({ actionName: "start_work", rowId: row.id, bridge: bridge() })
+    expect((r2 as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("in_progress")
+
+    // 3. close: in_progress → closed
+    scriptedResponses.push({ status: 200, body: {} })
+    const r3 = await app._invokeAction({ actionName: "close", rowId: row.id, bridge: bridge() })
+    expect((r3 as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("closed")
+
+    // 4. reopen: closed → reopened
+    scriptedResponses.push({ status: 200, body: {} })
+    const r4 = await app._invokeAction({ actionName: "reopen", rowId: row.id, bridge: bridge() })
+    expect((r4 as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("reopened")
+
+    // Dashboard card should reflect latest state
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card!.surface).toBe("ops_log")
+    expect(card!.status).toBe("reopened")
+    expect(card!.summary).toBe("Bug X")
+    expect(card!.deepLink).toBe("https://github.com/holaboss/holaboss/issues/42")
+  })
+
+  test("close is reversible (back to 'reopened')", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("issue", {
+      repo_full_name: "holaboss/holaboss", title: "x", external_id: "42",
+    }, "open")
+    app._state.updateRow(row.id, { externalId: "42" })
+
+    scriptedResponses.push({ status: 200, body: {} })
+    await app._invokeAction({ actionName: "close", rowId: row.id, bridge: bridge() })
+    expect(app._state.getRow(row.id)!.status).toBe("closed")
+
+    scriptedResponses.push({ status: 200, body: {} })
+    const rev = await app._invokeReverse({ actionName: "close", rowId: row.id, bridge: bridge() })
+    expect((rev as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("reopened")
+  })
+
+  test("comment: side effect, does NOT change issue status", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("issue", {
+      repo_full_name: "holaboss/holaboss", title: "x", external_id: "42",
+    }, "open")
+    app._state.updateRow(row.id, { externalId: "42" })
+    app._state.upsertOutput({
+      resourceName: "issue", rowId: row.id, surface: "ops_log",
+      status: "open", summary: "x", deepLink: null,
+    })
+
+    scriptedResponses.push({ status: 201, body: { id: 999 } })
+    const r = await app._invokeAction({
+      actionName: "comment",
+      rowId: row.id,
+      input: { body: "looks good" },
+      bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("open")    // unchanged
+    const card = app.state().outputs.find(o => o.rowId === row.id)!
+    expect(card.status).toBe("open")                          // dashboard not disturbed
+  })
+
+  test("assign: side effect, custom toolName check", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name)
+    expect(names).toContain("github_assign_issue")
+    expect(names).toContain("github_comment_on_issue")        // ← agent's override
+    expect(names).not.toContain("github_comment_issue")
+  })
+
+  test("invalid transition: start_work on closed issue rejected", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("issue", {
+      repo_full_name: "holaboss/holaboss", title: "x", external_id: "42",
+    }, "closed")
+    const r = await app._invokeAction({ actionName: "start_work", rowId: row.id, bridge: bridge() })
+    expect((r as any).fail.code).toBe("invalid_state")
+    expect((r as any).fail.message).toContain("from state 'closed'")
+  })
+
+  test("derived tools contain all action + reverse + sync tools", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name).sort()
+    expect(names).toContain("github_create_issue")
+    expect(names).toContain("github_start_work_issue")
+    expect(names).toContain("github_close_issue")
+    expect(names).toContain("github_cancel_close_issue")    // reversible
+    expect(names).toContain("github_reopen_issue")
+    expect(names).toContain("github_comment_on_issue")      // toolName override
+    expect(names).toContain("github_assign_issue")
+    expect(names).toContain("github_list_issues")
+    expect(names).toContain("github_list_repos")
+    expect(names).toContain("github_issue_activity_sync_status")
+    expect(names).toContain("github_snapshot")
+  })
+
+  test("failure: bad token surfaces with reauth hint", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("issue", {
+      repo_full_name: "holaboss/holaboss", title: "x",
+    }, "draft")
+    scriptedResponses.push({ status: 401, body: { message: "Bad credentials" } })
+    const r = await app._invokeAction({ actionName: "create", rowId: row.id, bridge: bridge() })
+    expect((r as any).fail.code).toBe("not_connected")
+    expect(app._state.getRow(row.id)!.status).toBe("failed")
+    expect(app.state().notifications[0].agentHint).toContain("reconnect")
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/manifest-and-entry-point.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/manifest-and-entry-point.test.ts
@@ -1,0 +1,168 @@
+// Verify the app.runtime.yaml manifest generator and the Slack v2 production
+// entry point. The entry point test spawns server.ts as a subprocess (which
+// is how the Holaboss runtime actually launches apps) and verifies the MCP
+// health endpoint becomes reachable.
+
+import { describe, test, expect } from "bun:test"
+import { spawn } from "node:child_process"
+import { mkdtempSync, unlinkSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { buildAppRuntimeManifest } from "../src/runtime/manifest.ts"
+import { buildSlackApp } from "../reference/slack-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+describe("manifest generator — buildAppRuntimeManifest", () => {
+  test("derives Slack manifest from app declaration with all expected sections", () => {
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const yaml = buildAppRuntimeManifest(app, { name: "Slack" })
+
+    // Top-level identity
+    expect(yaml).toContain(`app_id: "slack"`)
+    expect(yaml).toContain(`name: "Slack"`)
+    expect(yaml).toContain(`slug: "slack"`)
+
+    // Required sections
+    expect(yaml).toContain("lifecycle:")
+    expect(yaml).toContain("healthchecks:")
+    expect(yaml).toContain("mcp:")
+    expect(yaml).toContain("integration:")
+    expect(yaml).toContain("env_contract:")
+
+    // MCP config matches the SDK convention
+    expect(yaml).toContain("transport: http-sse")
+    expect(yaml).toContain("path: /mcp/sse")
+    expect(yaml).toContain("port: 3099")
+
+    // Tool list is derived from app.derivedTools()
+    expect(yaml).toContain("- slack_send_message_message")
+    expect(yaml).toContain("- slack_react")              // custom toolName
+    expect(yaml).toContain("- slack_cancel_schedule_send_message")  // reversible
+    expect(yaml).toContain("- slack_snapshot")
+    expect(yaml).toContain("- slack_connection_status")
+
+    // Integration links to Composio toolkit
+    expect(yaml).toContain(`destination: "slack"`)
+
+    // Env contract has the broker + workspace essentials
+    expect(yaml).toContain(`- "HOLABOSS_APP_GRANT"`)
+    expect(yaml).toContain(`- "HOLABOSS_INTEGRATION_BROKER_URL"`)
+    expect(yaml).toContain(`- "WORKSPACE_DB_PATH"`)
+    expect(yaml).toContain(`- "MCP_PORT"`)
+  })
+
+  test("custom lifecycle + uiPort options surface in manifest", () => {
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const yaml = buildAppRuntimeManifest(app, {
+      lifecycle: { setup: "pnpm install", start: "node dist/server.js", stop: "pkill node" },
+      uiPort: 4100,
+      extraEnv: ["MY_CUSTOM_VAR"],
+    })
+    expect(yaml).toContain(`setup: "pnpm install"`)
+    expect(yaml).toContain(`start: "node dist/server.js"`)
+    expect(yaml).toContain("ui:\n  port: 4100")
+    expect(yaml).toContain(`- "MY_CUSTOM_VAR"`)
+  })
+})
+
+describe("production entry point — reference/slack-messaging/server.ts boots end-to-end", () => {
+  test("spawns server.ts with env, /mcp/health responds, SIGTERM shuts down cleanly", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "slack-v2-e2e-"))
+    const dbPath = join(tmp, "workspace.db")
+    const port = 31099 + Math.floor(Math.random() * 1000)  // avoid collisions
+
+    // Spawn the real production entry — same way holaOS runtime would
+    const child = spawn("bun", ["run", "reference/slack-messaging/server.ts"], {
+      cwd: "/Users/joshua/holaboss-ai/holaboss/holaOS/experiments/app-builder-sdk",
+      env: {
+        ...process.env,
+        WORKSPACE_DB_PATH: dbPath,
+        MCP_PORT: String(port),
+        HOLABOSS_INTEGRATION_BROKER_URL: "http://localhost:8080",  // dummy; not called in this test
+        HOLABOSS_APP_GRANT: "grant:test_ws:slack:test_nonce",       // dummy
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stdout = "", stderr = ""
+    child.stdout!.on("data", d => { stdout += d.toString() })
+    child.stderr!.on("data", d => { stderr += d.toString() })
+
+    // Wait for "MCP server listening" boot message OR a hard fail
+    const booted = await waitFor(() => stdout.includes("MCP server listening on :") || stderr.length > 0, 5000)
+    if (!booted) {
+      child.kill("SIGKILL")
+      throw new Error(`Server did not boot in 5s. stdout:\n${stdout}\nstderr:\n${stderr}`)
+    }
+    if (stderr.includes("refusing to start") || stderr.includes("Error:")) {
+      child.kill("SIGKILL")
+      throw new Error(`Server errored on boot:\n${stderr}`)
+    }
+
+    // Verify /mcp/health
+    let healthOk = false
+    for (let i = 0; i < 10 && !healthOk; i++) {
+      try {
+        const r = await fetch(`http://localhost:${port}/mcp/health`)
+        if (r.ok) {
+          const body = await r.json() as { status: string; app_id: string }
+          expect(body.status).toBe("ok")
+          expect(body.app_id).toBe("slack")
+          healthOk = true
+        }
+      } catch {}
+      if (!healthOk) await sleep(100)
+    }
+    expect(healthOk).toBe(true)
+
+    // Send SIGTERM and verify clean exit
+    child.kill("SIGTERM")
+    const exitCode = await new Promise<number | null>(resolve => {
+      child.once("exit", code => resolve(code))
+    })
+    // Either exits 0 or null (signal exit); both are acceptable clean shutdowns
+    expect([0, null].includes(exitCode)).toBe(true)
+
+    // Verify shutdown message in stdout
+    expect(stdout).toContain("Received SIGTERM, shutting down")
+
+    // Cleanup
+    try { unlinkSync(dbPath) } catch {}
+    try { unlinkSync(dbPath + "-wal") } catch {}
+    try { unlinkSync(dbPath + "-shm") } catch {}
+  }, 15000)
+
+  test("entry point refuses to start without WORKSPACE_DB_PATH", async () => {
+    const child = spawn("bun", ["run", "reference/slack-messaging/server.ts"], {
+      cwd: "/Users/joshua/holaboss-ai/holaboss/holaOS/experiments/app-builder-sdk",
+      env: {
+        ...process.env,
+        WORKSPACE_DB_PATH: "",   // explicitly empty
+        MCP_PORT: "31199",
+        HOLABOSS_INTEGRATION_BROKER_URL: "http://localhost:8080",
+        HOLABOSS_APP_GRANT: "grant:x:x:x",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stderr = ""
+    child.stderr!.on("data", d => { stderr += d.toString() })
+    const code = await new Promise<number | null>(resolve => {
+      child.once("exit", c => resolve(c))
+    })
+    expect(code).toBe(1)
+    expect(stderr).toContain("WORKSPACE_DB_PATH not set")
+  }, 10000)
+})
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true
+    await sleep(50)
+  }
+  return false
+}
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)) }

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/mcp-server.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/mcp-server.test.ts
@@ -1,0 +1,435 @@
+// Verify the MCP server boots, exposes /mcp/health, registers expected tools
+// from a Slack app instance, and routes a tool call through to the SDK.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { startMcpServer, type StartedMcpServer } from "../src/runtime/mcp-server.ts"
+import { createBridge, type TransportFn } from "../src/index.ts"
+import { SLACK } from "../reference/slack-messaging/provider.ts"
+import { buildSlackApp } from "../reference/slack-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let server: StartedMcpServer
+let app: AppHandleInternal
+let baseUrl: string
+
+const scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async () => {
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error("no scripted response")
+  return next
+}
+
+beforeAll(async () => {
+  const built = buildSlackApp() as unknown as { app: AppHandleInternal }
+  app = built.app
+  app._setTurn({ turnId: "t_mcp", sessionId: "s_mcp" })
+  const bridge = createBridge({ provider: SLACK, transport })
+  server = await startMcpServer({ app, port: 0, bridge })
+  baseUrl = `http://localhost:${server.port}`
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+describe("MCP server — boot + tool registration + routing", () => {
+  test("health endpoint responds with status:ok and app_id", async () => {
+    const r = await fetch(`${baseUrl}/mcp/health`)
+    expect(r.status).toBe(200)
+    const body = await r.json() as { status: string; app_id: string }
+    expect(body.status).toBe("ok")
+    expect(body.app_id).toBe("slack")
+  })
+
+  test("tools/list via MCP JSON-RPC: derived tool names appear", async () => {
+    // Start an SSE session
+    const session = await openSseSession(baseUrl)
+    const tools = await mcpListTools(baseUrl, session.sessionId)
+    const names = tools.map(t => t.name)
+
+    // Connection / snapshot
+    expect(names).toContain("slack_connection_status")
+    expect(names).toContain("slack_snapshot")
+
+    // Per-resource CRUD
+    expect(names).toContain("slack_create_message")
+    expect(names).toContain("slack_list_messages")
+    expect(names).toContain("slack_get_message")
+    expect(names).toContain("slack_create_channel")
+
+    // Action tools (from buildSlackApp registrations)
+    expect(names).toContain("slack_send_message_message")
+    expect(names).toContain("slack_edit_message_message")
+    expect(names).toContain("slack_delete_message_message")
+    expect(names).toContain("slack_react")           // custom toolName override
+    expect(names).toContain("slack_schedule_send_message")
+
+    // Reverse tool (schedule_send is reversible)
+    expect(names).toContain("slack_cancel_schedule_send_message")
+
+    // Sync status descriptor
+    expect(names).toContain("slack_channel_directory_sync_status")
+
+    await session.close()
+  })
+
+  test("tools/call slack_create_message inserts a row in 'draft' state", async () => {
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_create_message", {
+      channel_id: "C12345", text: "hello via mcp",
+    })
+    expect(result.isError).toBeFalsy()
+    const created = JSON.parse(result.content[0]!.text!)
+    expect(created.status).toBe("draft")
+    expect(created.channel_id).toBe("C12345")
+    expect(created.text).toBe("hello via mcp")
+    expect(created.id).toMatch(/^r_/)
+
+    // Verify row really lives in app state
+    const stateRow = app._state.getRow(created.id)
+    expect(stateRow?.status).toBe("draft")
+
+    await session.close()
+  })
+
+  test("tools/call slack_send_message_message routes through SDK to bridge", async () => {
+    const row = app._state.insertRow("message", {
+      channel_id: "C9999", text: "hi from mcp tool",
+    }, "draft")
+
+    scriptedResponses.push({ status: 200, body: { ok: true, ts: "9999.000", channel: "C9999" } })
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_send_message_message", {
+      message_id: row.id,
+    })
+    expect(result.isError).toBeFalsy()
+    const ok = JSON.parse(result.content[0]!.text!)
+    expect(ok.ok).toBe(true)
+    expect(ok.externalId).toBe("9999.000")
+
+    // Row state updated
+    const updated = app._state.getRow(row.id)
+    expect(updated?.status).toBe("sent")
+    expect(updated?.externalId).toBe("9999.000")
+
+    await session.close()
+  })
+
+  test("tools/call with invalid state surfaces isError + typed code", async () => {
+    const draft = app._state.insertRow("message", {
+      channel_id: "C0000", text: "never react",
+    }, "draft")
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_react", {
+      message_id: draft.id, emoji: "rocket",
+    })
+    expect(result.isError).toBe(true)
+    const err = JSON.parse(result.content[0]!.text!)
+    expect(err.code).toBe("invalid_state")
+    await session.close()
+  })
+
+  test("tools/call slack_snapshot returns aggregate row counts", async () => {
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_snapshot", {})
+    expect(result.isError).toBeFalsy()
+    const snap = JSON.parse(result.content[0]!.text!)
+    expect(snap.app_id).toBe("slack")
+    expect(snap.rows_by_resource).toBeDefined()
+    // We've inserted multiple message rows above; should see "message" key
+    expect(snap.rows_by_resource.message).toBeDefined()
+    await session.close()
+  })
+
+  // ── connection_status: real whoami probe (was a stub returning connected:true) ──
+
+  test("connection_status probes provider.whoamiPath via bridge → connected:true", async () => {
+    scriptedResponses.push({ status: 200, body: { ok: true, user: "U123", team: "T999" } })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_connection_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.connected).toBe(true)
+    expect(body.app_id).toBe("slack")
+    expect(body.identity).toEqual({ ok: true, user: "U123", team: "T999" })
+    await session.close()
+  })
+
+  test("connection_status surfaces upstream auth failure → connected:false + reason", async () => {
+    // Bridge returns 401 → BridgeError code "not_connected"
+    scriptedResponses.push({
+      status: 401,
+      body: { error: "holaboss_session_invalid", message: "Holaboss session is invalid or expired." },
+    })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_connection_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.connected).toBe(false)
+    expect(body.reason).toBe("not_connected")
+    expect(String(body.message)).toMatch(/Holaboss session/i)
+    expect(body.upstream_status).toBe(401)
+    await session.close()
+  })
+
+  // ── refresh_<resource>: re-pulls fetch() and upserts cache rows ──
+
+  test("refresh_channels calls bridge.fetch and upserts new channels", async () => {
+    // 2 channels returned from /conversations.list
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [
+        { id: "C_NEW1", name: "general", is_private: false },
+        { id: "C_NEW2", name: "random", is_private: false },
+      ] },
+    })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_refresh_channels", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.ok).toBe(true)
+    expect(body.fetched).toBe(2)
+    expect(body.inserted).toBe(2)
+    expect(body.updated).toBe(0)
+
+    // Confirm rows actually landed
+    const channels = app._state.rowsByResource("channel")
+    expect(channels.some(r => r.data.id === "C_NEW1")).toBe(true)
+    expect(channels.some(r => r.data.id === "C_NEW2")).toBe(true)
+    await session.close()
+  })
+
+  test("refresh_channels updates existing channel (idempotent by data.id)", async () => {
+    // First call: insert
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [{ id: "C_DUP", name: "dup-original", is_private: false }] },
+    })
+    const sess1 = await openSseSession(baseUrl)
+    await mcpCallTool(baseUrl, sess1.sessionId, "slack_refresh_channels", {})
+    await sess1.close()
+
+    // Second call: same id, different name → should update
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [{ id: "C_DUP", name: "dup-renamed", is_private: true }] },
+    })
+    const sess2 = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, sess2.sessionId, "slack_refresh_channels", {})
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.updated).toBe(1)
+    expect(body.inserted).toBe(0)
+
+    const dup = app._state.rowsByResource("channel").filter(r => r.data.id === "C_DUP")
+    expect(dup.length).toBe(1)
+    expect(dup[0]!.data.name).toBe("dup-renamed")
+    await sess2.close()
+  })
+
+  // ── <sync>_sync_status: reads from audit (was a descriptor stub) ──
+
+  test("sync_status returns has_ever_run:false before any sync ran", async () => {
+    // Use a fresh app instance so audit is empty for this sync
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const freshServer = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge })
+    const session = await openSseSession(`http://localhost:${freshServer.port}`)
+    const result = await mcpCallTool(
+      `http://localhost:${freshServer.port}`,
+      session.sessionId,
+      "slack_channel_directory_sync_status",
+      {},
+    )
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.has_ever_run).toBe(false)
+    expect(body.sync_name).toBe("channel_directory")
+    expect(body.schedule).toBe("0 * * * *")
+    expect(body.records_total).toBe(0)
+    await session.close()
+    await freshServer.close()
+  })
+
+  test("sync_status returns has_ever_run:true + outcome after audit recorded", async () => {
+    // Simulate a successful sync run by writing audit entries directly
+    app._state.pushAudit("sync.start", { app: "slack", sync: "channel_directory" })
+    app._state.pushAudit("sync.end", {
+      app: "slack", sync: "channel_directory",
+      outcome: "ok", fetched: 5, upserted: 5, total_ms: 142,
+    })
+    app._state.upsertSyncRecord({
+      syncName: "channel_directory", attachedRowId: "", key: "C1",
+      raw: { id: "C1" }, normalized: { id: "C1", name: "n" },
+    })
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_channel_directory_sync_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.has_ever_run).toBe(true)
+    expect(body.outcome).toBe("ok")
+    expect(body.fetched).toBe(5)
+    expect(body.upserted).toBe(5)
+    expect(body.total_ms).toBe(142)
+    expect(body.records_total).toBe(1)
+    expect(body.started_at).toBeTruthy()
+    expect(body.ended_at).toBeTruthy()
+    await session.close()
+  })
+
+  test("httpPort option serves a headless web stub (200 HTML + /health JSON)", async () => {
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const stub = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge, httpPort: 0 })
+    expect(stub.httpPort).toBeTruthy()
+    const stubUrl = `http://localhost:${stub.httpPort}`
+
+    const root = await fetch(stubUrl)
+    expect(root.status).toBe(200)
+    const html = await root.text()
+    expect(html).toContain("headless module")
+    expect(root.headers.get("content-type") ?? "").toContain("text/html")
+
+    const health = await fetch(`${stubUrl}/health`)
+    expect(health.status).toBe(200)
+    const hb = await health.json() as Record<string, unknown>
+    expect(hb.status).toBe("ok")
+    expect(hb.surface).toBe("headless_stub")
+    expect(hb.app_id).toBe("slack")
+
+    await stub.close()
+  })
+
+  test("startMcpServer without httpPort does NOT bind a second port (httpPort:undefined returned)", async () => {
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const s = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge })
+    expect(s.httpPort).toBeUndefined()
+    await s.close()
+  })
+
+  test("tools/list includes refresh + sync_status (no longer descriptor-only)", async () => {
+    const session = await openSseSession(baseUrl)
+    const tools = await mcpListTools(baseUrl, session.sessionId)
+    const names = tools.map(t => t.name)
+    expect(names).toContain("slack_refresh_channels")              // resource has refreshEvery + fetch
+    expect(names).toContain("slack_channel_directory_sync_status")  // sync registered
+    // Message resource has NO refreshEvery → no refresh tool
+    expect(names).not.toContain("slack_refresh_messages")
+    await session.close()
+  })
+})
+
+// ─── MCP JSON-RPC client helpers (no @modelcontextprotocol/sdk client dep) ───
+//
+// We talk to the server directly over SSE + POST /mcp/messages so the tests
+// don't pull in extra client machinery.
+
+interface SseSession {
+  sessionId: string
+  close: () => Promise<void>
+}
+
+async function openSseSession(base: string): Promise<SseSession> {
+  // Open SSE; read the first event which carries the sessionId via the
+  // POST URL: SSEServerTransport emits "endpoint" event with /mcp/messages?sessionId=...
+  const abortCtrl = new AbortController()
+  const r = await fetch(`${base}/mcp/sse`, { signal: abortCtrl.signal })
+  if (!r.ok || !r.body) throw new Error(`SSE failed: ${r.status}`)
+  const reader = r.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  let sessionId = ""
+  // Read until we see the "endpoint" event with sessionId
+  for (let i = 0; i < 20; i++) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    const match = buf.match(/sessionId=([a-zA-Z0-9_-]+)/)
+    if (match) { sessionId = match[1]!; break }
+  }
+  if (!sessionId) throw new Error("no sessionId received")
+  return {
+    sessionId,
+    close: async () => { abortCtrl.abort(); try { await reader.cancel() } catch {} },
+  }
+}
+
+async function mcpListTools(base: string, sessionId: string): Promise<Array<{ name: string }>> {
+  const result = await mcpJsonRpc(base, sessionId, "tools/list", {})
+  return (result as { tools: Array<{ name: string }> }).tools
+}
+
+async function mcpCallTool(base: string, sessionId: string, name: string, args: Record<string, unknown>) {
+  const result = await mcpJsonRpc(base, sessionId, "tools/call", { name, arguments: args })
+  return result as { content: Array<{ type: string; text?: string }>; isError?: boolean; structuredContent?: unknown }
+}
+
+async function mcpJsonRpc(base: string, sessionId: string, method: string, params: unknown): Promise<unknown> {
+  // The MCP server's SSEServerTransport responds via the SSE stream we opened.
+  // We need to (a) POST the request, (b) read the matching response from SSE.
+  // Simpler approach: do request via POST + assume server posts back via SSE.
+  // For tests, McpServer.connect returns request/response over SSE. We'll
+  // re-open SSE per call to keep the helper minimal.
+  const sess = await openSseSessionWithReader(base)
+  const requestId = Math.floor(Math.random() * 1_000_000)
+  const postPromise = fetch(`${base}/mcp/messages?sessionId=${sess.sessionId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: requestId, method, params }),
+  })
+  const response = await sess.readUntilResponse(requestId, 5000)
+  await postPromise
+  await sess.close()
+  if (response.error) throw new Error(`MCP error: ${JSON.stringify(response.error)}`)
+  return response.result
+}
+
+interface SseSessionWithReader extends SseSession {
+  readUntilResponse: (id: number, timeoutMs: number) => Promise<{ result?: unknown; error?: unknown }>
+}
+
+async function openSseSessionWithReader(base: string): Promise<SseSessionWithReader> {
+  const abortCtrl = new AbortController()
+  const r = await fetch(`${base}/mcp/sse`, { signal: abortCtrl.signal })
+  if (!r.ok || !r.body) throw new Error(`SSE failed: ${r.status}`)
+  const reader = r.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  let sessionId = ""
+  while (!sessionId) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    const m = buf.match(/sessionId=([a-zA-Z0-9_-]+)/)
+    if (m) sessionId = m[1]!
+  }
+  if (!sessionId) throw new Error("no sessionId")
+  return {
+    sessionId,
+    close: async () => { abortCtrl.abort(); try { await reader.cancel() } catch {} },
+    readUntilResponse: async (id, timeoutMs) => {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        // Each SSE event ends in \n\n; data lines start with "data: "
+        const events = buf.split("\n\n")
+        buf = events.pop() ?? ""
+        for (const ev of events) {
+          const dataLine = ev.split("\n").find(l => l.startsWith("data: "))
+          if (!dataLine) continue
+          const raw = dataLine.slice("data: ".length)
+          try {
+            const parsed = JSON.parse(raw)
+            if (parsed.id === id) return { result: parsed.result, error: parsed.error }
+          } catch {}
+        }
+      }
+      throw new Error(`timeout waiting for response to id=${id}`)
+    },
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/pinterest.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/pinterest.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { PINTEREST } from "../reference/pinterest-publishing/provider.ts"
+import { buildPinterestApp } from "../reference/pinterest-publishing/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+function bridge() {
+  return createBridge({ provider: PINTEREST, transport })
+}
+function setup() {
+  calls = []
+  scriptedResponses = []
+  const built = buildPinterestApp() as unknown as { app: AppHandleInternal; pin: any; board: any }
+  built.app._setTurn({ turnId: "turn_1", sessionId: "sess_1" })
+  return built
+}
+
+describe("Pinterest — publishing shape works end-to-end", () => {
+  test("happy path 2-step publish lands in 'published'", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("pin", {
+      board_id: "b_42", image_url: "https://example.com/cat.jpg", title: "My cat",
+    }, "draft")
+    scriptedResponses.push({ status: 200, body: { id: "media_999" } })
+    scriptedResponses.push({ status: 200, body: { id: "pin_777" } })
+
+    const result = await app._invokeAction({ actionName: "publish", rowId: row.id, bridge: bridge() })
+    expect(result).toEqual({ ok: true, externalId: "pin_777" })
+
+    const final = app._state.getRow(row.id)!
+    expect(final.status).toBe("published")
+    expect(final.externalId).toBe("pin_777")
+    expect((final.data as any).media_id).toBe("media_999")
+    expect(final.createdInTurn).toBe("turn_1")
+
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card!.surface).toBe("content_plan")
+    expect(card!.status).toBe("published")
+    expect(card!.summary).toBe("My cat")
+    expect(card!.deepLink).toBe("https://pinterest.com/pin/pin_777")
+  })
+
+  test("partial success → row lands in 'failed' (declared failedState)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("pin", {
+      board_id: "b_42", image_url: "https://x", title: "x",
+    }, "draft")
+    scriptedResponses.push({ status: 200, body: { id: "media_999" } })
+    scriptedResponses.push({ status: 500, body: { error: "internal" } })
+
+    const result = await app._invokeAction({ actionName: "publish", rowId: row.id, bridge: bridge() })
+    expect("fail" in result).toBe(true)
+    const final = app._state.getRow(row.id)!
+    expect(final.status).toBe("failed")
+    expect((final.data as any).media_id).toBe("media_999")
+  })
+
+  test("reversible publish: cancel returns row to 'draft' and deletes upstream", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("pin", {
+      board_id: "b_42", image_url: "https://x", title: "x",
+    }, "draft")
+    scriptedResponses.push({ status: 200, body: { id: "media_999" } })
+    scriptedResponses.push({ status: 200, body: { id: "pin_777" } })
+    await app._invokeAction({ actionName: "publish", rowId: row.id, bridge: bridge() })
+    expect(app._state.getRow(row.id)!.status).toBe("published")
+
+    // Now cancel
+    scriptedResponses.push({ status: 204, body: null })   // DELETE returns 204
+    const r = await app._invokeReverse({ actionName: "publish", rowId: row.id, bridge: bridge() })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("draft")
+    expect(calls.at(-1)?.method).toBe("DELETE")
+  })
+
+  test("derived tools include reverse + connection + snapshot + sync", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name)
+    expect(names).toContain("pinterest_connection_status")
+    expect(names).toContain("pinterest_publish_pin")
+    expect(names).toContain("pinterest_cancel_publish_pin")   // reversible
+    expect(names).toContain("pinterest_edit_pin")
+    expect(names).toContain("pinterest_list_pins")
+    expect(names).toContain("pinterest_list_boards")
+    expect(names).toContain("pinterest_refresh_boards")
+    expect(names).toContain("pinterest_pin_metrics_sync_status")
+    expect(names).toContain("pinterest_snapshot")
+  })
+
+  test("auth error surfaces with reauth hint", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("pin", { board_id: "x", image_url: "https://x", title: "x" }, "draft")
+    scriptedResponses.push({ status: 401, body: { error: "expired" } })
+    const result = await app._invokeAction({ actionName: "publish", rowId: row.id, bridge: bridge() })
+    expect((result as any).fail.code).toBe("not_connected")
+    expect(app.state().notifications[0].agentHint).toContain("reconnect")
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/runtime-broker-transport.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/runtime-broker-transport.test.ts
@@ -1,0 +1,248 @@
+// Verify the runtime-broker transport's body shape, error mapping, and env
+// resolution. Mocks fetch so we don't need a real Holaboss runtime running.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { createRuntimeBrokerTransport } from "../src/bridge-transports/runtime-broker.ts"
+
+let capturedRequests: Array<{ url: string; init: RequestInit }> = []
+let scriptedResponses: Array<{ status: number; body: unknown; headers?: Record<string, string> }> = []
+
+function mockFetch(): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    capturedRequests.push({ url: String(input), init: init ?? {} })
+    const next = scriptedResponses.shift()
+    if (!next) throw new Error(`no scripted response for ${String(input)}`)
+    return new Response(JSON.stringify(next.body), {
+      status: next.status,
+      headers: next.headers ?? { "Content-Type": "application/json" },
+    })
+  }) as typeof fetch
+}
+
+beforeEach(() => {
+  capturedRequests = []
+  scriptedResponses = []
+})
+
+afterEach(() => {
+  delete process.env.HOLABOSS_INTEGRATION_BROKER_URL
+  delete process.env.HOLABOSS_APP_GRANT
+})
+
+describe("runtime-broker transport", () => {
+  test("happy path: POSTs to /broker/proxy with grant + provider + request envelope", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:ws_test:slack_app:nonce123",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+
+    scriptedResponses.push({
+      status: 200,
+      body: {
+        data: { ok: true, ts: "1700.111", channel: "C123" },
+        status: 200,
+        headers: { "x-slack-req-id": "abc" },
+      },
+    })
+
+    const result = await transport({
+      method: "POST",
+      url: "https://slack.com/api/chat.postMessage",
+      body: { channel: "C123", text: "hi" },
+    })
+
+    // What the SDK BridgeClient sees:
+    expect(result.status).toBe(200)
+    expect(result.body).toEqual({ ok: true, ts: "1700.111", channel: "C123" })
+    expect(result.headers!["x-slack-req-id"]).toBe("abc")
+
+    // What was sent to /broker/proxy:
+    expect(capturedRequests).toHaveLength(1)
+    const req = capturedRequests[0]!
+    expect(req.url).toBe("http://localhost:8080/broker/proxy")
+    expect(req.init.method).toBe("POST")
+    const sentBody = JSON.parse(req.init.body as string)
+    expect(sentBody).toEqual({
+      grant: "grant:ws_test:slack_app:nonce123",
+      provider: "slack",
+      request: {
+        method: "POST",
+        endpoint: "https://slack.com/api/chat.postMessage",
+        body: { channel: "C123", text: "hi" },
+      },
+    })
+  })
+
+  test("env fallback: brokerUrl + grant resolved from HOLABOSS_* env when not passed", async () => {
+    process.env.HOLABOSS_INTEGRATION_BROKER_URL = "http://runtime:9000/"  // trailing slash
+    process.env.HOLABOSS_APP_GRANT = "grant:ws_env:env_app:env_nonce"
+
+    const transport = createRuntimeBrokerTransport({
+      provider: "twitter",
+      fetchImpl: mockFetch(),
+    })
+
+    scriptedResponses.push({
+      status: 200,
+      body: { data: { id: "tweet_42" }, status: 200, headers: {} },
+    })
+
+    await transport({ method: "GET", url: "https://api.x.com/2/tweets/42" })
+
+    const req = capturedRequests[0]!
+    expect(req.url).toBe("http://runtime:9000/broker/proxy")  // trailing slash stripped
+    const sentBody = JSON.parse(req.init.body as string)
+    expect(sentBody.grant).toBe("grant:ws_env:env_app:env_nonce")
+    expect(sentBody.provider).toBe("twitter")
+  })
+
+  test("missing brokerUrl throws at construction (early fail)", () => {
+    expect(() => createRuntimeBrokerTransport({
+      provider: "slack",
+      grant: "grant:x:x:x",
+      fetchImpl: mockFetch(),
+    })).toThrow(/HOLABOSS_INTEGRATION_BROKER_URL/)
+  })
+
+  test("missing grant throws at construction", () => {
+    expect(() => createRuntimeBrokerTransport({
+      provider: "slack",
+      brokerUrl: "http://localhost:8080",
+      fetchImpl: mockFetch(),
+    })).toThrow(/HOLABOSS_APP_GRANT/)
+  })
+
+  test("missing provider throws at construction", () => {
+    expect(() => createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:x:x:x",
+      provider: "",
+      fetchImpl: mockFetch(),
+    })).toThrow(/provider is required/)
+  })
+
+  test("broker-level error (401 grant_invalid): status + body passed through for BridgeClient mapping", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:bad",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+
+    // Matches integration-broker.ts BrokerError shape for invalid grant
+    scriptedResponses.push({
+      status: 401,
+      body: { error: "grant_invalid", message: "app grant is malformed" },
+    })
+
+    const result = await transport({ method: "POST", url: "https://slack.com/api/chat.postMessage" })
+    expect(result.status).toBe(401)
+    expect(result.body).toEqual({ error: "grant_invalid", message: "app grant is malformed" })
+    // BridgeClient will map status 401 → BridgeError code "not_connected" automatically
+  })
+
+  test("upstream provider error (200 envelope + status:401 inside): both surfaced correctly", async () => {
+    // Broker succeeds (HTTP 200) but upstream Slack returned 401 — the
+    // envelope's status field carries the real provider status.
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:x:x:x",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+
+    scriptedResponses.push({
+      status: 200,
+      body: {
+        data: { error: "token_revoked" },
+        status: 401,                 // ← upstream's status, not broker's
+        headers: { "retry-after": "3600" },
+      },
+    })
+
+    const result = await transport({ method: "POST", url: "https://slack.com/api/users.info" })
+    expect(result.status).toBe(401)              // surfaces upstream status
+    expect(result.body).toEqual({ error: "token_revoked" })
+    expect(result.headers!["retry-after"]).toBe("3600")
+  })
+
+  test("body omitted when undefined (GET requests don't ship empty body)", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:x:x:x",
+      provider: "github",
+      fetchImpl: mockFetch(),
+    })
+    scriptedResponses.push({
+      status: 200,
+      body: { data: { login: "octocat" }, status: 200, headers: {} },
+    })
+    await transport({ method: "GET", url: "https://api.github.com/user" })
+
+    const sent = JSON.parse(capturedRequests[0]!.init.body as string)
+    expect(sent.request.method).toBe("GET")
+    expect(sent.request.endpoint).toBe("https://api.github.com/user")
+    expect("body" in sent.request).toBe(false)   // body field absent, not "body: undefined"
+  })
+
+  // Holaboss session crashes Hono auth middleware → Worker bubbles up a generic
+  // 500 wrapped by runtime's ComposioService. The transport recognises the
+  // signature and recasts to 401 so bridge.ts maps to `not_connected` and the
+  // agent surfaces "please re-login to Holaboss" instead of "upstream 500".
+  test("Hono auth crash (500 with 'Composio proxy via Hono failed' detail) recast to 401", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:x:x:x",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+    scriptedResponses.push({
+      status: 500,
+      body: { detail: "Composio proxy via Hono failed: 500 Internal Server Error" },
+    })
+
+    const result = await transport({ method: "GET", url: "https://slack.com/api/auth.test" })
+    expect(result.status).toBe(401)
+    const body = result.body as Record<string, unknown>
+    expect(body.error).toBe("holaboss_session_invalid")
+    expect(String(body.message)).toMatch(/log in to holaboss/i)
+    expect(body.broker_status).toBe(500)
+    expect((body.broker_body as Record<string, unknown>).detail).toMatch(/Composio proxy via Hono failed/)
+  })
+
+  test("Hono 401 (clean unauthorized) also recast — same signature in error body", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:x:x:x",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+    scriptedResponses.push({
+      status: 500,
+      body: { detail: "Composio proxy via Hono failed: 401 {\"error\":\"unauthorized\"}" },
+    })
+
+    const result = await transport({ method: "POST", url: "https://slack.com/api/chat.postMessage", body: {} })
+    expect(result.status).toBe(401)
+    expect((result.body as Record<string, unknown>).error).toBe("holaboss_session_invalid")
+  })
+
+  test("non-Hono broker errors (grant_invalid) NOT recast — pass through unchanged", async () => {
+    const transport = createRuntimeBrokerTransport({
+      brokerUrl: "http://localhost:8080",
+      grant: "grant:bad",
+      provider: "slack",
+      fetchImpl: mockFetch(),
+    })
+    scriptedResponses.push({
+      status: 401,
+      body: { error: "grant_invalid", message: "app grant is malformed" },
+    })
+
+    const result = await transport({ method: "GET", url: "https://slack.com/api/auth.test" })
+    expect(result.status).toBe(401)
+    expect((result.body as Record<string, unknown>).error).toBe("grant_invalid")  // NOT holaboss_session_invalid
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/slack.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/slack.test.ts
@@ -1,0 +1,240 @@
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { SLACK } from "../reference/slack-messaging/provider.ts"
+import { buildSlackApp } from "../reference/slack-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+function bridge() {
+  return createBridge({ provider: SLACK, transport })
+}
+function setup() {
+  calls = []
+  scriptedResponses = []
+  const built = buildSlackApp() as unknown as { app: AppHandleInternal; message: any; channel: any }
+  built.app._setTurn({ turnId: "turn_1", sessionId: "sess_1" })
+  return built
+}
+
+describe("Slack — Slack's own states (sent/scheduled/edited/deleted)", () => {
+  test("send_message: draft → sent (not 'published')", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "hello world",
+    }, "draft")
+    scriptedResponses.push({ status: 200, body: { ok: true, ts: "1234.567", channel: "C123" } })
+
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect(r).toEqual({ ok: true, externalId: "1234.567" })
+    expect(app._state.getRow(row.id)!.status).toBe("sent")
+    expect(app._state.getRow(row.id)!.externalId).toBe("1234.567")
+
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card!.surface).toBe("ops_log")
+    expect(card!.status).toBe("sent")
+  })
+
+  test("schedule_send + reverse: scheduled → draft (real upstream cancel)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "later",
+    }, "draft")
+    scriptedResponses.push({ status: 200, body: { ok: true, scheduled_message_id: "Q123", post_at: 999 } })
+    await app._invokeAction({
+      actionName: "schedule_send",
+      rowId: row.id,
+      input: { post_at: 999 },
+      bridge: bridge(),
+    })
+    expect(app._state.getRow(row.id)!.status).toBe("scheduled")
+
+    scriptedResponses.push({ status: 200, body: { ok: true } })
+    const rev = await app._invokeReverse({ actionName: "schedule_send", rowId: row.id, bridge: bridge() })
+    expect((rev as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("draft")
+    expect(calls.at(-1)?.url).toContain("deleteScheduledMessage")
+  })
+
+  test("edit_message: sent → edited", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "old", external_id: "1234.567",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "1234.567" })
+
+    scriptedResponses.push({ status: 200, body: { ok: true } })
+    const r = await app._invokeAction({
+      actionName: "edit_message", rowId: row.id, input: { text: "new" }, bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("edited")
+    expect((app._state.getRow(row.id)!.data as any).text).toBe("new")
+  })
+
+  test("react: SIDE EFFECT, does NOT change message status", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "hi", external_id: "1234.567",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "1234.567" })
+    app._state.upsertOutput({
+      resourceName: "message", rowId: row.id, surface: "ops_log",
+      status: "sent", summary: "hi", deepLink: null,
+    })
+
+    scriptedResponses.push({ status: 200, body: { ok: true } })
+    const r = await app._invokeAction({
+      actionName: "react", rowId: row.id, input: { emoji: "thumbsup" }, bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("sent")
+    const cards = app.state().outputs.filter(o => o.rowId === row.id)
+    expect(cards).toHaveLength(1)
+    expect(cards[0].status).toBe("sent")
+  })
+
+  test("custom toolName: react uses 'slack_react' not 'slack_react_message'", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name)
+    expect(names).toContain("slack_react")
+    expect(names).not.toContain("slack_react_message")
+  })
+
+  test("invalid state: trying to react on a draft is rejected", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "x",
+    }, "draft")
+    const r = await app._invokeAction({
+      actionName: "react", rowId: row.id, input: { emoji: "ok" }, bridge: bridge(),
+    })
+    expect((r as any).fail.code).toBe("invalid_state")
+  })
+
+  test("delete_message: sent → deleted", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "bye", external_id: "1234.567",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "1234.567" })
+
+    scriptedResponses.push({ status: 200, body: { ok: true } })
+    const r = await app._invokeAction({ actionName: "delete_message", rowId: row.id, bridge: bridge() })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("deleted")
+  })
+
+  // ─── Regression: real-Slack bugs found by E2E ────────────────────────────
+
+  test("REGRESSION: Slack returns 200 + {ok:false} → action MUST fail (not silent ok)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "x",
+    }, "draft")
+
+    // The exact pattern that real Slack uses for content/permission errors:
+    // HTTP 200, body says ok:false. Old code only checked HTTP status and
+    // treated this as success.
+    scriptedResponses.push({ status: 200, body: { ok: false, error: "channel_not_found" } })
+
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("channel_not_found")
+    // Row should be marked failed (via failedState), NOT 'sent'
+    expect(app._state.getRow(row.id)!.status).toBe("failed")
+  })
+
+  test("REGRESSION: Slack DM resolves user_id → DM channel; persisted back to row", async () => {
+    const { app } = setup()
+    // Agent sends to user_id (DM-self pattern); Slack auto-resolves to DM channel id
+    const row = app._state.insertRow("message", {
+      channel_id: "U07XXXX",       // user_id, not a real channel
+      text: "hello self",
+    }, "draft")
+
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, ts: "1700000000.111111", channel: "D0DMCHAN" },  // ← Slack returns DM channel
+    })
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect((r as any).ok).toBe(true)
+
+    // ★ The row.channel_id was overwritten with the DM channel id Slack actually addresses.
+    // Without this, subsequent edit/delete/react would hit a wrong channel and silently fail.
+    expect((app._state.getRow(row.id)!.data as any).channel_id).toBe("D0DMCHAN")
+  })
+
+  test("REGRESSION: schedule_send reverse propagates ALL errors (no swallow not_found)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      channel_id: "C123", text: "later", external_id: "Q123",
+    }, "scheduled")
+    app._state.updateRow(row.id, { externalId: "Q123" })
+
+    // Slack says the scheduled message no longer exists — old code swallowed this
+    // as success. But "not_found" might mean upstream actually fired the message;
+    // agent must see the failure and decide.
+    scriptedResponses.push({ status: 200, body: { ok: false, error: "not_found" } })
+    const r = await app._invokeReverse({ actionName: "schedule_send", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("not_found")
+  })
+
+  test("REGRESSION: schedule_send persists DM channel from response (verified via chat.scheduledMessages.list)", async () => {
+    const { app } = setup()
+    // Agent schedules to a user_id (DM-self pattern)
+    const row = app._state.insertRow("message", {
+      channel_id: "U07XXXX", text: "later",
+    }, "draft")
+
+    // Slack returns the DM channel. Slack's own chat.scheduledMessages.list
+    // verifies the message is stored under that DM channel — so the reverse
+    // (chat.deleteScheduledMessage) must use the DM channel too.
+    scriptedResponses.push({
+      status: 200,
+      body: {
+        ok: true,
+        scheduled_message_id: "Q0ABCDE",
+        post_at: 1700000060,
+        channel: "D0DMCHAN",
+      },
+    })
+    const r = await app._invokeAction({
+      actionName: "schedule_send",
+      rowId: row.id,
+      input: { post_at: 1700000060 },
+      bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect((app._state.getRow(row.id)!.data as any).channel_id).toBe("D0DMCHAN")
+  })
+
+  test("REGRESSION: invalid_scheduled_message_id from delete propagates as fail (Slack's 60s rule)", async () => {
+    const { app } = setup()
+    // Setup: row already in 'scheduled' state with persisted DM channel
+    const row = app._state.insertRow("message", {
+      channel_id: "D0DMCHAN", text: "x", external_id: "Q0LATE",
+    }, "scheduled")
+    app._state.updateRow(row.id, { externalId: "Q0LATE" })
+
+    // Real Slack behavior: if cancel is invoked <60s before post_at, Slack returns
+    // invalid_scheduled_message_id (message has graduated out of the cancellable queue).
+    // Action MUST propagate as fail, NOT silently claim success.
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: false, error: "invalid_scheduled_message_id" },
+    })
+    const r = await app._invokeReverse({ actionName: "schedule_send", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("invalid_scheduled_message_id")
+    // Row stays in 'scheduled' — agent must know the cancel didn't succeed
+    expect(app._state.getRow(row.id)!.status).toBe("scheduled")
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/sqlite-backend.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/sqlite-backend.test.ts
@@ -1,0 +1,155 @@
+// Verify SqliteStateBackend:
+//   1. Implements StateBackend correctly (parity with InMemoryStateBackend)
+//   2. Truly persists — data survives backend recreation against the same DB
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { unlinkSync, mkdtempSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { SqliteStateBackend } from "../src/runtime/state-backend-sqlite.ts"
+import { RuntimeState } from "../src/runtime/state.ts"
+import { createApp, z, createBridge, type TransportFn } from "../src/index.ts"
+import { PINTEREST } from "../reference/pinterest-publishing/provider.ts"
+import { buildPinterestApp } from "../reference/pinterest-publishing/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let tmpDir: string
+let dbPath: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "app-sdk-sqlite-"))
+  dbPath = join(tmpDir, "workspace.db")
+})
+
+afterEach(() => {
+  try { unlinkSync(dbPath) } catch {}
+  try { unlinkSync(dbPath + "-wal") } catch {}
+  try { unlinkSync(dbPath + "-shm") } catch {}
+})
+
+describe("SqliteStateBackend — implements StateBackend with persistence", () => {
+  test("CRUD parity: same operations produce same snapshot shape as InMemoryStateBackend", () => {
+    const sqlite = new SqliteStateBackend({ dbPath, appId: "t1" })
+    const memory = new RuntimeState()
+
+    for (const backend of [sqlite, memory]) {
+      backend.setTurnContext({ turnId: "turn_x", sessionId: "sess_x" })
+      const row = backend.insertRow("post", { content: "hello" }, "draft")
+      backend.updateRow(row.id, { status: "published", externalId: "ext_123" })
+      backend.pushAudit("action.start", { foo: "bar" })
+      backend.upsertOutput({
+        resourceName: "post", rowId: row.id, surface: "content_plan",
+        status: "published", summary: "hello", deepLink: "https://x.test/123",
+      })
+      backend.pushNotification({ level: "info", summary: "all good", agentHint: "carry on" })
+      backend.upsertSyncRecord({
+        syncName: "metrics", key: "k1", attachedRowId: row.id,
+        raw: { views: 5 }, normalized: { reach: 5, engagement: 0, clicks: 0 },
+      })
+    }
+
+    const sqliteSnap = sqlite.snapshot()
+    const memorySnap = memory.snapshot()
+
+    // Shape parity — same counts everywhere
+    expect(sqliteSnap.rows.length).toBe(memorySnap.rows.length)
+    expect(sqliteSnap.audit.length).toBe(memorySnap.audit.length)
+    expect(sqliteSnap.outputs.length).toBe(memorySnap.outputs.length)
+    expect(sqliteSnap.notifications.length).toBe(memorySnap.notifications.length)
+    expect(sqliteSnap.syncRecords.length).toBe(memorySnap.syncRecords.length)
+
+    // Spot-check specific values
+    expect(sqliteSnap.rows[0]!.status).toBe("published")
+    expect(sqliteSnap.rows[0]!.externalId).toBe("ext_123")
+    expect((sqliteSnap.rows[0]!.data as any).content).toBe("hello")
+    expect(sqliteSnap.rows[0]!.createdInTurn).toBe("turn_x")
+    expect(sqliteSnap.outputs[0]!.deepLink).toBe("https://x.test/123")
+    expect(sqliteSnap.notifications[0]!.level).toBe("info")
+    expect(sqliteSnap.notifications[0]!.agentHint).toBe("carry on")
+
+    sqlite.close()
+  })
+
+  test("PERSISTENCE: data survives backend recreation against the same DB file", () => {
+    // First instance: write
+    const b1 = new SqliteStateBackend({ dbPath, appId: "t2" })
+    b1.setTurnContext({ turnId: "turn_a", sessionId: "sess_a" })
+    const row = b1.insertRow("post", { content: "persistent hi" }, "draft")
+    b1.updateRow(row.id, { status: "sent", externalId: "ext_persist" })
+    b1.upsertOutput({
+      resourceName: "post", rowId: row.id, surface: "ops_log",
+      status: "sent", summary: "persistent hi", deepLink: null,
+    })
+    b1.close()
+
+    // Second instance: read fresh
+    const b2 = new SqliteStateBackend({ dbPath, appId: "t2" })
+    const persisted = b2.getRow(row.id)
+    expect(persisted).toBeDefined()
+    expect(persisted!.status).toBe("sent")
+    expect(persisted!.externalId).toBe("ext_persist")
+    expect((persisted!.data as any).content).toBe("persistent hi")
+    expect(persisted!.createdInTurn).toBe("turn_a")
+
+    const snap = b2.snapshot()
+    expect(snap.outputs).toHaveLength(1)
+    expect(snap.outputs[0]!.summary).toBe("persistent hi")
+
+    b2.close()
+  })
+
+  test("ISOLATION: two apps in the same DB don't see each other's rows", () => {
+    const slack = new SqliteStateBackend({ dbPath, appId: "slack" })
+    const pinterest = new SqliteStateBackend({ dbPath, appId: "pinterest" })
+
+    slack.insertRow("message", { text: "slack hello" }, "sent")
+    pinterest.insertRow("pin", { title: "pinterest hello" }, "draft")
+
+    const slackSnap = slack.snapshot()
+    const pinterestSnap = pinterest.snapshot()
+    expect(slackSnap.rows).toHaveLength(1)
+    expect(pinterestSnap.rows).toHaveLength(1)
+    expect((slackSnap.rows[0]!.data as any).text).toBe("slack hello")
+    expect((pinterestSnap.rows[0]!.data as any).title).toBe("pinterest hello")
+
+    slack.close()
+    pinterest.close()
+  })
+
+  test("INTEGRATION: a full Pinterest app with SqliteStateBackend runs end-to-end", async () => {
+    const sqlite = new SqliteStateBackend({ dbPath, appId: "pinterest" })
+    const { app } = buildPinterestApp({ backend: sqlite }) as unknown as { app: AppHandleInternal }
+    app._setTurn({ turnId: "t_int", sessionId: "s_int" })
+
+    const calls: any[] = []
+    const transport: TransportFn = async (req) => {
+      calls.push(req)
+      if (req.url.endsWith("/media")) return { status: 200, body: { id: "media_42" } }
+      if (req.url.endsWith("/pins")) return { status: 200, body: { id: "pin_42" } }
+      throw new Error(`unexpected ${req.url}`)
+    }
+    const bridge = createBridge({ provider: PINTEREST, transport })
+
+    const row = app._state.insertRow("pin", {
+      board_id: "b_1", image_url: "https://x/y.jpg", title: "my pin",
+    }, "draft")
+
+    const result = await app._invokeAction({ actionName: "publish", rowId: row.id, bridge })
+    expect((result as any).ok).toBe(true)
+    expect((result as any).externalId).toBe("pin_42")
+
+    // Row state survived through SQLite
+    const finalRow = app._state.getRow(row.id)
+    expect(finalRow!.status).toBe("published")
+    expect(finalRow!.externalId).toBe("pin_42")
+    expect((finalRow!.data as any).media_id).toBe("media_42")  // checkpoint via persist
+
+    // Dashboard card emitted to SQLite
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card?.status).toBe("published")
+    expect(card?.deepLink).toBe("https://pinterest.com/pin/pin_42")
+
+    sqlite.close()
+  })
+})
+

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/sync.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/sync.test.ts
@@ -1,0 +1,181 @@
+// Verifies that app.sync(...) actually runs fetch → upsert → normalize.
+
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { PINTEREST } from "../reference/pinterest-publishing/provider.ts"
+import { GITHUB } from "../reference/github-workflow/provider.ts"
+import { SLACK } from "../reference/slack-messaging/provider.ts"
+import { buildPinterestApp } from "../reference/pinterest-publishing/app.ts"
+import { buildGithubIssuesApp } from "../reference/github-workflow/app.ts"
+import { buildSlackApp } from "../reference/slack-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+
+describe("Sync — runs fetch + upsert + normalize end-to-end", () => {
+  test("Pinterest pin_metrics: fetches analytics for published pins, normalizes to {reach,engagement,clicks}", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildPinterestApp() as unknown as { app: AppHandleInternal }
+    app._setTurn({ turnId: "t1", sessionId: "s1" })
+
+    // Seed 2 published pins
+    const p1 = app._state.insertRow("pin", { board_id: "b", image_url: "https://x" }, "published")
+    app._state.updateRow(p1.id, { externalId: "pin_A" })
+    const p2 = app._state.insertRow("pin", { board_id: "b", image_url: "https://y" }, "published")
+    app._state.updateRow(p2.id, { externalId: "pin_B" })
+
+    // Script analytics responses for both
+    scriptedResponses.push({
+      status: 200,
+      body: { IMPRESSION: 1000, SAVE: 50, PIN_CLICK: 10, OUTBOUND_CLICK: 5 },
+    })
+    scriptedResponses.push({
+      status: 200,
+      body: { IMPRESSION: 500, SAVE: 20, PIN_CLICK: 3, OUTBOUND_CLICK: 1 },
+    })
+
+    const r = await app._runSync("pin_metrics", createBridge({ provider: PINTEREST, transport }))
+    expect(r.ok).toBe(true)
+    expect(r.fetched).toBe(2)
+    expect(r.upserted).toBe(2)
+
+    // Sync records stored, normalized correctly
+    const records = app.state().syncRecords
+    expect(records).toHaveLength(2)
+    const first = records.find(s => s.key === p1.id)!
+    expect(first.normalized).toEqual({ reach: 1000, engagement: 60, clicks: 5 })
+    expect(first.attachedRowId).toBe(p1.id)   // attached to pin row
+
+    // Audit log has sync.start + sync.end
+    const events = app.state().audit.map(a => a.event)
+    expect(events).toContain("sync.start")
+    expect(events).toContain("sync.end")
+  })
+
+  test("GitHub issue_activity: fetches open issues, normalizes engagement metrics", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildGithubIssuesApp() as unknown as { app: AppHandleInternal }
+    app._setTurn({ turnId: "t1", sessionId: "s1" })
+
+    const i = app._state.insertRow("issue", { repo_full_name: "x/y", title: "Bug" }, "open")
+    app._state.updateRow(i.id, { externalId: "42" })
+
+    scriptedResponses.push({
+      status: 200,
+      body: { reactions: { total_count: 8 }, comments: 4 },
+    })
+
+    const r = await app._runSync("issue_activity", createBridge({ provider: GITHUB, transport }))
+    expect(r.ok).toBe(true)
+    expect(r.fetched).toBe(1)
+    expect(r.upserted).toBe(1)
+
+    const rec = app.state().syncRecords.find(s => s.key === i.id)!
+    expect(rec.normalized).toEqual({ reach: 8, engagement: 4, clicks: 0 })
+  })
+
+  test("Slack channel_directory: lists channels", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    app._setTurn({ turnId: "t1", sessionId: "s1" })
+
+    scriptedResponses.push({
+      status: 200,
+      body: { channels: [{ id: "C1", name: "general" }, { id: "C2", name: "random" }] },
+    })
+
+    const r = await app._runSync("channel_directory", createBridge({ provider: SLACK, transport }))
+    expect(r.ok).toBe(true)
+    expect(r.fetched).toBe(2)
+    expect(r.upserted).toBe(2)
+
+    const records = app.state().syncRecords
+    expect(records).toHaveLength(2)
+    expect(records[0]!.normalized).toEqual({ id: "C1", name: "general" })
+  })
+
+  test("Sync UPSTREAM ERROR: r.ok=false, notification raised, NOT confused with 'empty success'", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+
+    scriptedResponses.push({ status: 500, body: { error: "internal" } })
+
+    const r = await app._runSync("channel_directory", createBridge({ provider: SLACK, transport }))
+    expect(r.ok).toBe(false)                  // ← was the regression: silently true before
+    expect(r.error?.code).toBe("upstream_error")
+
+    // Notification raised so automations / agent can react
+    const notif = app.state().notifications.find(n => n.summary.includes("channel_directory"))
+    expect(notif).toBeDefined()
+    expect(notif!.level).toBe("error")
+    expect(notif!.agentHint).toContain("retry")
+  })
+
+  test("Sync UPSTREAM SUCCESS WITH EMPTY: r.ok=true, fetched=0 — distinct from upstream error", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+
+    // 200 with empty list = legitimately nothing to sync
+    scriptedResponses.push({ status: 200, body: { channels: [] } })
+
+    const r = await app._runSync("channel_directory", createBridge({ provider: SLACK, transport }))
+    expect(r.ok).toBe(true)
+    expect(r.fetched).toBe(0)
+    expect(r.upserted).toBe(0)
+    // No error notification for legitimate empty result
+    const errNotifs = app.state().notifications.filter(n => n.level === "error")
+    expect(errNotifs).toHaveLength(0)
+  })
+
+  test("Sync AUTH ERROR: notification hints 'reconnect'", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+
+    scriptedResponses.push({ status: 401, body: { error: "token expired" } })
+
+    const r = await app._runSync("channel_directory", createBridge({ provider: SLACK, transport }))
+    expect(r.ok).toBe(false)
+    expect(r.error?.code).toBe("not_connected")
+    const notif = app.state().notifications.find(n => n.level === "error")
+    expect(notif?.agentHint).toContain("reconnect")
+  })
+
+  test("Sync against unknown name throws", async () => {
+    const { app } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    await expect(app._runSync("nonexistent", createBridge({ provider: SLACK, transport })))
+      .rejects.toThrow(/not registered/)
+  })
+
+  test("DbView.query.where: filter is type-safe (status comes from resource.states)", async () => {
+    calls = []
+    scriptedResponses = []
+    const { app, pin } = buildPinterestApp() as unknown as { app: AppHandleInternal; pin: any }
+
+    // Insert 3 pins in different states
+    app._state.insertRow("pin", { board_id: "b", image_url: "https://1" }, "draft")
+    const p2 = app._state.insertRow("pin", { board_id: "b", image_url: "https://2" }, "published")
+    app._state.updateRow(p2.id, { externalId: "pin_B" })
+    const p3 = app._state.insertRow("pin", { board_id: "b", image_url: "https://3" }, "published")
+    app._state.updateRow(p3.id, { externalId: "pin_C" })
+
+    // 2 analytics responses (only published rows should hit the API)
+    scriptedResponses.push({ status: 200, body: { IMPRESSION: 100, SAVE: 5, PIN_CLICK: 1, OUTBOUND_CLICK: 0 } })
+    scriptedResponses.push({ status: 200, body: { IMPRESSION: 200, SAVE: 10, PIN_CLICK: 2, OUTBOUND_CLICK: 1 } })
+
+    const r = await app._runSync("pin_metrics", createBridge({ provider: PINTEREST, transport }))
+    expect(r.fetched).toBe(2)   // only the 2 published, not the draft
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/telegram.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/telegram.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test"
+import { createBridge, type TransportFn } from "../src/bridge.ts"
+import { TELEGRAM } from "../reference/telegram-messaging/provider.ts"
+import { buildTelegramApp } from "../reference/telegram-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let calls: Array<{ method: string; url: string; body?: any }> = []
+let scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async (req) => {
+  calls.push({ method: req.method, url: req.url, body: req.body })
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error(`no scripted response for ${req.method} ${req.url}`)
+  return next
+}
+function bridge() {
+  return createBridge({ provider: TELEGRAM, transport })
+}
+function setup() {
+  calls = []
+  scriptedResponses = []
+  const built = buildTelegramApp() as unknown as { app: AppHandleInternal; message: any; chat: any }
+  built.app._setTurn({ turnId: "turn_1", sessionId: "sess_1" })
+  return built
+}
+
+describe("Telegram — bot messaging state machine", () => {
+  test("send_message: draft → sent, persists numeric message_id as string", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "hello",
+    }, "draft")
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, result: { message_id: 42, chat: { id: 12345 } } },
+    })
+
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect((r as any).ok).toBe(true)
+    expect((r as any).externalId).toBe("42")
+    expect(app._state.getRow(row.id)!.status).toBe("sent")
+    expect(app._state.getRow(row.id)!.externalId).toBe("42")
+
+    const card = app.state().outputs.find(o => o.rowId === row.id)
+    expect(card!.surface).toBe("ops_log")
+    expect(card!.status).toBe("sent")
+  })
+
+  test("edit_message: sent → edited, persists new text", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "old", external_id: "42",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "42" })
+
+    scriptedResponses.push({ status: 200, body: { ok: true, result: true } })
+    const r = await app._invokeAction({
+      actionName: "edit_message", rowId: row.id, input: { text: "new" }, bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("edited")
+    expect((app._state.getRow(row.id)!.data as any).text).toBe("new")
+  })
+
+  test("delete_message: sent → deleted", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "bye", external_id: "42",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "42" })
+
+    scriptedResponses.push({ status: 200, body: { ok: true, result: true } })
+    const r = await app._invokeAction({ actionName: "delete_message", rowId: row.id, bridge: bridge() })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("deleted")
+  })
+
+  test("react: SIDE EFFECT, does NOT change message status", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "hi", external_id: "42",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "42" })
+    app._state.upsertOutput({
+      resourceName: "message", rowId: row.id, surface: "ops_log",
+      status: "sent", summary: "hi", deepLink: null,
+    })
+
+    scriptedResponses.push({ status: 200, body: { ok: true, result: true } })
+    const r = await app._invokeAction({
+      actionName: "react", rowId: row.id, input: { emoji: "👍" }, bridge: bridge(),
+    })
+    expect((r as any).ok).toBe(true)
+    expect(app._state.getRow(row.id)!.status).toBe("sent")
+    const cards = app.state().outputs.filter(o => o.rowId === row.id)
+    expect(cards).toHaveLength(1)
+
+    // verify the reaction body shape Telegram requires
+    const last = calls.at(-1)!
+    expect(last.url).toContain("/setMessageReaction")
+    expect(last.body.reaction[0]).toEqual({ type: "emoji", emoji: "👍" })
+  })
+
+  test("custom toolName: react uses 'telegram_react' not 'telegram_react_message'", async () => {
+    const { app } = setup()
+    const names = app.derivedTools().map(t => t.name)
+    expect(names).toContain("telegram_react")
+    expect(names).not.toContain("telegram_react_message")
+  })
+
+  test("invalid state: trying to react on a draft is rejected", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "x",
+    }, "draft")
+    const r = await app._invokeAction({
+      actionName: "react", rowId: row.id, input: { emoji: "👍" }, bridge: bridge(),
+    })
+    expect((r as any).fail.code).toBe("invalid_state")
+  })
+
+  test("REGRESSION: Telegram returns 200 + {ok:false} → action MUST fail (not silent ok)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "x",
+    }, "draft")
+
+    // Real Telegram response shape for errors
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: false, error_code: 400, description: "Bad Request: chat not found" },
+    })
+
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("telegram_400")
+    expect((r as any).fail.message).toContain("chat not found")
+    expect(app._state.getRow(row.id)!.status).toBe("failed")
+  })
+
+  test("REGRESSION: send_message returns ok but no message_id → fail (not silent success)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "x",
+    }, "draft")
+
+    // Malformed Telegram response — defensive guard
+    scriptedResponses.push({ status: 200, body: { ok: true, result: {} } })
+    const r = await app._invokeAction({ actionName: "send_message", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("telegram_missing_message_id")
+  })
+
+  test("REGRESSION: delete_message 'message not found' propagates as fail (no swallow)", async () => {
+    const { app } = setup()
+    const row = app._state.insertRow("message", {
+      chat_id: "12345", text: "x", external_id: "42",
+    }, "sent")
+    app._state.updateRow(row.id, { externalId: "42" })
+
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: false, error_code: 400, description: "Bad Request: message to delete not found" },
+    })
+    const r = await app._invokeAction({ actionName: "delete_message", rowId: row.id, bridge: bridge() })
+    expect("fail" in r).toBe(true)
+    expect((r as any).fail.code).toBe("telegram_400")
+  })
+})

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/workspace-integration.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/test/workspace-integration.test.ts
@@ -1,0 +1,148 @@
+// Workspace integration smoke test.
+//
+// Proves the SDK is usable from a "real workspace app" layout — i.e. an
+// app directory with its own package.json that depends on
+// @holaboss/app-builder-sdk via file: protocol, then `bun install` and
+// `bun run server.ts` actually work end-to-end.
+//
+// This is what the Holaboss runtime will do when launching an SDK app:
+//   1. workspace.yaml registers `apps/slack-v2/`
+//   2. app-lifecycle-worker runs lifecycle.setup (bun install)
+//   3. app-lifecycle-worker runs lifecycle.start (bun run server.ts)
+//   4. injects WORKSPACE_DB_PATH / MCP_PORT / HOLABOSS_APP_GRANT /
+//      HOLABOSS_INTEGRATION_BROKER_URL via env
+//
+// We do exactly that here, against a temp workspace, to prove the contract
+// holds end-to-end without depending on a real desktop / runtime running.
+
+import { describe, test, expect } from "bun:test"
+import { spawn, spawnSync } from "node:child_process"
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+const SDK_DIR = "/Users/joshua/holaboss-ai/holaboss/holaOS/experiments/app-builder-sdk"
+
+describe("Workspace integration — slack v2 installed via file: dep", () => {
+  test("bun install resolves SDK via file:, server boots, /mcp/health responds", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "ws-int-"))
+    const appDir = join(workspace, "apps", "slack-v2")
+    mkdirSync(appDir, { recursive: true })
+
+    try {
+      // Materialize the app as it would appear in a real workspace
+      const pkg = {
+        name: "slack-v2-app",
+        version: "0.0.1",
+        private: true,
+        type: "module",
+        scripts: { start: "bun run server.ts" },
+        dependencies: {
+          "@holaboss/app-builder-sdk": `file:${SDK_DIR}`,
+          zod: "^3.23.0",
+        },
+      }
+      writeFileSync(join(appDir, "package.json"), JSON.stringify(pkg, null, 2))
+
+      // Copy the app source, rewriting relative SDK imports to use the
+      // package name. In a real workspace the app-builder skill / scaffold
+      // tool would emit code with package imports directly; here we
+      // transform the in-experiment relative imports on the fly.
+      const rewriteImports = (src: string) =>
+        src
+          .replace(/from\s+"\.\.\/\.\.\/src\/index\.ts"/g, 'from "@holaboss/app-builder-sdk"')
+          .replace(/from\s+"\.\.\/\.\.\/src\/types\.ts"/g, 'from "@holaboss/app-builder-sdk"')
+      for (const f of ["app.ts", "provider.ts", "server.ts"]) {
+        const src = readFileSync(join(SDK_DIR, "reference/slack-messaging", f), "utf-8")
+        writeFileSync(join(appDir, f), rewriteImports(src))
+      }
+      // Non-code asset, copy verbatim
+      writeFileSync(
+        join(appDir, "app.runtime.yaml"),
+        readFileSync(join(SDK_DIR, "reference/slack-messaging/app.runtime.yaml"), "utf-8"),
+      )
+
+      // Step 1: lifecycle.setup
+      const install = spawnSync("bun", ["install"], { cwd: appDir, stdio: "pipe", encoding: "utf-8" })
+      expect(install.status).toBe(0)
+
+      // Verify the SDK is actually linked (not duplicated)
+      const linkedSdk = spawnSync("bun", ["pm", "ls"], { cwd: appDir, stdio: "pipe", encoding: "utf-8" })
+      expect(linkedSdk.stdout).toContain("@holaboss/app-builder-sdk")
+
+      // Step 2: lifecycle.start
+      const dbPath = join(workspace, "workspace.db")
+      const port = 32100 + Math.floor(Math.random() * 500)
+
+      const child = spawn("bun", ["run", "server.ts"], {
+        cwd: appDir,
+        env: {
+          ...process.env,
+          WORKSPACE_DB_PATH: dbPath,
+          MCP_PORT: String(port),
+          HOLABOSS_INTEGRATION_BROKER_URL: "http://localhost:9999",  // dummy
+          HOLABOSS_APP_GRANT: "grant:test_ws:slack:integration_nonce",  // dummy
+          HOLABOSS_WORKSPACE_ID: "test_ws",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+
+      let stdout = "", stderr = ""
+      child.stdout!.on("data", d => { stdout += d.toString() })
+      child.stderr!.on("data", d => { stderr += d.toString() })
+
+      // Wait for boot signal
+      const booted = await waitFor(() => stdout.includes("MCP server listening on :"), 8000)
+      if (!booted) {
+        child.kill("SIGKILL")
+        throw new Error(`Server did not boot. stdout:\n${stdout}\nstderr:\n${stderr}`)
+      }
+
+      // Step 3: verify /mcp/health
+      let healthOk = false
+      for (let i = 0; i < 20 && !healthOk; i++) {
+        try {
+          const r = await fetch(`http://localhost:${port}/mcp/health`)
+          if (r.ok) {
+            const body = await r.json() as { status: string; app_id: string }
+            expect(body.status).toBe("ok")
+            expect(body.app_id).toBe("slack")
+            healthOk = true
+          }
+        } catch {}
+        if (!healthOk) await sleep(100)
+      }
+      expect(healthOk).toBe(true)
+
+      // Step 4: verify Slack-specific tools registered (proves SDK derivedTools()
+      // flowed through to MCP — full integration plumbing works)
+      expect(stdout).toContain("Tools registered:")
+      // Number is variable; just confirm it's > 10 (we have ~14 for slack)
+      const match = stdout.match(/Tools registered: (\d+)/)
+      expect(match).toBeTruthy()
+      expect(Number(match![1])).toBeGreaterThan(10)
+
+      // Step 5: clean shutdown
+      child.kill("SIGTERM")
+      const exitCode = await new Promise<number | null>(resolve => {
+        child.once("exit", c => resolve(c))
+      })
+      expect([0, null].includes(exitCode)).toBe(true)
+      expect(stdout).toContain("Received SIGTERM, shutting down")
+
+    } finally {
+      // Cleanup temp workspace (best-effort)
+      try { rmSync(workspace, { recursive: true, force: true }) } catch {}
+    }
+  }, 60000)
+})
+
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true
+    await sleep(100)
+  }
+  return false
+}
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)) }

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/tsconfig.json
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk-package/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2022"],
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "reference/**/*", "test/**/*"]
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/README.txt
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/README.txt
@@ -1,0 +1,203 @@
+# @holaboss/app-builder-sdk — Holaboss app module SDK (experimental)
+
+> Distinct from `@holaboss/app-sdk` (the generated product API client) and
+> `@holaboss/bridge` (the legacy app SDK that pre-dates this redesign).
+> This package is what new Holaboss app modules are built against. The
+> existing `app-builder` skill in `runtime/harnesses/src/embedded-skills/`
+> will be updated to know about this SDK once it reaches production runtime
+> integration.
+
+A TypeScript prototype rebuilding the Holaboss app SDK around **5 orthogonal
+primitives**. The goal: let agents author apps of any shape (publishing,
+messaging, workflow, event-with-time, sync-mirror) with zero `as any`, strong
+compile-time guardrails, and no scheduling/retry concerns leaking into app code.
+
+**This is not production code.** It is a spike with passing end-to-end tests
+to validate the API surface before integrating into the real Holaboss runtime.
+
+## What's the SDK, what isn't
+
+```
+src/                      ← THE SDK — ~11 files, ~1100 lines. Touched only
+│                            by SDK maintainers; agents adding apps NEVER
+│                            modify this directory.
+├── index.ts                public exports
+├── types.ts                all type definitions
+├── app.ts                  createApp + 5 primitive registrars
+├── bridge.ts               BridgeClient + createBridge (transport contract)
+├── bridge-transports/      bearer / composio-direct / runtime-broker
+└── runtime/                internal execution: action-runner, sync-runner,
+                            state backends (in-memory + sqlite), mcp-server,
+                            manifest helper
+
+reference/<shape>-<provider>/  ← SDK REFERENCE APPS (NOT production code).
+                                  Demo + test fixtures + agent templates.
+                                  Each illustrates one app shape:
+                                    pinterest-publishing
+                                    slack-messaging
+                                    github-workflow
+                                    gcalendar-events
+                                    telegram-messaging
+                                  Read these to learn the SDK; copy them to
+                                  bootstrap a new module; do NOT ship them
+                                  unmodified.
+
+test/<area>.test.ts        ← UNIT + INTEGRATION TESTS
+```
+
+**Three places code about Holaboss apps can live**:
+
+| Location | Role | Status |
+|---|---|---|
+| `experiments/app-builder-sdk/reference/<shape>/` | **SDK reference** — demos, test fixtures, agent templates. Used to validate SDK design across shapes. | Spike phase |
+| `hola-boss-apps/<name>/` | **Production app modules** — legacy bridge-SDK-era apps shipped to users. ~20 modules. | Stable, runs in workspaces today |
+| `<workspace>/apps/<id>/` | **Workspace-installed apps** — what a user's actual workspace contains. Materialized via marketplace install or agent-build skill. | Per-workspace |
+
+Reference apps are **not** production apps. If a reference and a production app share a name (e.g. `reference/slack-messaging/` vs `hola-boss-apps/slack/`), they cover different ground — different tool names, different coverage. See each `app.ts`'s top-of-file banner for what it demonstrates.
+
+> Note on Holaboss "skills": this SDK does NOT define a per-app SKILL.md
+> convention — the real Holaboss skill system lives at
+> `runtime/harnesses/src/embedded-skills/<skill-id>/SKILL.md` (system-wide,
+> with frontmatter) and `<workspace>/skills/<skill-id>/SKILL.md`
+> (workspace-local, created via the `skill-creator` skill). Provider quirks
+> stay as code comments in `app.ts`; the existing `app-builder` skill needs
+> an update — to know about the 5-primitive v2 SDK shape — when v2 SDK
+> reaches production runtime integration.
+
+## The 5 primitives
+
+```ts
+app.connection()                      // declares provider connection
+app.resource(name, def)               // declares a typed entity with its own state alphabet
+app.action(resource, name, def)       // declares a callable that transitions states
+app.sync(name, def)                   // periodic fetch+upsert+normalize (automations-scheduled)
+app.start()                           // boot
+```
+
+Read [`src/types.ts`](./src/types.ts) for the full type surface and the
+ActionDef / SyncDef doc comments for the SDK ↔ Automations boundary.
+
+## What's verified
+
+| File | Shape | Tests |
+|---|---|---|
+| [`reference/pinterest-publishing/app.ts`](./reference/pinterest-publishing/app.ts) | publishing (multi-step + reversible) | 5 |
+| [`reference/slack-messaging/app.ts`](./reference/slack-messaging/app.ts) | messaging (custom states, side-effect react, 3 prod quirks fixed) | 11 |
+| [`reference/github-workflow/app.ts`](./reference/github-workflow/app.ts) | workflow (6-state lifecycle) | 7 |
+| [`reference/gcalendar-events/app.ts`](./reference/gcalendar-events/app.ts) | event-with-time (RSVP, recurring) | 9 |
+| [`reference/telegram-messaging/app.ts`](./reference/telegram-messaging/app.ts) | messaging (cold-subagent-built; integer IDs; no schedule) | 9 |
+| `test/sync.test.ts` | sync E2E across 3 apps | 8 |
+| `test/agent-mistakes.test.ts` | compile + runtime double-guard | 8 |
+| `test/sqlite-backend.test.ts` | SqliteStateBackend parity + persistence + isolation + integration | 4 |
+| `test/emit-context.test.ts` | emit row.id/status/external_id regression lock | 1 |
+| **Total** | **5 example apps + Iter 1 persistence** | **63 / 247 expect / 0 fail / tsc clean** |
+
+```bash
+bun install
+bun test           # 63 pass / 0 fail
+bunx tsc --noEmit  # clean
+```
+
+## Transports — the SDK is auth-mechanism agnostic
+
+The SDK never assumes Hono, Composio, OAuth, or any specific provider. The
+`BridgeClient` delegates network I/O to a `TransportFn` (`(req) => response`).
+You pick the transport that matches your deployment.
+
+Bundled options under `src/bridge-transports/`:
+
+| Transport | When to use | What you supply |
+|---|---|---|
+| `createBearerTokenTransport` | **Self-host OAuth** — you manage tokens (Auth0 / Clerk / your own auth server / manual). | `accessToken: string \| (() => Promise<string>)` |
+| `createComposioDirectTransport` | Composio managed auth, no broker hop. Good for single-tenant deploys, local dev, E2E. | `COMPOSIO_API_KEY` + `connectedAccountId` |
+| `createRuntimeBrokerTransport` | **Production** — running inside Holaboss runtime sandbox. Same `/broker/proxy` + grant model as `@holaboss/bridge`. | `provider` + env `HOLABOSS_INTEGRATION_BROKER_URL` + `HOLABOSS_APP_GRANT` (auto-resolved) |
+| Roll your own | Custom auth (Vault, mTLS, internal gateway). | Implement ~20 lines of `fetch` returning `{ status, body, headers }`. |
+
+Bundled transports never call Holaboss backend / Hono. Production runtime
+integrations are wired by the runtime team via the broker-proxy pattern; that's
+separate from this SDK.
+
+## Real E2E (single command, no Holaboss backend required)
+
+```bash
+cd experiments/app-builder-sdk
+export COMPOSIO_API_KEY=ck_...
+export COMPOSIO_SLACK_ACCOUNT_ID=ca_...   # from workspace.db, see e2e.ts header
+export TEST_SLACK_CHANNEL=C0123ABCD
+bun run reference/slack-messaging/e2e.ts
+```
+
+Sends real messages to your Slack workspace via `createComposioDirectTransport`.
+Watch Slack — message + edit + 🚀 reaction should appear within seconds.
+
+## What's in scope
+
+- HOW an action does its work (steps, checkpoint, state transitions, reverse handler)
+- Resource schema → typed callbacks (no `as any` in agent code)
+- HTTP-level error normalization via `BridgeClient`
+- Auto-derive MCP tool list from declarations
+- Auto-emit `OutputCard` to dashboard surface on every state change
+
+## What's NOT in scope (lives in automations)
+
+- WHEN actions run (cron, schedule, future-time)
+- Retry on transient failure (rate limit, network)
+- Cross-app orchestration
+- User-visible "what's scheduled" view
+
+Actions MUST be idempotent: re-invoking on a row that carries persisted
+intermediate state (e.g. `media_id` from a prior failed publish attempt) must
+safely no-op the already-completed steps. The 4 examples demonstrate the
+pattern via `row.external_id` short-circuit.
+
+## Known weaknesses (honestly listed after a cold review pass)
+
+1. **Idempotency is by convention, not by type.** Agent could write a
+   non-idempotent action; type system won't catch it. Examples demonstrate
+   the `row.external_id` short-circuit pattern. Future: optional
+   `idempotencyKey: (row) => row.external_id` hook so SDK can short-circuit
+   automatically.
+
+2. **`askUser` protocol not designed.** No way for an action mid-step to pause
+   and ask the user to choose a value. Requires runtime turn-suspend
+   coordination — single-handed SDK can't define it cleanly.
+
+3. **`app.start()` is a 1-line check.** Real implementation (start MCP SSE
+   server, register with runtime, etc.) lands when this SDK is wired into the
+   actual Holaboss runtime.
+
+4. **Reverse tool naming convention.** Defaults to
+   `<app>_cancel_<action>_<resource>`, or `<toolName>_reverse` when `toolName`
+   was overridden on the forward action. Convention not encoded in types.
+
+5. **`DbView.where()` supports scalar equality only** (string/number/boolean/
+   null). Type system enforces via `ScalarFilter<T>` — passing an array or
+   object as a where condition won't compile. Array-membership / object-deep
+   queries need a separate primitive if/when needed.
+
+6. **Sync record retention.** When a row is deleted (state="deleted") or an
+   external resource disappears from sync results, prior sync records stay in
+   `state.syncRecords` with dangling `attachedRowId`. Needs a retention
+   policy. Low priority — only matters once SyncRecord drives UI.
+
+7. **Three `as unknown` casts in `src/app.ts`** at storage boundaries (action
+   and sync registration). These widen agent-precise types to a generic
+   `Record<string, unknown>` shape so the storage arrays can be homogeneous.
+   Each is annotated with intent. **Agent code (reference/) has zero `as
+   any`.**
+
+## Origin
+
+Distilled from a multi-round design discussion (architecture review →
+stress-test by independent subagents → cold review by a third subagent →
+type-system fixes → sync execution). The design dossier lives in the parent
+workspace, not in this repo.
+
+## Next steps (if this lands)
+
+1. Wire `BridgeClient` to the real `/broker/proxy`.
+2. Replace in-memory state with SQLite (via `@holaboss/runtime-state-store`).
+3. Replace derived tool list with real MCP SSE server registration.
+4. Migrate one wrapper-shape module (e.g. `bannerbear`) as the first
+   dog-fooding test (current: ~600 lines → target: ~80 lines).
+5. Design `askUser` protocol with runtime team.

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/app.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/app.ts
@@ -1,0 +1,331 @@
+import type { ZodTypeAny } from "zod"
+import { z } from "zod"
+import type {
+  ActionDef,
+  AppConfig,
+  AppHandle,
+  AppState,
+  BridgeClient,
+  DerivedTool,
+  ResourceDef,
+  ResourceHandle,
+  RowOf,
+  StateBackend,
+  StateTuple,
+  SyncDef,
+  TurnContext,
+} from "./types.ts"
+import { RuntimeState } from "./runtime/state.ts"
+import { runAction } from "./runtime/action-runner.ts"
+import { runSync, type SyncRunResult } from "./runtime/sync-runner.ts"
+
+// Storage shape — homogeneous so the actions[] array can hold registrations
+// from different resources/schemas. Agent-facing type safety lives at the
+// app.action<TS, S, I>(...) call site, not at storage. The runtime operates
+// on Record<string, unknown> rows by design, so widening here is honest.
+interface RegisteredAction {
+  resource: ResourceHandle<ZodTypeAny, StateTuple>
+  name: string
+  def: ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>>
+}
+
+interface RegisteredSync {
+  name: string
+  def: SyncDef<ZodTypeAny, unknown, unknown>
+}
+
+export interface AppHandleInternal extends AppHandle {
+  _invokeAction(opts: {
+    actionName: string
+    rowId: string
+    input?: unknown
+    bridge: BridgeClient
+  }): Promise<any>
+  _invokeReverse(opts: {
+    actionName: string
+    rowId: string
+    bridge: BridgeClient
+  }): Promise<any>
+  _runSync(name: string, bridge: BridgeClient): Promise<SyncRunResult>
+  _state: StateBackend
+  _setTurn(ctx: TurnContext | null): void
+  _resources: Map<string, ResourceHandle<any, any>>
+  _actions: RegisteredAction[]
+  _syncs: RegisteredSync[]
+}
+
+/**
+ * createApp options. `backend` defaults to in-memory; production runtime
+ * should pass a SqliteStateBackend (see runtime/state-backend-sqlite.ts).
+ */
+export interface CreateAppOptions {
+  backend?: StateBackend
+}
+
+export function createApp(config: AppConfig, options: CreateAppOptions = {}): AppHandleInternal {
+  const state: StateBackend = options.backend ?? new RuntimeState()
+  const resources = new Map<string, ResourceHandle<any, any>>()
+  const actions: RegisteredAction[] = []
+  const syncs: RegisteredSync[] = []
+  let connectionCalled = false
+
+  function connection(_opts?: { whoamiPath?: string }): void {
+    connectionCalled = true
+  }
+
+  function resource<TSchema extends ZodTypeAny, States extends StateTuple>(
+    name: string,
+    def: ResourceDef<TSchema, States>,
+  ): ResourceHandle<TSchema, States> {
+    if (!(def.states as readonly string[]).includes(def.initialState)) {
+      throw new Error(
+        `[${config.id}] resource '${name}': initialState '${def.initialState}' not in states [${def.states.join(",")}]`,
+      )
+    }
+    if (def.failedState !== undefined && !(def.states as readonly string[]).includes(def.failedState)) {
+      throw new Error(
+        `[${config.id}] resource '${name}': failedState '${def.failedState}' not in states [${def.states.join(",")}]`,
+      )
+    }
+    const handle: ResourceHandle<TSchema, States> = {
+      __resource: true,
+      name,
+      states: def.states,
+      schema: def.schema,
+      def,
+      // ref() returns plain z.string() (NOT branded). Branding broke round-trip
+      // updates — provider responses come back as plain strings and couldn't
+      // satisfy the brand, forcing `as` casts at every persist call.
+      // The semantic "this is an <X> id" is documented by the field name +
+      // schema location; type-system enforcement adds more friction than value.
+      ref: () => z.string(),
+    }
+    resources.set(name, handle)
+    return handle
+  }
+
+  function action<TSchema extends ZodTypeAny, States extends StateTuple, I = {}>(
+    res: ResourceHandle<TSchema, States>,
+    name: string,
+    def: ActionDef<RowOf<TSchema>, States, I>,
+  ): void {
+    if (!def.steps && !def.run) {
+      throw new Error(`[${config.id}] action ${name}: must provide either run or steps`)
+    }
+    if (def.steps && def.run) {
+      throw new Error(`[${config.id}] action ${name}: provide either run or steps, not both`)
+    }
+    const allowed = res.def.states as readonly string[]
+    for (const s of def.fromStates) {
+      if (!allowed.includes(s as string)) {
+        throw new Error(
+          `[${config.id}] action ${name}: fromStates contains '${s}' not in resource '${res.name}' states [${allowed.join(",")}]`,
+        )
+      }
+    }
+    if (def.toState !== null && !allowed.includes(def.toState as string)) {
+      throw new Error(
+        `[${config.id}] action ${name}: toState '${def.toState}' not in resource '${res.name}' states [${allowed.join(",")}]`,
+      )
+    }
+    if (def.reversible && !allowed.includes(def.reversible.toState as string)) {
+      throw new Error(
+        `[${config.id}] action ${name}: reversible.toState '${def.reversible.toState}' not in resource '${res.name}' states`,
+      )
+    }
+    // Single intentional widening at storage boundary — runtime operates on
+    // Record<string, unknown> rows, so the precise TSchema/I types are
+    // discarded here. The agent's compile-time guarantee lives at the
+    // app.action<TSchema, States, I>(...) call above; storage doesn't need it.
+    actions.push({
+      resource: res as unknown as ResourceHandle<ZodTypeAny, StateTuple>,
+      name,
+      def: def as unknown as ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>>,
+    })
+  }
+
+  function sync<TSchema extends ZodTypeAny, RAW, N>(
+    name: string,
+    def: SyncDef<TSchema, RAW, N>,
+  ): void {
+    // Storage widens: runtime calls fetch/normalize generically. Agent-side
+    // typing was preserved at the app.sync<TSchema, RAW, N>(...) call above.
+    syncs.push({
+      name,
+      def: def as unknown as SyncDef<ZodTypeAny, unknown, unknown>,
+    })
+  }
+
+  async function start(): Promise<void> {
+    if (!connectionCalled) {
+      throw new Error(`[${config.id}] app.connection() must be called before app.start()`)
+    }
+  }
+
+  function derivedTools(): DerivedTool[] {
+    const tools: DerivedTool[] = []
+
+    if (connectionCalled) {
+      tools.push({
+        name: `${config.id}_connection_status`,
+        inputShape: "{}",
+        description: `Check ${config.id} connection state.`,
+        category: "connection",
+      })
+    }
+
+    for (const [rname, rhandle] of resources) {
+      tools.push({
+        name: `${config.id}_list_${plural(rname)}`,
+        inputShape: "{ status?, limit? }",
+        description: `List ${rname} rows.`,
+        category: "resource_query",
+      })
+      tools.push({
+        name: `${config.id}_get_${rname}`,
+        inputShape: `{ ${rname}_id }`,
+        description: `Fetch a single ${rname}.`,
+        category: "resource_query",
+      })
+      if (rhandle.def.refreshEvery) {
+        tools.push({
+          name: `${config.id}_refresh_${plural(rname)}`,
+          inputShape: "{}",
+          description: `Force-refresh ${rname} cache.`,
+          category: "resource_query",
+        })
+      }
+    }
+
+    for (const { resource: r, name, def } of actions) {
+      const toolName = def.toolName ?? `${config.id}_${name}_${r.name}`
+      tools.push({
+        name: toolName,
+        inputShape: `{ ${r.name}_id${def.schema ? ", ...extra" : ""} }`,
+        description: `${name} a ${r.name} (from ${def.fromStates.join("|")} → ${def.toState ?? "side-effect"}).`,
+        category: "action",
+      })
+      if (def.reversible) {
+        const reverseToolName = def.toolName
+          ? `${def.toolName}_reverse`
+          : `${config.id}_cancel_${name}_${r.name}`
+        tools.push({
+          name: reverseToolName,
+          inputShape: `{ ${r.name}_id }`,
+          description: `Reverse ${name} on a ${r.name} (→ ${def.reversible.toState}).`,
+          category: "reverse_action",
+        })
+      }
+    }
+
+    for (const { name } of syncs) {
+      tools.push({
+        name: `${config.id}_${name}_sync_status`,
+        inputShape: "{}",
+        description: `Status of ${name} sync.`,
+        category: "sync",
+      })
+    }
+
+    tools.push({
+      name: `${config.id}_snapshot`,
+      inputShape: "{}",
+      description: `Compact situational read of ${config.id}.`,
+      category: "snapshot",
+    })
+
+    return tools
+  }
+
+  function getStateSnapshot(): AppState {
+    const snap = state.snapshot()
+    snap.derivedTools = derivedTools()
+    return snap
+  }
+
+  return {
+    config,
+    connection,
+    resource,
+    action,
+    sync,
+    start,
+    derivedTools,
+    state: getStateSnapshot,
+    _state: state,
+    _resources: resources,
+    _actions: actions,
+    _syncs: syncs,
+    _setTurn: (ctx) => state.setTurnContext(ctx),
+    async _invokeAction({ actionName, rowId, input, bridge }) {
+      const reg = actions.find(a => a.name === actionName)
+      if (!reg) throw new Error(`action ${actionName} not registered`)
+      return runAction({
+        appId: config.id,
+        resourceName: reg.resource.name,
+        resourceDef: reg.resource.def,
+        actionName: reg.name,
+        actionDef: reg.def,
+        rowId,
+        input: (input ?? {}) as Record<string, unknown>,
+        bridge,
+        state,
+      })
+    },
+    async _invokeReverse({ actionName, rowId, bridge }) {
+      const reg = actions.find(a => a.name === actionName)
+      if (!reg) throw new Error(`action ${actionName} not registered`)
+      if (!reg.def.reversible) {
+        throw new Error(`action ${actionName} is not reversible`)
+      }
+      const row = state.getRow(rowId)
+      if (!row) throw new Error(`row ${rowId} not found`)
+      if (row.status !== reg.def.toState) {
+        return {
+          fail: {
+            code: "invalid_state",
+            message: `cannot reverse ${actionName}: row is in '${row.status}', expected '${reg.def.toState}'`,
+          },
+        }
+      }
+      const reverseDef: ActionDef<Record<string, unknown>, StateTuple, Record<string, unknown>> = {
+        fromStates: [reg.def.toState as string],
+        toState: reg.def.reversible.toState,
+        run: reg.def.reversible.run,
+      }
+      // Pass a resourceDef WITHOUT failedState: if reverse fails, the row
+      // stays in its current state (the forward action's toState) because
+      // upstream reality hasn't changed — the thing we tried to undo is still
+      // in effect. The error is recorded via errorMessage + notification.
+      const reverseResourceDef = { ...reg.resource.def, failedState: undefined }
+      return runAction({
+        appId: config.id,
+        resourceName: reg.resource.name,
+        resourceDef: reverseResourceDef,
+        actionName: `cancel_${reg.name}`,
+        actionDef: reverseDef,
+        rowId,
+        input: {},
+        bridge,
+        state,
+      })
+    },
+    async _runSync(name, bridge) {
+      const reg = syncs.find(s => s.name === name)
+      if (!reg) throw new Error(`sync ${name} not registered`)
+      return runSync({
+        appId: config.id,
+        syncName: reg.name,
+        syncDef: reg.def,
+        bridge,
+        state,
+      })
+    },
+  }
+}
+
+function plural(name: string): string {
+  if (name.endsWith("s") || name.endsWith("x") || name.endsWith("ch")) return `${name}es`
+  if (name.endsWith("y")) return `${name.slice(0, -1)}ies`
+  return `${name}s`
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/index.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/index.ts
@@ -1,0 +1,48 @@
+// Public API surface for @holaboss/app-builder-sdk.
+
+// Core
+export { createApp } from "./app.ts"
+export type { CreateAppOptions } from "./app.ts"
+export { createBridge } from "./bridge.ts"
+export type { TransportFn } from "./bridge.ts"
+export { z } from "zod"
+
+// State backends
+export { SqliteStateBackend } from "./runtime/state-backend-sqlite.ts"
+export type { SqliteStateBackendOpts } from "./runtime/state-backend-sqlite.ts"
+
+// MCP server (production boot)
+export { startMcpServer } from "./runtime/mcp-server.ts"
+export type { StartMcpServerOpts, StartedMcpServer } from "./runtime/mcp-server.ts"
+
+// Bridge transports (pick the one that matches your deployment)
+export { createBearerTokenTransport } from "./bridge-transports/bearer.ts"
+export type { BearerTokenOpts } from "./bridge-transports/bearer.ts"
+export { createComposioDirectTransport } from "./bridge-transports/composio-direct.ts"
+export type { ComposioDirectOpts } from "./bridge-transports/composio-direct.ts"
+export { createRuntimeBrokerTransport } from "./bridge-transports/runtime-broker.ts"
+export type { RuntimeBrokerOpts } from "./bridge-transports/runtime-broker.ts"
+
+export type {
+  AppHandle,
+  AppConfig,
+  AppState,
+  BridgeClient,
+  BridgeError,
+  BridgeErrorCode,
+  DerivedTool,
+  StateBackend,
+  ProxyResult,
+  ProviderRegistry,
+  ResourceDef,
+  ResourceHandle,
+  StateTuple,
+  ActionDef,
+  ReversibleDef,
+  Step,
+  StepContext,
+  StepResult,
+  SyncDef,
+  TurnContext,
+  HttpMethod,
+} from "./types.ts"

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/mcp-server.test.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/mcp-server.test.ts
@@ -1,0 +1,435 @@
+// Verify the MCP server boots, exposes /mcp/health, registers expected tools
+// from a Slack app instance, and routes a tool call through to the SDK.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { startMcpServer, type StartedMcpServer } from "../src/runtime/mcp-server.ts"
+import { createBridge, type TransportFn } from "../src/index.ts"
+import { SLACK } from "../reference/slack-messaging/provider.ts"
+import { buildSlackApp } from "../reference/slack-messaging/app.ts"
+import type { AppHandleInternal } from "../src/app.ts"
+
+let server: StartedMcpServer
+let app: AppHandleInternal
+let baseUrl: string
+
+const scriptedResponses: Array<{ status: number; body: unknown }> = []
+const transport: TransportFn = async () => {
+  const next = scriptedResponses.shift()
+  if (!next) throw new Error("no scripted response")
+  return next
+}
+
+beforeAll(async () => {
+  const built = buildSlackApp() as unknown as { app: AppHandleInternal }
+  app = built.app
+  app._setTurn({ turnId: "t_mcp", sessionId: "s_mcp" })
+  const bridge = createBridge({ provider: SLACK, transport })
+  server = await startMcpServer({ app, port: 0, bridge })
+  baseUrl = `http://localhost:${server.port}`
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+describe("MCP server — boot + tool registration + routing", () => {
+  test("health endpoint responds with status:ok and app_id", async () => {
+    const r = await fetch(`${baseUrl}/mcp/health`)
+    expect(r.status).toBe(200)
+    const body = await r.json() as { status: string; app_id: string }
+    expect(body.status).toBe("ok")
+    expect(body.app_id).toBe("slack")
+  })
+
+  test("tools/list via MCP JSON-RPC: derived tool names appear", async () => {
+    // Start an SSE session
+    const session = await openSseSession(baseUrl)
+    const tools = await mcpListTools(baseUrl, session.sessionId)
+    const names = tools.map(t => t.name)
+
+    // Connection / snapshot
+    expect(names).toContain("slack_connection_status")
+    expect(names).toContain("slack_snapshot")
+
+    // Per-resource CRUD
+    expect(names).toContain("slack_create_message")
+    expect(names).toContain("slack_list_messages")
+    expect(names).toContain("slack_get_message")
+    expect(names).toContain("slack_create_channel")
+
+    // Action tools (from buildSlackApp registrations)
+    expect(names).toContain("slack_send_message_message")
+    expect(names).toContain("slack_edit_message_message")
+    expect(names).toContain("slack_delete_message_message")
+    expect(names).toContain("slack_react")           // custom toolName override
+    expect(names).toContain("slack_schedule_send_message")
+
+    // Reverse tool (schedule_send is reversible)
+    expect(names).toContain("slack_cancel_schedule_send_message")
+
+    // Sync status descriptor
+    expect(names).toContain("slack_channel_directory_sync_status")
+
+    await session.close()
+  })
+
+  test("tools/call slack_create_message inserts a row in 'draft' state", async () => {
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_create_message", {
+      channel_id: "C12345", text: "hello via mcp",
+    })
+    expect(result.isError).toBeFalsy()
+    const created = JSON.parse(result.content[0]!.text!)
+    expect(created.status).toBe("draft")
+    expect(created.channel_id).toBe("C12345")
+    expect(created.text).toBe("hello via mcp")
+    expect(created.id).toMatch(/^r_/)
+
+    // Verify row really lives in app state
+    const stateRow = app._state.getRow(created.id)
+    expect(stateRow?.status).toBe("draft")
+
+    await session.close()
+  })
+
+  test("tools/call slack_send_message_message routes through SDK to bridge", async () => {
+    const row = app._state.insertRow("message", {
+      channel_id: "C9999", text: "hi from mcp tool",
+    }, "draft")
+
+    scriptedResponses.push({ status: 200, body: { ok: true, ts: "9999.000", channel: "C9999" } })
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_send_message_message", {
+      message_id: row.id,
+    })
+    expect(result.isError).toBeFalsy()
+    const ok = JSON.parse(result.content[0]!.text!)
+    expect(ok.ok).toBe(true)
+    expect(ok.externalId).toBe("9999.000")
+
+    // Row state updated
+    const updated = app._state.getRow(row.id)
+    expect(updated?.status).toBe("sent")
+    expect(updated?.externalId).toBe("9999.000")
+
+    await session.close()
+  })
+
+  test("tools/call with invalid state surfaces isError + typed code", async () => {
+    const draft = app._state.insertRow("message", {
+      channel_id: "C0000", text: "never react",
+    }, "draft")
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_react", {
+      message_id: draft.id, emoji: "rocket",
+    })
+    expect(result.isError).toBe(true)
+    const err = JSON.parse(result.content[0]!.text!)
+    expect(err.code).toBe("invalid_state")
+    await session.close()
+  })
+
+  test("tools/call slack_snapshot returns aggregate row counts", async () => {
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_snapshot", {})
+    expect(result.isError).toBeFalsy()
+    const snap = JSON.parse(result.content[0]!.text!)
+    expect(snap.app_id).toBe("slack")
+    expect(snap.rows_by_resource).toBeDefined()
+    // We've inserted multiple message rows above; should see "message" key
+    expect(snap.rows_by_resource.message).toBeDefined()
+    await session.close()
+  })
+
+  // ── connection_status: real whoami probe (was a stub returning connected:true) ──
+
+  test("connection_status probes provider.whoamiPath via bridge → connected:true", async () => {
+    scriptedResponses.push({ status: 200, body: { ok: true, user: "U123", team: "T999" } })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_connection_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.connected).toBe(true)
+    expect(body.app_id).toBe("slack")
+    expect(body.identity).toEqual({ ok: true, user: "U123", team: "T999" })
+    await session.close()
+  })
+
+  test("connection_status surfaces upstream auth failure → connected:false + reason", async () => {
+    // Bridge returns 401 → BridgeError code "not_connected"
+    scriptedResponses.push({
+      status: 401,
+      body: { error: "holaboss_session_invalid", message: "Holaboss session is invalid or expired." },
+    })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_connection_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.connected).toBe(false)
+    expect(body.reason).toBe("not_connected")
+    expect(String(body.message)).toMatch(/Holaboss session/i)
+    expect(body.upstream_status).toBe(401)
+    await session.close()
+  })
+
+  // ── refresh_<resource>: re-pulls fetch() and upserts cache rows ──
+
+  test("refresh_channels calls bridge.fetch and upserts new channels", async () => {
+    // 2 channels returned from /conversations.list
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [
+        { id: "C_NEW1", name: "general", is_private: false },
+        { id: "C_NEW2", name: "random", is_private: false },
+      ] },
+    })
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_refresh_channels", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.ok).toBe(true)
+    expect(body.fetched).toBe(2)
+    expect(body.inserted).toBe(2)
+    expect(body.updated).toBe(0)
+
+    // Confirm rows actually landed
+    const channels = app._state.rowsByResource("channel")
+    expect(channels.some(r => r.data.id === "C_NEW1")).toBe(true)
+    expect(channels.some(r => r.data.id === "C_NEW2")).toBe(true)
+    await session.close()
+  })
+
+  test("refresh_channels updates existing channel (idempotent by data.id)", async () => {
+    // First call: insert
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [{ id: "C_DUP", name: "dup-original", is_private: false }] },
+    })
+    const sess1 = await openSseSession(baseUrl)
+    await mcpCallTool(baseUrl, sess1.sessionId, "slack_refresh_channels", {})
+    await sess1.close()
+
+    // Second call: same id, different name → should update
+    scriptedResponses.push({
+      status: 200,
+      body: { ok: true, channels: [{ id: "C_DUP", name: "dup-renamed", is_private: true }] },
+    })
+    const sess2 = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, sess2.sessionId, "slack_refresh_channels", {})
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.updated).toBe(1)
+    expect(body.inserted).toBe(0)
+
+    const dup = app._state.rowsByResource("channel").filter(r => r.data.id === "C_DUP")
+    expect(dup.length).toBe(1)
+    expect(dup[0]!.data.name).toBe("dup-renamed")
+    await sess2.close()
+  })
+
+  // ── <sync>_sync_status: reads from audit (was a descriptor stub) ──
+
+  test("sync_status returns has_ever_run:false before any sync ran", async () => {
+    // Use a fresh app instance so audit is empty for this sync
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const freshServer = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge })
+    const session = await openSseSession(`http://localhost:${freshServer.port}`)
+    const result = await mcpCallTool(
+      `http://localhost:${freshServer.port}`,
+      session.sessionId,
+      "slack_channel_directory_sync_status",
+      {},
+    )
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.has_ever_run).toBe(false)
+    expect(body.sync_name).toBe("channel_directory")
+    expect(body.schedule).toBe("0 * * * *")
+    expect(body.records_total).toBe(0)
+    await session.close()
+    await freshServer.close()
+  })
+
+  test("sync_status returns has_ever_run:true + outcome after audit recorded", async () => {
+    // Simulate a successful sync run by writing audit entries directly
+    app._state.pushAudit("sync.start", { app: "slack", sync: "channel_directory" })
+    app._state.pushAudit("sync.end", {
+      app: "slack", sync: "channel_directory",
+      outcome: "ok", fetched: 5, upserted: 5, total_ms: 142,
+    })
+    app._state.upsertSyncRecord({
+      syncName: "channel_directory", attachedRowId: "", key: "C1",
+      raw: { id: "C1" }, normalized: { id: "C1", name: "n" },
+    })
+
+    const session = await openSseSession(baseUrl)
+    const result = await mcpCallTool(baseUrl, session.sessionId, "slack_channel_directory_sync_status", {})
+    expect(result.isError).toBeFalsy()
+    const body = JSON.parse(result.content[0]!.text!)
+    expect(body.has_ever_run).toBe(true)
+    expect(body.outcome).toBe("ok")
+    expect(body.fetched).toBe(5)
+    expect(body.upserted).toBe(5)
+    expect(body.total_ms).toBe(142)
+    expect(body.records_total).toBe(1)
+    expect(body.started_at).toBeTruthy()
+    expect(body.ended_at).toBeTruthy()
+    await session.close()
+  })
+
+  test("httpPort option serves a headless web stub (200 HTML + /health JSON)", async () => {
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const stub = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge, httpPort: 0 })
+    expect(stub.httpPort).toBeTruthy()
+    const stubUrl = `http://localhost:${stub.httpPort}`
+
+    const root = await fetch(stubUrl)
+    expect(root.status).toBe(200)
+    const html = await root.text()
+    expect(html).toContain("headless module")
+    expect(root.headers.get("content-type") ?? "").toContain("text/html")
+
+    const health = await fetch(`${stubUrl}/health`)
+    expect(health.status).toBe(200)
+    const hb = await health.json() as Record<string, unknown>
+    expect(hb.status).toBe("ok")
+    expect(hb.surface).toBe("headless_stub")
+    expect(hb.app_id).toBe("slack")
+
+    await stub.close()
+  })
+
+  test("startMcpServer without httpPort does NOT bind a second port (httpPort:undefined returned)", async () => {
+    const { app: fresh } = buildSlackApp() as unknown as { app: AppHandleInternal }
+    const freshBridge = createBridge({ provider: SLACK, transport })
+    const s = await startMcpServer({ app: fresh, port: 0, bridge: freshBridge })
+    expect(s.httpPort).toBeUndefined()
+    await s.close()
+  })
+
+  test("tools/list includes refresh + sync_status (no longer descriptor-only)", async () => {
+    const session = await openSseSession(baseUrl)
+    const tools = await mcpListTools(baseUrl, session.sessionId)
+    const names = tools.map(t => t.name)
+    expect(names).toContain("slack_refresh_channels")              // resource has refreshEvery + fetch
+    expect(names).toContain("slack_channel_directory_sync_status")  // sync registered
+    // Message resource has NO refreshEvery → no refresh tool
+    expect(names).not.toContain("slack_refresh_messages")
+    await session.close()
+  })
+})
+
+// ─── MCP JSON-RPC client helpers (no @modelcontextprotocol/sdk client dep) ───
+//
+// We talk to the server directly over SSE + POST /mcp/messages so the tests
+// don't pull in extra client machinery.
+
+interface SseSession {
+  sessionId: string
+  close: () => Promise<void>
+}
+
+async function openSseSession(base: string): Promise<SseSession> {
+  // Open SSE; read the first event which carries the sessionId via the
+  // POST URL: SSEServerTransport emits "endpoint" event with /mcp/messages?sessionId=...
+  const abortCtrl = new AbortController()
+  const r = await fetch(`${base}/mcp/sse`, { signal: abortCtrl.signal })
+  if (!r.ok || !r.body) throw new Error(`SSE failed: ${r.status}`)
+  const reader = r.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  let sessionId = ""
+  // Read until we see the "endpoint" event with sessionId
+  for (let i = 0; i < 20; i++) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    const match = buf.match(/sessionId=([a-zA-Z0-9_-]+)/)
+    if (match) { sessionId = match[1]!; break }
+  }
+  if (!sessionId) throw new Error("no sessionId received")
+  return {
+    sessionId,
+    close: async () => { abortCtrl.abort(); try { await reader.cancel() } catch {} },
+  }
+}
+
+async function mcpListTools(base: string, sessionId: string): Promise<Array<{ name: string }>> {
+  const result = await mcpJsonRpc(base, sessionId, "tools/list", {})
+  return (result as { tools: Array<{ name: string }> }).tools
+}
+
+async function mcpCallTool(base: string, sessionId: string, name: string, args: Record<string, unknown>) {
+  const result = await mcpJsonRpc(base, sessionId, "tools/call", { name, arguments: args })
+  return result as { content: Array<{ type: string; text?: string }>; isError?: boolean; structuredContent?: unknown }
+}
+
+async function mcpJsonRpc(base: string, sessionId: string, method: string, params: unknown): Promise<unknown> {
+  // The MCP server's SSEServerTransport responds via the SSE stream we opened.
+  // We need to (a) POST the request, (b) read the matching response from SSE.
+  // Simpler approach: do request via POST + assume server posts back via SSE.
+  // For tests, McpServer.connect returns request/response over SSE. We'll
+  // re-open SSE per call to keep the helper minimal.
+  const sess = await openSseSessionWithReader(base)
+  const requestId = Math.floor(Math.random() * 1_000_000)
+  const postPromise = fetch(`${base}/mcp/messages?sessionId=${sess.sessionId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: requestId, method, params }),
+  })
+  const response = await sess.readUntilResponse(requestId, 5000)
+  await postPromise
+  await sess.close()
+  if (response.error) throw new Error(`MCP error: ${JSON.stringify(response.error)}`)
+  return response.result
+}
+
+interface SseSessionWithReader extends SseSession {
+  readUntilResponse: (id: number, timeoutMs: number) => Promise<{ result?: unknown; error?: unknown }>
+}
+
+async function openSseSessionWithReader(base: string): Promise<SseSessionWithReader> {
+  const abortCtrl = new AbortController()
+  const r = await fetch(`${base}/mcp/sse`, { signal: abortCtrl.signal })
+  if (!r.ok || !r.body) throw new Error(`SSE failed: ${r.status}`)
+  const reader = r.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  let sessionId = ""
+  while (!sessionId) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    const m = buf.match(/sessionId=([a-zA-Z0-9_-]+)/)
+    if (m) sessionId = m[1]!
+  }
+  if (!sessionId) throw new Error("no sessionId")
+  return {
+    sessionId,
+    close: async () => { abortCtrl.abort(); try { await reader.cancel() } catch {} },
+    readUntilResponse: async (id, timeoutMs) => {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        // Each SSE event ends in \n\n; data lines start with "data: "
+        const events = buf.split("\n\n")
+        buf = events.pop() ?? ""
+        for (const ev of events) {
+          const dataLine = ev.split("\n").find(l => l.startsWith("data: "))
+          if (!dataLine) continue
+          const raw = dataLine.slice("data: ".length)
+          try {
+            const parsed = JSON.parse(raw)
+            if (parsed.id === id) return { result: parsed.result, error: parsed.error }
+          } catch {}
+        }
+      }
+      throw new Error(`timeout waiting for response to id=${id}`)
+    },
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/types.ts
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/sdk/types.ts
@@ -1,0 +1,367 @@
+import type { ZodSchema, ZodTypeAny, z } from "zod"
+
+// ─── Bridge ────────────────────────────────────────────────────────────────
+
+export type BridgeErrorCode =
+  | "not_connected"
+  | "rate_limited"
+  | "not_found"
+  | "validation_failed"
+  | "upstream_error"
+
+export interface BridgeError {
+  kind: "error"
+  code: BridgeErrorCode
+  message: string
+  upstreamStatus?: number
+  upstreamBody?: unknown
+  retryAfter?: number
+  reauthUrl?: string
+}
+
+export type ProxyResult<T = unknown> =
+  | { kind: "ok"; data: T; status: number }
+  | BridgeError
+
+export interface BridgeClient {
+  call<T = unknown>(method: HttpMethod, path: string, body?: unknown): Promise<ProxyResult<T>>
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
+// ─── Transport contract ────────────────────────────────────────────────────
+//
+// The SDK is transport-agnostic. BridgeClient delegates the actual network
+// I/O to a TransportFn — the SDK never assumes Hono, Composio, OAuth, or any
+// specific authentication mechanism.
+//
+// Bundled transport adapters live under src/bridge-transports/:
+//   - bearer.ts            — self-host OAuth (bring your own access token)
+//   - composio-direct.ts   — Composio managed auth, no Holaboss backend in path
+//
+// You can write your own: a TransportFn is just (req) => Promise<response>.
+// Put your auth headers / proxy / vault token resolution there. The SDK only
+// cares that the response shape comes back populated.
+
+// ─── Provider Registry ─────────────────────────────────────────────────────
+
+export interface ProviderRegistry {
+  /**
+   * Canonical Composio toolkit slug. Same value flows through yaml
+   * `integration.destination`, `pending_integrations[].provider_id`,
+   * Hono `/composio/connect` body.provider (= Composio `toolkit_slug`),
+   * `integration_connections.provider_id`,
+   * `integration_bindings.integration_key`, and broker
+   * `createRuntimeBrokerTransport({ provider })`. Must match Composio's
+   * catalog exactly (e.g. `"discordbot"` for Discord bot, NOT `"discord"`).
+   */
+  id: string
+  baseUrl: string
+  allowedHosts: string[]
+  whoamiPath?: string
+  /**
+   * @deprecated Use `id` instead. The runtime does NOT consult this field;
+   * only `manifest.ts` falls back to it when generating `integration.destination`,
+   * which causes confusion when authors set `id` and `composioToolkit` to
+   * different values. Set `id` to the Composio toolkit slug and leave this
+   * unset.
+   */
+  composioToolkit?: string
+}
+
+// ─── Type helpers: schema → row type vending ───────────────────────────────
+//
+// The agent declares schema once (z.object({...})). All callbacks
+// (step.run / emit / db.query) receive a row typed as the inferred shape
+// PLUS system fields { id, status, external_id }. No more `as any` chasing.
+
+export type Infer<TSchema extends ZodTypeAny> = z.infer<TSchema>
+
+/**
+ * Row shape exposed to step.run / emit / db callbacks.
+ *
+ * external_id is intentionally typed as `string` (not string | number).
+ * Many provider APIs return integer IDs (Telegram message_id, GitHub issue
+ * number, Reddit post id). Stringify them on persist; cast back at the
+ * upstream call site:
+ *
+ *     // Telegram example:
+ *     return { ok: true, externalId: String(r.data.message_id) }
+ *     // ...later:
+ *     await bridge.call("POST", "/editMessageText", {
+ *       message_id: Number(row.external_id), ...
+ *     })
+ */
+export type RowOf<TSchema extends ZodTypeAny> = Infer<TSchema> & {
+  id: string
+  status: string
+  external_id?: string
+}
+
+// ─── Resource ──────────────────────────────────────────────────────────────
+
+export type StateTuple = readonly [string, ...string[]]
+
+export interface EmitConfig<TRow> {
+  surface: string                            // "content_plan" | "ops_log" | "none" | <agent-defined>
+  summary?: (row: TRow) => string | null
+  deepLink?: (row: TRow) => string | null
+}
+
+export interface ResourceDef<TSchema extends ZodTypeAny, States extends StateTuple> {
+  schema: TSchema
+  states: States
+  initialState: States[number]
+  /** Where to put row when an action on it fails. Optional — if absent, status preserved on failure. */
+  failedState?: States[number]
+  emit?: EmitConfig<RowOf<TSchema>>
+  refreshEvery?: string
+  fetch?: (ctx: { bridge: BridgeClient }) => Promise<Infer<TSchema>[]>
+}
+
+export interface ResourceHandle<TSchema extends ZodTypeAny = ZodTypeAny, States extends StateTuple = StateTuple> {
+  __resource: true
+  name: string
+  states: States
+  schema: TSchema
+  def: ResourceDef<TSchema, States>
+  /** Foreign-key reference. Returns a branded zod string schema. */
+  ref(): ZodSchema<string>
+}
+
+// ─── Action ────────────────────────────────────────────────────────────────
+
+export type StepResult<TOut = {}> =
+  | { ok: true; data?: TOut; externalId?: string }
+  | { fail: BridgeError | { kind: "error"; code: string; message: string } }
+
+export interface StepContext<TRow, TInput> {
+  row: TRow
+  input: TInput
+  bridge: BridgeClient
+  persist: (patch: Partial<TRow>) => Promise<void>
+  log: (msg: string, extra?: Record<string, unknown>) => void
+}
+
+export interface Step<TRow, TInput, TOut = {}> {
+  name: string
+  run: (ctx: StepContext<TRow, TInput>) => Promise<StepResult<TOut>>
+}
+
+export interface ReversibleDef<TRow, States extends StateTuple> {
+  toState: States[number]
+  run: (ctx: StepContext<TRow, {}>) => Promise<StepResult>
+}
+
+/**
+ * SDK boundary: ActionDef describes HOW to do something — its inputs, steps,
+ * state transitions, and reversal path. WHEN to do it (now / in 5h / every
+ * Monday) is NOT an SDK concern; that lives in the Holaboss automations
+ * subsystem. The SDK therefore intentionally has NO `schedulable` flag and NO
+ * retry policy — re-invocation on failure is the caller's choice.
+ *
+ * Actions MUST be idempotent: re-running an action on a row that already
+ * carries persisted intermediate state (e.g. media_id from a prior failed
+ * publish attempt) must safely no-op the already-done steps. Use row.external_id
+ * and row.<persisted_field> to detect "already done".
+ */
+export interface ActionDef<TRow, States extends StateTuple, I = {}> {
+  fromStates: readonly States[number][]
+  /**
+   * State to put the row in on success.
+   * `null` = side-effect action; row.status is NOT changed, NO output is re-emitted.
+   */
+  toState: States[number] | null
+  schema?: ZodSchema<I>
+  /** Override the auto-derived tool name. Default: `<app>_<action>_<resource>`.
+   *  If overridden, the reverse tool becomes `<toolName>_reverse`. */
+  toolName?: string
+  reversible?: ReversibleDef<TRow, States>
+  // exactly one of:
+  run?: (ctx: StepContext<TRow, I>) => Promise<StepResult>
+  steps?: Step<TRow, I>[]
+}
+
+// ─── Sync ──────────────────────────────────────────────────────────────────
+//
+// A sync is just a special background action that automations triggers on a
+// `schedule` hint. The SDK provides the execution machinery (DbView, upsert,
+// normalize); the SDK does NOT internally schedule.
+//
+// fetch() MUST return an explicit ok/error union — the SDK distinguishes
+// "upstream succeeded with 0 items" from "upstream failed". Returning an empty
+// array on failure (the old pattern) would silently mask outages from
+// dashboards and automations retry logic.
+
+export type SyncFetchResult<TRaw> =
+  | { ok: true; items: TRaw[] }
+  | { ok: false; error: BridgeError | { kind: "error"; code: string; message: string } }
+
+export interface SyncDef<TSchema extends ZodTypeAny, TRaw, TNormalized> {
+  /** Hint to automations (cron expression). SDK does not enforce. */
+  schedule: string
+  /** The resource these metrics attach to (for deep_link / aggregation). */
+  attachTo?: ResourceHandle<TSchema, any>
+  fetch: (ctx: { bridge: BridgeClient; db: DbView }) => Promise<SyncFetchResult<TRaw>>
+  upsert: { key: keyof TRaw & string }
+  normalize: (raw: TRaw) => TNormalized
+}
+
+// ─── DbView ────────────────────────────────────────────────────────────────
+//
+// where() supports scalar-equality filtering only. Arrays / objects are
+// excluded at the type level because the runtime uses === comparison and
+// can't meaningfully match deeply.
+
+type ScalarValue = string | number | boolean | null | undefined
+type ScalarKeys<T> = {
+  [K in keyof T]-?: T[K] extends ScalarValue ? K : never
+}[keyof T]
+type ScalarFilter<T> = Partial<Pick<T, ScalarKeys<T>>>
+
+export interface DbView {
+  query<TSchema extends ZodTypeAny, States extends StateTuple>(
+    resource: ResourceHandle<TSchema, States>,
+  ): {
+    where: (cond: ScalarFilter<RowOf<TSchema> & { status: States[number] }>) => {
+      recent: (window: string) => RowOf<TSchema>[]
+      all: () => RowOf<TSchema>[]
+    }
+    all: () => RowOf<TSchema>[]
+  }
+}
+
+// ─── App ───────────────────────────────────────────────────────────────────
+
+export interface AppConfig {
+  id: string
+  provider: ProviderRegistry
+  description?: string
+}
+
+export interface DerivedTool {
+  name: string
+  inputShape: string
+  description: string
+  category: "connection" | "resource_query" | "action" | "reverse_action" | "sync" | "snapshot"
+}
+
+export interface AppHandle {
+  config: AppConfig
+  connection(opts?: { whoamiPath?: string }): void
+  resource<TSchema extends ZodTypeAny, States extends StateTuple>(
+    name: string,
+    def: ResourceDef<TSchema, States>,
+  ): ResourceHandle<TSchema, States>
+  action<TSchema extends ZodTypeAny, States extends StateTuple, I = {}>(
+    resource: ResourceHandle<TSchema, States>,
+    name: string,
+    def: ActionDef<RowOf<TSchema>, States, I>,
+  ): void
+  sync<TSchema extends ZodTypeAny, RAW, N>(
+    name: string,
+    def: SyncDef<TSchema, RAW, N>,
+  ): void
+  start(): Promise<void>
+  derivedTools(): DerivedTool[]
+  state(): AppState
+}
+
+// ─── Internal runtime state ────────────────────────────────────────────────
+
+export interface RowRecord {
+  id: string
+  resource: string
+  status: string
+  data: Record<string, unknown>
+  externalId?: string
+  errorMessage?: string
+  scheduledAt?: string
+  createdInTurn?: string
+  sessionId?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AuditEntry {
+  at: string
+  event: "action.start" | "step.complete" | "action.retry" | "action.end" | "tool.call" | "sync.start" | "sync.end"
+  fields: Record<string, unknown>
+}
+
+export interface OutputCard {
+  resourceName: string
+  rowId: string
+  surface: string
+  status: string
+  summary: string | null
+  deepLink: string | null
+  updatedAt: string
+}
+
+export interface NotificationEntry {
+  at: string
+  level: "info" | "warning" | "error"
+  summary: string
+  agentHint?: string
+  ref?: { kind: string; id: string }
+}
+
+export interface SyncRecord {
+  syncName: string
+  attachedRowId: string                       // the row from the attachTo resource
+  key: string
+  raw: Record<string, unknown>
+  normalized: Record<string, unknown>
+  syncedAt: string
+}
+
+export interface AppState {
+  rows: RowRecord[]
+  audit: AuditEntry[]
+  outputs: OutputCard[]
+  notifications: NotificationEntry[]
+  syncRecords: SyncRecord[]
+  derivedTools: DerivedTool[]
+}
+
+// ─── State backend contract ────────────────────────────────────────────────
+//
+// All persistence (rows, audit, outputs, notifications, sync records) goes
+// through this interface. The SDK ships two implementations:
+//   - InMemoryStateBackend (the default) — testing + dev
+//   - SqliteStateBackend (in `runtime/state-backend-sqlite.ts`) — production
+//     deploy, persists to workspace.db + Holaboss runtime state-store
+//
+// createApp() accepts an optional `backend?: StateBackend` so production
+// runtime can inject SQLite without breaking unit tests' in-memory shape.
+
+export interface StateBackend {
+  setTurnContext(ctx: TurnContext | null): void
+
+  // Row CRUD (per-resource rows)
+  insertRow(resource: string, data: Record<string, unknown>, status: string): RowRecord
+  updateRow(id: string, patch: Partial<RowRecord>): RowRecord
+  getRow(id: string): RowRecord | undefined
+  rowsByResource(resource: string): RowRecord[]
+
+  // Audit log
+  pushAudit(event: AuditEntry["event"], fields: Record<string, unknown>): void
+
+  // Dashboard outputs
+  upsertOutput(card: Omit<OutputCard, "updatedAt">): void
+
+  // Notifications (push to user / agent next turn)
+  pushNotification(n: Omit<NotificationEntry, "at">): void
+
+  // Sync records (periodic data pulls)
+  upsertSyncRecord(rec: Omit<SyncRecord, "syncedAt">): void
+
+  // Snapshot for tests / inspection
+  snapshot(): AppState
+}
+
+export interface TurnContext {
+  turnId: string
+  sessionId: string
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/components.json
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/components.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "menuColor": "inverted-translucent",
+  "menuAccent": "subtle",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {
+    "@dotmatrix": "https://dotmatrix.zzzzshawn.cloud/r/{name}.json"
+  }
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/themes/holaos.css
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/themes/holaos.css
@@ -1,0 +1,121 @@
+/* holaOS — the brand-native theme. Quiet near-neutral grays with a cool
+   undertone and the holaboss orange reserved for brand/CTA. Hairlines read
+   as page rhythm, not cell walls; surfaces (card, muted, accent) sit close
+   enough to background that elevation comes from structure rather than tint. */
+
+/* Light mode */
+[data-theme="holaos-light"] {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.18 0.003 250);
+  --card: oklch(0.985 0.002 250);
+  --card-foreground: oklch(0.18 0.003 250);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0.003 250);
+  --primary: oklch(0.624 0.229 32);
+  --primary-foreground: oklch(0.98 0.01 32);
+  --secondary: oklch(0.97 0.002 250);
+  --secondary-foreground: oklch(0.21 0.003 250);
+  --muted: oklch(0.97 0.002 250);
+  --muted-foreground: oklch(0.56 0.005 250);
+  --accent: oklch(0.95 0.002 250);
+  --accent-foreground: oklch(0.18 0.003 250);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.92 0.003 250);
+  --input: oklch(0.92 0.003 250);
+  --ring: oklch(0.624 0.229 32);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.675rem;
+  --sidebar: oklch(0.945 0.002 250);
+  --sidebar-foreground: oklch(0.18 0.003 250);
+  --sidebar-primary: oklch(0.624 0.229 32);
+  --sidebar-primary-foreground: oklch(0.98 0.01 32);
+  --sidebar-accent: oklch(0.92 0.002 250);
+  --sidebar-accent-foreground: oklch(0.21 0.003 250);
+  --sidebar-border: oklch(0.9 0.003 250);
+  --sidebar-ring: oklch(0.624 0.229 32);
+  --font-sans: 'Inter Variable', sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
+  --spacing: 0.25rem;
+  --shadow-2xs:
+    inset 0 0.5px 1px #ffffff30, 0 0.5px 1px #0000000a, 0 1px 2px #00000006;
+  --shadow-xs:
+    inset 0 0.5px 1px #ffffff35, 0 0.5px 1px #0000000c, 0 1px 2px #00000008;
+  --shadow-sm:
+    inset 0 1px 2px #ffffff40, 0 1px 2px #00000012, 0 2px 4px #0000000a;
+  --shadow: inset 0 1px 2px #ffffff50, 0 2px 4px #00000014, 0 4px 6px #0000000c;
+  --shadow-md:
+    inset 0 1px 2px #ffffff55, 0 3px 6px #00000016, 0 6px 10px #0000000d;
+  --shadow-lg:
+    inset 0 1px 2px #ffffff60, 0 4px 8px #00000018, 0 8px 15px #00000010;
+  --shadow-xl:
+    inset 0 1px 2px #ffffff65, 0 6px 12px #0000001a, 0 12px 20px #00000012;
+  --shadow-2xl:
+    inset 0 1px 2px #ffffff70, 0 8px 15px #0000001c, 0 18px 28px #00000014;
+}
+
+/* Dark mode */
+[data-theme="holaos-dark"] {
+  --background: oklch(0.16 0.003 250);
+  --foreground: oklch(0.97 0.002 250);
+  --card: oklch(0.235 0.003 250);
+  --card-foreground: oklch(0.97 0.002 250);
+  --popover: oklch(0.235 0.003 250);
+  --popover-foreground: oklch(0.97 0.002 250);
+  --primary: oklch(0.624 0.229 32);
+  --primary-foreground: oklch(0.98 0.01 32);
+  --secondary: oklch(0.27 0.003 250);
+  --secondary-foreground: oklch(0.97 0.002 250);
+  /* Muted reads as a soft mid-tone above background so surfaces using
+     bg-muted — tab list rails, code blocks, disabled fields, the user
+     chat bubble base mix — actually read on a dark page. */
+  --muted: oklch(0.205 0.003 250);
+  --muted-foreground: oklch(0.66 0.005 250);
+  --accent: oklch(0.30 0.003 250);
+  --accent-foreground: oklch(0.97 0.002 250);
+  --destructive: oklch(0.653 0.232 25.964);
+  --destructive-foreground: oklch(1 0 0);
+  /* Border sits clearly above card (0.235) so hairlines on cards are
+     visible without being loud against the page surface. */
+  --border: oklch(0.32 0.003 250);
+  --input: oklch(0.32 0.003 250);
+  --ring: oklch(0.624 0.229 32);
+  --chart-1: oklch(0.44 0.004 250);
+  --chart-2: oklch(0.56 0.004 250);
+  --chart-3: oklch(0.71 0.004 250);
+  --chart-4: oklch(0.87 0.004 250);
+  --chart-5: oklch(0.92 0.004 250);
+  --radius: 0.675rem;
+  --sidebar: oklch(0.125 0.003 250);
+  --sidebar-foreground: oklch(0.97 0.002 250);
+  --sidebar-primary: oklch(0.624 0.229 32);
+  --sidebar-primary-foreground: oklch(0.97 0.002 250);
+  --sidebar-accent: oklch(0.20 0.003 250);
+  --sidebar-accent-foreground: oklch(0.97 0.002 250);
+  --sidebar-border: oklch(0.24 0.003 250);
+  --sidebar-ring: oklch(0.624 0.229 32);
+  --font-sans: 'Inter Variable', sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
+  --spacing: 0.25rem;
+  --shadow-2xs:
+    inset 0 0.5px 1px #ffffff0a, 0 0.5px 1px #00000050, 0 1px 2px #00000030;
+  --shadow-xs:
+    inset 0 0.5px 1px #ffffff0d, 0 0.5px 1px #00000050, 0 1px 2px #00000030;
+  --shadow-sm:
+    inset 0 1px 2px #ffffff15, 0 1px 2px #00000040, 0 2px 4px #00000025;
+  --shadow: inset 0 1px 2px #ffffff18, 0 1px 3px #00000045, 0 3px 6px #00000030;
+  --shadow-md:
+    inset 0 1px 2px #ffffff1a, 0 2px 4px #00000045, 0 4px 8px #00000028;
+  --shadow-lg:
+    inset 0 1px 2px #ffffff1c, 0 4px 6px #00000045, 0 6px 10px #00000030;
+  --shadow-xl:
+    inset 0 1px 2px #ffffff20, 0 6px 10px #00000045, 0 8px 15px #00000032;
+  --shadow-2xl:
+    inset 0 1px 2px #ffffff22, 0 10px 15px #00000045, 0 15px 25px #00000030;
+}

--- a/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/tokens.css
+++ b/runtime/harnesses/src/embedded-skills/app-builder-sdk/ui-reference/tokens.css
@@ -1,0 +1,446 @@
+/* Design tokens — single source of truth for color, type, radius, motion,
+   shadow, z-index. Theme files (./themes/*.css) override --background,
+   --foreground, --primary etc. by [data-theme="*"] attribute. */
+
+@theme inline {
+  --font-heading: var(--font-sans);
+  --font-sans: "Inter Variable", sans-serif;
+  --font-mono:
+    "Geist Mono Variable", ui-monospace, SFMono-Regular, Menlo, Consolas,
+    "Liberation Mono", monospace;
+
+  /* Foreground-mix utilities — opaque tint of foreground into bg.
+     Use bg-fg-3 etc. (Distinct from bg-foreground/N alpha.) */
+  --color-fg-2: var(--fg-2);
+  --color-fg-4: var(--fg-4);
+  --color-fg-6: var(--fg-6);
+  --color-fg-8: var(--fg-8);
+  --color-fg-12: var(--fg-12);
+  --color-fg-16: var(--fg-16);
+  --color-fg-24: var(--fg-24);
+  --color-fg-32: var(--fg-32);
+  --color-fg-48: var(--fg-48);
+  --color-fg-64: var(--fg-64);
+  --color-fg-80: var(--fg-80);
+  --color-fg-92: var(--fg-92);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-scrim: var(--scrim);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  /* Radius scale — integer px steps off base 8px. */
+  --radius-sm: calc(var(--radius) * 0.5); /* 4px */
+  --radius-md: calc(var(--radius) * 0.75); /* 6px — button/menu-item */
+  --radius-lg: var(--radius); /* 8px — card/input */
+  --radius-xl: calc(var(--radius) * 1.25); /* 10px — popover/dropdown */
+  --radius-2xl: calc(var(--radius) * 1.5); /* 12px — panel inner */
+  --radius-3xl: calc(var(--radius) * 2); /* 16px */
+  --radius-4xl: calc(var(--radius) * 2.5); /* 20px */
+
+  /* Font weights — each step ~50 lighter than Tailwind default. */
+  --font-weight-thin: 300;
+  --font-weight-extralight: 325;
+  --font-weight-light: 350;
+  --font-weight-normal: 350;
+  --font-weight-medium: 400;
+  --font-weight-semibold: 450;
+  --font-weight-bold: 500;
+  --font-weight-extrabold: 550;
+  --font-weight-black: 600;
+
+  /* Tight type scale — ~10-20% denser than Tailwind default. */
+  --text-xs: 0.725rem;
+  --text-xs--line-height: 1.2rem;
+  --text-xs--letter-spacing: 0.01em;
+  --text-sm: 0.775rem;
+  --text-sm--line-height: 1.3rem;
+  --text-sm--letter-spacing: 0.008em;
+  --text-base: 0.875rem;
+  --text-base--line-height: 1.5rem;
+  --text-lg: 0.975rem;
+  --text-lg--line-height: 1.75rem;
+  --text-xl: 1.175rem;
+  --text-xl--line-height: 1.95rem;
+  --text-2xl: 1.275rem;
+  --text-2xl--line-height: 2.25rem;
+  --text-3xl: 1.375rem;
+  --text-3xl--line-height: 2.5rem;
+  --text-4xl: 1.475rem;
+  --text-4xl--line-height: 2.75rem;
+  --text-5xl: 3.052rem;
+
+  /* Entrance animations */
+  --animate-reveal-pop: reveal-pop 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  --animate-fade-in-once: fade-in-once 0.6s ease-out forwards;
+
+  /* Brand alias — tracks whichever theme is active.
+     Use bg-brand / text-brand in new code. */
+  --color-brand: var(--primary);
+  --color-brand-foreground: var(--primary-foreground);
+
+  /* Layered shadow scale. 2xs/xs are hairline-ring + tiny drops for
+     surfaces that should read as "barely lifted" (cards, sticky toolbars).
+     sm steps up to a Linear/Stripe-style 8-layer stack for buttons +
+     popovers. md/lg/xl/2xl keep the hairline + blur scale. Dark mode
+     re-derives from --hairline-alpha / --shadow-alpha. */
+  --shadow-2xs:
+    rgba(0, 0, 0, 0.025) 0 1px 1px -0.5px, rgba(0, 0, 0, 0.05) 0 2px 2px -1px,
+    rgba(0, 0, 0, 0.05) 0 0 0 1px;
+  --shadow-xs:
+    rgba(0, 0, 0, 0.02) 0 1px 1px -0.5px, rgba(0, 0, 0, 0.04) 0 1px 1px -0.5px,
+    rgba(0, 0, 0, 0.04) 0 2px 2px -1px, rgba(0, 0, 0, 0.03) 0 0 0 0.5px;
+  --shadow-sm:
+    0 1px 1px 0.5px rgba(51, 51, 51, 0.03),
+    0 3px 3px -1.5px rgba(51, 51, 51, 0.015),
+    0 6px 6px -3px rgba(51, 51, 51, 0.03),
+    0 12px 12px -6px rgba(51, 51, 51, 0.03),
+    0 24px 24px -12px rgba(51, 51, 51, 0.03),
+    0 48px 48px -24px rgba(51, 51, 51, 0.03),
+    0 0 0 1px rgba(51, 51, 51, 0.08),
+    inset 0 -1px 1px -0.5px rgba(51, 51, 51, 0.05);
+  --shadow-md:
+    0 0 0 1px oklch(from var(--foreground) l c h / var(--hairline-alpha)),
+    0 1px 2px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 3px 5px -1px rgba(0, 0, 0, var(--shadow-alpha));
+  --shadow-lg:
+    0 0 0 1px oklch(from var(--foreground) l c h / var(--hairline-alpha)),
+    0 1px 2px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 3px 5px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 6px 10px -2px rgba(0, 0, 0, var(--shadow-alpha));
+  --shadow-xl:
+    0 0 0 1px oklch(from var(--foreground) l c h / var(--hairline-alpha)),
+    0 1px 2px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 3px 5px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 6px 10px -2px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 14px 22px -6px rgba(0, 0, 0, calc(var(--shadow-alpha) * 0.7));
+  --shadow-2xl:
+    0 0 0 1px oklch(from var(--foreground) l c h / var(--hairline-alpha)),
+    0 1px 2px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 3px 5px -1px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 6px 10px -2px rgba(0, 0, 0, var(--shadow-alpha)),
+    0 14px 22px -6px rgba(0, 0, 0, calc(var(--shadow-alpha) * 0.7)),
+    0 24px 36px -8px rgba(0, 0, 0, calc(var(--shadow-alpha) * 0.5));
+
+  /* Z-index — semantic app-chrome layers (Tailwind z-0..z-50 still
+     used for in-component layering). 100-step rhythm. */
+  --z-index-sticky: 100;
+  --z-index-chrome: 200;
+  --z-index-panel: 300;
+  --z-index-popover: 500;
+  --z-index-tooltip: 600;
+  --z-index-modal: 700;
+  --z-index-overlay: 800;
+  --z-index-toast: 900;
+  --z-index-splash: 1000;
+
+  /* Motion — 180ms default + custom curve. */
+  --default-transition-duration: 180ms;
+  --default-transition-timing-function: cubic-bezier(0.32, 0.08, 0.24, 1);
+  --ease-standard: cubic-bezier(0.32, 0.08, 0.24, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Linear-style emphasized curve — used for modals, collapses,
+     expansions, anything where the user needs to feel a deliberate
+     enter/exit. */
+  --ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+  /* Smooth ease-out for slide-ins where the element should decelerate
+     into rest. */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --duration-fast: 120ms;
+  --duration-snappy: 180ms;
+  --duration-base: 220ms;
+  --duration-stride: 240ms;
+  --duration-slow: 360ms;
+}
+
+@keyframes reveal-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.96) translateY(10px);
+  }
+  70% {
+    opacity: 1;
+    transform: scale(1.01) translateY(-2px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes fade-in-once {
+  0% {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes holaboss-splash-halo {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes holaboss-splash-dot {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-1.5px);
+  }
+}
+
+/* @property — register theme colors as animatable so theme switches
+   interpolate smoothly. */
+@property --background {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.985 0.002 60);
+}
+@property --foreground {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.18 0.015 55);
+}
+@property --primary {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.68 0.21 37);
+}
+@property --info {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.62 0.17 240);
+}
+@property --success {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.58 0.16 148);
+}
+@property --destructive {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.55 0.24 18);
+}
+/* Surface palette — registered so theme switches interpolate the
+   whole canvas instead of hard-cutting on most surfaces. Initial
+   values mirror the holaos-light defaults. */
+@property --card {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.985 0.002 250);
+}
+@property --popover {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(1 0 0);
+}
+@property --muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.97 0.002 250);
+}
+@property --muted-foreground {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.56 0.005 250);
+}
+@property --accent {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.95 0.002 250);
+}
+@property --secondary {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.97 0.002 250);
+}
+@property --border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.92 0.003 250);
+}
+@property --ring {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.624 0.229 32);
+}
+@property --sidebar {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: oklch(0.97 0.002 250);
+}
+
+/* Token fallbacks — tweakcn themes override these. Anything declared here
+   keeps the app renderable during the brief frame before [data-theme] is
+   set on <html>, and during theme switches. Themes shadow these. */
+:root {
+  --radius: 0.5rem;
+
+  /* Surface + content. Quiet near-neutral grays with a subtle cool
+     undertone; mirrors holaos-light. */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.18 0.003 250);
+  --card: oklch(0.985 0.002 250);
+  --card-foreground: oklch(0.18 0.003 250);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0.003 250);
+  --primary: oklch(0.624 0.229 32);
+  --primary-foreground: oklch(0.98 0.01 32);
+  --secondary: oklch(0.97 0.002 250);
+  --secondary-foreground: oklch(0.21 0.003 250);
+  --muted: oklch(0.97 0.002 250);
+  --muted-foreground: oklch(0.56 0.005 250);
+  --accent: oklch(0.95 0.002 250);
+  --accent-foreground: oklch(0.18 0.003 250);
+  --border: oklch(0.92 0.003 250);
+  --input: oklch(0.92 0.003 250);
+  --ring: oklch(0.624 0.229 32);
+  --sidebar: oklch(0.945 0.002 250);
+  --sidebar-foreground: oklch(0.18 0.003 250);
+  --sidebar-primary: oklch(0.624 0.229 32);
+  --sidebar-primary-foreground: oklch(0.98 0.01 32);
+  --sidebar-accent: oklch(0.92 0.002 250);
+  --sidebar-accent-foreground: oklch(0.21 0.003 250);
+  --sidebar-border: oklch(0.9 0.003 250);
+  --sidebar-ring: oklch(0.624 0.229 32);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+
+  --success: oklch(0.58 0.16 148);
+  --warning: oklch(0.82 0.17 83);
+  --info: oklch(0.62 0.17 240);
+  --scrim: oklch(0.15 0.01 240 / 0.46);
+  --destructive: oklch(0.55 0.24 18);
+
+  /* Foreground colours for tonal CTAs (text/icon on a solid tone-bg
+     button or chip). Default to `var(--background)` so contrast
+     auto-adapts to theme mode: light themes (bg ≈ white) end up
+     with white text — which reads against the typically-darker
+     light-mode tones; dark themes (bg ≈ near-black) get dark text,
+     which reads against the typically-lighter dark-mode pastels
+     most themes ship (catppuccin / nord / one-dark-pro et al.).
+     Warning stays anchored dark because amber/yellow is usually
+     light in both modes and never plays well with white text.
+     Themes that have unusual tones can still override per-tone. */
+  --destructive-foreground: var(--background);
+  --success-foreground: var(--background);
+  --warning-foreground: oklch(0.18 0 0);
+  --info-foreground: var(--background);
+
+  --hairline-alpha: 0.05;
+  --shadow-alpha: 0.07;
+
+  /* Elevated bg for unfocused panels. */
+  --background-elevated: color-mix(
+    in srgb,
+    var(--foreground) 2%,
+    var(--background)
+  );
+
+  /* Foreground-on-background opaque blends. Use --fg-N for tinted
+     surfaces; Tailwind's bg-foreground/N for transparent overlays. */
+  --fg-2: color-mix(in srgb, var(--foreground) 2%, var(--background));
+  --fg-4: color-mix(in srgb, var(--foreground) 4%, var(--background));
+  --fg-6: color-mix(in srgb, var(--foreground) 6%, var(--background));
+  --fg-8: color-mix(in srgb, var(--foreground) 8%, var(--background));
+  --fg-12: color-mix(in srgb, var(--foreground) 12%, var(--background));
+  --fg-16: color-mix(in srgb, var(--foreground) 16%, var(--background));
+  --fg-24: color-mix(in srgb, var(--foreground) 24%, var(--background));
+  --fg-32: color-mix(in srgb, var(--foreground) 32%, var(--background));
+  --fg-48: color-mix(in srgb, var(--foreground) 48%, var(--background));
+  --fg-64: color-mix(in srgb, var(--foreground) 64%, var(--background));
+  --fg-80: color-mix(in srgb, var(--foreground) 80%, var(--background));
+  --fg-92: color-mix(in srgb, var(--foreground) 92%, var(--background));
+
+  /* Status text — tinted toward foreground for labels on neutral bg. */
+  --success-text: color-mix(in oklab, var(--success) 45%, var(--foreground));
+  --destructive-text: color-mix(
+    in oklab,
+    var(--destructive) 45%,
+    var(--foreground)
+  );
+  --info-text: color-mix(in oklab, var(--info) 45%, var(--foreground));
+
+  /* Workspace identity tint — neutral gray composed with --background /
+     --foreground via color-mix, so dark mode adapts automatically without
+     a separate theme override. */
+  --workspace-color-gray: oklch(0.55 0.005 270);
+
+  --workspace-color-gray-bg: color-mix(
+    in srgb,
+    var(--workspace-color-gray) 14%,
+    var(--background)
+  );
+  --workspace-color-gray-fg: color-mix(
+    in oklab,
+    var(--workspace-color-gray) 65%,
+    var(--foreground)
+  );
+}
+
+.dark {
+  --hairline-alpha: 0.14;
+  --shadow-alpha: 0.13;
+
+  /* Black drops + white hairline ring + white top inset
+     (lit-from-above). Mirrors light stack with inverted polarity. */
+  --shadow-sm:
+    0 1px 1px 0.5px rgba(0, 0, 0, 0.32),
+    0 3px 3px -1.5px rgba(0, 0, 0, 0.16),
+    0 6px 6px -3px rgba(0, 0, 0, 0.32),
+    0 12px 12px -6px rgba(0, 0, 0, 0.32),
+    0 24px 24px -12px rgba(0, 0, 0, 0.32),
+    0 48px 48px -24px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.05);
+}


### PR DESCRIPTION
## Context
The packaged desktop runtime was shipping an embedded `app-builder-sdk` skill that still referenced repo-root paths. In direct Codex runs this pushed subagents into ENOENT recovery loops and path-guessing outside the active workspace.

## What Changed
- rewrote the embedded `app-builder-sdk` skill to point only at bundled local assets
- added bundled reference apps, UI reference files, and SDK/package snapshots required by the packaged skill
- hardened runtime prompt routing so ENOENT/path-not-found failures stop path guessing outside the active workspace
- added regression coverage for packaged embedded skills and prompt recovery guidance

## Validation
- `node --import tsx --test src/agent-runtime-prompt.test.ts`
- `node --import tsx --test src/agent-runtime-config.test.ts`
- `node --import tsx --test src/workspace-skills.test.ts`
- `node --test prune_packaged_tree.test.mjs`

## Notes
- no Supabase migrations or branch changes
- no environment changes required