### PR TITLE
fix: keep local claimed input leases alive

### DIFF
--- a/docs/implementation_notes/fix-claim-input-lease-expire-implementation-notes.html
+++ b/docs/implementation_notes/fix-claim-input-lease-expire-implementation-notes.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fix Claim Input Lease Expire Implementation Notes</title>
+  </head>
+  <body>
+    <h1>Fix Claim Input Lease Expire Implementation Notes</h1>
+    <h2>Design decisions</h2>
+    <ul>
+      <li>Added a queue-worker keepalive for locally active claimed inputs so the owning worker refreshes the claim even before or between executor-level lease renewals.</li>
+      <li>When the active run already owns the runtime-state row, the keepalive also refreshes the runtime-state heartbeat and lease fields so peer workers do not misclassify quiet local work as abandoned.</li>
+    </ul>
+    <h2>Deviations</h2>
+    <ul>
+      <li>No intentional product-spec deviation. The change narrows false-positive recovery behavior without changing terminal event semantics.</li>
+    </ul>
+    <h2>Tradeoffs</h2>
+    <ul>
+      <li>The queue worker now writes extra claim/runtime-state heartbeats while a local run is active. This slightly increases SQLite write volume in exchange for eliminating a higher-cost false failure mode.</li>
+      <li>The keepalive trusts the local worker while its promise is still active, so a truly wedged in-process run may retain ownership longer than before. Existing runner timeouts still bound the common subprocess path.</li>
+    </ul>
+    <h2>Open questions</h2>
+    <ul>
+      <li>If we later need stricter hung-run detection for non-runner phases, the next step should be an explicit executor activity callback instead of inferring liveness only from promise lifetime.</li>
+    </ul>
+  </body>
+</html>

--- a/runtime/api-server/src/queue-worker.test.ts
+++ b/runtime/api-server/src/queue-worker.test.ts
@@ -951,6 +951,218 @@ test("runtime queue worker renews an expired claimed input while it waits on a s
   store.close();
 });
 
