### PR TITLE
fix: unify session compaction fit checks

### DIFF
--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -5003,9 +5003,9 @@ test("claimed input compacts a reused PI session before a smaller-window model r
         reason: null,
         diagnostics: {
           context_usage: {
-            tokens: 650_000,
-            contextWindow: 1_000_000,
-            percent: 65,
+            tokens: 110_000,
+            contextWindow: 400_000,
+            percent: 27.5,
           },
         },
         error: null,
@@ -5484,9 +5484,9 @@ test("claimed input synthesizes a turn request snapshot for main-session backgro
         reason: null,
         diagnostics: {
           context_usage: {
-            tokens: 650_000,
-            contextWindow: 1_000_000,
-            percent: 65,
+            tokens: 110_000,
+            contextWindow: 400_000,
+            percent: 27.5,
           },
         },
         error: null,

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -15,7 +15,10 @@ import {
 } from "./claimed-input-executor.js";
 import type { MemoryServiceLike } from "./memory.js";
 import type { RuntimeSentryCaptureOptions } from "./runtime-sentry.js";
-import type { PiContextUsage } from "./session-checkpoint.js";
+import type {
+  PiContextUsage,
+  SessionCheckpointSessionOps,
+} from "./session-checkpoint.js";
 import {
   persistWorkspaceHarnessSessionId,
   readWorkspaceHarnessSessionId,
@@ -5062,6 +5065,200 @@ test("claimed input compacts a reused PI session before a smaller-window model r
   assert.equal(preRunTelemetry?.previous_selected_model, "openai_codex/gpt-5.4");
   assert.equal(preRunTelemetry?.target_selected_model, "openai_codex/gpt-5.5");
   assert.ok(latestPiCompactionEntry(sessionFile));
+  store.close();
+});
+
+test("claimed input uses compaction diagnostics for the final pre-run fit check", async () => {
+  const store = makeStore("hb-claimed-input-prerun-compaction-diagnostics-");
+  const workspace = store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const workspaceDir = store.workspaceDir(workspace.id);
+  const { sessionManager, sessionFile } = createPiSessionFile({
+    workspaceDir,
+    sessionDir: path.join(workspaceDir, ".holaboss", "pi-sessions"),
+  });
+  sessionManager.appendMessage(piUserMessage("x".repeat(900_000)));
+  sessionManager.appendMessage(piAssistantMessage("previous response"));
+  store.upsertBinding({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    harness: "pi",
+    harnessSessionId: sessionFile,
+  });
+  const previousInput = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "previous", model: "openai_codex/gpt-5.4" },
+  });
+  store.updateInput({
+    workspaceId: workspace.id,
+    inputId: previousInput.inputId,
+    fields: { status: "DONE" },
+  });
+  store.upsertTurnResult({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: previousInput.inputId,
+    startedAt: "2026-05-11T00:00:00.000Z",
+    completedAt: "2026-05-11T00:01:00.000Z",
+    status: "completed",
+    stopReason: "completed",
+    assistantText: "previous response",
+    toolUsageSummary: {
+      total_calls: 0,
+      completed_calls: 0,
+      failed_calls: 0,
+      tool_names: [],
+      tool_ids: [],
+    },
+    permissionDenials: [],
+    promptSectionIds: [],
+    capabilityManifestFingerprint: null,
+    requestSnapshotFingerprint: null,
+    promptCacheProfile: null,
+    contextBudgetDecisions: {
+      context_usage: {
+        tokens: 650_000,
+        context_window: 1_000_000,
+        percent: 65,
+      },
+    },
+    tokenUsage: null,
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "new task", model: "openai_codex/gpt-5.5" },
+  });
+  upsertTurnRequestSnapshotFixture({
+    store,
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    inputId: queued.inputId,
+    model: "openai_codex/gpt-5.5",
+    providerId: "openai_codex",
+    modelId: "gpt-5.5",
+    instructionSize: 2_048,
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+  let compactionCalls = 0;
+  let runnerCalled = false;
+  const sessionCheckpointSessionOps = {
+    currentLeafCheckpointState() {
+      const branch = openPiSessionManager(sessionFile).getBranch();
+      return {
+        leafId:
+          typeof branch.at(-1)?.id === "string" ? String(branch.at(-1)?.id) : null,
+        latestCompactionId:
+          typeof latestPiCompactionEntry(sessionFile)?.id === "string"
+            ? String(latestPiCompactionEntry(sessionFile)?.id)
+            : null,
+      };
+    },
+    canMergeCheckpointIntoLiveSession() {
+      return true;
+    },
+    appendSnapshotCompactionToLiveSession() {
+      return true;
+    },
+  } satisfies SessionCheckpointSessionOps;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {},
+    relayRunEventFn: async () => {},
+    sessionCheckpointSessionOps,
+    resolveRuntimeModelClientFn: () => ({
+      providerId: "openai_codex",
+      configuredProviderId: "openai_codex",
+      modelId: "gpt-5.5",
+      modelToken: "openai_codex/gpt-5.5",
+      modelProxyProvider: "openai_compatible",
+      modelClient: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "runtime-api-key",
+        base_url: "https://runtime.example/api/v1/model-proxy",
+        default_headers: {
+          "X-API-Key": "runtime-api-key",
+        },
+      },
+    }),
+    runPiSessionCompactionFn: async (requestPayload) => {
+      compactionCalls += 1;
+      return {
+        compacted: true,
+        session_file: String(requestPayload.harness_session_id),
+        result: {
+          summary: "Compacted history",
+          firstKeptEntryId: "entry-1",
+          tokensBefore: 650_000,
+          details: { readFiles: [], modifiedFiles: [] },
+        },
+        reason: null,
+        diagnostics: {
+          context_usage: {
+            tokens: 110_000,
+            contextWindow: 400_000,
+            percent: 27.5,
+          },
+        },
+        error: null,
+      };
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      runnerCalled = true;
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 1,
+        event_type: "run_started",
+        payload: {},
+      });
+      await options.onEvent?.({
+        session_id: String(payload.session_id),
+        input_id: String(payload.input_id),
+        sequence: 2,
+        event_type: "run_completed",
+        payload: {
+          status: "completed",
+          harness_session_id: sessionFile,
+          context_usage: {
+            tokens: 110_000,
+            context_window: 400_000,
+            percent: 27.5,
+          },
+        },
+      });
+      return {
+        events: [],
+        skippedLines: [],
+        stderr: "",
+        returnCode: 0,
+        sawTerminal: true,
+      };
+    },
+  });
+
+  assert.equal(compactionCalls, 1);
+  assert.equal(runnerCalled, true);
+  const turnResult = turnResultForInput(store, queued);
+  const preRunTelemetry = recordValue(
+    recordValue(turnResult?.contextBudgetDecisions)?.pre_run_compaction,
+  );
+  assert.equal(turnResult?.status, "completed");
+  assert.ok(preRunTelemetry);
+  assert.equal(preRunTelemetry?.initial_decision, "would_overflow");
+  assert.equal(preRunTelemetry?.final_decision, "fit");
   store.close();
 });
 

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -42,6 +42,9 @@ import {
 import type { MemoryServiceLike } from "./memory.js";
 import { createBackgroundTaskMemoryModelClient } from "./background-task-model.js";
 import {
+  effectiveSessionTokenCount,
+  effectiveSessionTokensFromContextBudgetDecisions,
+  estimateSessionContextTokens,
   evaluatePreRunSessionCompaction,
   enqueueSessionCheckpointJob,
   forceCompactSessionWithSnapshotMerge,
@@ -1940,6 +1943,32 @@ function contextUsagePayload(contextUsage: PiContextUsage | null): Record<string
   };
 }
 