+test("runtime queue worker keeps a local claimed input lease fresh while delegated execution is still active", async () => {
+  const root = makeTempDir("hb-runtime-queue-worker-active-lease-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    payload: { text: "hold the lease" },
+  });
+  const release = deferred<void>();
+  const started = deferred<void>();
+
+  const worker = new RuntimeQueueWorker({
+    store,
+    leaseSeconds: 1,
+    pollIntervalMs: 50,
+    executeClaimedInput: async () => {
+      started.resolve();
+      await release.promise;
+      store.updateInput({
+        workspaceId: queued.workspaceId,
+        inputId: queued.inputId,
+        fields: {
+          status: "DONE",
+          claimedBy: null,
+          claimedUntil: null,
+        },
+      });
+      store.updateRuntimeState({
+        workspaceId: queued.workspaceId,
+        sessionId: queued.sessionId,
+        status: "IDLE",
+        currentInputId: null,
+        currentWorkerId: null,
+        leaseUntil: null,
+        heartbeatAt: null,
+        lastError: null,
+      });
+    },
+  });
+
+  await worker.start();
+  worker.wake();
+
+  await waitFor(
+    () =>
+      store.getInput({
+        workspaceId: queued.workspaceId,
+        inputId: queued.inputId,
+      })?.status === "CLAIMED",
+  );
+  await started.promise;
+  const claimedBefore = store.getInput({
+    workspaceId: queued.workspaceId,
+    inputId: queued.inputId,
+  });
+  assert.ok(claimedBefore?.claimedUntil);
+
+  await sleep(1_250);
+
+  const claimedDuringRun = store.getInput({
+    workspaceId: queued.workspaceId,
+    inputId: queued.inputId,
+  });
+  assert.ok(claimedDuringRun);
+  assert.equal(claimedDuringRun.status, "CLAIMED");
+  assert.ok(claimedDuringRun.claimedUntil);
+  assert.ok(Date.parse(claimedDuringRun.claimedUntil) > Date.now());
+  assert.ok(
+    Date.parse(claimedDuringRun.claimedUntil) >
+      Date.parse(claimedBefore.claimedUntil!),
+  );
+
+  release.resolve();
+  await waitFor(
+    () =>
+      store.getInput({
+        workspaceId: queued.workspaceId,
+        inputId: queued.inputId,
+      })?.status === "DONE",
+    5_000,
+  );
+  await worker.close();
+  store.close();
+});
+
+test("runtime queue worker refreshes the runtime heartbeat for a local active run so peer workers do not recover it as abandoned", async () => {
+  const root = makeTempDir("hb-runtime-queue-worker-active-heartbeat-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    payload: { text: "stay local" },
+  });
+  const release = deferred<void>();
+  const started = deferred<void>();
+  const ownerId = "worker-owner";
+
+  const ownerWorker = new RuntimeQueueWorker({
+    store,
+    claimedBy: ownerId,
+    leaseSeconds: 300,
+    pollIntervalMs: 50,
+    executeClaimedInput: async () => {
+      store.updateRuntimeState({
+        workspaceId: queued.workspaceId,
+        sessionId: queued.sessionId,
+        status: "BUSY",
+        currentInputId: queued.inputId,
+        currentWorkerId: ownerId,
+        leaseUntil: new Date(Date.now() + 300_000).toISOString(),
+        heartbeatAt: new Date().toISOString(),
+        lastError: null,
+      });
+      started.resolve();
+      await release.promise;
+      store.updateInput({
+        workspaceId: queued.workspaceId,
+        inputId: queued.inputId,
+        fields: {
+          status: "DONE",
+          claimedBy: null,
+          claimedUntil: null,
+        },
+      });
+      store.updateRuntimeState({
+        workspaceId: queued.workspaceId,
+        sessionId: queued.sessionId,
+        status: "IDLE",
+        currentInputId: null,
+        currentWorkerId: null,
+        leaseUntil: null,
+        heartbeatAt: null,
+        lastError: null,
+      });
+    },
+  });
+  const peerWorker = new RuntimeQueueWorker({
+    store,
+    claimedBy: "worker-peer",
+    pollIntervalMs: 50,
+    claimStaleHeartbeatMs: 1_000,
+    executeClaimedInput: async () => {
+      throw new Error("peer worker should not steal the local run");
+    },
+  });
+
+  await ownerWorker.start();
+  ownerWorker.wake();
+  await started.promise;
+
+  const heartbeatBefore = store.getRuntimeState({
+    workspaceId: queued.workspaceId,
+    sessionId: queued.sessionId,
+  })?.heartbeatAt;
+  assert.ok(heartbeatBefore);
+
+  await sleep(1_250);
+
+  const runtimeStateDuringRun = store.getRuntimeState({
+    workspaceId: queued.workspaceId,
+    sessionId: queued.sessionId,
+  });
+  const processed = await peerWorker.processAvailableInputsOnce();
+  const updated = store.getInput({
+    workspaceId: queued.workspaceId,
+    inputId: queued.inputId,
+  });
+  const events = store.listOutputEvents({
+    workspaceId: queued.workspaceId,
+    sessionId: queued.sessionId,
+    inputId: queued.inputId,
+  });
+
+  assert.equal(processed, 0);
+  assert.ok(runtimeStateDuringRun?.heartbeatAt);
+  assert.ok(
+    Date.parse(runtimeStateDuringRun.heartbeatAt) > Date.parse(heartbeatBefore),
+  );
+  assert.equal(updated?.status, "CLAIMED");
+  assert.equal(events.length, 0);
+
+  release.resolve();
+  await waitFor(
+    () =>
+      store.getInput({
+        workspaceId: queued.workspaceId,
+        inputId: queued.inputId,
+      })?.status === "DONE",
+    5_000,
+  );
+  await ownerWorker.close();
+  store.close();
+});
+
 test("queue route wakes configured queue worker", async () => {
   const root = makeTempDir("hb-runtime-queue-worker-");
   const store = new RuntimeStateStore({

--- a/runtime/api-server/src/queue-worker.ts
+++ b/runtime/api-server/src/queue-worker.ts
@@ -22,6 +22,8 @@ const DEFAULT_LEASE_SECONDS = 300;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_MAX_CONCURRENCY = 5;
 const DEFAULT_CLAIM_STALE_HEARTBEAT_MS = 20_000;
+const ACTIVE_RUN_KEEPALIVE_MIN_INTERVAL_MS = 250;
+const ACTIVE_RUN_KEEPALIVE_MAX_INTERVAL_MS = 1_000;
 const TERMINAL_EVENT_TYPES = new Set(["run_completed", "run_failed"]);
 const SESSION_CHECKPOINT_JOB_TYPE = "session_checkpoint";
 
@@ -87,6 +89,19 @@ function isoTimeMs(value: string | null | undefined): number | null {
 function isExpiredIso(value: string | null | undefined, nowMs: number): boolean {
   const valueMs = isoTimeMs(value);
   return valueMs !== null && valueMs <= nowMs;
+}
+
+function activeRunKeepaliveIntervalMs(leaseSeconds: number): number {
+  if (leaseSeconds <= 0) {
+    return ACTIVE_RUN_KEEPALIVE_MIN_INTERVAL_MS;
+  }
+  return Math.max(
+    ACTIVE_RUN_KEEPALIVE_MIN_INTERVAL_MS,
+    Math.min(
+      ACTIVE_RUN_KEEPALIVE_MAX_INTERVAL_MS,
+      Math.trunc((leaseSeconds * 1000) / 2),
+    ),
+  );
 }
 
 export function runtimeQueueWorkerClaimedBy(prefix = DEFAULT_CLAIMED_BY): string {
@@ -255,6 +270,58 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
 
   #startClaimedInput(record: SessionInputRecord): void {
     const controller = new AbortController();
+    let keepalive: NodeJS.Timeout | null = null;
+    const stopKeepalive = () => {
+      if (!keepalive) {
+        return;
+      }
+      clearInterval(keepalive);
+      keepalive = null;
+    };
+    const renewActiveRunClaim = () => {
+      const currentRecord = this.#store.getInput({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+      });
+      if (
+        !currentRecord ||
+        currentRecord.status !== "CLAIMED" ||
+        currentRecord.claimedBy !== this.#claimedBy
+      ) {
+        return;
+      }
+      const renewedClaim = this.#store.renewInputClaim({
+        workspaceId: record.workspaceId,
+        inputId: record.inputId,
+        claimedBy: this.#claimedBy,
+        leaseSeconds: this.#leaseSeconds,
+      });
+      if (!renewedClaim?.claimedUntil) {
+        return;
+      }
+      const runtimeState = this.#store.getRuntimeState({
+        workspaceId: record.workspaceId,
+        sessionId: record.sessionId,
+      });
+      if (
+        runtimeState?.currentInputId === record.inputId &&
+        runtimeState.currentWorkerId === this.#claimedBy
+      ) {
+        this.#store.updateRuntimeState({
+          workspaceId: record.workspaceId,
+          sessionId: record.sessionId,
+          status: runtimeState.status,
+          currentInputId: record.inputId,
+          currentWorkerId: this.#claimedBy,
+          leaseUntil: renewedClaim.claimedUntil,
+          lastError: runtimeState.lastError,
+        });
+      }
+    };
+    keepalive = setInterval(() => {
+      renewActiveRunClaim();
+    }, activeRunKeepaliveIntervalMs(this.#leaseSeconds));
+    keepalive.unref?.();
     const codexConfigured = hasCodexProviderConfigured();
     const promise = (async () => {
       try {
@@ -309,6 +376,7 @@ export class RuntimeQueueWorker implements QueueWorkerLike {
           lastError: { message }
         });
       } finally {
+        stopKeepalive();
         this.#activeRuns.delete(record.inputId);
         this.wake();
       }


### PR DESCRIPTION
## Context
- The diagnostics bundle `holaboss-diagnostics-general-purpose-agent-2026-05-20T09-15-57Z.zip` shows subagent input `f35866ac-8bb7-45d0-ae3f-c6c5a3f59111` failing at `2026-05-20T05:04:58.456Z` with `claimed input lease expired before the runner emitted a terminal event`.
- The same runtime log timestamp records `Recovered stale claimed runtime inputs`, which means the failure came from stale-claim recovery rather than a normal terminal runner event.
- That run emitted live output through roughly `2026-05-20T04:54:05.607Z`, so this change focuses on preventing false stale-claim recovery while a local claimed run is still active.

## What Changed
- add a queue-worker keepalive that periodically renews the claimed input lease for locally active runs
- refresh `session_runtime_state` heartbeat and lease fields when the local worker still owns the active session input
- add regression coverage for local active-run lease renewal and peer-worker stale-recovery protection
- add implementation notes under `docs/implementation_notes/fix-claim-input-lease-expire-implementation-notes.html`

## Validation
- `npm --workspace @holaboss/runtime-api-server test -- src/queue-worker.test.ts` (blocked locally: missing `tsx` in this checkout)
- `bun test runtime/api-server/src/queue-worker.test.ts` (blocked locally: missing installed app deps such as `fastify`)

## Impact
- No Supabase or migration changes.
- No required environment changes beyond installing the repo's JS dependencies before running the test suite.