+function effectiveSessionTokensForTurn(params: {
+  contextUsage: PiContextUsage | null;
+  harnessSessionId?: string | null;
+  preRunCompaction?: PreRunCompactionTelemetryRecord | null;
+}): number | null {
+  const preRunSessionTokens =
+    params.preRunCompaction?.after_session_tokens ??
+    params.preRunCompaction?.before_session_tokens ??
+    null;
+  let serializedSessionTokens: number | null = null;
+  if (params.harnessSessionId && fs.existsSync(params.harnessSessionId)) {
+    try {
+      serializedSessionTokens = estimateSessionContextTokens(
+        params.harnessSessionId,
+      );
+    } catch {
+      serializedSessionTokens = null;
+    }
+  }
+  return effectiveSessionTokenCount([
+    preRunSessionTokens,
+    params.contextUsage?.tokens,
+    serializedSessionTokens,
+  ]);
+}
+
 function latestPriorTurnCompactionContext(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -1966,14 +1995,29 @@ function latestPriorTurnCompactionContext(params: {
     const contextBudgetDecisions = isRecord(turn.contextBudgetDecisions)
       ? turn.contextBudgetDecisions
       : null;
+    const normalizedContextUsage = normalizePiContextUsage(
+      contextBudgetDecisions?.context_usage,
+    );
+    const previousEffectiveSessionTokens =
+      effectiveSessionTokensFromContextBudgetDecisions(contextBudgetDecisions);
     return {
       previousSelectedModel:
         typeof previousInput?.payload.model === "string"
           ? previousInput.payload.model.trim() || null
           : null,
-      previousContextUsage: normalizePiContextUsage(
-        contextBudgetDecisions?.context_usage,
-      ),
+      previousContextUsage:
+        normalizedContextUsage && previousEffectiveSessionTokens !== null
+          ? {
+              ...normalizedContextUsage,
+              tokens: previousEffectiveSessionTokens,
+              percent:
+                normalizedContextUsage.contextWindow > 0
+                  ? (previousEffectiveSessionTokens /
+                      normalizedContextUsage.contextWindow) *
+                    100
+                  : normalizedContextUsage.percent,
+            }
+          : normalizedContextUsage,
     };
   }
   return {
@@ -2234,6 +2278,7 @@ function buildContextBudgetObservabilityPayload(params: {
   telemetry: TurnContextBudgetTelemetry;
   toolCallCount: number;
   checkpointQueued: boolean;
+  effectiveSessionTokens?: number | null;
   preRunCompaction?: PreRunCompactionTelemetryRecord | null;
   overflowRecovery?: OverflowRecoveryTelemetryRecord | null;
   providerTerminationRecovery?: ProviderTerminationRecoveryTelemetryRecord | null;
@@ -2278,13 +2323,17 @@ function buildContextBudgetObservabilityPayload(params: {
     mode: "observability_only",
     pressure_stage: null,
     lane_decisions: [],
-    checkpoint_recommended: shouldQueueSessionCheckpoint(params.contextUsage),
+    checkpoint_recommended: shouldQueueSessionCheckpoint(
+      params.contextUsage,
+      params.effectiveSessionTokens ?? null,
+    ),
     checkpoint_queued: params.checkpointQueued,
     prompt_cache_stable_candidate: promptCacheStableCandidate(params.promptCacheProfile),
     tool_replay_trimmed: false,
     retrieval_clipped: false,
     reason_codes: [],
     context_usage: contextUsagePayload(params.contextUsage),
+    effective_session_tokens: params.effectiveSessionTokens ?? null,
     model_context_window: params.contextUsage?.contextWindow ?? null,
     ...(params.preRunCompaction
       ? { pre_run_compaction: preRunCompactionPayload(params.preRunCompaction) }
@@ -2344,6 +2393,7 @@ function buildMergedContextBudgetPayload(params: {
   toolReplayTrimmed: boolean;
   retrievalClipped?: boolean;
   checkpointQueued: boolean;
+  effectiveSessionTokens?: number | null;
   preRunCompaction?: PreRunCompactionTelemetryRecord | null;
   overflowRecovery?: OverflowRecoveryTelemetryRecord | null;
   providerTerminationRecovery?: ProviderTerminationRecoveryTelemetryRecord | null;
@@ -2360,6 +2410,7 @@ function buildMergedContextBudgetPayload(params: {
       telemetry: params.telemetry,
       toolCallCount: params.toolCallCount,
       checkpointQueued: params.checkpointQueued,
+      effectiveSessionTokens: params.effectiveSessionTokens,
       preRunCompaction: params.preRunCompaction,
       overflowRecovery: params.overflowRecovery,
       providerTerminationRecovery: params.providerTerminationRecovery,
@@ -4778,7 +4829,12 @@ export async function processClaimedInput(params: {
             snapshotPayload,
             selectedModel,
             previousSelectedModel,
-            previousContextUsage: null,
+            previousContextUsage: compactionResult.merged
+              ? compactionResult.contextUsage
+              : null,
+            currentSessionTokensOverride: compactionResult.merged
+              ? compactionResult.effectiveSessionTokens
+              : null,
           });
           const currentPreRunCompaction =
             preRunCompaction ?? initialPreRunCompaction;
@@ -5636,6 +5692,11 @@ export async function processClaimedInput(params: {
         store.getWorkspace(record.workspaceId)?.harness ??
         normalizeHarnessId(priorExecContext.harness) ??
         "pi";
+      const effectiveSessionTokens = effectiveSessionTokensForTurn({
+        contextUsage,
+        harnessSessionId: checkpointHarnessSessionId,
+        preRunCompaction,
+      });
       if (syncedEphemeralLiveSessionFile) {
         if (deferredTerminalEvent) {
           deferredTerminalEvent.payload.harness_session_id =
@@ -5667,6 +5728,7 @@ export async function processClaimedInput(params: {
               })?.harnessSessionId ??
                 null),
             contextUsage,
+            effectiveSessionTokens,
             wakeWorker: params.wakeDurableMemoryWorker ?? null,
           });
       const contextBudgetDecisions = buildMergedContextBudgetPayload({
@@ -5681,6 +5743,7 @@ export async function processClaimedInput(params: {
         toolCallCount: toolCallsById.size,
         toolReplayTrimmed,
         checkpointQueued: Boolean(checkpointJob),
+        effectiveSessionTokens,
         preRunCompaction,
         overflowRecovery,
         providerTerminationRecovery,
@@ -5940,6 +6003,11 @@ export async function processClaimedInput(params: {
       }
       const message = error instanceof Error ? error.message : String(error);
       const errorStopReason = executorFailureStopReason(error);
+      const effectiveSessionTokens = effectiveSessionTokensForTurn({
+        contextUsage,
+        harnessSessionId: checkpointHarnessSessionId,
+        preRunCompaction,
+      });
       store.updateInput({
         workspaceId: record.workspaceId,
         inputId: record.inputId,
@@ -5974,6 +6042,7 @@ export async function processClaimedInput(params: {
             toolCallCount: toolCallsById.size,
             toolReplayTrimmed,
             checkpointQueued: false,
+            effectiveSessionTokens,
             preRunCompaction,
             overflowRecovery,
             providerTerminationRecovery,
@@ -6022,6 +6091,7 @@ export async function processClaimedInput(params: {
           toolCallCount: toolCallsById.size,
           toolReplayTrimmed,
           checkpointQueued: false,
+          effectiveSessionTokens,
           preRunCompaction,
           overflowRecovery,
           providerTerminationRecovery,

--- a/runtime/api-server/src/session-checkpoint.test.ts
+++ b/runtime/api-server/src/session-checkpoint.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { RuntimeStateStore } from "@holaboss/runtime-state-store";
 
 import {
+  evaluatePreRunSessionCompaction,
   type SessionCheckpointSessionOps,
   enqueueSessionCheckpointJob,
   processSessionCheckpointJob,
@@ -103,6 +104,54 @@ test("session checkpoint queues only after PI context crosses the 70 percent res
     }),
     true,
   );
+});
+
+test("session checkpoint can queue from effective session tokens when provider context usage stays low", () => {
+  assert.equal(
+    shouldQueueSessionCheckpoint(
+      {
+        tokens: 63_004,
+        contextWindow: 1_050_000,
+        percent: 6.0,
+      },
+      470_721,
+    ),
+    true,
+  );
+});
+
+test("pre-run compaction can trust a compaction-provided session token override", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hb-prerun-override-"));
+  const sessionFile = path.join(root, "session.jsonl");
+  fs.writeFileSync(sessionFile, '{"type":"header"}\n', "utf8");
+  try {
+    const decision = evaluatePreRunSessionCompaction({
+      liveSessionFile: sessionFile,
+      snapshotPayload: {
+        harness_request: {
+          provider_id: "openai_codex",
+          model_id: "gpt-5.5",
+          model_client: {
+            model_proxy_provider: "openai_compatible",
+            base_url: "https://runtime.example/api/v1/model-proxy",
+          },
+          instruction: "continue",
+        },
+      },
+      selectedModel: "openai_codex/gpt-5.5",
+      previousSelectedModel: "openai_codex/gpt-5.4",
+      previousContextUsage: {
+        tokens: 650_000,
+        contextWindow: 1_000_000,
+        percent: 65,
+      },
+      currentSessionTokensOverride: 110_000,
+    });
+    assert.equal(decision.decision, "fit");
+    assert.equal(decision.currentSessionTokens, 110_000);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 function appendFakeCompaction(params: {

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 
 import type { PostRunJobRecord, RuntimeStateStore } from "@holaboss/runtime-state-store";
 
+import type { HarnessCatalogModelEntry } from "../../harnesses/src/model-routing.js";
+import { resolveHarnessModelBudget } from "../../harnesses/src/model-routing.js";
 import { resolveRuntimeModelClient } from "./agent-runtime-config.js";
 import { buildRunnerEnv } from "./runner-worker.js";
 import { captureRuntimeException } from "./runtime-sentry.js";
@@ -30,6 +32,7 @@ interface SessionCheckpointJobPayload {
   base_leaf_id: string | null;
   base_latest_compaction_id: string | null;
   context_usage: PiContextUsage;
+  effective_session_tokens: number | null;
 }
 
 export interface PiCompactionCommandResult {
@@ -154,6 +157,8 @@ export interface ForceSessionCompactionResult {
   merged: boolean;
   boundaryWritten: boolean;
   compaction: SessionCheckpointCompactionRecord | null;
+  contextUsage: PiContextUsage | null;
+  effectiveSessionTokens: number | null;
 }
 
 const require = createRequire(import.meta.url);
@@ -165,6 +170,10 @@ const PI_SESSION_MANAGER_MODULE_PATH = path.join(
   "core",
   "session-manager.js",
 );
+const EMPTY_MODEL_CATALOG = Object.create(null) as Record<
+  string,
+  Record<string, HarnessCatalogModelEntry>
+>;
 
 function loadPiSessionManagerModule(): {
   SessionManager: PiSessionManagerStatic;
@@ -241,7 +250,7 @@ function estimateJsonTokens(value: unknown): number | null {
   return Math.ceil(bytes / ESTIMATED_BYTES_PER_TOKEN);
 }
 
-function maxFiniteNumber(...values: Array<number | null | undefined>): number | null {
+export function maxFiniteNumber(...values: Array<number | null | undefined>): number | null {
   let max: number | null = null;
   for (const value of values) {
     if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -318,20 +327,6 @@ function checkpointModelProxyProvider(
   return nonEmptyString(modelClient?.model_proxy_provider);
 }
 
-function normalizeHarnessModelId(modelId: string): string {
-  const normalized = modelId.trim().toLowerCase();
-  if (!normalized) {
-    return "";
-  }
-  if (normalized.startsWith("openai/")) {
-    return normalized.slice("openai/".length);
-  }
-  if (normalized.startsWith("holaboss_model_proxy/")) {
-    return normalized.slice("holaboss_model_proxy/".length);
-  }
-  return normalized;
-}
-
 function selectedModelParts(
   selectedModel: string | null,
 ): { providerId: string; modelId: string } | null {
@@ -349,15 +344,12 @@ function selectedModelParts(
   };
 }
 
-function isOpenAiGpt5Model(modelId: string): boolean {
-  return /^gpt-5(?:[.-]|$)/.test(modelId);
-}
-
 function targetModelContextWindow(params: {
   snapshotPayload: Record<string, unknown> | null;
   selectedModel: string | null;
   fallbackContextWindow?: number | null;
 }): number {
+  const fallback = finiteNumberOrNull(params.fallbackContextWindow);
   const selectedFromSnapshot = params.snapshotPayload
     ? checkpointSelectedModel({
         snapshotPayload: params.snapshotPayload,
@@ -369,60 +361,74 @@ function targetModelContextWindow(params: {
   const selectedParts =
     selectedFromSnapshot ??
     selectedModelParts(params.selectedModel);
-  const modelProxyProvider = checkpointModelProxyProvider(params.snapshotPayload);
   if (selectedParts) {
-    const providerId = selectedParts.providerId.trim().toLowerCase();
-    const normalizedModelId = normalizeHarnessModelId(selectedParts.modelId);
-    const openAiCompat =
-      modelProxyProvider?.trim().toLowerCase() === "openai_compatible";
-    if (openAiCompat && providerId === "openai_codex") {
-      switch (normalizedModelId) {
-        case "gpt-5.5":
-        case "gpt-5.3-codex":
-          return 400_000;
-        case "gpt-5.4":
-        case "gpt-5.4-pro":
-          return 1_000_000;
-        default:
-          break;
-      }
-    }
-    if (
-      openAiCompat &&
-      isOpenAiGpt5Model(normalizedModelId) &&
-      (providerId === "openai_direct" ||
-        providerId === "openai" ||
-        providerId === "holaboss_model_proxy" ||
-        providerId === "holaboss")
-    ) {
-      switch (normalizedModelId) {
-        case "gpt-5.4":
-        case "gpt-5.4-pro":
-          return 1_000_000;
-        case "gpt-5.4-mini":
-          return 1_050_000;
-        case "gpt-5.5":
-        case "gpt-5.2":
-          return 400_000;
-        default:
-          break;
-      }
-    }
+    const snapshotRuntimeConfig = checkpointSnapshotRuntimeConfig(
+      params.snapshotPayload,
+    );
+    const snapshotHarnessRequest =
+      params.snapshotPayload && isRecord(params.snapshotPayload.harness_request)
+        ? params.snapshotPayload.harness_request
+        : null;
+    const runtimeModelClient =
+      snapshotRuntimeConfig && isRecord(snapshotRuntimeConfig.model_client)
+        ? snapshotRuntimeConfig.model_client
+        : null;
+    const harnessModelClient =
+      snapshotHarnessRequest && isRecord(snapshotHarnessRequest.model_client)
+        ? snapshotHarnessRequest.model_client
+        : null;
+    return resolveHarnessModelBudget(
+      {
+        provider_id: selectedParts.providerId,
+        model_id: selectedParts.modelId,
+        model_client: {
+          model_proxy_provider:
+            nonEmptyString(runtimeModelClient?.model_proxy_provider) ??
+            nonEmptyString(harnessModelClient?.model_proxy_provider) ??
+            checkpointModelProxyProvider(params.snapshotPayload) ??
+            "",
+          api_key: "",
+          base_url:
+            nonEmptyString(runtimeModelClient?.base_url) ??
+            nonEmptyString(harnessModelClient?.base_url) ??
+            "https://checkpoint.invalid",
+          default_headers:
+            Object.keys(stringRecord(runtimeModelClient?.default_headers)).length > 0
+              ? stringRecord(runtimeModelClient?.default_headers)
+              : stringRecord(harnessModelClient?.default_headers),
+        },
+      },
+      {
+        modelCatalog: EMPTY_MODEL_CATALOG,
+        ...(fallback !== null && fallback > 0
+          ? {
+              fallbackBudget: {
+                contextWindow: fallback,
+                maxTokens: 128_000,
+              },
+            }
+          : {}),
+      },
+    ).contextWindow;
   }
-  const fallback = finiteNumberOrNull(params.fallbackContextWindow);
-  if (fallback !== null && fallback > 0) {
-    return fallback;
-  }
-  return DEFAULT_PRE_RUN_CONTEXT_WINDOW;
+  return fallback !== null && fallback > 0
+    ? fallback
+    : DEFAULT_PRE_RUN_CONTEXT_WINDOW;
 }
 
-function estimateSessionContextTokens(sessionFile: string): number | null {
+export function estimateSessionContextTokens(sessionFile: string): number | null {
   const sessionManager = openSessionManager(sessionFile);
   const sessionContext = sessionManager.buildSessionContext?.();
   const messages = Array.isArray(sessionContext?.messages)
     ? sessionContext.messages
     : null;
   return messages ? estimateJsonTokens(messages) : null;
+}
+
+export function effectiveSessionTokenCount(
+  values: Array<number | null | undefined>,
+): number | null {
+  return maxFiniteNumber(...values);
 }
 
 function estimateSnapshotRequestTokens(
@@ -460,6 +466,22 @@ function normalizePiContextUsage(value: unknown): PiContextUsage | null {
     contextWindow,
     percent,
   };
+}
+
+export function effectiveSessionTokensFromContextBudgetDecisions(
+  value: unknown,
+): number | null {
+  const decisions = isRecord(value) ? value : null;
+  const preRunCompaction =
+    decisions && isRecord(decisions.pre_run_compaction)
+      ? decisions.pre_run_compaction
+      : null;
+  return effectiveSessionTokenCount([
+    finiteNumberOrNull(decisions?.effective_session_tokens),
+    finiteNumberOrNull(preRunCompaction?.after_session_tokens),
+    finiteNumberOrNull(preRunCompaction?.before_session_tokens),
+    normalizePiContextUsage(decisions?.context_usage)?.tokens,
+  ]);
 }
 
 export function sessionCheckpointThresholdTokens(
@@ -509,11 +531,16 @@ function recordSessionCheckpointResult(params: {
   });
 }
 
-export function shouldQueueSessionCheckpoint(contextUsage: PiContextUsage | null): boolean {
+export function shouldQueueSessionCheckpoint(
+  contextUsage: PiContextUsage | null,
+  effectiveSessionTokens: number | null = finiteNumberOrNull(
+    contextUsage?.tokens,
+  ),
+): boolean {
   if (
     !contextUsage ||
-    contextUsage.tokens == null ||
-    !Number.isFinite(contextUsage.tokens) ||
+    effectiveSessionTokens == null ||
+    !Number.isFinite(effectiveSessionTokens) ||
     !Number.isFinite(contextUsage.contextWindow) ||
     contextUsage.contextWindow <= 0
   ) {
@@ -522,7 +549,7 @@ export function shouldQueueSessionCheckpoint(contextUsage: PiContextUsage | null
   const thresholdTokens = sessionCheckpointThresholdTokens(
     contextUsage.contextWindow,
   );
-  return thresholdTokens !== null && contextUsage.tokens > thresholdTokens;
+  return thresholdTokens !== null && effectiveSessionTokens > thresholdTokens;
 }
 
 export function evaluatePreRunSessionCompaction(params: {
@@ -531,6 +558,7 @@ export function evaluatePreRunSessionCompaction(params: {
   selectedModel: string | null;
   previousSelectedModel: string | null;
   previousContextUsage: PiContextUsage | null;
+  currentSessionTokensOverride?: number | null;
 }): PreRunSessionCompactionDecision {
   const previousContextWindow =
     finiteNumberOrNull(params.previousContextUsage?.contextWindow) ?? null;
@@ -539,10 +567,12 @@ export function evaluatePreRunSessionCompaction(params: {
     selectedModel: params.selectedModel,
     fallbackContextWindow: previousContextWindow,
   });
-  const currentSessionTokens = maxFiniteNumber(
-    finiteNumberOrNull(params.previousContextUsage?.tokens),
-    estimateSessionContextTokens(params.liveSessionFile),
-  );
+  const currentSessionTokens =
+    finiteNumberOrNull(params.currentSessionTokensOverride) ??
+    maxFiniteNumber(
+      finiteNumberOrNull(params.previousContextUsage?.tokens),
+      estimateSessionContextTokens(params.liveSessionFile),
+    );
   const estimatedRequestTokens = estimateSnapshotRequestTokens(params.snapshotPayload);
   const projectedTotalTokens =
     currentSessionTokens !== null && estimatedRequestTokens !== null
@@ -660,14 +690,25 @@ export function enqueueSessionCheckpointJob(params: {
   harness: string;
   harnessSessionId: string | null;
   contextUsage: PiContextUsage | null;
+  effectiveSessionTokens?: number | null;
   wakeWorker?: (() => void) | null;
   sessionOps?: SessionCheckpointSessionOps;
 }): PostRunJobRecord | null {
   const harnessSessionId = nonEmptyString(params.harnessSessionId);
-  if (!harnessSessionId || !shouldQueueSessionCheckpoint(params.contextUsage)) {
+  if (!harnessSessionId) {
     return null;
   }
   if (!fs.existsSync(harnessSessionId)) {
+    return null;
+  }
+  const effectiveSessionTokens = effectiveSessionTokenCount([
+    params.effectiveSessionTokens,
+    params.contextUsage?.tokens,
+    estimateSessionContextTokens(harnessSessionId),
+  ]);
+  if (
+    !shouldQueueSessionCheckpoint(params.contextUsage, effectiveSessionTokens)
+  ) {
     return null;
   }
   const checkpointState = (
@@ -696,6 +737,7 @@ export function enqueueSessionCheckpointJob(params: {
       base_leaf_id: checkpointState.leafId,
       base_latest_compaction_id: checkpointState.latestCompactionId,
       context_usage: params.contextUsage,
+      effective_session_tokens: effectiveSessionTokens,
     },
   });
   params.wakeWorker?.();
@@ -710,6 +752,10 @@ function decodeSessionCheckpointJobPayload(value: unknown): SessionCheckpointJob
   const baseLeafId = nonEmptyString(payload.base_leaf_id);
   const baseLatestCompactionId = nonEmptyString(payload.base_latest_compaction_id);
   const contextUsage = normalizePiContextUsage(payload.context_usage);
+  const effectiveSessionTokens = effectiveSessionTokenCount([
+    finiteNumberOrNull(payload.effective_session_tokens),
+    contextUsage?.tokens,
+  ]);
   if (!harness || !baseHarnessSessionId || !baseSessionFingerprint || !contextUsage) {
     throw new Error("session checkpoint payload is missing required fields");
   }
@@ -720,6 +766,7 @@ function decodeSessionCheckpointJobPayload(value: unknown): SessionCheckpointJob
     base_leaf_id: baseLeafId,
     base_latest_compaction_id: baseLatestCompactionId,
     context_usage: contextUsage,
+    effective_session_tokens: effectiveSessionTokens,
   };
 }
 
@@ -877,6 +924,15 @@ function summarizeCheckpointCompactionResult(
       ? (jsonValue(result.error) as Record<string, unknown>)
       : null,
   };
+}
+
+function compactionResultContextUsage(
+  result: PiCompactionCommandResult | null | undefined,
+): PiContextUsage | null {
+  const diagnostics = result && isRecord(result.diagnostics)
+    ? result.diagnostics
+    : null;
+  return normalizePiContextUsage(diagnostics?.context_usage);
 }
 
 function compactionResultFromError(
@@ -1141,6 +1197,10 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
           },
         );
         const compaction = summarizeCheckpointCompactionResult(result);
+        const contextUsage = compactionResultContextUsage(result);
+        const effectiveSessionTokens = effectiveSessionTokenCount([
+          contextUsage?.tokens,
+        ]);
         if (!result.compacted) {
           return {
             outcome: "not_compacted",
@@ -1148,6 +1208,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
             merged: false,
             boundaryWritten: false,
             compaction,
+            contextUsage,
+            effectiveSessionTokens,
           };
         }
         const latestHarnessSessionId =
@@ -1162,6 +1224,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
             merged: false,
             boundaryWritten: false,
             compaction,
+            contextUsage,
+            effectiveSessionTokens,
           };
         }
         if (!fs.existsSync(liveSessionPath)) {
@@ -1171,6 +1235,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
             merged: false,
             boundaryWritten: false,
             compaction,
+            contextUsage,
+            effectiveSessionTokens,
           };
         }
         if (
@@ -1186,6 +1252,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
             merged: false,
             boundaryWritten: false,
             compaction,
+            contextUsage,
+            effectiveSessionTokens,
           };
         }
         const merged = sessionOps.appendSnapshotCompactionToLiveSession({
@@ -1200,6 +1268,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
             merged: false,
             boundaryWritten: false,
             compaction,
+            contextUsage,
+            effectiveSessionTokens,
           };
         }
         return {
@@ -1207,6 +1277,8 @@ export async function forceCompactSessionWithSnapshotMerge(params: {
           merged: true,
           boundaryWritten: false,
           compaction,
+          contextUsage,
+          effectiveSessionTokens,
         };
       } finally {
         maybeDeleteFile(compactedSessionPath);
@@ -1230,7 +1302,12 @@ export async function processSessionCheckpointJob(params: {
   }
   const payload = decodeSessionCheckpointJobPayload(params.record.payload);
   const sessionOps = params.sessionOps ?? defaultSessionCheckpointSessionOps;
-  if (!shouldQueueSessionCheckpoint(payload.context_usage)) {
+  if (
+    !shouldQueueSessionCheckpoint(
+      payload.context_usage,
+      payload.effective_session_tokens,
+    )
+  ) {
     recordSessionCheckpointResult({
       store: params.store,
       record: params.record,

--- a/runtime/harnesses/src/model-routing.ts
+++ b/runtime/harnesses/src/model-routing.ts
@@ -603,6 +603,28 @@ function catalogModelCostForRequest(params: {
   return globalMatches.size === 1 ? Array.from(globalMatches.values())[0] ?? null : null;
 }
 
+export function resolveHarnessModelBudget(
+  request: HarnessModelRoutingRequest,
+  options: {
+    modelCatalog: Record<string, Record<string, HarnessCatalogModelEntry>>;
+    fallbackBudget?: HarnessModelBudget;
+  },
+): HarnessModelBudget {
+  const api = resolveHarnessModelApi(request);
+  return (
+    knownModelBudgetOverride(request, api) ??
+    catalogModelBudgetForRequest({
+      request,
+      api,
+      modelCatalog: options.modelCatalog,
+    }) ??
+    options.fallbackBudget ?? {
+      contextWindow: DEFAULT_FALLBACK_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_FALLBACK_MAX_TOKENS,
+    }
+  );
+}
+
 export function resolveHarnessModelProfile(
   request: HarnessModelRoutingRequest,
   options: {
@@ -630,17 +652,7 @@ export function resolveHarnessModelProfile(
   const requestedThinkingLevel = requestedHarnessThinkingLevel(request);
   const requestedThinkingBudgets = requestedHarnessThinkingBudgets(request);
   const requestedCompat = api === "openai-completions" ? requestedOpenAiCompat(request) : undefined;
-  const budget =
-    knownModelBudgetOverride(request, api) ??
-    catalogModelBudgetForRequest({
-      request,
-      api,
-      modelCatalog: options.modelCatalog,
-    }) ??
-    options.fallbackBudget ?? {
-      contextWindow: DEFAULT_FALLBACK_CONTEXT_WINDOW,
-      maxTokens: DEFAULT_FALLBACK_MAX_TOKENS,
-    };
+  const budget = resolveHarnessModelBudget(request, options);
   const cost =
     catalogModelCostForRequest({
       request,


### PR DESCRIPTION
## Summary
- share harness model-window resolution between runtime routing and pre-run compaction checks
- persist `effective_session_tokens` and reuse compaction diagnostics instead of re-estimating after forced compaction
- add regression coverage for checkpoint gating and final fit after forced compaction

## Validation
- `git diff --check`
- live desktop repro in workspace `vibe-code-compact`
- fresh main session with delegated build -> auto-queued polish -> tiny `continue` follow-up on `openai_codex/gpt-5.5`
- observed pre-run compaction on the codex follow-up with `before_session_tokens = 182133`, `after_session_tokens = 86208`, and `reset_required = false`

## Notes
- automated package tests were not rerun here; prior `bun x tsc --noEmit -p runtime/api-server/tsconfig.json` is still blocked by existing local toolchain/config issues outside this patch
