### PR TITLE
feat(integrations+onboarding): end-to-end integration UX overhaul

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9781,6 +9781,37 @@ async function archiveBackgroundTask(
   );
 }
 
+async function continueBackgroundTask(
+  payload: ContinueBackgroundTaskPayload,
+): Promise<ContinueBackgroundTaskResponsePayload> {
+  if (!payload.workspaceId.trim()) {
+    throw new Error("workspaceId is required");
+  }
+  if (!payload.subagentId.trim()) {
+    throw new Error("subagentId is required");
+  }
+  if (!payload.ownerMainSessionId.trim()) {
+    throw new Error("ownerMainSessionId is required");
+  }
+  const instruction = payload.instruction.trim();
+  if (!instruction) {
+    throw new Error("instruction is required");
+  }
+  return requestWorkspaceRuntimeJson<ContinueBackgroundTaskResponsePayload>(
+    payload.workspaceId,
+    {
+      method: "POST",
+      path: `/api/v1/capabilities/runtime-tools/subagents/${encodeURIComponent(payload.subagentId)}/continue`,
+      payload: {
+        workspace_id: payload.workspaceId,
+        session_id: payload.ownerMainSessionId,
+        instruction,
+        title: payload.title ?? undefined,
+      },
+    },
+  );
+}
+
 async function acceptTaskProposal(
   payload: TaskProposalAcceptPayload,
 ): Promise<TaskProposalAcceptResponsePayload> {
@@ -10371,23 +10402,6 @@ async function listAllWorkspaceIntegrationOverrides(): Promise<{
   }>({
     method: "GET",
     path: "/api/v1/integrations/all-workspace-overrides",
-  });
-}
-
-async function listComposioToolkitCapabilities(): Promise<{
-  toolkits: Record<
-    string,
-    Array<{ name: string; description: string; tool_slug: string; read_only: boolean }>
-  >;
-}> {
-  return requestRuntimeJson<{
-    toolkits: Record<
-      string,
-      Array<{ name: string; description: string; tool_slug: string; read_only: boolean }>
-    >;
-  }>({
-    method: "GET",
-    path: "/api/v1/integrations/composio-capabilities",
   });
 }
 
@@ -23810,6 +23824,12 @@ app.whenReady().then(async () => {
       archiveBackgroundTask(payload),
   );
   handleTrustedIpc(
+    "workspace:continueBackgroundTask",
+    ["main"],
+    async (_event, payload: ContinueBackgroundTaskPayload) =>
+      continueBackgroundTask(payload),
+  );
+  handleTrustedIpc(
     "workspace:acceptTaskProposal",
     ["main"],
     async (_event, payload: TaskProposalAcceptPayload) =>
@@ -24032,11 +24052,6 @@ app.whenReady().then(async () => {
     "workspace:listConnectionWorkspaceUsage",
     ["main"],
     async () => listConnectionWorkspaceUsage(),
-  );
-  handleTrustedIpc(
-    "workspace:listComposioToolkitCapabilities",
-    ["main"],
-    async () => listComposioToolkitCapabilities(),
   );
   handleTrustedIpc(
     "workspace:listIntegrationStoreCatalog",

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1016,17 +1016,6 @@ interface ConnectionWorkspaceUsagePayload {
   usage: ConnectionWorkspaceUsageEntry[];
 }
 
-interface ComposioToolkitCapability {
-  name: string;
-  description: string;
-  tool_slug: string;
-  read_only: boolean;
-}
-
-interface ComposioToolkitCapabilitiesPayload {
-  toolkits: Record<string, ComposioToolkitCapability[]>;
-}
-
 interface IntegrationStoreCatalogEntry {
   slug: string;
   tier: "hero" | "supported";
@@ -1486,6 +1475,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:listBackgroundTasks", payload) as Promise<BackgroundTaskListResponsePayload>,
     archiveBackgroundTask: (payload: ArchiveBackgroundTaskPayload) =>
       ipcRenderer.invoke("workspace:archiveBackgroundTask", payload) as Promise<ArchiveBackgroundTaskResponsePayload>,
+    continueBackgroundTask: (payload: ContinueBackgroundTaskPayload) =>
+      ipcRenderer.invoke("workspace:continueBackgroundTask", payload) as Promise<ContinueBackgroundTaskResponsePayload>,
     acceptTaskProposal: (payload: TaskProposalAcceptPayload) =>
       ipcRenderer.invoke("workspace:acceptTaskProposal", payload) as Promise<TaskProposalAcceptResponsePayload>,
     updateTaskProposalState: (workspaceId: string, proposalId: string, state: string) =>
@@ -1587,8 +1578,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("workspace:deleteIntegrationBinding", bindingId, workspaceId) as Promise<{ deleted: boolean }>,
     listConnectionWorkspaceUsage: () =>
       ipcRenderer.invoke("workspace:listConnectionWorkspaceUsage") as Promise<ConnectionWorkspaceUsagePayload>,
-    listComposioToolkitCapabilities: () =>
-      ipcRenderer.invoke("workspace:listComposioToolkitCapabilities") as Promise<ComposioToolkitCapabilitiesPayload>,
     listIntegrationStoreCatalog: () =>
       ipcRenderer.invoke("workspace:listIntegrationStoreCatalog") as Promise<IntegrationStoreCatalogPayload>,
     listAllWorkspaceIntegrationOverrides: () =>

--- a/apps/desktop/src/components/auth/CodexOAuthModal.tsx
+++ b/apps/desktop/src/components/auth/CodexOAuthModal.tsx
@@ -182,7 +182,7 @@ export function CodexOAuthModal({
                     )}
                     aria-label="Copy device code"
                   >
-                    <span className="font-mono text-lg font-semibold tracking-[0.18em] text-foreground">
+                    <span className="font-mono text-lg font-semibold text-foreground">
                       {userCode}
                     </span>
                     <span className="flex items-center gap-1 text-xs text-muted-foreground transition-colors group-hover:text-foreground">

--- a/apps/desktop/src/components/integration/IntegrationLogo.tsx
+++ b/apps/desktop/src/components/integration/IntegrationLogo.tsx
@@ -1,6 +1,6 @@
 import { Plug } from "lucide-react";
 import { useState } from "react";
-import { getIntegrationLogo } from "@/lib/integrationLogo";
+import { brandLogoOverride, getIntegrationLogo } from "@/lib/integrationLogo";
 import { cn } from "@/lib/utils";
 
 /**
@@ -30,9 +30,13 @@ export function IntegrationLogo({
   overrideUrl?: string | null;
 }) {
   const [failed, setFailed] = useState(false);
+  const brandOverride = brandLogoOverride(slug);
   const fromCatalog = overrideUrl?.trim() || null;
   const fromCdn = getIntegrationLogo(slug).url;
-  const url = fromCatalog || fromCdn;
+  // Brand override wins over caller-provided URL because the Composio
+  // toolkit.logo for these slugs (github, linear) is itself broken — see
+  // bd82591c. Otherwise the caller's URL wins over the CDN guess.
+  const url = brandOverride ?? fromCatalog ?? fromCdn;
   const sizeClass =
     size === "sm" ? "size-6" : size === "lg" ? "size-8" : "size-7";
 

--- a/apps/desktop/src/components/layout/AppShell.tsx
+++ b/apps/desktop/src/components/layout/AppShell.tsx
@@ -1295,7 +1295,7 @@ function FocusPlaceholder({
         <div className="mt-3 text-[28px] font-semibold text-foreground">
           {title}
         </div>
-        <div className="mt-3 text-[13px] leading-7 text-muted-foreground">
+        <div className="mt-3 text-[13px] text-muted-foreground">
           {description}
         </div>
       </div>
@@ -1354,8 +1354,7 @@ function WorkspaceOnboardingTakeover({
   focusRequestKey: number;
 }) {
   return (
-    <section className="relative flex h-full min-h-0 min-w-0 overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_16%,rgba(247,90,84,0.1),transparent_28%),radial-gradient(circle_at_88%_10%,rgba(247,170,126,0.08),transparent_24%),radial-gradient(circle_at_50%_100%,rgba(247,90,84,0.06),transparent_34%)]" />
+    <section className="relative flex h-full min-h-0 min-w-0 overflow-hidden bg-background">
       <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
         <WorkspaceOnboardingSurface
           onOpenOutput={onOpenOutput}

--- a/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
@@ -207,6 +207,7 @@ function SidebarExpanded() {
           </motion.div>
         </AnimatePresence>
       </div>
+      <SidebarGlobalFooter />
     </aside>
   );
 }
@@ -315,10 +316,7 @@ function SidebarSectionNav() {
 
 function SidebarHomeSection() {
   const { selectedWorkspaceId } = useWorkspaceSelection();
-  const setSettingsOpen = useSetAtom(settingsOpenAtom);
   const setSearchOpen = useSetAtom(searchOpenAtom);
-  const setSettingsSection = useSetAtom(settingsSectionAtom);
-  const settingsOpen = useAtomValue(settingsOpenAtom);
 
   const skills = useWorkspaceSkills(selectedWorkspaceId || null);
   const cronjobs = useWorkspaceCronjobs(selectedWorkspaceId || null);
@@ -399,21 +397,32 @@ function SidebarHomeSection() {
           ) : null}
         </SidebarGroup>
       ) : null}
+    </div>
+  );
+}
 
-      <div className="mt-auto" />
-
-      <SidebarGroup>
-        <NavItem
-          icon={<Settings />}
-          active={settingsOpen}
-          onClick={() => {
-            setSettingsSection("settings");
-            setSettingsOpen(true);
-          }}
-        >
-          Settings
-        </NavItem>
-      </SidebarGroup>
+// Settings is an app-global entry point, not a Home-tab item. Rendered as
+// a persistent sidebar footer (outside the per-section content block)
+// so it stays reachable from any tab — matches Linear / Notion / Slack's
+// sidebar pattern. Previously it lived inside SidebarHomeSection, which
+// (1) made Settings vanish whenever the user switched away from Home,
+// and (2) read like Settings somehow belonged to "Home" semantically.
+function SidebarGlobalFooter() {
+  const setSettingsOpen = useSetAtom(settingsOpenAtom);
+  const setSettingsSection = useSetAtom(settingsSectionAtom);
+  const settingsOpen = useAtomValue(settingsOpenAtom);
+  return (
+    <div className="shrink-0 border-t border-sidebar-border px-2 py-1.5">
+      <NavItem
+        icon={<Settings />}
+        active={settingsOpen}
+        onClick={() => {
+          setSettingsSection("settings");
+          setSettingsOpen(true);
+        }}
+      >
+        Settings
+      </NavItem>
     </div>
   );
 }

--- a/apps/desktop/src/components/panes/BackgroundTasksPane.tsx
+++ b/apps/desktop/src/components/panes/BackgroundTasksPane.tsx
@@ -6,6 +6,7 @@ import {
   Clock3,
   Loader2,
   Pause,
+  RotateCw,
   Trash2,
   X,
 } from "lucide-react";
@@ -173,6 +174,7 @@ export function BackgroundTasksPane({
   const [errorMessage, setErrorMessage] = useState("");
   const [inlineExpanded, setInlineExpanded] = useState(false);
   const [removingTaskId, setRemovingTaskId] = useState<string | null>(null);
+  const [continuingTaskId, setContinuingTaskId] = useState<string | null>(null);
 
   const refreshTasks = useCallback(
     async (options?: { showLoading?: boolean }) => {
@@ -275,11 +277,67 @@ export function BackgroundTasksPane({
     [activeWorkspaceId, removingTaskId],
   );
 
+  const handleContinueTask = useCallback(
+    async (task: BackgroundTaskRecordPayload) => {
+      if (!activeWorkspaceId || continuingTaskId === task.subagent_id) {
+        return;
+      }
+      const ownerSessionId = (
+        task.owner_main_session_id ??
+        activeOwnerMainSessionId ??
+        ""
+      ).trim();
+      if (!ownerSessionId) {
+        setErrorMessage(
+          "Cannot continue this task — main session is unknown.",
+        );
+        return;
+      }
+      const instruction =
+        task.goal.trim() || "Please continue this task from where it stopped.";
+      setContinuingTaskId(task.subagent_id);
+      try {
+        await window.electronAPI.workspace.continueBackgroundTask({
+          workspaceId: activeWorkspaceId,
+          subagentId: task.subagent_id,
+          ownerMainSessionId: ownerSessionId,
+          instruction,
+        });
+        setTasks((current) =>
+          current.map((item) =>
+            item.subagent_id === task.subagent_id
+              ? { ...item, status: "queued" }
+              : item,
+          ),
+        );
+        setErrorMessage("");
+        void refreshTasks({ showLoading: false });
+      } catch (error) {
+        setErrorMessage(normalizeErrorMessage(error));
+      } finally {
+        setContinuingTaskId((current) =>
+          current === task.subagent_id ? null : current,
+        );
+      }
+    },
+    [
+      activeOwnerMainSessionId,
+      activeWorkspaceId,
+      continuingTaskId,
+      refreshTasks,
+    ],
+  );
+
   const sortedTasks = sortBackgroundTasks(tasks);
 
   function canRemoveTask(task: BackgroundTaskRecordPayload) {
     const status = task.status.trim().toLowerCase();
     return status !== "queued" && status !== "running";
+  }
+
+  function canContinueTask(task: BackgroundTaskRecordPayload) {
+    const status = task.status.trim().toLowerCase();
+    return status === "failed" || status === "cancelled";
   }
 
   if (variant === "inline") {
@@ -340,6 +398,7 @@ export function BackgroundTasksPane({
                     typeof onOpenTaskSession === "function" &&
                     Boolean(task.child_session_id.trim());
                   const showRemoveAction = canRemoveTask(task);
+                  const showContinueAction = canContinueTask(task);
                   const taskBody = (
                     <div className="flex min-w-0 items-center gap-2">
                       <span
@@ -368,6 +427,23 @@ export function BackgroundTasksPane({
                       ) : (
                         <div className="min-w-0 flex-1">{taskBody}</div>
                       )}
+                      {showContinueAction ? (
+                        <button
+                          type="button"
+                          aria-label={`Retry background task ${task.title.trim() || task.subagent_id}`}
+                          disabled={continuingTaskId === task.subagent_id}
+                          onClick={() => {
+                            void handleContinueTask(task);
+                          }}
+                          className="shrink-0 rounded-full p-1 text-muted-foreground transition hover:bg-muted-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {continuingTaskId === task.subagent_id ? (
+                            <Loader2 size={12} className="animate-spin" />
+                          ) : (
+                            <RotateCw size={12} />
+                          )}
+                        </button>
+                      ) : null}
                       {showRemoveAction ? (
                         <button
                           type="button"
@@ -440,6 +516,7 @@ export function BackgroundTasksPane({
                 typeof onOpenTaskSession === "function" &&
                 Boolean(task.child_session_id.trim());
               const showRemoveAction = canRemoveTask(task);
+              const showContinueAction = canContinueTask(task);
               const taskBody = (
                 <div className="flex min-w-0 items-center gap-2">
                   <span
@@ -468,6 +545,23 @@ export function BackgroundTasksPane({
                   ) : (
                     <div className="min-w-0 flex-1">{taskBody}</div>
                   )}
+                  {showContinueAction ? (
+                    <button
+                      type="button"
+                      aria-label={`Retry background task ${task.title.trim() || task.subagent_id}`}
+                      disabled={continuingTaskId === task.subagent_id}
+                      onClick={() => {
+                        void handleContinueTask(task);
+                      }}
+                      className="shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:bg-fg-8 hover:text-foreground focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {continuingTaskId === task.subagent_id ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : (
+                        <RotateCw size={12} />
+                      )}
+                    </button>
+                  ) : null}
                   {showRemoveAction ? (
                     <button
                       type="button"

--- a/apps/desktop/src/components/panes/BrowserPane.tsx
+++ b/apps/desktop/src/components/panes/BrowserPane.tsx
@@ -509,7 +509,7 @@ export function BrowserPane({
           }}
           className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-foreground ${
             depth === 0
-              ? "text-[10px] font-medium uppercase tracking-[0.08em]"
+              ? "text-[10px] font-medium"
               : "text-xs"
           }`}
           style={depth > 0 ? { paddingLeft: `${10 + depth * 14}px` } : undefined}
@@ -1080,7 +1080,7 @@ export function BrowserPane({
                     sideOffset={6}
                     className="max-h-80 w-80 gap-0 overflow-y-auto p-1"
                   >
-                    <div className="px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                    <div className="px-2.5 py-1 text-[10px] font-medium text-muted-foreground">
                       Imported folders
                     </div>
                     {bookmarkTree.folders.map((folder) => renderBookmarkFolder(folder))}

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/IntegrationProposalCard.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/IntegrationProposalCard.tsx
@@ -1,8 +1,9 @@
-import { Check, LoaderCircle, Plug } from "lucide-react";
+import { Check, LoaderCircle, Plug, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { rebindWorkspaceAppsForProvider } from "@/lib/rebindWorkspaceAppsForProvider";
+import { useIntegrationConnect } from "@/lib/useIntegrationConnect";
 
 export interface AssistantTurnProposedIntegration {
   toolkit_slug: string;
@@ -51,17 +52,32 @@ function IntegrationProposalCard({
   workspaceId: string | null;
   onAfterConnect?: (toolkitSlug: string) => void;
 }) {
-  const { composioToolkitsByProvider, connectIntegrationProvider } =
-    useWorkspaceDesktop();
+  const { composioToolkitsByProvider } = useWorkspaceDesktop();
   const slug = proposal.toolkit_slug.trim().toLowerCase();
   const toolkit = composioToolkitsByProvider[slug];
   const displayName = toolkit?.name ?? proposal.toolkit_slug;
   const logo = toolkit?.logo ?? `https://logos.composio.dev/api/${slug}`;
 
-  const [phase, setPhase] = useState<"idle" | "connecting" | "done" | "error">(
-    "idle",
-  );
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { status, connect, cancel } = useIntegrationConnect({
+    onDone: async (connectionId) => {
+      if (workspaceId) {
+        await rebindWorkspaceAppsForProvider({
+          workspaceId,
+          provider: slug,
+          connectionId,
+        });
+      }
+    },
+  });
+  // Cancelled state maps to idle for the UI — the user actively backed
+  // out, no need to render a "Cancelled" badge.
+  const phase = status.kind === "cancelled" ? "idle" : status.kind;
+  const errorMessage =
+    status.kind === "error"
+      ? status.error instanceof Error
+        ? status.error.message
+        : "Connection failed."
+      : null;
 
   // Local `phase` resets to "idle" on every mount, so the post-connect "done"
   // confirmation would vanish on app restart. Source the connected-state from
@@ -92,32 +108,15 @@ function IntegrationProposalCard({
   }, [slug]);
 
   const handleConnect = async () => {
-    if (!workspaceId) {
-      setErrorMessage("Open a workspace before connecting.");
-      setPhase("error");
-      return;
-    }
-    setPhase("connecting");
-    setErrorMessage(null);
-    try {
-      const { connectionId } = await connectIntegrationProvider({
-        provider: slug,
-        accountLabel: `${displayName} (Managed)`,
-      });
-      if (workspaceId && connectionId) {
-        await rebindWorkspaceAppsForProvider({
-          workspaceId,
-          provider: slug,
-          connectionId,
-        });
-      }
-      setPhase("done");
+    if (!workspaceId) return;
+    const outcome = await connect({ provider: slug, accountLabel: displayName });
+    if (outcome.kind === "done") {
       onAfterConnect?.(slug);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Connection failed.";
-      setErrorMessage(msg);
-      setPhase("error");
     }
+  };
+
+  const handleCancel = () => {
+    cancel();
   };
 
   // Wait for the readiness check before rendering, otherwise the Connect
@@ -196,23 +195,35 @@ function IntegrationProposalCard({
             </div>
           )}
         </div>
-        <Button
-          className="h-7 px-3 text-xs"
-          disabled={phase === "connecting" || !workspaceId}
-          onClick={() => void handleConnect()}
-          size="sm"
-          type="button"
-          variant="default"
-        >
-          {phase === "connecting" ? (
-            <>
-              <LoaderCircle className="mr-1 size-3 animate-spin" />
+        {phase === "connecting" ? (
+          <div className="flex shrink-0 items-center gap-1">
+            <div className="inline-flex h-7 items-center gap-1 px-2 text-xs text-muted-foreground">
+              <LoaderCircle className="size-3 animate-spin" />
               Connecting…
-            </>
-          ) : (
-            "Connect"
-          )}
-        </Button>
+            </div>
+            <Button
+              aria-label="Cancel connection"
+              className="h-7 w-7 p-0"
+              onClick={handleCancel}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+        ) : (
+          <Button
+            className="h-7 px-3 text-xs"
+            disabled={!workspaceId}
+            onClick={() => void handleConnect()}
+            size="sm"
+            type="button"
+            variant="default"
+          >
+            Connect
+          </Button>
+        )}
       </div>
       {errorMessage ? (
         <div className="rounded-md bg-destructive/10 px-2 py-1 text-[11px] text-destructive">

--- a/apps/desktop/src/components/panes/ChatPane/Composer/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/Composer/index.tsx
@@ -953,7 +953,7 @@ export function Composer({
                 ? disabledReason || "Chat unavailable right now"
                 : placeholder
             }
-            className="composer-input block max-h-[220px] min-h-[40px] w-full resize-none overflow-y-auto bg-transparent text-sm leading-7 text-foreground outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed disabled:opacity-55"
+            className="composer-input block max-h-[220px] min-h-[40px] w-full resize-none overflow-y-auto bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed disabled:opacity-55"
           />
         </div>
 

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -7949,7 +7949,7 @@ export function ChatPane({
         <div className="space-y-5 px-5 py-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <div className="text-[10px] font-medium text-muted-foreground">
                 {`Question ${safeOnboardingQuestionSlideIndex + 1}/${alignmentQuestionCount} (${unansweredAlignmentQuestionCount} unanswered)`}
               </div>
               {activeAlignmentQuestion.title || alignmentQuestion?.title ? (
@@ -7989,7 +7989,7 @@ export function ChatPane({
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {option.recommended ? (
-                      <div className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-primary">
+                      <div className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
                         Recommended
                       </div>
                     ) : null}
@@ -8008,7 +8008,7 @@ export function ChatPane({
           </div>
           {activeAlignmentQuestion.allowFreeform ? (
             <div className="space-y-2">
-              <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              <div className="text-xs font-medium text-muted-foreground">
                 Natural language response
               </div>
               <textarea
@@ -8099,14 +8099,14 @@ export function ChatPane({
         <div className="space-y-4 px-5 py-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <div className="text-[10px] font-medium text-muted-foreground">
                 Alignment report
               </div>
               <div className="mt-1 text-sm font-medium text-foreground">
                 Review before implementation starts
               </div>
             </div>
-            <div className="rounded-full bg-primary/10 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-primary">
+            <div className="rounded-full bg-primary/10 px-2.5 py-1 text-[10px] font-medium text-primary">
               Awaiting review
             </div>
           </div>
@@ -8127,7 +8127,7 @@ export function ChatPane({
                 <div className="space-y-3">
                   {alignmentReportDetails.map((entry) => (
                     <div key={entry.key}>
-                      <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      <div className="text-[11px] font-medium text-muted-foreground">
                         {entry.label}
                       </div>
                       <div className="mt-1 space-y-1 text-sm leading-6 text-muted-foreground">
@@ -8195,14 +8195,14 @@ export function ChatPane({
         <div className="space-y-4 px-5 py-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <div className="text-[10px] font-medium text-muted-foreground">
                 Verification report
               </div>
               <div className="mt-1 text-sm font-medium text-foreground">
                 Review before final merge
               </div>
             </div>
-            <div className="rounded-full bg-primary/10 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-primary">
+            <div className="rounded-full bg-primary/10 px-2.5 py-1 text-[10px] font-medium text-primary">
               Awaiting acceptance
             </div>
           </div>
@@ -8223,7 +8223,7 @@ export function ChatPane({
                 <div className="space-y-3">
                   {verificationReportDetails.map((entry) => (
                     <div key={entry.key}>
-                      <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      <div className="text-[11px] font-medium text-muted-foreground">
                         {entry.label}
                       </div>
                       <div className="mt-1 space-y-1 text-sm leading-6 text-muted-foreground">

--- a/apps/desktop/src/components/panes/ChatPane/skeletons.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/skeletons.tsx
@@ -1,16 +1,13 @@
 import { Check, ChevronRight, CircleAlert, RotateCw } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { OAuthWaitIndicator } from "@/components/integration/OAuthWaitIndicator";
 import {
   type IntegrationErrorCopy,
   resolveIntegrationError,
 } from "@/lib/integrationErrorMessages";
 import { toolkitDisplayName } from "@/lib/toolkitDisplay";
+import { useIntegrationConnect } from "@/lib/useIntegrationConnect";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
-import {
-  IntegrationConnectCancelled,
-  useWorkspaceDesktop,
-} from "@/lib/workspaceDesktop";
 import { rebindWorkspaceAppsForProvider } from "@/lib/rebindWorkspaceAppsForProvider";
 
 export function HistoryRestoreSkeleton() {
@@ -155,38 +152,12 @@ function IntegrationErrorBannerBody({
     error: errorText,
   });
 
-  const { connectIntegrationProvider } = useWorkspaceDesktop();
   const { selectedWorkspaceId } = useWorkspaceSelection();
-  const [phase, setPhase] = useState<"idle" | "connecting" | "done" | "error">(
-    "idle",
-  );
   const [reconnectError, setReconnectError] = useState<IntegrationErrorCopy | null>(
     null,
   );
-  const abortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort();
-    };
-  }, []);
-
-  if (copy.action === "silent") return null;
-
-  const canReconnect = copy.action === "reconnect" && Boolean(parsed.slug);
-
-  const startReconnect = async () => {
-    if (!parsed.slug) return;
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setReconnectError(null);
-    setPhase("connecting");
-    try {
-      const { connectionId } = await connectIntegrationProvider({
-        provider: parsed.slug,
-        accountLabel: `${displayName} (Managed)`,
-        signal: controller.signal,
-      });
+  const { status, connect, cancel, reset } = useIntegrationConnect({
+    onDone: async (connectionId) => {
       // OAuth alone isn't enough: workspace apps capture HOLABOSS_APP_GRANT
       // at boot pointing at the OLD (now-expired) connection. The agent's
       // direct Composio path is restarted automatically via
@@ -194,33 +165,53 @@ function IntegrationErrorBannerBody({
       // bound to the previous connection keep using a dead grant until
       // someone rebinds them. Mirror what useIntegrationBinding does for
       // every app binding in this workspace that matches the failing slug.
-      if (selectedWorkspaceId && !controller.signal.aborted) {
+      if (selectedWorkspaceId && parsed.slug) {
         await rebindWorkspaceAppsForProvider({
           workspaceId: selectedWorkspaceId,
           provider: parsed.slug,
           connectionId,
         });
       }
-      setPhase("done");
-    } catch (err) {
-      if (err instanceof IntegrationConnectCancelled) {
-        setPhase("idle");
-        return;
-      }
-      const errorCopy = resolveIntegrationError({ provider: displayName, error: err });
+    },
+  });
+  // Connecting / done flow straight through. Error only renders when we've
+  // resolved a user-facing copy block — raw cancel / silent errors collapse
+  // back to idle so the row doesn't hold an empty error slot.
+  const phase: "idle" | "connecting" | "done" | "error" =
+    status.kind === "connecting"
+      ? "connecting"
+      : status.kind === "done"
+        ? "done"
+        : reconnectError
+          ? "error"
+          : "idle";
+
+  if (copy.action === "silent") return null;
+
+  const canReconnect = copy.action === "reconnect" && Boolean(parsed.slug);
+
+  const startReconnect = async () => {
+    if (!parsed.slug) return;
+    setReconnectError(null);
+    const outcome = await connect({
+      provider: parsed.slug,
+      accountLabel: displayName,
+    });
+    if (outcome.kind === "error") {
+      const errorCopy = resolveIntegrationError({
+        provider: displayName,
+        error: outcome.error,
+      });
       if (errorCopy.action === "silent") {
-        setPhase("idle");
+        reset();
         return;
       }
       setReconnectError(errorCopy);
-      setPhase("error");
-    } finally {
-      abortRef.current = null;
     }
   };
 
   const cancelReconnect = () => {
-    abortRef.current?.abort();
+    cancel();
   };
 
   if (phase === "done") {

--- a/apps/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/apps/desktop/src/components/panes/IntegrationsPane.tsx
@@ -722,7 +722,7 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
           connected_account_id: connectedAccountId,
           provider: integration.providerId,
           owner_user_id: userId,
-          account_label: `${integration.name} (Managed)`,
+          account_label: integration.name,
         });
         // Layer-2 auto-default: when the user explicitly connects an
         // account from Settings AND the selected workspace has no

--- a/apps/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/apps/desktop/src/components/panes/IntegrationsPane.tsx
@@ -27,14 +27,6 @@ import {
   SettingsSection,
 } from "@/components/settings";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { accountDisplayLabel } from "@/lib/integrationDisplay";
 import { brandLogoOverride } from "@/lib/integrationLogo";
@@ -274,9 +266,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
   const [workspaceUsageByConnection, setWorkspaceUsageByConnection] = useState<
     Map<string, ConnectionWorkspaceUsageEntry["workspaces"]>
   >(new Map());
-  const [capabilitiesByToolkit, setCapabilitiesByToolkit] = useState<
-    Record<string, ComposioToolkitCapability[]>
-  >({});
   const [storeCatalog, setStoreCatalog] = useState<
     Map<string, IntegrationStoreCatalogEntry>
   >(new Map());
@@ -298,7 +287,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
         connectionResult,
         toolkitResult,
         usageResult,
-        capabilitiesResult,
         storeCatalogResult,
         overridesResult,
       ] = await Promise.all([
@@ -310,9 +298,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
         window.electronAPI.workspace
           .listConnectionWorkspaceUsage()
           .catch(() => ({ usage: [] as ConnectionWorkspaceUsageEntry[] })),
-        window.electronAPI.workspace
-          .listComposioToolkitCapabilities()
-          .catch(() => ({ toolkits: {} as Record<string, ComposioToolkitCapability[]> })),
         window.electronAPI.workspace
           .listIntegrationStoreCatalog()
           .catch(() => ({ entries: [] as IntegrationStoreCatalogEntry[] })),
@@ -331,7 +316,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
         usageMap.set(entry.connection_id, entry.workspaces);
       }
       setWorkspaceUsageByConnection(usageMap);
-      setCapabilitiesByToolkit(capabilitiesResult.toolkits ?? {});
       const storeMap = new Map<string, IntegrationStoreCatalogEntry>();
       for (const entry of storeCatalogResult.entries) {
         storeMap.set(entry.slug.trim().toLowerCase(), entry);
@@ -1278,7 +1262,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
                 contextFetchStatusByConnectionId={
                   contextFetchStatusByConnectionId
                 }
-                toolkitCapabilities={capabilitiesByToolkit[integration.providerId] ?? []}
                 toolkitOverrides={
                   overridesByToolkit.get(integration.providerId) ?? new Map()
                 }
@@ -1496,7 +1479,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
                   contextFetchStatusByConnectionId={
                     contextFetchStatusByConnectionId
                   }
-                  toolkitCapabilities={capabilitiesByToolkit[integration.providerId] ?? []}
                   toolkitOverrides={
                     overridesByToolkit.get(integration.providerId) ?? new Map()
                   }
@@ -1595,10 +1577,6 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
           open={Boolean(pendingMemoryClear)}
           title="Clear this account's memory?"
         />
-        <ComposioRuntimeDebugRow
-          capabilitiesByToolkit={capabilitiesByToolkit}
-          connections={connections}
-        />
       </div>
     );
   }
@@ -1651,7 +1629,6 @@ function ConnectedProviderCard({
   metadata,
   compact,
   workspaceUsageByConnection,
-  toolkitCapabilities,
   workspaces,
   toolkitOverrides,
   expanded,
@@ -1687,7 +1664,6 @@ function ConnectedProviderCard({
   metadata: Map<string, ComposioAccountStatus>;
   compact: boolean;
   workspaceUsageByConnection: Map<string, ConnectionWorkspaceUsageEntry["workspaces"]>;
-  toolkitCapabilities: ComposioToolkitCapability[];
   workspaces: WorkspaceSummary[];
   toolkitOverrides: Map<string, WorkspaceOverrideDescriptor>;
   expanded: boolean;
@@ -1945,7 +1921,6 @@ function ConnectedProviderCard({
           );
         })}
         <WorkspaceScopeSection
-          capabilities={toolkitCapabilities}
           expanded={expanded}
           mutatingOverrideKey={mutatingOverrideKey}
           onSetWorkspaceEnabled={onSetWorkspaceEnabled}
@@ -1963,7 +1938,6 @@ function WorkspaceScopeSection({
   workspaces,
   toolkitOverrides,
   toolkitSlug,
-  capabilities,
   expanded,
   onToggleExpanded,
   onSetWorkspaceEnabled,
@@ -1972,7 +1946,6 @@ function WorkspaceScopeSection({
   workspaces: WorkspaceSummary[];
   toolkitOverrides: Map<string, WorkspaceOverrideDescriptor>;
   toolkitSlug: string;
-  capabilities: ComposioToolkitCapability[];
   expanded: boolean;
   onToggleExpanded: () => void;
   onSetWorkspaceEnabled: (workspaceId: string, enabled: boolean) => void;
@@ -1993,7 +1966,6 @@ function WorkspaceScopeSection({
       : disabledNames.length === workspaces.length
         ? "Disabled in all workspaces"
         : `Disabled in: ${disabledNames.join(", ")}`;
-  const toolCount = capabilities.length;
   return (
     <div className="mt-1 border-border border-t pt-2">
       <button
@@ -2002,12 +1974,7 @@ function WorkspaceScopeSection({
         onClick={onToggleExpanded}
         type="button"
       >
-        <span className="truncate text-left">
-          {summary}
-          {toolCount > 0
-            ? ` · ${toolCount} agent ${toolCount === 1 ? "tool" : "tools"}`
-            : ""}
-        </span>
+        <span className="truncate text-left">{summary}</span>
         <span className="shrink-0">{expanded ? "Hide" : "Manage"}</span>
       </button>
       {expanded ? (
@@ -2050,313 +2017,9 @@ function WorkspaceScopeSection({
               })}
             </ul>
           )}
-
-          <AgentCapabilityList
-            capabilities={capabilities}
-            toolkitSlug={toolkitSlug}
-          />
         </div>
       ) : null}
     </div>
   );
 }
 
-// "Agent can …" panel for a connected toolkit. Splits the catalog into
-// two trust-relevant buckets — Read (safe, looks at your data) vs Write
-// (actions taken on your behalf) — so the user can quickly tell what
-// surface area they're authorizing. Default to 5 entries per bucket
-// with an inline expander, because dumping all of Composio's 20-40
-// tools at once is a wall of SCREAMING_SNAKE_CASE that erodes trust
-// instead of building it. The raw `tool_slug` is moved into the row's
-// `title` (hover tooltip) so power users / debuggers can still see it
-// without polluting the primary view.
-function AgentCapabilityList({
-  capabilities,
-  toolkitSlug,
-}: {
-  capabilities: ComposioToolkitCapability[];
-  toolkitSlug: string;
-}) {
-  if (capabilities.length === 0) return null;
-  const reads = capabilities.filter((cap) => cap.read_only);
-  const writes = capabilities.filter((cap) => !cap.read_only);
-  return (
-    <div>
-      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        Agent can
-      </div>
-      {reads.length > 0 ? (
-        <CapabilityGroup
-          capabilities={reads}
-          label="Read"
-          tone="muted"
-          toolkitSlug={toolkitSlug}
-        />
-      ) : null}
-      {writes.length > 0 ? (
-        <CapabilityGroup
-          capabilities={writes}
-          label="Write"
-          tone="emphasis"
-          toolkitSlug={toolkitSlug}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-const CAPABILITY_GROUP_VISIBLE = 5;
-
-function CapabilityGroup({
-  capabilities,
-  label,
-  tone,
-  toolkitSlug,
-}: {
-  capabilities: ComposioToolkitCapability[];
-  label: string;
-  /** "muted" = Read group (safe; quieter). "emphasis" = Write group (the
-   *  one users should actually read; subtle amber accent on the count). */
-  tone: "muted" | "emphasis";
-  toolkitSlug: string;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const visible = expanded
-    ? capabilities
-    : capabilities.slice(0, CAPABILITY_GROUP_VISIBLE);
-  const hidden = capabilities.length - visible.length;
-  return (
-    <div className="mt-2.5">
-      <div className="flex items-baseline gap-1.5 text-[10px] font-medium uppercase tracking-wide">
-        <span
-          className={
-            tone === "emphasis"
-              ? "text-amber-700 dark:text-amber-400"
-              : "text-muted-foreground"
-          }
-        >
-          {label}
-        </span>
-        <span className="font-normal normal-case text-muted-foreground/60">
-          · {capabilities.length}
-        </span>
-      </div>
-      <ul className="mt-1 space-y-1">
-        {visible.map((cap) => (
-          <li className="text-[11px]" key={cap.tool_slug} title={cap.tool_slug}>
-            <div className="font-medium text-foreground">
-              {humanizeCapabilityName(cap.name, toolkitSlug)}
-            </div>
-            <div className="line-clamp-2 text-[11px] leading-5 text-muted-foreground">
-              {cap.description}
-            </div>
-          </li>
-        ))}
-      </ul>
-      {hidden > 0 ? (
-        <button
-          className="mt-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-          onClick={() => setExpanded(true)}
-          type="button"
-        >
-          + {hidden} more
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-// `gmail_fetch_emails` → "Fetch emails". Strips the toolkit-prefix, swaps
-// underscores for spaces, sentence-cases the first word. Falls back to the
-// raw name when the prefix isn't where we expect — better than throwing.
-function humanizeCapabilityName(name: string, toolkitSlug: string): string {
-  const prefix = `${toolkitSlug.toLowerCase()}_`;
-  const sansPrefix = name.toLowerCase().startsWith(prefix)
-    ? name.slice(prefix.length)
-    : name;
-  const spaced = sansPrefix.replace(/_/g, " ").trim();
-  if (!spaced) return name;
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
-
-// Temporary diagnostic — hits runtime POST /api/v1/debug/composio-
-// runtime-test, which uses ComposioApiClient end-to-end (env-injected
-// HOLABOSS_AUTH_BEARER_TOKEN → Hono /internal/tools/execute → Composio).
-// Exposes a one-click "fetch 5 Gmail messages via runtime" probe so we
-// can confirm the full server-side path is alive before any product
-// feature lands. Editable provider + tool slug + args via small inputs;
-// defaults are the canonical Gmail fetch case. Safe to delete alongside
-// the runtime endpoint once a real consumer is in product.
-function ComposioRuntimeDebugRow({
-  connections,
-  capabilitiesByToolkit,
-}: {
-  connections: IntegrationConnectionPayload[];
-  capabilitiesByToolkit: Record<string, ComposioToolkitCapability[]>;
-}) {
-  const [providerSlug, setProviderSlug] = useState("gmail");
-  const [toolSlug, setToolSlug] = useState("GMAIL_FETCH_EMAILS");
-  const [argsText, setArgsText] = useState(
-    JSON.stringify({ max_results: 5 }, null, 2),
-  );
-
-  // One preset per connected provider whose toolkit catalog has at
-  // least one capability. Picking a preset fills all three inputs
-  // together so we never end up with e.g. linkedin + GMAIL_FETCH_EMAILS,
-  // which is the failure mode that made every non-gmail probe error.
-  const presets = useMemo(() => {
-    const seen = new Set<string>();
-    const list: {
-      providerSlug: string;
-      label: string;
-      toolSlug: string;
-      args: string;
-    }[] = [];
-    for (const c of connections) {
-      const slug = c.provider_id.trim().toLowerCase();
-      if (!slug || seen.has(slug)) continue;
-      seen.add(slug);
-      const caps = capabilitiesByToolkit[slug] ?? [];
-      const preferred = caps.find((cap) => cap.read_only) ?? caps[0];
-      if (!preferred) continue;
-      list.push({
-        providerSlug: slug,
-        label: `${slug} — ${preferred.tool_slug}`,
-        toolSlug: preferred.tool_slug,
-        args: slug === "gmail" ? JSON.stringify({ max_results: 5 }, null, 2) : "{}",
-      });
-    }
-    return list;
-  }, [connections, capabilitiesByToolkit]);
-
-  function applyPreset(value: string | null) {
-    if (!value) return;
-    const preset = presets.find((p) => p.providerSlug === value);
-    if (!preset) return;
-    setProviderSlug(preset.providerSlug);
-    setToolSlug(preset.toolSlug);
-    setArgsText(preset.args);
-  }
-  const [busy, setBusy] = useState(false);
-  const [result, setResult] = useState<unknown>(null);
-  const [errorMessage, setErrorMessage] = useState("");
-
-  async function handleRun() {
-    setBusy(true);
-    setErrorMessage("");
-    setResult(null);
-    let parsedArgs: Record<string, unknown> = {};
-    try {
-      const raw = argsText.trim();
-      parsedArgs = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-    } catch (parseError) {
-      setBusy(false);
-      setErrorMessage(
-        `arguments must be valid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-      );
-      return;
-    }
-    try {
-      const response = await window.electronAPI.workspace.debugComposioRuntimeTest(
-        {
-          providerSlug: providerSlug.trim() || undefined,
-          toolSlug: toolSlug.trim() || undefined,
-          arguments: parsedArgs,
-        },
-      );
-      setResult(response);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : String(error));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <div className="rounded-xl border border-dashed border-border bg-muted/30 px-4 py-3 text-xs">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="font-medium text-foreground">
-            Debug — runtime → Composio via ComposioApiClient
-          </div>
-          <div className="text-muted-foreground">
-            Hits <code>POST /api/v1/debug/composio-runtime-test</code> on
-            the embedded runtime. Exercises the full path: env-injected
-            bearer token → ComposioApiClient → Hono{" "}
-            <code>/internal/tools/execute</code> → Composio. Defaults
-            fetch your 5 most recent Gmail messages.
-          </div>
-        </div>
-        <Button
-          className="h-7 px-3 text-xs"
-          disabled={busy}
-          onClick={() => void handleRun()}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          {busy ? "Running…" : "Run probe"}
-        </Button>
-      </div>
-      {presets.length > 0 ? (
-        <label className="mt-3 flex flex-col gap-1">
-          <span className="text-[11px] text-muted-foreground">
-            preset (connected provider → first cataloged tool)
-          </span>
-          <Select onValueChange={applyPreset} value={providerSlug}>
-            <SelectTrigger className="h-7 text-xs">
-              <SelectValue placeholder="Pick a connected provider…" />
-            </SelectTrigger>
-            <SelectContent>
-              {presets.map((preset) => (
-                <SelectItem key={preset.providerSlug} value={preset.providerSlug}>
-                  {preset.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </label>
-      ) : null}
-      <div className="mt-3 grid grid-cols-2 gap-2">
-        <label className="flex flex-col gap-1">
-          <span className="text-[11px] text-muted-foreground">
-            provider_slug
-          </span>
-          <Input
-            className="h-7 text-xs"
-            onChange={(e) => setProviderSlug(e.target.value)}
-            value={providerSlug}
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[11px] text-muted-foreground">tool_slug</span>
-          <Input
-            className="h-7 text-xs"
-            onChange={(e) => setToolSlug(e.target.value)}
-            value={toolSlug}
-          />
-        </label>
-      </div>
-      <label className="mt-2 flex flex-col gap-1">
-        <span className="text-[11px] text-muted-foreground">
-          arguments (JSON)
-        </span>
-        <textarea
-          className="h-20 w-full resize-y rounded-md border border-border bg-background px-2 py-1 font-mono text-[11px] leading-4 text-foreground focus:outline-none"
-          onChange={(e) => setArgsText(e.target.value)}
-          value={argsText}
-        />
-      </label>
-      {errorMessage ? (
-        <div className="mt-3 rounded-md bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
-          {errorMessage}
-        </div>
-      ) : null}
-      {result !== null ? (
-        <pre className="mt-3 max-h-80 w-full max-w-full overflow-auto whitespace-pre-wrap break-all rounded-md bg-background px-2 py-1.5 text-[11px] leading-5 text-foreground">
-          {JSON.stringify(result, null, 2)}
-        </pre>
-      ) : null}
-    </div>
-  );
-}

--- a/apps/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/apps/desktop/src/components/panes/IntegrationsPane.tsx
@@ -26,7 +26,6 @@ import {
   SettingsCard,
   SettingsSection,
 } from "@/components/settings";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -38,6 +37,7 @@ import {
 } from "@/components/ui/select";
 import { useDesktopAuthSession } from "@/lib/auth/authClient";
 import { accountDisplayLabel } from "@/lib/integrationDisplay";
+import { brandLogoOverride } from "@/lib/integrationLogo";
 import { rebindWorkspaceAppsForProvider } from "@/lib/rebindWorkspaceAppsForProvider";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import {
@@ -166,20 +166,6 @@ function composioFallbackLogo(slug: string): string | null {
     return null;
   }
   return `https://logos.composio.dev/api/${cleaned}`;
-}
-
-// Composio's logo CDN returns wide wordmark SVGs (and sometimes a pure
-// white fill) for a handful of providers, so the square thumbnail in
-// the integrations grid renders as a sliver-in-a-banner or invisibly
-// white-on-white. Simple Icons publishes a square monochrome SVG per
-// brand at a stable unpkg URL — short-circuit just those slugs.
-const BRAND_LOGO_OVERRIDES: Record<string, string> = {
-  github: "https://unpkg.com/simple-icons@16.20.0/icons/github.svg",
-  linear: "https://unpkg.com/simple-icons@16.20.0/icons/linear.svg",
-};
-
-function brandLogoOverride(slug: string): string | null {
-  return BRAND_LOGO_OVERRIDES[slug.trim().toLowerCase()] ?? null;
 }
 
 function mergeIntegrationCards(
@@ -1926,7 +1912,7 @@ function ConnectedProviderCard({
                       {contextFetchStatus.current_chunk_label ||
                         contextFetchDisplayMessage(contextFetchStatus)}
                     </p>
-                    <span className="shrink-0 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                    <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
                       {contextFetchStatus.status}
                     </span>
                   </div>
@@ -2065,37 +2051,132 @@ function WorkspaceScopeSection({
             </ul>
           )}
 
-          {capabilities.length > 0 ? (
-            <div>
-              <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                Agent can
-              </div>
-              <ul className="mt-1.5 space-y-1">
-                {capabilities.map((cap) => (
-                  <li className="text-[11px]" key={cap.tool_slug}>
-                    <div className="flex items-center gap-1.5">
-                      <span className="font-medium text-foreground">{cap.name}</span>
-                      {cap.read_only ? (
-                        <Badge
-                          className="border-border bg-background/60 text-[9px] text-muted-foreground"
-                          variant="outline"
-                        >
-                          read-only
-                        </Badge>
-                      ) : null}
-                    </div>
-                    <div className="text-[11px] leading-5 text-muted-foreground">
-                      {cap.description}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
+          <AgentCapabilityList
+            capabilities={capabilities}
+            toolkitSlug={toolkitSlug}
+          />
         </div>
       ) : null}
     </div>
   );
+}
+
+// "Agent can …" panel for a connected toolkit. Splits the catalog into
+// two trust-relevant buckets — Read (safe, looks at your data) vs Write
+// (actions taken on your behalf) — so the user can quickly tell what
+// surface area they're authorizing. Default to 5 entries per bucket
+// with an inline expander, because dumping all of Composio's 20-40
+// tools at once is a wall of SCREAMING_SNAKE_CASE that erodes trust
+// instead of building it. The raw `tool_slug` is moved into the row's
+// `title` (hover tooltip) so power users / debuggers can still see it
+// without polluting the primary view.
+function AgentCapabilityList({
+  capabilities,
+  toolkitSlug,
+}: {
+  capabilities: ComposioToolkitCapability[];
+  toolkitSlug: string;
+}) {
+  if (capabilities.length === 0) return null;
+  const reads = capabilities.filter((cap) => cap.read_only);
+  const writes = capabilities.filter((cap) => !cap.read_only);
+  return (
+    <div>
+      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Agent can
+      </div>
+      {reads.length > 0 ? (
+        <CapabilityGroup
+          capabilities={reads}
+          label="Read"
+          tone="muted"
+          toolkitSlug={toolkitSlug}
+        />
+      ) : null}
+      {writes.length > 0 ? (
+        <CapabilityGroup
+          capabilities={writes}
+          label="Write"
+          tone="emphasis"
+          toolkitSlug={toolkitSlug}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+const CAPABILITY_GROUP_VISIBLE = 5;
+
+function CapabilityGroup({
+  capabilities,
+  label,
+  tone,
+  toolkitSlug,
+}: {
+  capabilities: ComposioToolkitCapability[];
+  label: string;
+  /** "muted" = Read group (safe; quieter). "emphasis" = Write group (the
+   *  one users should actually read; subtle amber accent on the count). */
+  tone: "muted" | "emphasis";
+  toolkitSlug: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded
+    ? capabilities
+    : capabilities.slice(0, CAPABILITY_GROUP_VISIBLE);
+  const hidden = capabilities.length - visible.length;
+  return (
+    <div className="mt-2.5">
+      <div className="flex items-baseline gap-1.5 text-[10px] font-medium uppercase tracking-wide">
+        <span
+          className={
+            tone === "emphasis"
+              ? "text-amber-700 dark:text-amber-400"
+              : "text-muted-foreground"
+          }
+        >
+          {label}
+        </span>
+        <span className="font-normal normal-case text-muted-foreground/60">
+          · {capabilities.length}
+        </span>
+      </div>
+      <ul className="mt-1 space-y-1">
+        {visible.map((cap) => (
+          <li className="text-[11px]" key={cap.tool_slug} title={cap.tool_slug}>
+            <div className="font-medium text-foreground">
+              {humanizeCapabilityName(cap.name, toolkitSlug)}
+            </div>
+            <div className="line-clamp-2 text-[11px] leading-5 text-muted-foreground">
+              {cap.description}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {hidden > 0 ? (
+        <button
+          className="mt-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          onClick={() => setExpanded(true)}
+          type="button"
+        >
+          + {hidden} more
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// `gmail_fetch_emails` → "Fetch emails". Strips the toolkit-prefix, swaps
+// underscores for spaces, sentence-cases the first word. Falls back to the
+// raw name when the prefix isn't where we expect — better than throwing.
+function humanizeCapabilityName(name: string, toolkitSlug: string): string {
+  const prefix = `${toolkitSlug.toLowerCase()}_`;
+  const sansPrefix = name.toLowerCase().startsWith(prefix)
+    ? name.slice(prefix.length)
+    : name;
+  const spaced = sansPrefix.replace(/_/g, " ").trim();
+  if (!spaced) return name;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
 // Temporary diagnostic — hits runtime POST /api/v1/debug/composio-

--- a/apps/desktop/src/components/panes/IntegrationsPane.tsx
+++ b/apps/desktop/src/components/panes/IntegrationsPane.tsx
@@ -266,6 +266,18 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
   const [workspaceUsageByConnection, setWorkspaceUsageByConnection] = useState<
     Map<string, ConnectionWorkspaceUsageEntry["workspaces"]>
   >(new Map());
+  // workspace-default account per (provider slug, workspace id). Drives the
+  // "Default here" inline chip on connection rows and the Manage-expand
+  // dropdown that lets users pick which account each workspace defaults to.
+  // Nested map shape: providerSlug → workspaceId → connectionId.
+  const [defaultsByProvider, setDefaultsByProvider] = useState<
+    Map<string, Map<string, string>>
+  >(new Map());
+  // Connection id currently being mutated to a different default — used
+  // to disable the dropdown row while the PUT is in flight.
+  const [mutatingDefaultKey, setMutatingDefaultKey] = useState<string | null>(
+    null,
+  );
   const [storeCatalog, setStoreCatalog] = useState<
     Map<string, IntegrationStoreCatalogEntry>
   >(new Map());
@@ -347,6 +359,112 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
   useEffect(() => {
     void loadData();
   }, [isSignedIn, loadData]);
+
+  // Fetch each (workspace × provider-with-connections) default-account
+  // mapping. Runs whenever workspaces or connections shift. Keyed off
+  // connection ids so reordering or unchanged connection lists don't refetch.
+  const connectionIdsKey = useMemo(
+    () => connections.map((c) => c.connection_id).sort().join("|"),
+    [connections],
+  );
+  const workspaceIdsKey = useMemo(
+    () => workspaces.map((w) => w.id).sort().join("|"),
+    [workspaces],
+  );
+  useEffect(() => {
+    if (workspaces.length === 0 || connections.length === 0) {
+      setDefaultsByProvider(new Map());
+      return;
+    }
+    const distinctProviders = Array.from(
+      new Set(connections.map((c) => c.provider_id)),
+    );
+    const pairs: Array<{ wsId: string; provider: string }> = [];
+    for (const ws of workspaces) {
+      for (const provider of distinctProviders) {
+        pairs.push({ wsId: ws.id, provider });
+      }
+    }
+    let cancelled = false;
+    void Promise.all(
+      pairs.map((pair) =>
+        window.electronAPI.workspace
+          .getWorkspaceDefaultAccount(pair.wsId, pair.provider)
+          .then((res) => ({
+            ...pair,
+            connectionId: res.connection_id,
+          }))
+          .catch(() => ({
+            ...pair,
+            connectionId: null as string | null,
+          })),
+      ),
+    ).then((results) => {
+      if (cancelled) return;
+      const map = new Map<string, Map<string, string>>();
+      for (const r of results) {
+        if (!r.connectionId) continue;
+        let inner = map.get(r.provider);
+        if (!inner) {
+          inner = new Map();
+          map.set(r.provider, inner);
+        }
+        inner.set(r.wsId, r.connectionId);
+      }
+      setDefaultsByProvider(map);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // workspaceIdsKey + connectionIdsKey collapse identity-stable arrays into
+    // strings so this only re-runs on real membership change.
+  }, [workspaceIdsKey, connectionIdsKey, workspaces, connections]);
+
+  const handleSetWorkspaceDefault = useCallback(
+    async (
+      workspaceId: string,
+      providerId: string,
+      connectionId: string,
+    ) => {
+      const key = `${workspaceId}:${providerId}`;
+      setMutatingDefaultKey(key);
+      // Optimistic: snap the controlled <select> to the new value
+      // immediately, otherwise it would visibly bounce back during the
+      // in-flight PUT.
+      let previousDefault: string | undefined;
+      setDefaultsByProvider((prev) => {
+        const next = new Map(prev);
+        const inner = new Map(next.get(providerId) ?? new Map());
+        previousDefault = inner.get(workspaceId);
+        inner.set(workspaceId, connectionId);
+        next.set(providerId, inner);
+        return next;
+      });
+      try {
+        await window.electronAPI.workspace.setWorkspaceDefaultAccount(
+          workspaceId,
+          providerId,
+          connectionId,
+        );
+      } catch (error) {
+        setDefaultsByProvider((prev) => {
+          const next = new Map(prev);
+          const inner = new Map(next.get(providerId) ?? new Map());
+          if (previousDefault) {
+            inner.set(workspaceId, previousDefault);
+          } else {
+            inner.delete(workspaceId);
+          }
+          next.set(providerId, inner);
+          return next;
+        });
+        setStatusMessage(normalizeErrorMessage(error));
+      } finally {
+        setMutatingDefaultKey(null);
+      }
+    },
+    [],
+  );
 
   const runningContextFetchConnectionIds = useMemo(
     () =>
@@ -1267,6 +1385,18 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
                 }
                 workspaceUsageByConnection={workspaceUsageByConnection}
                 workspaces={workspaces.map((w) => ({ id: w.id, name: w.name }))}
+                defaultsByWorkspace={
+                  defaultsByProvider.get(integration.providerId) ?? new Map()
+                }
+                selectedWorkspaceId={selectedWorkspaceId}
+                mutatingDefaultKey={mutatingDefaultKey}
+                onSetWorkspaceDefault={(workspaceId, connectionId) =>
+                  void handleSetWorkspaceDefault(
+                    workspaceId,
+                    integration.providerId,
+                    connectionId,
+                  )
+                }
               />
             ))}
           </div>
@@ -1484,6 +1614,18 @@ export function IntegrationsPane({ embedded }: { embedded?: boolean } = {}) {
                   }
                   workspaceUsageByConnection={workspaceUsageByConnection}
                   workspaces={workspaces.map((w) => ({ id: w.id, name: w.name }))}
+                  defaultsByWorkspace={
+                    defaultsByProvider.get(integration.providerId) ?? new Map()
+                  }
+                  selectedWorkspaceId={selectedWorkspaceId}
+                  mutatingDefaultKey={mutatingDefaultKey}
+                  onSetWorkspaceDefault={(workspaceId, connectionId) =>
+                    void handleSetWorkspaceDefault(
+                      workspaceId,
+                      integration.providerId,
+                      connectionId,
+                    )
+                  }
                 />
               ))}
             </div>
@@ -1635,6 +1777,10 @@ function ConnectedProviderCard({
   onToggleExpanded,
   onSetWorkspaceEnabled,
   mutatingOverrideKey,
+  defaultsByWorkspace,
+  selectedWorkspaceId,
+  mutatingDefaultKey,
+  onSetWorkspaceDefault,
 }: {
   integration: IntegrationCard;
   connections: IntegrationConnectionPayload[];
@@ -1670,6 +1816,14 @@ function ConnectedProviderCard({
   onToggleExpanded: () => void;
   onSetWorkspaceEnabled: (workspaceId: string, enabled: boolean) => void;
   mutatingOverrideKey: string | null;
+  /** Map of workspaceId → default connectionId for THIS provider. */
+  defaultsByWorkspace: Map<string, string>;
+  /** Currently focused workspace — drives the inline "Default here" chip
+   *  on the connection row. */
+  selectedWorkspaceId: string | null;
+  /** Key `${workspaceId}:${providerId}` currently being mutated. */
+  mutatingDefaultKey: string | null;
+  onSetWorkspaceDefault: (workspaceId: string, connectionId: string) => void;
 }) {
   const containerClass = compact
     ? "flex flex-col gap-1 rounded-xl bg-card px-3 py-2.5 ring-1 ring-border"
@@ -1752,6 +1906,9 @@ function ConnectedProviderCard({
             : 0;
           const usage = workspaceUsageByConnection.get(conn.connection_id) ?? [];
           const workspaceCount = new Set(usage.map((u) => u.workspace_id)).size;
+          const isDefaultHere =
+            selectedWorkspaceId != null &&
+            defaultsByWorkspace.get(selectedWorkspaceId) === conn.connection_id;
           const flashRejected =
             flashRejectedConnectionId === conn.connection_id;
           return (
@@ -1791,6 +1948,14 @@ function ConnectedProviderCard({
                 <span className="min-w-0 flex-1 truncate text-xs text-foreground">
                   {label}
                 </span>
+                {isDefaultHere ? (
+                  <span
+                    className="shrink-0 rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-foreground"
+                    title="Default account for the currently-selected workspace"
+                  >
+                    Default here
+                  </span>
+                ) : null}
                 {workspaceCount > 0 ? (
                   <span className="shrink-0 text-[10px] text-muted-foreground">
                     {workspaceCount === 1
@@ -1928,6 +2093,11 @@ function ConnectedProviderCard({
           toolkitOverrides={toolkitOverrides}
           toolkitSlug={integration.providerId}
           workspaces={workspaces}
+          connections={connections}
+          metadata={metadata}
+          defaultsByWorkspace={defaultsByWorkspace}
+          mutatingDefaultKey={mutatingDefaultKey}
+          onSetWorkspaceDefault={onSetWorkspaceDefault}
         />
       </div>
     </div>
@@ -1942,6 +2112,11 @@ function WorkspaceScopeSection({
   onToggleExpanded,
   onSetWorkspaceEnabled,
   mutatingOverrideKey,
+  connections,
+  metadata,
+  defaultsByWorkspace,
+  mutatingDefaultKey,
+  onSetWorkspaceDefault,
 }: {
   workspaces: WorkspaceSummary[];
   toolkitOverrides: Map<string, WorkspaceOverrideDescriptor>;
@@ -1950,6 +2125,12 @@ function WorkspaceScopeSection({
   onToggleExpanded: () => void;
   onSetWorkspaceEnabled: (workspaceId: string, enabled: boolean) => void;
   mutatingOverrideKey: string | null;
+  connections: IntegrationConnectionPayload[];
+  metadata: Map<string, ComposioAccountStatus>;
+  /** Map of workspaceId → default connectionId for this provider. */
+  defaultsByWorkspace: Map<string, string>;
+  mutatingDefaultKey: string | null;
+  onSetWorkspaceDefault: (workspaceId: string, connectionId: string) => void;
 }) {
   const disabledWorkspaceIds: string[] = [];
   for (const ws of workspaces) {
@@ -1990,14 +2171,60 @@ function WorkspaceScopeSection({
                 const enabled = override?.state !== "disabled";
                 const key = `${ws.id}:${toolkitSlug}`;
                 const mutating = mutatingOverrideKey === key;
+                const defaultConnectionId = defaultsByWorkspace.get(ws.id) ?? "";
+                const defaultMutating =
+                  mutatingDefaultKey === `${ws.id}:${toolkitSlug}`;
+                // Hide the default picker when there's nothing to pick
+                // (zero or one connection) — the implicit default is
+                // unambiguous in that case.
+                const showDefaultPicker = enabled && connections.length > 1;
                 return (
                   <li
                     className="flex items-center justify-between gap-3 rounded-md bg-muted/40 px-2.5 py-1.5"
                     key={ws.id}
                   >
-                    <span className="truncate text-xs text-foreground">
+                    <span className="min-w-0 flex-1 truncate text-xs text-foreground">
                       {ws.name || ws.id}
                     </span>
+                    {showDefaultPicker ? (
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        {defaultMutating ? (
+                          <Loader2 className="size-3 animate-spin text-muted-foreground" />
+                        ) : null}
+                        <select
+                          aria-label={`Default account for ${ws.name || ws.id}`}
+                          className="max-w-[160px] cursor-pointer truncate rounded-sm border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground outline-none focus:ring-1 focus:ring-ring"
+                          disabled={defaultMutating}
+                          onChange={(e) => {
+                            const nextId = e.currentTarget.value;
+                            if (!nextId || nextId === defaultConnectionId)
+                              return;
+                            onSetWorkspaceDefault(ws.id, nextId);
+                          }}
+                          value={defaultConnectionId}
+                        >
+                          {defaultConnectionId ? null : (
+                            <option value="">Auto (first available)</option>
+                          )}
+                          {connections.map((conn, connIndex) => {
+                            const m = metadata.get(conn.connection_id);
+                            const optLabel = accountDisplayLabel(
+                              conn,
+                              m,
+                              connIndex,
+                            );
+                            return (
+                              <option
+                                key={conn.connection_id}
+                                value={conn.connection_id}
+                              >
+                                {optLabel}
+                              </option>
+                            );
+                          })}
+                        </select>
+                      </div>
+                    ) : null}
                     <label className="flex shrink-0 cursor-pointer items-center gap-2 text-[10px] text-muted-foreground">
                       {mutating ? (
                         <Loader2 className="size-3 animate-spin" />

--- a/apps/desktop/src/components/panes/MarketplacePane.tsx
+++ b/apps/desktop/src/components/panes/MarketplacePane.tsx
@@ -206,7 +206,7 @@ export function MarketplacePane({
             connected_account_id: newConnection.id,
             provider,
             owner_user_id: userId,
-            account_label: `${provider} (Managed)`,
+            account_label: toolkitDisplayName(provider),
           });
           if (cancelled) {
             return;

--- a/apps/desktop/src/components/panes/MemoryPane.tsx
+++ b/apps/desktop/src/components/panes/MemoryPane.tsx
@@ -980,7 +980,7 @@ export function MemoryPane({ embedded }: { embedded?: boolean } = {}) {
       <SettingsCard className={embedded ? "" : "overflow-hidden"}>
         <div className="grid h-[540px] grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[220px_minmax(0,1fr)]">
           <div className="flex min-h-0 flex-col border-r border-border bg-muted/10">
-            <div className="border-b border-border px-4 py-3 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+            <div className="border-b border-border px-4 py-3 text-xs font-medium text-muted-foreground">
               Explorer
             </div>
             <div className="min-h-0 overflow-auto p-2">

--- a/apps/desktop/src/components/panes/PresentationPreview.tsx
+++ b/apps/desktop/src/components/panes/PresentationPreview.tsx
@@ -33,7 +33,7 @@ export function PresentationPreview({
       <div className="mx-auto flex max-w-5xl flex-col gap-6">
         {slides.map((slide) => (
           <section key={`${name}-slide-${slide.index}`} className="space-y-2">
-            <div className="flex items-center justify-between px-1 text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+            <div className="flex items-center justify-between px-1 text-[11px] text-muted-foreground">
               <span>{name}</span>
               <span>Slide {slide.index}</span>
             </div>

--- a/apps/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
+++ b/apps/desktop/src/components/panes/SpaceBrowserExplorerPane.tsx
@@ -273,7 +273,7 @@ export function SpaceBrowserExplorerPane({
           className={cn(
             "flex w-full items-center gap-2 rounded-md px-2.5 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
             depth === 0
-              ? "text-[10px] font-medium uppercase tracking-[0.08em]"
+              ? "text-[10px] font-medium"
               : "text-xs",
           )}
           style={depth > 0 ? { paddingLeft: `${10 + depth * 14}px` } : undefined}
@@ -396,14 +396,14 @@ export function SpaceBrowserExplorerPane({
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
         {hasBookmarks ? (
           <div className="mb-3 space-y-0.5">
-            <div className="px-2.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            <div className="px-2.5 pb-1 text-[10px] font-medium text-muted-foreground">
               Bookmarks
             </div>
             {bookmarkTree.folders.map((folder) => renderBookmarkFolder(folder))}
             {bookmarkTree.rootBookmarks.length > 0 ? (
               bookmarkTree.folders.length > 0 ? (
                 <div className="pt-1">
-                  <div className="px-2.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                  <div className="px-2.5 pb-1 text-[10px] font-medium text-muted-foreground">
                     Saved
                   </div>
                   {bookmarkTree.rootBookmarks.map((bookmark) =>

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.test.mjs
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.test.mjs
@@ -19,12 +19,11 @@ test("deterministic workspace onboarding does not enqueue a starter prompt", asy
   assert.doesNotMatch(source, /queueSessionInput\(/);
   assert.match(
     source,
-    /async function handleContinue\(\) \{[\s\S]*await continueDeterministicOnboarding\(\);[\s\S]*\}/,
+    /async function handleContinue\(\) \{[\s\S]*await Promise\.allSettled\([\s\S]*startContextFetch\([\s\S]*await continueDeterministicOnboarding\(\);[\s\S]*\}/,
   );
   assert.match(source, /deterministic_context_fetching/);
-  assert.match(source, />\s*Fetching your context\s*</);
+  assert.match(source, /Importing in background/);
   assert.match(source, /listIntegrationContextFetchStatuses/);
-  assert.match(source, /Overall progress/);
   assert.match(source, /chunks complete/);
   assert.match(
     source,

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -1,6 +1,7 @@
 import { Check, LoaderCircle, Plug } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { bindConnectionToWorkspace } from "@/lib/bindConnectionToWorkspace";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 type HeroEntry = {
@@ -83,6 +84,14 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const [connectionIdByToolkit, setConnectionIdByToolkit] = useState<
     Record<string, string>
   >({});
+  // Existing active connections the user already has across all workspaces,
+  // keyed by provider slug. Lets onboarding skip re-OAuth + render a
+  // "Connected as @handle" state instead of a misleading fresh Connect
+  // button. Populated by an effect on mount and refreshed whenever the
+  // workspace switches.
+  const [existingConnectionBySlug, setExistingConnectionBySlug] = useState<
+    Record<string, IntegrationConnectionPayload>
+  >({});
   const [contextFetchStatusByConnectionId, setContextFetchStatusByConnectionId] =
     useState<Record<string, IntegrationContextFetchStatusPayload>>({});
   const [isContinuing, setIsContinuing] = useState(false);
@@ -97,7 +106,78 @@ export function DeterministicWorkspaceOnboardingSurface() {
     setErrorByToolkit({});
     setConnectionIdByToolkit({});
     setContextFetchStatusByConnectionId({});
+    setExistingConnectionBySlug({});
   }, [selectedWorkspace?.id]);
+
+  // Pull the user's existing active connections (across all workspaces)
+  // so we can recognize tiles the user has already authorized. Without
+  // this, onboarding renders the same "Connect" button for every hero
+  // entry and re-OAuthing duplicates the Composio connected_account row.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { connections } =
+          await window.electronAPI.workspace.listIntegrationConnections();
+        if (cancelled) return;
+        // Index by lowercase provider slug. If the user has multiple
+        // accounts for the same provider, take the most-recently-updated
+        // one — same heuristic the agent uses elsewhere when resolving
+        // "the default Gmail account" for this user.
+        const byProvider: Record<string, IntegrationConnectionPayload> = {};
+        for (const conn of connections) {
+          if (conn.status !== "active") continue;
+          const slug = conn.provider_id.trim().toLowerCase();
+          if (!slug) continue;
+          const incumbent = byProvider[slug];
+          if (
+            !incumbent ||
+            Date.parse(conn.updated_at) > Date.parse(incumbent.updated_at)
+          ) {
+            byProvider[slug] = conn;
+          }
+        }
+        setExistingConnectionBySlug(byProvider);
+      } catch {
+        // Onboarding can still function without the pre-existing scan —
+        // user just sees the legacy "Connect everything fresh" UX.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWorkspace?.id]);
+
+  // Once both `heroEntries` and `existingConnectionBySlug` have loaded,
+  // mark any already-connected hero as `done` and seed its connection
+  // id into the tracked map. The continue step then binds those
+  // connections to the new workspace — without this seeding, the
+  // collected map would be empty for unchanged tiles and Phase 2 would
+  // skip them entirely.
+  useEffect(() => {
+    if (!heroEntries || heroEntries.length === 0) return;
+    if (Object.keys(existingConnectionBySlug).length === 0) return;
+    setPhaseByToolkit((prev) => {
+      const next = { ...prev };
+      for (const entry of heroEntries) {
+        const existing = existingConnectionBySlug[entry.slug];
+        if (existing && !next[entry.slug]) {
+          next[entry.slug] = "done";
+        }
+      }
+      return next;
+    });
+    setConnectionIdByToolkit((prev) => {
+      const next = { ...prev };
+      for (const entry of heroEntries) {
+        const existing = existingConnectionBySlug[entry.slug];
+        if (existing && !next[entry.slug]) {
+          next[entry.slug] = existing.connection_id;
+        }
+      }
+      return next;
+    });
+  }, [heroEntries, existingConnectionBySlug]);
 
   useEffect(() => {
     let cancelled = false;
@@ -209,7 +289,25 @@ export function DeterministicWorkspaceOnboardingSurface() {
     };
   }, [isFetchingContext, shouldPollFetchStatuses, trackedConnectionIds, trackedConnectionIdsKey]);
 
-  async function handleConnect(entry: HeroEntry) {
+  async function handleConnect(
+    entry: HeroEntry,
+    opts?: { force?: boolean },
+  ) {
+    // Short-circuit when this provider is already connected and the caller
+    // didn't explicitly ask for a fresh OAuth (the "Switch account" link
+    // sets force=true). Avoids creating a duplicate Composio
+    // connected_account row for users who already authorized Gmail in a
+    // previous workspace — they should be able to just click Continue.
+    const existing = existingConnectionBySlug[entry.slug];
+    if (existing && !opts?.force) {
+      setConnectionIdByToolkit((prev) => ({
+        ...prev,
+        [entry.slug]: existing.connection_id,
+      }));
+      setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "done" }));
+      return;
+    }
+
     setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "connecting" }));
     setErrorByToolkit((prev) => ({ ...prev, [entry.slug]: null }));
     try {
@@ -251,6 +349,26 @@ export function DeterministicWorkspaceOnboardingSurface() {
   async function handleContinue() {
     setIsContinuing(true);
     try {
+      // Phase 2: persist every (slug → connection_id) we collected during
+      // onboarding — whether the user freshly OAuth'd or we reused a
+      // pre-existing connection — into this workspace's binding state.
+      // Without this the IDs sit dead in React state and the workspace
+      // has no idea which integrations the user "chose" during setup.
+      const workspaceId = selectedWorkspace?.id;
+      if (workspaceId) {
+        const entries = Object.entries(connectionIdByToolkit).filter(
+          ([, connectionId]) => connectionId.trim().length > 0,
+        );
+        await Promise.allSettled(
+          entries.map(([slug, connectionId]) =>
+            bindConnectionToWorkspace({
+              workspaceId,
+              providerSlug: slug,
+              connectionId,
+            }),
+          ),
+        );
+      }
       await continueDeterministicOnboarding();
     } finally {
       setIsContinuing(false);
@@ -441,15 +559,29 @@ export function DeterministicWorkspaceOnboardingSurface() {
                   </p>
                 ) : (
                   <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {heroEntries.map((entry) => (
-                      <HeroConnectCard
-                        entry={entry}
-                        error={errorByToolkit[entry.slug] ?? null}
-                        key={entry.slug}
-                        onConnect={() => void handleConnect(entry)}
-                        phase={phaseByToolkit[entry.slug] ?? "idle"}
-                      />
-                    ))}
+                    {heroEntries.map((entry) => {
+                      const existing = existingConnectionBySlug[entry.slug];
+                      return (
+                        <HeroConnectCard
+                          connectedAccountLabel={
+                            existing
+                              ? accountDisplayHandle(existing)
+                              : null
+                          }
+                          entry={entry}
+                          error={errorByToolkit[entry.slug] ?? null}
+                          key={entry.slug}
+                          onConnect={() => void handleConnect(entry)}
+                          onSwitchAccount={
+                            existing
+                              ? () =>
+                                  void handleConnect(entry, { force: true })
+                              : null
+                          }
+                          phase={phaseByToolkit[entry.slug] ?? "idle"}
+                        />
+                      );
+                    })}
                   </ul>
                 )}
               </div>
@@ -505,11 +637,20 @@ function HeroConnectCard({
   phase,
   error,
   onConnect,
+  connectedAccountLabel,
+  onSwitchAccount,
 }: {
   entry: HeroEntry;
   phase: ConnectPhase;
   error: string | null;
   onConnect: () => void;
+  /** Friendly label of the already-connected account (e.g. "@jotyy" or
+   *  "josh@example.com"). Null when there's no pre-existing connection. */
+  connectedAccountLabel: string | null;
+  /** Triggers a fresh OAuth that creates a NEW connection for the same
+   *  provider. Null when the tile has no existing connection to switch
+   *  away from. */
+  onSwitchAccount: (() => void) | null;
 }) {
   const isDone = phase === "done";
   const isConnecting = phase === "connecting";
@@ -539,6 +680,11 @@ function HeroConnectCard({
           <div className="truncate text-sm font-medium text-foreground">
             {entry.displayName}
           </div>
+          {isDone && connectedAccountLabel ? (
+            <div className="truncate text-[11px] leading-4 text-muted-foreground">
+              {connectedAccountLabel}
+            </div>
+          ) : null}
         </div>
         {isDone ? (
           <div className="grid size-7 place-items-center rounded-md bg-emerald-500/15 text-emerald-600">
@@ -563,6 +709,18 @@ function HeroConnectCard({
           </Button>
         )}
       </div>
+      {isDone && onSwitchAccount ? (
+        // Tiny escape hatch — most users will accept the reused account,
+        // but power users with multiple Gmails / GitHubs need a way to
+        // force a fresh OAuth into a different account for this workspace.
+        <button
+          className="self-start text-[11px] leading-4 text-muted-foreground transition-colors hover:text-foreground"
+          onClick={onSwitchAccount}
+          type="button"
+        >
+          Switch account
+        </button>
+      ) : null}
       {error ? (
         <p className="line-clamp-2 text-[11px] leading-4 text-destructive">
           {error}
@@ -570,4 +728,21 @@ function HeroConnectCard({
       ) : null}
     </li>
   );
+}
+
+// Pick the most-recognizable string from a connection for inline display
+// on the onboarding tile. Falls back through handle → email → label →
+// "Connected" so we always render something useful.
+function accountDisplayHandle(
+  connection: IntegrationConnectionPayload,
+): string {
+  const handle = connection.account_handle?.trim();
+  if (handle) {
+    return handle.startsWith("@") ? handle : `@${handle}`;
+  }
+  const email = connection.account_email?.trim();
+  if (email) return email;
+  const label = connection.account_label?.trim();
+  if (label) return label;
+  return "Connected";
 }

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -1285,7 +1285,7 @@ function HeroConnectCard({
               return (
                 <DropdownMenuItem
                   key={acct.connection_id}
-                  onSelect={() => {
+                  onClick={() => {
                     if (isSelected) return;
                     onSelectAccount(acct.connection_id);
                   }}
@@ -1302,7 +1302,7 @@ function HeroConnectCard({
               );
             })}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={onAddNewAccount}>
+            <DropdownMenuItem onClick={onAddNewAccount}>
               <Plus className="size-3.5" />
               <span>Add another account…</span>
             </DropdownMenuItem>

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -7,7 +7,7 @@ import {
   RotateCw,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { IntegrationLogo } from "@/components/integration/IntegrationLogo";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,7 +19,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { bindConnectionToWorkspace } from "@/lib/bindConnectionToWorkspace";
 import { toolkitDisplayName } from "@/lib/toolkitDisplay";
-import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
+import {
+  IntegrationConnectCancelled,
+  useWorkspaceDesktop,
+} from "@/lib/workspaceDesktop";
 
 type HeroEntry = {
   slug: string;
@@ -335,6 +338,20 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const [dismissedWorkspaceError, setDismissedWorkspaceError] = useState<
     string | null
   >(null);
+
+  // Per-toolkit AbortControllers so each card's Cancel button can short-
+  // circuit `connectIntegrationProvider`'s ~5-minute timeout. One entry
+  // per slug; new attempts replace the prior controller. Cleared on
+  // workspace switch + on unmount.
+  const connectControllersRef = useRef<Record<string, AbortController>>({});
+  useEffect(() => {
+    return () => {
+      for (const controller of Object.values(connectControllersRef.current)) {
+        controller.abort();
+      }
+      connectControllersRef.current = {};
+    };
+  }, []);
   const onboardingFlowState = (selectedWorkspace?.onboarding_state || "")
     .trim()
     .toLowerCase();
@@ -361,6 +378,10 @@ export function DeterministicWorkspaceOnboardingSurface() {
     setContextFetchStatusByConnectionId({});
     setExistingConnectionsBySlug({});
     setHasReachedFetching(false);
+    for (const controller of Object.values(connectControllersRef.current)) {
+      controller.abort();
+    }
+    connectControllersRef.current = {};
   }, [selectedWorkspace?.id]);
 
   // Pull the user's existing active connections (across all workspaces)
@@ -629,10 +650,14 @@ export function DeterministicWorkspaceOnboardingSurface() {
 
     setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "connecting" }));
     setErrorByToolkit((prev) => ({ ...prev, [entry.slug]: null }));
+    connectControllersRef.current[entry.slug]?.abort();
+    const controller = new AbortController();
+    connectControllersRef.current[entry.slug] = controller;
     try {
       const { connectionId } = await connectIntegrationProvider({
         provider: entry.slug,
-        accountLabel: `${entry.displayName} (Managed)`,
+        accountLabel: entry.displayName,
+        signal: controller.signal,
       });
       setConnectionIdByToolkit((prev) => ({
         ...prev,
@@ -652,10 +677,27 @@ export function DeterministicWorkspaceOnboardingSurface() {
         errorToolkitSlug: entry.slug,
       });
     } catch (err) {
+      // User cancelled — drop back to idle silently (no error, the user
+      // intended this).
+      if (
+        err instanceof IntegrationConnectCancelled ||
+        controller.signal.aborted
+      ) {
+        setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "idle" }));
+        return;
+      }
       const msg = err instanceof Error ? err.message : "Connection failed.";
       setErrorByToolkit((prev) => ({ ...prev, [entry.slug]: msg }));
       setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "error" }));
+    } finally {
+      if (connectControllersRef.current[entry.slug] === controller) {
+        delete connectControllersRef.current[entry.slug];
+      }
     }
+  }
+
+  function handleCancelConnect(slug: string) {
+    connectControllersRef.current[slug]?.abort();
   }
 
   // Trigger a fresh OAuth for a provider whose context fetch failed (e.g.
@@ -666,10 +708,14 @@ export function DeterministicWorkspaceOnboardingSurface() {
   async function handleReconnectFailed(providerId: string) {
     if (!providerId || reconnectingProvider === providerId) return;
     setReconnectingProvider(providerId);
+    connectControllersRef.current[providerId]?.abort();
+    const controller = new AbortController();
+    connectControllersRef.current[providerId] = controller;
     try {
       const { connectionId } = await connectIntegrationProvider({
         provider: providerId,
-        accountLabel: `${toolkitDisplayName(providerId)} (Managed)`,
+        accountLabel: toolkitDisplayName(providerId),
+        signal: controller.signal,
       });
       await startContextFetch({
         connectionId,
@@ -678,8 +724,12 @@ export function DeterministicWorkspaceOnboardingSurface() {
       });
     } catch {
       // OAuth itself failed (user closed popup, network, etc.) — leave
-      // the failed row visible so they can try again.
+      // the failed row visible so they can try again. Cancellation drops
+      // back silently for the same reason.
     } finally {
+      if (connectControllersRef.current[providerId] === controller) {
+        delete connectControllersRef.current[providerId];
+      }
       setReconnectingProvider((current) =>
         current === providerId ? null : current,
       );
@@ -1034,6 +1084,7 @@ export function DeterministicWorkspaceOnboardingSurface() {
                           onAddNewAccount={() =>
                             void handleConnect(entry, { force: true })
                           }
+                          onCancel={() => handleCancelConnect(entry.slug)}
                           onConnect={() => void handleConnect(entry)}
                           onSelectAccount={(connectionId) => {
                             setConnectionIdByToolkit((prev) => ({
@@ -1129,6 +1180,7 @@ function HeroConnectCard({
   phase,
   error,
   onConnect,
+  onCancel,
   accounts,
   selectedConnectionId,
   onSelectAccount,
@@ -1138,6 +1190,10 @@ function HeroConnectCard({
   phase: ConnectPhase;
   error: string | null;
   onConnect: () => void;
+  /** Abort the in-flight OAuth poll. Wired to the inline Cancel affordance
+   *  on the connecting state so the user doesn't have to wait through the
+   *  ~5-minute timeout after closing the OAuth browser. */
+  onCancel: () => void;
   /** Every active connection the user has for this provider, newest-first.
    *  Empty array when no pre-existing connections — the tile renders a
    *  plain Connect button in that case. */
@@ -1183,23 +1239,26 @@ function HeroConnectCard({
           ) : null}
         </div>
       </div>
-      {!isDone ? (
+      {!isDone && isConnecting ? (
+        <div className="mt-auto inline-flex items-center gap-1.5 text-[11px] leading-4 text-muted-foreground">
+          <LoaderCircle className="size-3 animate-spin" />
+          <span>Connecting…</span>
+          <button
+            aria-label="Cancel connection"
+            className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-fg-4 hover:text-foreground"
+            onClick={onCancel}
+            type="button"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      ) : !isDone ? (
         <button
-          className="mt-auto inline-flex w-fit items-center gap-1 text-[11px] leading-4 font-medium text-foreground transition-colors hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
-          disabled={isConnecting}
+          className="mt-auto inline-flex w-fit items-center gap-1 text-[11px] leading-4 font-medium text-foreground transition-colors hover:text-primary"
           onClick={onConnect}
           type="button"
         >
-          {isConnecting ? (
-            <>
-              <LoaderCircle className="size-3 animate-spin" />
-              Connecting…
-            </>
-          ) : phase === "error" ? (
-            "Retry"
-          ) : (
-            "Connect"
-          )}
+          {phase === "error" ? "Retry" : "Connect"}
         </button>
       ) : null}
       {isDone && accounts.length > 0 ? (

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -262,6 +262,42 @@ function fetchTone(status: string): FetchToneTokens {
   }
 }
 
+function makeContextFetchStartFailureStatus(params: {
+  connectionId: string;
+  providerId: string;
+  accountKey?: string | null;
+  accountLabel?: string | null;
+  errorMessage: string;
+}): IntegrationContextFetchStatusPayload {
+  const now = new Date().toISOString();
+  return {
+    connection_id: params.connectionId,
+    provider_id: params.providerId,
+    run_id: `local-start-failure-${params.connectionId}`,
+    supported: true,
+    status: "failed",
+    account_key: params.accountKey?.trim() || null,
+    account_label: params.accountLabel?.trim() || null,
+    tree_id: null,
+    current_chunk_label: `Context fetch failed for ${params.providerId}`,
+    chunks_total: 0,
+    chunks_completed: 0,
+    messages_seen: 0,
+    messages_persisted: 0,
+    leaves_created: 0,
+    leaves_superseding: 0,
+    leaves_unchanged: 0,
+    summary_nodes: 0,
+    actions: [],
+    started_at: now,
+    updated_at: now,
+    completed_at: now,
+    fetched_at: null,
+    error_message: params.errorMessage,
+    reason: null,
+  };
+}
+
 export function DeterministicWorkspaceOnboardingSurface() {
   const {
     selectedWorkspace,
@@ -528,6 +564,49 @@ export function DeterministicWorkspaceOnboardingSurface() {
     };
   }, [isFetchingContext, shouldPollFetchStatuses, trackedConnectionIds, trackedConnectionIdsKey]);
 
+  async function startContextFetch(params: {
+    connectionId: string;
+    providerId: string;
+    accountKey?: string | null;
+    accountLabel?: string | null;
+    errorToolkitSlug?: string;
+  }) {
+    try {
+      const response =
+        await window.electronAPI.workspace.fetchIntegrationContext(
+          params.connectionId,
+        );
+      setContextFetchStatusByConnectionId((prev) => ({
+        ...prev,
+        [params.connectionId]: response.status,
+      }));
+      return response.status;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Context fetch could not be started.";
+      setContextFetchStatusByConnectionId((prev) => ({
+        ...prev,
+        [params.connectionId]: makeContextFetchStartFailureStatus({
+          connectionId: params.connectionId,
+          providerId: params.providerId,
+          accountKey: params.accountKey,
+          accountLabel: params.accountLabel,
+          errorMessage: message,
+        }),
+      }));
+      if (params.errorToolkitSlug) {
+        const toolkitSlug = params.errorToolkitSlug;
+        setErrorByToolkit((prev) => ({
+          ...prev,
+          [toolkitSlug]: `Connected, but context fetch could not be started: ${message}`,
+        }));
+      }
+      return null;
+    }
+  }
+
   async function handleConnect(
     entry: HeroEntry,
     opts?: { force?: boolean },
@@ -566,27 +645,12 @@ export function DeterministicWorkspaceOnboardingSurface() {
       // spinner appear stuck for the 30s–minutes that the runtime takes
       // to enqueue/start the fetch, which the user reads as "broken".
       setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "done" }));
-      void (async () => {
-        try {
-          const response =
-            await window.electronAPI.workspace.fetchIntegrationContext(
-              connectionId,
-            );
-          setContextFetchStatusByConnectionId((prev) => ({
-            ...prev,
-            [connectionId]: response.status,
-          }));
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : "Context fetch could not be started.";
-          setErrorByToolkit((prev) => ({
-            ...prev,
-            [entry.slug]: `Connected, but context fetch could not be started: ${message}`,
-          }));
-        }
-      })();
+      void startContextFetch({
+        connectionId,
+        providerId: entry.slug,
+        accountLabel: `${entry.displayName} (Managed)`,
+        errorToolkitSlug: entry.slug,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Connection failed.";
       setErrorByToolkit((prev) => ({ ...prev, [entry.slug]: msg }));
@@ -607,19 +671,11 @@ export function DeterministicWorkspaceOnboardingSurface() {
         provider: providerId,
         accountLabel: `${toolkitDisplayName(providerId)} (Managed)`,
       });
-      try {
-        const response =
-          await window.electronAPI.workspace.fetchIntegrationContext(
-            connectionId,
-          );
-        setContextFetchStatusByConnectionId((prev) => ({
-          ...prev,
-          [connectionId]: response.status,
-        }));
-      } catch {
-        // Context fetch trigger failed — the status poller will retry on
-        // the runtime side; user can also click Reconnect again.
-      }
+      await startContextFetch({
+        connectionId,
+        providerId,
+        accountLabel: `${toolkitDisplayName(providerId)} (Managed)`,
+      });
     } catch {
       // OAuth itself failed (user closed popup, network, etc.) — leave
       // the failed row visible so they can try again.
@@ -651,6 +707,26 @@ export function DeterministicWorkspaceOnboardingSurface() {
               connectionId,
             }),
           ),
+        );
+        await Promise.allSettled(
+          entries.map(async ([slug, connectionId]) => {
+            const existingConnection =
+              existingConnectionsBySlug[slug]?.find(
+                (connection) => connection.connection_id === connectionId,
+              ) ?? null;
+            await startContextFetch({
+              connectionId,
+              providerId: slug,
+              accountKey:
+                existingConnection?.account_handle ||
+                existingConnection?.account_email ||
+                existingConnection?.account_external_id ||
+                null,
+              accountLabel:
+                existingConnection?.account_label ||
+                `${toolkitDisplayName(slug)} (Managed)`,
+            });
+          }),
         );
       }
       await continueDeterministicOnboarding();

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -1,5 +1,14 @@
-import { Check, ChevronDown, LoaderCircle, Plug, Plus } from "lucide-react";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  LoaderCircle,
+  Plus,
+  RotateCw,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { IntegrationLogo } from "@/components/integration/IntegrationLogo";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -9,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { bindConnectionToWorkspace } from "@/lib/bindConnectionToWorkspace";
+import { toolkitDisplayName } from "@/lib/toolkitDisplay";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
 type HeroEntry = {
@@ -32,8 +42,36 @@ const HERO_PRIORITY = [
 
 const FETCH_TERMINAL_STATUSES = new Set(["completed", "failed", "unsupported"]);
 
+// "<Platform> (Managed)" / "<slug> (managed)" / bare slug — labels we
+// set ourselves during connect as a stand-in until whoami populates the
+// real account info. Treat them as missing for display purposes so the
+// row falls back to the canonical platform name (e.g. "Notion") instead
+// of leaking our internal placeholder.
+function isPlaceholderLabel(label: string, slug: string): boolean {
+  const cleaned = label.trim().toLowerCase();
+  if (!cleaned) return true;
+  const slugLower = slug.trim().toLowerCase();
+  if (cleaned === slugLower) return true;
+  if (cleaned === `${slugLower} (managed)`) return true;
+  const platform = toolkitDisplayName(slug).trim().toLowerCase();
+  if (cleaned === platform) return true;
+  if (cleaned === `${platform} (managed)`) return true;
+  return false;
+}
+
+function formatAccountHandle(handle: string): string {
+  const trimmed = handle.trim();
+  if (!trimmed) return "";
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
 function contextFetchDisplayName(status: IntegrationContextFetchStatusPayload) {
-  return status.account_label || status.account_key || status.provider_id;
+  const slug = status.provider_id;
+  const label = status.account_label?.trim() ?? "";
+  if (label && !isPlaceholderLabel(label, slug)) return label;
+  const key = status.account_key?.trim() ?? "";
+  if (key && key.toLowerCase() !== slug.toLowerCase()) return key;
+  return toolkitDisplayName(slug);
 }
 
 function contextFetchChunkTotal(status: IntegrationContextFetchStatusPayload) {
@@ -72,6 +110,158 @@ function contextFetchStateLabel(status: IntegrationContextFetchStatusPayload) {
   return "Running";
 }
 
+type FetchErrorCategory =
+  | "auth_revoked"
+  | "permission_denied"
+  | "server_error"
+  | "rate_limit"
+  | "unknown";
+
+function categorizeFetchError(message: string | null | undefined): FetchErrorCategory {
+  const text = (message || "").toLowerCase();
+  if (!text) return "unknown";
+  if (
+    text.includes("revoked") ||
+    text.includes("active state") ||
+    text.includes("expired") ||
+    text.includes("invalid_grant") ||
+    text.includes("unauthorized") ||
+    text.includes("401")
+  ) {
+    return "auth_revoked";
+  }
+  if (text.includes("permission") || text.includes("scope") || text.includes("403")) {
+    return "permission_denied";
+  }
+  if (text.includes("rate limit") || text.includes("429") || text.includes("too many requests")) {
+    return "rate_limit";
+  }
+  if (
+    text.includes("internal server") ||
+    text.includes("500") ||
+    text.includes("502") ||
+    text.includes("503") ||
+    text.includes("504") ||
+    text.includes("timeout")
+  ) {
+    return "server_error";
+  }
+  return "unknown";
+}
+
+function humanizeFetchError(
+  category: FetchErrorCategory,
+  rawMessage: string,
+): string {
+  switch (category) {
+    case "auth_revoked":
+      return "Access was revoked — reconnect to retry.";
+    case "permission_denied":
+      return "Missing permissions — reconnect with full access.";
+    case "rate_limit":
+      return "Hit a rate limit — we'll retry shortly.";
+    case "server_error":
+      return "The provider returned a server error — we'll retry shortly.";
+    default:
+      return rawMessage.length > 120
+        ? `${rawMessage.slice(0, 117)}…`
+        : rawMessage;
+  }
+}
+
+interface FetchToneTokens {
+  /** Background tint + text color for a status pill. */
+  pill: string;
+  /** Filled dot color (small bg circle). */
+  dot: string;
+  /** Filled bar color (legacy horizontal progress fill). */
+  bar: string;
+  /** Text color class used by CircularProgress via `stroke-current`. */
+  ring: string;
+}
+
+function CircularProgress({
+  value,
+  size = 14,
+  strokeWidth = 2,
+  className,
+  trackClassName = "stroke-fg-4",
+}: {
+  value: number;
+  size?: number;
+  strokeWidth?: number;
+  className?: string;
+  trackClassName?: string;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const safeValue = Math.max(0, Math.min(100, value));
+  const offset = circumference - (safeValue / 100) * circumference;
+  return (
+    <svg
+      aria-hidden="true"
+      className={`shrink-0 ${className ?? ""}`}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      width={size}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        fill="none"
+        r={radius}
+        strokeWidth={strokeWidth}
+        className={trackClassName}
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        fill="none"
+        r={radius}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        strokeWidth={strokeWidth}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        className="stroke-current transition-[stroke-dashoffset] duration-300"
+      />
+    </svg>
+  );
+}
+
+function fetchTone(status: string): FetchToneTokens {
+  switch (status) {
+    case "completed":
+      return {
+        pill: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+        dot: "bg-emerald-500",
+        bar: "bg-emerald-500",
+        ring: "text-emerald-500",
+      };
+    case "failed":
+      return {
+        pill: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+        dot: "bg-amber-500",
+        bar: "bg-amber-500",
+        ring: "text-amber-500",
+      };
+    case "unsupported":
+      return {
+        pill: "bg-muted text-muted-foreground",
+        dot: "bg-muted-foreground/60",
+        bar: "bg-muted-foreground/40",
+        ring: "text-muted-foreground/50",
+      };
+    default:
+      return {
+        pill: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+        dot: "bg-blue-500",
+        bar: "bg-blue-500",
+        ring: "text-blue-500",
+      };
+  }
+}
+
 export function DeterministicWorkspaceOnboardingSurface() {
   const {
     selectedWorkspace,
@@ -103,6 +293,12 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const [contextFetchStatusByConnectionId, setContextFetchStatusByConnectionId] =
     useState<Record<string, IntegrationContextFetchStatusPayload>>({});
   const [isContinuing, setIsContinuing] = useState(false);
+  const [reconnectingProvider, setReconnectingProvider] = useState<
+    string | null
+  >(null);
+  const [dismissedWorkspaceError, setDismissedWorkspaceError] = useState<
+    string | null
+  >(null);
   const onboardingFlowState = (selectedWorkspace?.onboarding_state || "")
     .trim()
     .toLowerCase();
@@ -208,7 +404,7 @@ export function DeterministicWorkspaceOnboardingSurface() {
             const toolkit = composioToolkitsByProvider[entry.slug];
             return {
               slug: entry.slug,
-              displayName: toolkit?.name ?? entry.slug,
+              displayName: toolkitDisplayName(entry.slug),
               logo:
                 toolkit?.logo ?? `https://logos.composio.dev/api/${entry.slug}`,
             };
@@ -251,6 +447,27 @@ export function DeterministicWorkspaceOnboardingSurface() {
         ),
     [contextFetchStatusByConnectionId, trackedConnectionIds],
   );
+  // Render a row for every connection we're tracking — even before the
+  // first status poll returns — so the user immediately sees the tools
+  // they connected (with a "Preparing" placeholder) instead of an empty
+  // card during the network round-trip.
+  const trackedEntries = useMemo(() => {
+    return Object.entries(connectionIdByToolkit)
+      .map(([slug, connectionId]) => {
+        const id = connectionId.trim();
+        if (!id) return null;
+        const connection =
+          existingConnectionsBySlug[slug]?.find(
+            (c) => c.connection_id === id,
+          ) ?? null;
+        return { slug, connectionId: id, connection };
+      })
+      .filter(
+        (entry): entry is { slug: string; connectionId: string; connection: IntegrationConnectionPayload | null } =>
+          entry !== null,
+      )
+      .sort((a, b) => a.slug.localeCompare(b.slug));
+  }, [connectionIdByToolkit, existingConnectionsBySlug]);
   const supportedFetchStatuses = trackedFetchStatuses.filter(
     (status) => status.supported,
   );
@@ -363,6 +580,42 @@ export function DeterministicWorkspaceOnboardingSurface() {
     }
   }
 
+  // Trigger a fresh OAuth for a provider whose context fetch failed (e.g.
+  // Notion access revoked), then explicitly kick off the context fetch
+  // for the new connection. Without the fetchIntegrationContext call the
+  // runtime never re-enqueues the import — matches the post-OAuth path
+  // in handleConnect above.
+  async function handleReconnectFailed(providerId: string) {
+    if (!providerId || reconnectingProvider === providerId) return;
+    setReconnectingProvider(providerId);
+    try {
+      const { connectionId } = await connectIntegrationProvider({
+        provider: providerId,
+        accountLabel: `${toolkitDisplayName(providerId)} (Managed)`,
+      });
+      try {
+        const response =
+          await window.electronAPI.workspace.fetchIntegrationContext(
+            connectionId,
+          );
+        setContextFetchStatusByConnectionId((prev) => ({
+          ...prev,
+          [connectionId]: response.status,
+        }));
+      } catch {
+        // Context fetch trigger failed — the status poller will retry on
+        // the runtime side; user can also click Reconnect again.
+      }
+    } catch {
+      // OAuth itself failed (user closed popup, network, etc.) — leave
+      // the failed row visible so they can try again.
+    } finally {
+      setReconnectingProvider((current) =>
+        current === providerId ? null : current,
+      );
+    }
+  }
+
   async function handleContinue() {
     setIsContinuing(true);
     try {
@@ -392,7 +645,6 @@ export function DeterministicWorkspaceOnboardingSurface() {
     }
   }
 
-  const workspaceName = selectedWorkspace?.name?.trim() || "Workspace";
   const fetchingContextMessage =
     connectedCount > 0
       ? `We're importing the first batch of context from your ${connectedCount} connected ${connectedCount === 1 ? "tool" : "tools"} now. You can enter the workspace while that keeps running in the background.`
@@ -409,15 +661,15 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const aggregateProgressPercent =
     aggregateChunkTotal > 0
       ? Math.max(
-          0,
-          Math.min(
-            100,
-            Math.round((aggregateChunkCompleted / aggregateChunkTotal) * 100),
-          ),
-        )
+        0,
+        Math.min(
+          100,
+          Math.round((aggregateChunkCompleted / aggregateChunkTotal) * 100),
+        ),
+      )
       : supportedFetchStatuses.every((status) =>
-            FETCH_TERMINAL_STATUSES.has(status.status),
-          ) && supportedFetchStatuses.length > 0
+        FETCH_TERMINAL_STATUSES.has(status.status),
+      ) && supportedFetchStatuses.length > 0
         ? 100
         : 0;
   const runningFetchStatuses = supportedFetchStatuses.filter(
@@ -440,132 +692,217 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const aggregateDetailLine =
     runningFetchStatuses.length > 0
       ? runningFetchStatuses[0]?.current_chunk_label ||
-        "Importing the first chunks now."
+      "Importing the first chunks now."
       : failedFetchStatuses.length > 0
         ? failedFetchStatuses[0]?.error_message ||
-          "One of the background imports failed."
+        "One of the background imports failed."
         : completedFetchCount > 0
           ? "Your connected context is ready inside the workspace memory browser."
           : "Context fetch status will appear here as soon as the imports start.";
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center overflow-y-auto px-6 py-10 sm:px-10">
-      <div className="flex w-full max-w-2xl flex-col items-center gap-6">
-        <div className="w-full rounded-[32px] border border-border/70 bg-background/90 px-8 py-10 shadow-[0_28px_90px_rgba(15,23,42,0.08)] backdrop-blur sm:px-12 sm:py-12">
+    <div className="flex h-full min-h-0 w-full flex-1 justify-center overflow-y-auto px-6 py-10 sm:px-10">
+      <div className="my-auto flex w-full max-w-3xl flex-col items-center gap-4">
+        <div className="w-full rounded-3xl border border-border bg-background px-8 py-8 sm:px-10 sm:py-10">
           {isFetchingContext ? (
-            <div className="flex flex-col items-center justify-center gap-6 py-6 text-center">
-              <div className="grid size-14 place-items-center rounded-full bg-accent/60 text-foreground">
-                <LoaderCircle className="size-6 animate-spin" />
+            <div className="flex flex-col gap-5">
+              <div className="text-xs font-medium text-muted-foreground">
+                Importing in background
               </div>
+
               <div className="space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-                  Set up {workspaceName}
-                </p>
                 <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-                  Fetching your context
+                  Your workspace is being prepared
                 </h1>
-                <p className="mx-auto max-w-md text-sm leading-7 text-muted-foreground">
+                <p className="max-w-xl text-sm text-muted-foreground">
                   {fetchingContextMessage}
                 </p>
-                <p className="mx-auto max-w-md text-sm leading-7 text-muted-foreground">
-                  This can take a minute depending on the accounts you linked.
-                </p>
               </div>
+
               {supportedFetchStatuses.length > 0 ? (
-                <div className="mx-auto w-full max-w-lg rounded-2xl border border-border/70 bg-background/70 p-4 text-left">
-                  <div className="flex items-center justify-between gap-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    <span>Overall progress</span>
-                    <span>{aggregateStatusLine}</span>
+                <div className="rounded-2xl border border-border bg-fg-2 p-5">
+                  <div className="flex items-baseline justify-between gap-4">
+                    <div className="flex items-baseline gap-2.5">
+                      <span className="text-2xl font-semibold leading-none tabular-nums text-foreground">
+                        {aggregateProgressPercent}%
+                      </span>
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {aggregateChunkCompleted.toLocaleString()}/
+                        {aggregateChunkTotal.toLocaleString()} chunks
+                      </span>
+                    </div>
                   </div>
-                  <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
+                  <div className="mt-4 h-1 overflow-hidden rounded-full bg-fg-4">
                     <div
-                      className="h-full rounded-full bg-foreground transition-[width] duration-300"
+                      className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out"
                       style={{ width: `${aggregateProgressPercent}%` }}
                     />
                   </div>
-                  <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                  <div className="mt-2.5 line-clamp-1 text-xs text-muted-foreground">
                     {aggregateDetailLine}
-                  </p>
+                  </div>
                 </div>
               ) : null}
-              {trackedFetchStatuses.length > 0 ? (
-                <ul className="w-full space-y-3 text-left">
-                  {trackedFetchStatuses.map((status) => {
-                    const progressPercent = contextFetchProgressPercent(status);
-                    const chunkTotal = contextFetchChunkTotal(status);
-                    return (
-                      <li
-                        className="rounded-2xl border border-border/70 bg-background/70 p-4"
-                        key={status.connection_id}
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-sm font-medium text-foreground">
-                              {contextFetchDisplayName(status)}
-                            </p>
-                            <p className="text-xs leading-5 text-muted-foreground">
-                              {status.current_chunk_label ||
-                                (status.supported
-                                  ? "Preparing background import."
-                                  : status.reason ||
-                                    "Context fetch is not supported yet for this integration.")}
+
+              {trackedEntries.length > 0 ? (
+                <ul className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-background">
+                  {trackedEntries.map((entry) => {
+                    const status =
+                      contextFetchStatusByConnectionId[entry.connectionId];
+                    if (!status) {
+                      const handle = entry.connection?.account_handle?.trim();
+                      const email = entry.connection?.account_email?.trim();
+                      const label = entry.connection?.account_label?.trim();
+                      const pendingName = handle
+                        ? formatAccountHandle(handle)
+                        : email
+                          ? email
+                          : label && !isPlaceholderLabel(label, entry.slug)
+                            ? label
+                            : toolkitDisplayName(entry.slug);
+                      return (
+                        <li
+                          className="flex items-center gap-3 px-3.5 py-2.5"
+                          key={entry.connectionId}
+                        >
+                          <IntegrationLogo
+                            alt={pendingName}
+                            size="sm"
+                            slug={entry.slug}
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium text-foreground">
+                              {pendingName}
+                            </div>
+                            <p className="mt-0.5 line-clamp-1 text-[11px] text-muted-foreground">
+                              Preparing import…
                             </p>
                           </div>
-                          <p className="shrink-0 text-xs font-medium text-muted-foreground">
-                            {contextFetchStateLabel(status)}
-                          </p>
-                        </div>
-                        {status.supported ? (
-                          <>
-                            <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
-                              <div
-                                className="h-full rounded-full bg-foreground transition-[width] duration-300"
-                                style={{ width: `${progressPercent}%` }}
-                              />
-                            </div>
-                            <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
-                              {chunkTotal > 0
-                                ? `${Math.min(status.chunks_completed, chunkTotal)}/${chunkTotal} chunks complete`
-                                : "Waiting for chunk progress"}
-                              {status.error_message
-                                ? ` - ${status.error_message}`
-                                : ""}
+                          <LoaderCircle className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+                        </li>
+                      );
+                    }
+                    const progressPercent =
+                      contextFetchProgressPercent(status);
+                    const chunkTotal = contextFetchChunkTotal(status);
+                    const tone = fetchTone(status.status);
+                    const isFailed = status.status === "failed";
+                    const errorCategory = isFailed
+                      ? categorizeFetchError(status.error_message)
+                      : "unknown";
+                    const canReconnect =
+                      isFailed &&
+                      (errorCategory === "auth_revoked" ||
+                        errorCategory === "permission_denied");
+                    const isReconnectingThis =
+                      reconnectingProvider === status.provider_id;
+                    const detailLine = isFailed
+                      ? humanizeFetchError(
+                          errorCategory,
+                          status.error_message || "Context fetch failed.",
+                        )
+                      : !status.supported
+                        ? status.reason || "Not supported yet."
+                        : null;
+                    const countLabel =
+                      chunkTotal > 0
+                        ? `${Math.min(status.chunks_completed, chunkTotal)}/${chunkTotal}`
+                        : "—";
+                    return (
+                      <li
+                        className={`flex items-center gap-3 px-3.5 py-2.5 ${isFailed ? "bg-amber-500/[0.03]" : ""}`}
+                        key={status.connection_id}
+                      >
+                        <IntegrationLogo
+                          alt={contextFetchDisplayName(status)}
+                          size="sm"
+                          slug={status.provider_id}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium text-foreground">
+                            {contextFetchDisplayName(status)}
+                          </div>
+                          {detailLine ? (
+                            <p
+                              className={`mt-0.5 line-clamp-1 text-[11px] ${isFailed ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"}`}
+                            >
+                              {detailLine}
                             </p>
-                          </>
-                        ) : (
-                          <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
-                            {status.reason ||
-                              "Context fetch is not available yet for this provider."}
-                          </p>
-                        )}
+                          ) : null}
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          {canReconnect ? (
+                            <button
+                              className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-[11px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                              disabled={isReconnectingThis}
+                              onClick={() =>
+                                void handleReconnectFailed(status.provider_id)
+                              }
+                              type="button"
+                            >
+                              {isReconnectingThis ? (
+                                <>
+                                  <LoaderCircle className="size-3 animate-spin" />
+                                  Connecting…
+                                </>
+                              ) : (
+                                <>
+                                  <RotateCw className="size-3" />
+                                  Reconnect
+                                </>
+                              )}
+                            </button>
+                          ) : (
+                            <>
+                              <span className="text-[11px] tabular-nums text-muted-foreground">
+                                {countLabel}
+                              </span>
+                              {status.supported ? (
+                                <CircularProgress
+                                  className={tone.ring}
+                                  size={14}
+                                  strokeWidth={1.75}
+                                  value={progressPercent}
+                                />
+                              ) : (
+                                <span
+                                  className={`size-1.5 rounded-full ${tone.dot}`}
+                                />
+                              )}
+                            </>
+                          )}
+                        </div>
                       </li>
                     );
                   })}
                 </ul>
               ) : null}
+
               {unsupportedFetchStatuses.length > 0 ? (
-                <p className="mx-auto max-w-lg text-xs leading-5 text-muted-foreground">
-                  Some connected tools do not support context import yet. You
-                  can still enter the workspace now.
+                <p className="text-xs leading-5 text-muted-foreground">
+                  Some connected tools don't support context import yet —
+                  they'll still work once you're inside.
                 </p>
               ) : null}
             </div>
           ) : (
             <>
-              <div className="space-y-3 text-center">
-                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-                  Set up {workspaceName}
-                </p>
+              <div className="space-y-4 text-center">
                 <h1 className="text-3xl font-semibold tracking-tight text-foreground">
                   Hook up your tools
                 </h1>
-                <p className="mx-auto max-w-md text-sm leading-7 text-muted-foreground">
+                <p className="mx-auto max-w-md text-sm text-muted-foreground">
                   Connect anything you want the agent to use. One click each —
                   you can always add more from Settings later.
                 </p>
+                {heroEntries && heroEntries.length > 0 ? (
+                  <p className="text-xs tabular-nums text-muted-foreground">
+                    {connectedCount} of {heroEntries.length} connected
+                  </p>
+                ) : null}
               </div>
 
-              <div className="mt-8">
+              <div className="mt-10">
                 {heroEntries === null ? (
                   <HeroGridSkeleton />
                 ) : heroEntries.length === 0 ? (
@@ -575,7 +912,7 @@ export function DeterministicWorkspaceOnboardingSurface() {
                     continuing.
                   </p>
                 ) : (
-                  <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  <ul className="grid auto-rows-fr grid-cols-2 gap-3 sm:grid-cols-3">
                     {heroEntries.map((entry) => {
                       const accounts =
                         existingConnectionsBySlug[entry.slug] ?? [];
@@ -613,7 +950,27 @@ export function DeterministicWorkspaceOnboardingSurface() {
           )}
         </div>
 
-        <div className="flex items-center gap-4">
+        {workspaceErrorMessage &&
+        workspaceErrorMessage !== dismissedWorkspaceError ? (
+          <div className="flex w-full max-w-md items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/[0.06] px-4 py-3">
+            <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <div className="min-w-0 flex-1 text-sm leading-5 text-foreground">
+              {workspaceErrorMessage}
+            </div>
+            <button
+              aria-label="Dismiss error"
+              className="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-amber-500/10 hover:text-foreground"
+              onClick={() =>
+                setDismissedWorkspaceError(workspaceErrorMessage)
+              }
+              type="button"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        ) : null}
+
+        <div className="flex flex-col items-center gap-2">
           <Button
             className="min-w-[180px]"
             disabled={isContinuing}
@@ -628,16 +985,15 @@ export function DeterministicWorkspaceOnboardingSurface() {
               : isFetchingContext
                 ? "Enter workspace now"
                 : connectedCount > 0
-                ? `Continue (${connectedCount} connected)`
-                : "Continue"}
+                  ? `Continue (${connectedCount} connected)`
+                  : "Skip for now"}
           </Button>
+          {isFetchingContext ? (
+            <p className="text-[11px] text-muted-foreground">
+              Imports continue in the background while you work.
+            </p>
+          ) : null}
         </div>
-
-        {workspaceErrorMessage ? (
-          <p className="max-w-md text-center text-sm text-destructive">
-            {workspaceErrorMessage}
-          </p>
-        ) : null}
       </div>
     </div>
   );
@@ -694,58 +1050,46 @@ function HeroConnectCard({
   return (
     <li
       className={
-        "flex flex-col gap-1.5 rounded-xl border border-border bg-card px-3 py-2.5 transition-colors hover:bg-accent/40"
+        "group flex h-full flex-col gap-2 rounded-xl border border-border bg-card px-3.5 py-3 transition-colors hover:bg-accent/40"
       }
     >
-      <div className="flex items-center gap-2.5">
-        <div className="grid size-7 shrink-0 place-items-center overflow-hidden rounded-md border border-border bg-background">
-          {entry.logo ? (
-            <img
-              alt=""
-              className="size-full object-contain p-0.5"
-              onError={(e) => {
-                e.currentTarget.style.display = "none";
-              }}
-              referrerPolicy="no-referrer"
-              src={entry.logo}
-            />
-          ) : (
-            <Plug className="size-3.5 text-muted-foreground" />
-          )}
-        </div>
+      <div className="flex items-start gap-3">
+        <IntegrationLogo
+          slug={entry.slug}
+          overrideUrl={entry.logo}
+          alt={entry.displayName}
+          size="md"
+        />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
+          <div className="line-clamp-2 text-sm font-medium leading-tight text-foreground">
             {entry.displayName}
           </div>
           {isDone && selectedAccount ? (
-            <div className="truncate text-[11px] leading-4 text-muted-foreground">
+            <div className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground">
               {accountDisplayHandle(selectedAccount)}
             </div>
           ) : null}
         </div>
-        {isDone ? (
-          <div className="grid size-7 place-items-center rounded-md bg-emerald-500/15 text-emerald-600">
-            <Check className="size-3.5" />
-          </div>
-        ) : (
-          <Button
-            className="h-7 px-2.5 text-xs"
-            disabled={isConnecting}
-            onClick={onConnect}
-            size="sm"
-            type="button"
-            variant={phase === "error" ? "outline" : "secondary"}
-          >
-            {isConnecting ? (
-              <LoaderCircle className="size-3 animate-spin" />
-            ) : phase === "error" ? (
-              "Retry"
-            ) : (
-              "Connect"
-            )}
-          </Button>
-        )}
       </div>
+      {!isDone ? (
+        <button
+          className="mt-auto inline-flex w-fit items-center gap-1 text-[11px] leading-4 font-medium text-foreground transition-colors hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isConnecting}
+          onClick={onConnect}
+          type="button"
+        >
+          {isConnecting ? (
+            <>
+              <LoaderCircle className="size-3 animate-spin" />
+              Connecting…
+            </>
+          ) : phase === "error" ? (
+            "Retry"
+          ) : (
+            "Connect"
+          )}
+        </button>
+      ) : null}
       {isDone && accounts.length > 0 ? (
         // Power users with multiple Gmails / GitHubs need a way to point
         // this workspace at a specific one (or add a new one). The menu
@@ -756,7 +1100,7 @@ function HeroConnectCard({
           <DropdownMenuTrigger
             render={
               <button
-                className="inline-flex w-fit items-center gap-1 text-[11px] leading-4 text-muted-foreground transition-colors hover:text-foreground"
+                className="mt-auto inline-flex w-fit items-center gap-1 text-[11px] leading-4 text-muted-foreground opacity-0 transition-[opacity,color] duration-150 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
                 type="button"
               >
                 Switch account

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -304,6 +304,19 @@ export function DeterministicWorkspaceOnboardingSurface() {
     .toLowerCase();
   const isFetchingContext =
     onboardingFlowState === "deterministic_context_fetching";
+  // Sticky latch — once the workspace has crossed into the fetching
+  // step, keep the fetching view visible even if `onboarding_state`
+  // briefly reads as something else (workspace re-fetch race, transient
+  // selectedWorkspace=null, etc.). Without this, the page occasionally
+  // flickers back to the connect grid mid-import. Resets only when the
+  // active workspace itself changes.
+  const [hasReachedFetching, setHasReachedFetching] = useState(false);
+  useEffect(() => {
+    if (isFetchingContext) {
+      setHasReachedFetching(true);
+    }
+  }, [isFetchingContext]);
+  const showFetchingView = isFetchingContext || hasReachedFetching;
 
   useEffect(() => {
     setPhaseByToolkit({});
@@ -311,6 +324,7 @@ export function DeterministicWorkspaceOnboardingSurface() {
     setConnectionIdByToolkit({});
     setContextFetchStatusByConnectionId({});
     setExistingConnectionsBySlug({});
+    setHasReachedFetching(false);
   }, [selectedWorkspace?.id]);
 
   // Pull the user's existing active connections (across all workspaces)
@@ -704,7 +718,24 @@ export function DeterministicWorkspaceOnboardingSurface() {
     <div className="flex h-full min-h-0 w-full flex-1 justify-center overflow-y-auto px-6 py-10 sm:px-10">
       <div className="my-auto flex w-full max-w-3xl flex-col items-center gap-4">
         <div className="w-full rounded-3xl border border-border bg-background px-8 py-8 sm:px-10 sm:py-10">
-          {isFetchingContext ? (
+          {showFetchingView && trackedConnectionIds.length === 0 ? (
+            // Skip the full fetching panel when the user continued with
+            // zero connections — there's nothing to render rows for, and
+            // showing an empty progress card reads as "broken". Hold a
+            // minimal loading state until the workspace transitions out
+            // and the parent unmounts us.
+            <div className="flex flex-col items-center gap-4 py-8 text-center">
+              <LoaderCircle className="size-6 animate-spin text-muted-foreground" />
+              <div className="space-y-1">
+                <h1 className="text-xl font-semibold text-foreground">
+                  Setting up your workspace
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Almost ready…
+                </p>
+              </div>
+            </div>
+          ) : showFetchingView ? (
             <div className="flex flex-col gap-5">
               <div className="text-xs font-medium text-muted-foreground">
                 Importing in background
@@ -973,22 +1004,27 @@ export function DeterministicWorkspaceOnboardingSurface() {
         <div className="flex flex-col items-center gap-2">
           <Button
             className="min-w-[180px]"
-            disabled={isContinuing}
+            disabled={
+              isContinuing ||
+              (showFetchingView && trackedConnectionIds.length === 0)
+            }
             onClick={() => void handleContinue()}
             size="lg"
             type="button"
           >
             {isContinuing
-              ? isFetchingContext
+              ? showFetchingView
                 ? "Opening workspace..."
                 : "Continuing..."
-              : isFetchingContext
-                ? "Enter workspace now"
+              : showFetchingView
+                ? trackedConnectionIds.length === 0
+                  ? "Opening workspace..."
+                  : "Enter workspace now"
                 : connectedCount > 0
                   ? `Continue (${connectedCount} connected)`
                   : "Skip for now"}
           </Button>
-          {isFetchingContext ? (
+          {showFetchingView && trackedConnectionIds.length > 0 ? (
             <p className="text-[11px] text-muted-foreground">
               Imports continue in the background while you work.
             </p>

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -1,6 +1,13 @@
-import { Check, LoaderCircle, Plug } from "lucide-react";
+import { Check, ChevronDown, LoaderCircle, Plug, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { bindConnectionToWorkspace } from "@/lib/bindConnectionToWorkspace";
 import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 
@@ -84,13 +91,14 @@ export function DeterministicWorkspaceOnboardingSurface() {
   const [connectionIdByToolkit, setConnectionIdByToolkit] = useState<
     Record<string, string>
   >({});
-  // Existing active connections the user already has across all workspaces,
-  // keyed by provider slug. Lets onboarding skip re-OAuth + render a
-  // "Connected as @handle" state instead of a misleading fresh Connect
-  // button. Populated by an effect on mount and refreshed whenever the
-  // workspace switches.
-  const [existingConnectionBySlug, setExistingConnectionBySlug] = useState<
-    Record<string, IntegrationConnectionPayload>
+  // All existing active connections the user already has across all
+  // workspaces, keyed by provider slug. Stored as an ARRAY (not just the
+  // most-recent one) so the Switch-account menu can list every alternate
+  // the user can pick between — without this we'd be back to forcing a
+  // fresh OAuth for users who happen to have two Gmails already
+  // authorized. Ordered newest-first by `updated_at`.
+  const [existingConnectionsBySlug, setExistingConnectionsBySlug] = useState<
+    Record<string, IntegrationConnectionPayload[]>
   >({});
   const [contextFetchStatusByConnectionId, setContextFetchStatusByConnectionId] =
     useState<Record<string, IntegrationContextFetchStatusPayload>>({});
@@ -106,7 +114,7 @@ export function DeterministicWorkspaceOnboardingSurface() {
     setErrorByToolkit({});
     setConnectionIdByToolkit({});
     setContextFetchStatusByConnectionId({});
-    setExistingConnectionBySlug({});
+    setExistingConnectionsBySlug({});
   }, [selectedWorkspace?.id]);
 
   // Pull the user's existing active connections (across all workspaces)
@@ -120,24 +128,23 @@ export function DeterministicWorkspaceOnboardingSurface() {
         const { connections } =
           await window.electronAPI.workspace.listIntegrationConnections();
         if (cancelled) return;
-        // Index by lowercase provider slug. If the user has multiple
-        // accounts for the same provider, take the most-recently-updated
-        // one — same heuristic the agent uses elsewhere when resolving
-        // "the default Gmail account" for this user.
-        const byProvider: Record<string, IntegrationConnectionPayload> = {};
+        // Index by lowercase provider slug, keeping ALL active connections
+        // sorted newest-first. Multiple accounts surface in the Switch-
+        // account menu so the user can pick between e.g. work + personal
+        // Gmail without being forced through a fresh OAuth.
+        const byProvider: Record<string, IntegrationConnectionPayload[]> = {};
         for (const conn of connections) {
           if (conn.status !== "active") continue;
           const slug = conn.provider_id.trim().toLowerCase();
           if (!slug) continue;
-          const incumbent = byProvider[slug];
-          if (
-            !incumbent ||
-            Date.parse(conn.updated_at) > Date.parse(incumbent.updated_at)
-          ) {
-            byProvider[slug] = conn;
-          }
+          (byProvider[slug] ??= []).push(conn);
         }
-        setExistingConnectionBySlug(byProvider);
+        for (const list of Object.values(byProvider)) {
+          list.sort(
+            (a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at),
+          );
+        }
+        setExistingConnectionsBySlug(byProvider);
       } catch {
         // Onboarding can still function without the pre-existing scan —
         // user just sees the legacy "Connect everything fresh" UX.
@@ -148,19 +155,20 @@ export function DeterministicWorkspaceOnboardingSurface() {
     };
   }, [selectedWorkspace?.id]);
 
-  // Once both `heroEntries` and `existingConnectionBySlug` have loaded,
-  // mark any already-connected hero as `done` and seed its connection
-  // id into the tracked map. The continue step then binds those
-  // connections to the new workspace — without this seeding, the
+  // Once both `heroEntries` and `existingConnectionsBySlug` have loaded,
+  // mark any already-connected hero as `done` and seed the FIRST (newest)
+  // connection id into the tracked map. The continue step then binds
+  // those connections to the new workspace — without this seeding, the
   // collected map would be empty for unchanged tiles and Phase 2 would
-  // skip them entirely.
+  // skip them entirely. The user can still flip the selection via the
+  // Switch-account menu before clicking Continue.
   useEffect(() => {
     if (!heroEntries || heroEntries.length === 0) return;
-    if (Object.keys(existingConnectionBySlug).length === 0) return;
+    if (Object.keys(existingConnectionsBySlug).length === 0) return;
     setPhaseByToolkit((prev) => {
       const next = { ...prev };
       for (const entry of heroEntries) {
-        const existing = existingConnectionBySlug[entry.slug];
+        const existing = existingConnectionsBySlug[entry.slug]?.[0];
         if (existing && !next[entry.slug]) {
           next[entry.slug] = "done";
         }
@@ -170,14 +178,14 @@ export function DeterministicWorkspaceOnboardingSurface() {
     setConnectionIdByToolkit((prev) => {
       const next = { ...prev };
       for (const entry of heroEntries) {
-        const existing = existingConnectionBySlug[entry.slug];
+        const existing = existingConnectionsBySlug[entry.slug]?.[0];
         if (existing && !next[entry.slug]) {
           next[entry.slug] = existing.connection_id;
         }
       }
       return next;
     });
-  }, [heroEntries, existingConnectionBySlug]);
+  }, [heroEntries, existingConnectionsBySlug]);
 
   useEffect(() => {
     let cancelled = false;
@@ -294,11 +302,12 @@ export function DeterministicWorkspaceOnboardingSurface() {
     opts?: { force?: boolean },
   ) {
     // Short-circuit when this provider is already connected and the caller
-    // didn't explicitly ask for a fresh OAuth (the "Switch account" link
-    // sets force=true). Avoids creating a duplicate Composio
-    // connected_account row for users who already authorized Gmail in a
-    // previous workspace — they should be able to just click Continue.
-    const existing = existingConnectionBySlug[entry.slug];
+    // didn't explicitly ask for a fresh OAuth ("Add another account…" in
+    // the Switch-account menu sets force=true). Avoids creating a duplicate
+    // Composio connected_account row for users who already authorized
+    // Gmail in a previous workspace — they should be able to just click
+    // Continue.
+    const existing = existingConnectionsBySlug[entry.slug]?.[0];
     if (existing && !opts?.force) {
       setConnectionIdByToolkit((prev) => ({
         ...prev,
@@ -560,25 +569,32 @@ export function DeterministicWorkspaceOnboardingSurface() {
                 ) : (
                   <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                     {heroEntries.map((entry) => {
-                      const existing = existingConnectionBySlug[entry.slug];
+                      const accounts =
+                        existingConnectionsBySlug[entry.slug] ?? [];
+                      const selectedConnectionId =
+                        connectionIdByToolkit[entry.slug] ?? null;
                       return (
                         <HeroConnectCard
-                          connectedAccountLabel={
-                            existing
-                              ? accountDisplayHandle(existing)
-                              : null
-                          }
+                          accounts={accounts}
                           entry={entry}
                           error={errorByToolkit[entry.slug] ?? null}
                           key={entry.slug}
-                          onConnect={() => void handleConnect(entry)}
-                          onSwitchAccount={
-                            existing
-                              ? () =>
-                                  void handleConnect(entry, { force: true })
-                              : null
+                          onAddNewAccount={() =>
+                            void handleConnect(entry, { force: true })
                           }
+                          onConnect={() => void handleConnect(entry)}
+                          onSelectAccount={(connectionId) => {
+                            setConnectionIdByToolkit((prev) => ({
+                              ...prev,
+                              [entry.slug]: connectionId,
+                            }));
+                            setPhaseByToolkit((prev) => ({
+                              ...prev,
+                              [entry.slug]: "done",
+                            }));
+                          }}
                           phase={phaseByToolkit[entry.slug] ?? "idle"}
+                          selectedConnectionId={selectedConnectionId}
                         />
                       );
                     })}
@@ -637,23 +653,36 @@ function HeroConnectCard({
   phase,
   error,
   onConnect,
-  connectedAccountLabel,
-  onSwitchAccount,
+  accounts,
+  selectedConnectionId,
+  onSelectAccount,
+  onAddNewAccount,
 }: {
   entry: HeroEntry;
   phase: ConnectPhase;
   error: string | null;
   onConnect: () => void;
-  /** Friendly label of the already-connected account (e.g. "@jotyy" or
-   *  "josh@example.com"). Null when there's no pre-existing connection. */
-  connectedAccountLabel: string | null;
-  /** Triggers a fresh OAuth that creates a NEW connection for the same
-   *  provider. Null when the tile has no existing connection to switch
-   *  away from. */
-  onSwitchAccount: (() => void) | null;
+  /** Every active connection the user has for this provider, newest-first.
+   *  Empty array when no pre-existing connections — the tile renders a
+   *  plain Connect button in that case. */
+  accounts: IntegrationConnectionPayload[];
+  /** Which connection (from `accounts`) is currently chosen for this
+   *  workspace's binding. Null until the user picks one or accepts the
+   *  default-seeded newest entry. Drives the checkmark in the menu. */
+  selectedConnectionId: string | null;
+  /** Switch the workspace binding to a different already-authorized
+   *  connection — no OAuth, no new Composio row. */
+  onSelectAccount: (connectionId: string) => void;
+  /** Pop fresh OAuth to create a NEW connected_account for this provider.
+   *  The "Add another account…" menu item. */
+  onAddNewAccount: () => void;
 }) {
   const isDone = phase === "done";
   const isConnecting = phase === "connecting";
+  const selectedAccount =
+    accounts.find((acct) => acct.connection_id === selectedConnectionId) ??
+    accounts[0] ??
+    null;
   return (
     <li
       className={
@@ -680,9 +709,9 @@ function HeroConnectCard({
           <div className="truncate text-sm font-medium text-foreground">
             {entry.displayName}
           </div>
-          {isDone && connectedAccountLabel ? (
+          {isDone && selectedAccount ? (
             <div className="truncate text-[11px] leading-4 text-muted-foreground">
-              {connectedAccountLabel}
+              {accountDisplayHandle(selectedAccount)}
             </div>
           ) : null}
         </div>
@@ -709,17 +738,53 @@ function HeroConnectCard({
           </Button>
         )}
       </div>
-      {isDone && onSwitchAccount ? (
-        // Tiny escape hatch — most users will accept the reused account,
-        // but power users with multiple Gmails / GitHubs need a way to
-        // force a fresh OAuth into a different account for this workspace.
-        <button
-          className="self-start text-[11px] leading-4 text-muted-foreground transition-colors hover:text-foreground"
-          onClick={onSwitchAccount}
-          type="button"
-        >
-          Switch account
-        </button>
+      {isDone && accounts.length > 0 ? (
+        // Power users with multiple Gmails / GitHubs need a way to point
+        // this workspace at a specific one (or add a new one). The menu
+        // lists every active connection the user has for this provider —
+        // picking one is a pure binding swap (no OAuth), and "Add another
+        // account…" pops a fresh OAuth that creates a new Composio row.
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <button
+                className="inline-flex w-fit items-center gap-1 text-[11px] leading-4 text-muted-foreground transition-colors hover:text-foreground"
+                type="button"
+              >
+                Switch account
+                <ChevronDown className="size-3" />
+              </button>
+            }
+          />
+          <DropdownMenuContent align="start" className="min-w-[220px]">
+            {accounts.map((acct) => {
+              const isSelected = acct.connection_id === selectedConnectionId;
+              return (
+                <DropdownMenuItem
+                  key={acct.connection_id}
+                  onSelect={() => {
+                    if (isSelected) return;
+                    onSelectAccount(acct.connection_id);
+                  }}
+                >
+                  <Check
+                    className={
+                      isSelected
+                        ? "size-3.5 text-foreground"
+                        : "size-3.5 opacity-0"
+                    }
+                  />
+                  <span className="truncate">{accountDisplayHandle(acct)}</span>
+                </DropdownMenuItem>
+              );
+            })}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onAddNewAccount}>
+              <Plus className="size-3.5" />
+              <span>Add another account…</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       ) : null}
       {error ? (
         <p className="line-clamp-2 text-[11px] leading-4 text-destructive">

--- a/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
+++ b/apps/desktop/src/features/workspace-onboarding/DeterministicWorkspaceOnboardingSurface.tsx
@@ -328,26 +328,34 @@ export function DeterministicWorkspaceOnboardingSurface() {
         ...prev,
         [entry.slug]: connectionId,
       }));
-      try {
-        const response =
-          await window.electronAPI.workspace.fetchIntegrationContext(
-            connectionId,
-          );
-        setContextFetchStatusByConnectionId((prev) => ({
-          ...prev,
-          [connectionId]: response.status,
-        }));
-      } catch (error) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Context fetch could not be started.";
-        setErrorByToolkit((prev) => ({
-          ...prev,
-          [entry.slug]: `Connected, but context fetch could not be started: ${message}`,
-        }));
-      }
+      // OAuth is done — flip the tile to "Connected" immediately so the
+      // spinner stops as soon as the runtime returns a connection_id.
+      // Context fetch (Gmail history scan, Notion page crawl, etc.) is
+      // best-effort background work; gating the UI on it makes the
+      // spinner appear stuck for the 30s–minutes that the runtime takes
+      // to enqueue/start the fetch, which the user reads as "broken".
       setPhaseByToolkit((prev) => ({ ...prev, [entry.slug]: "done" }));
+      void (async () => {
+        try {
+          const response =
+            await window.electronAPI.workspace.fetchIntegrationContext(
+              connectionId,
+            );
+          setContextFetchStatusByConnectionId((prev) => ({
+            ...prev,
+            [connectionId]: response.status,
+          }));
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Context fetch could not be started.";
+          setErrorByToolkit((prev) => ({
+            ...prev,
+            [entry.slug]: `Connected, but context fetch could not be started: ${message}`,
+          }));
+        }
+      })();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Connection failed.";
       setErrorByToolkit((prev) => ({ ...prev, [entry.slug]: msg }));

--- a/apps/desktop/src/lib/bindConnectionToWorkspace.ts
+++ b/apps/desktop/src/lib/bindConnectionToWorkspace.ts
@@ -1,0 +1,55 @@
+import { rebindWorkspaceAppsForProvider } from "@/lib/rebindWorkspaceAppsForProvider";
+
+/**
+ * "I just chose this connection to power this provider in this workspace."
+ * Used by three flows that all need the same two-step write:
+ *   - Settings → Integrations → connect (IntegrationsPane.handleConnect)
+ *   - Agent chat → propose_connect card (IntegrationProposalCard)
+ *   - Onboarding → hero integration tile
+ *
+ * Two steps:
+ *   1. Set this connection as the workspace's default account for the
+ *      provider — but ONLY if no default is set yet. Won't clobber a
+ *      user's previous "I want work-gmail for this workspace" choice.
+ *   2. Rebind any app-scoped bindings that already point at a different
+ *      connection for the same provider, and restart those apps. No-op
+ *      for fresh workspaces (no apps installed yet).
+ *
+ * Best-effort throughout — partial success still helps the user; the
+ * caller has already shown them a "connected" confirmation by this point.
+ */
+export async function bindConnectionToWorkspace(params: {
+  workspaceId: string;
+  providerSlug: string;
+  connectionId: string;
+}): Promise<void> {
+  const { workspaceId, providerSlug, connectionId } = params;
+
+  // Set workspace-default only if unset. Composio resolves
+  // workspace-default at app-runtime when there's no app-scoped binding,
+  // so this is what makes the integration "just work" in a fresh
+  // workspace where no apps are bound yet.
+  try {
+    const existing =
+      await window.electronAPI.workspace.getWorkspaceDefaultAccount(
+        workspaceId,
+        providerSlug,
+      );
+    if (!existing.connection_id) {
+      await window.electronAPI.workspace.setWorkspaceDefaultAccount(
+        workspaceId,
+        providerSlug,
+        connectionId,
+      );
+    }
+  } catch {
+    // Default-set is a convenience; failure shouldn't block.
+  }
+
+  // App-scoped rebind. No-op on fresh workspaces (no apps installed).
+  await rebindWorkspaceAppsForProvider({
+    workspaceId,
+    provider: providerSlug,
+    connectionId,
+  });
+}

--- a/apps/desktop/src/lib/integrationDisplay.ts
+++ b/apps/desktop/src/lib/integrationDisplay.ts
@@ -6,8 +6,9 @@ import { useIntegrationAccountMetadata } from "./integrationAccountStore";
  * latter can be stale or admin-supplied — but each tier falls back to the
  * persisted column so a missed whoami fetch (offline, Composio hiccup, or
  * a connection minted before whoami enrichment shipped) still surfaces a
- * recognisable identity instead of a generic "Account N". Auto-generated
- * `<provider> (Managed)` labels and raw `ca_…` Composio IDs fall through.
+ * recognisable identity instead of a generic "Account N". Legacy auto-
+ * generated `<provider> (Managed)` labels have their suffix stripped so
+ * the internal classifier never leaks to the user.
  */
 export function accountDisplayLabel(
   conn: IntegrationConnectionPayload,
@@ -22,12 +23,14 @@ export function accountDisplayLabel(
   if (email) return email;
   const displayName = meta?.displayName?.trim();
   if (displayName) return displayName;
-  // Auto-generated `<provider> (Managed)` and raw `ca_…` Composio IDs
-  // are noisy — but they still tell the user "this is the foo provider"
-  // better than a generic index. Keep them as a last-resort label;
-  // they only lose to real identity above, not to the index fallback.
   const label = (conn.account_label ?? "").trim();
-  if (label) return label;
+  if (label) {
+    // Strip the legacy "(Managed)" suffix that older connections still
+    // carry in their account_label column — new connect call sites no
+    // longer write it, but old data is still in the store.
+    const cleaned = label.replace(/\s*\(Managed\)\s*$/i, "").trim();
+    return cleaned || label;
+  }
   return `Account ${index + 1}`;
 }
 

--- a/apps/desktop/src/lib/integrationErrorMessages.ts
+++ b/apps/desktop/src/lib/integrationErrorMessages.ts
@@ -46,6 +46,14 @@ export function resolveIntegrationError(opts: ResolveOptions): IntegrationErrorC
         detail: `Reconnect to keep using ${provider}.`,
         action: "reconnect",
       };
+    case "forbidden":
+    case "permission_denied":
+    case "insufficient_scope":
+      return {
+        headline: `${provider} access is incomplete`,
+        detail: `Reconnect and make sure to grant all permissions on the consent screen.`,
+        action: "reconnect",
+      };
     case "rate_limited":
       return {
         headline: `${provider} is busy`,
@@ -152,5 +160,16 @@ function inferCode(message: string, error: unknown): string {
   // Pull the marker emitted by composio-mcp-host (composio-mcp-host.ts).
   const marker = /\[composio_error:([a-z_]+)/i.exec(message);
   if (marker?.[1]) return marker[1].toLowerCase();
+  // Fallback: raw "forbidden" / 403 messages from upstream that didn't
+  // make it through the marker. Treat as scope/permission issue so the
+  // UI offers Reconnect instead of a generic "try again".
+  if (
+    /\bforbidden\b/.test(lower) ||
+    /\b403\b/.test(lower) ||
+    lower.includes("insufficient scope") ||
+    lower.includes("permission denied")
+  ) {
+    return "forbidden";
+  }
   return "unknown";
 }

--- a/apps/desktop/src/lib/integrationLogo.ts
+++ b/apps/desktop/src/lib/integrationLogo.ts
@@ -18,13 +18,20 @@
 
 const CDN_BASE = "https://logos.composio.dev/api";
 
-// Slugs where the CDN asset is known to be broken or low-quality. Render
-// the Plug fallback instead of the broken image.
-const KNOWN_BROKEN_LOGO_SLUGS = new Set<string>([
-  // intentionally empty — fill in as production reports come in. Existing
-  // overrides (e.g. GitHub white-on-white at bd82591c) are handled
-  // separately in the receiving components today; we'll migrate them here.
-]);
+// Composio's logo CDN returns wide wordmark SVGs (and sometimes a pure
+// white fill) for a handful of providers, so the square thumbnails render
+// as a sliver-in-a-banner or invisibly white-on-white. Simple Icons
+// publishes a square monochrome SVG per brand at a stable unpkg URL —
+// short-circuit just those slugs.
+const BRAND_LOGO_OVERRIDES: Record<string, string> = {
+  github: "https://unpkg.com/simple-icons@16.20.0/icons/github.svg",
+  linear: "https://unpkg.com/simple-icons@16.20.0/icons/linear.svg",
+};
+
+// Slugs where the CDN asset is known to be broken or low-quality and no
+// override is provided. Render the Plug fallback instead of the broken
+// image.
+const KNOWN_BROKEN_LOGO_SLUGS = new Set<string>([]);
 
 export interface IntegrationLogoSource {
   url: string | null;
@@ -37,20 +44,21 @@ function normalizeSlug(slug: string): string {
   return slug.trim().toLowerCase();
 }
 
+export function brandLogoOverride(slug: string): string | null {
+  const key = normalizeSlug(slug);
+  if (!key) return null;
+  return BRAND_LOGO_OVERRIDES[key] ?? null;
+}
+
 export function getIntegrationLogo(slug: string): IntegrationLogoSource {
   const key = normalizeSlug(slug);
   if (!key) return { url: null, isLocal: false };
+  const override = BRAND_LOGO_OVERRIDES[key];
+  if (override) {
+    return { url: override, isLocal: false };
+  }
   if (KNOWN_BROKEN_LOGO_SLUGS.has(key)) {
     return { url: null, isLocal: false };
   }
   return { url: `${CDN_BASE}/${key}`, isLocal: false };
-}
-
-/**
- * Compatibility shim for older callers that only expect a concrete
- * brand-specific override URL and otherwise fall back to toolkit/CDN logos.
- */
-export function brandLogoOverride(slug: string): string | null {
-  const { url, isLocal } = getIntegrationLogo(slug);
-  return isLocal ? url : null;
 }

--- a/apps/desktop/src/lib/integrationLogo.ts
+++ b/apps/desktop/src/lib/integrationLogo.ts
@@ -33,11 +33,24 @@ export interface IntegrationLogoSource {
   isLocal: boolean;
 }
 
+function normalizeSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
 export function getIntegrationLogo(slug: string): IntegrationLogoSource {
-  const key = slug.trim().toLowerCase();
+  const key = normalizeSlug(slug);
   if (!key) return { url: null, isLocal: false };
   if (KNOWN_BROKEN_LOGO_SLUGS.has(key)) {
     return { url: null, isLocal: false };
   }
   return { url: `${CDN_BASE}/${key}`, isLocal: false };
+}
+
+/**
+ * Compatibility shim for older callers that only expect a concrete
+ * brand-specific override URL and otherwise fall back to toolkit/CDN logos.
+ */
+export function brandLogoOverride(slug: string): string | null {
+  const { url, isLocal } = getIntegrationLogo(slug);
+  return isLocal ? url : null;
 }

--- a/apps/desktop/src/lib/useIntegrationBinding.ts
+++ b/apps/desktop/src/lib/useIntegrationBinding.ts
@@ -166,6 +166,22 @@ export function useIntegrationBinding({
     void refresh();
   }, [refresh]);
 
+  // Bindings can change from outside this hook — agent-driven binds (chat
+  // → runtime → main → state-store) and Settings-driven binds don't go
+  // through `connect()` / `bind()` here, so the sidebar's status dot
+  // would otherwise stay stuck on its mount-time value forever. Poll every
+  // 8s as a low-cost catchall: two IPC reads per AppRow per integration,
+  // negligible at typical scale. The 8s cadence is fast enough that a
+  // user finishing a chat-side connect sees the dot flip "ready" before
+  // they look back at the sidebar.
+  useEffect(() => {
+    if (!selectedWorkspaceId || !trimmedProvider || !trimmedAppId) return;
+    const id = setInterval(() => {
+      void refresh();
+    }, 8000);
+    return () => clearInterval(id);
+  }, [selectedWorkspaceId, trimmedProvider, trimmedAppId, refresh]);
+
   // The running app captured HOLABOSS_APP_GRANT at boot in its bridge
   // transport. Any bind change is invisible until the app process cycles —
   // unconditional restart is cheaper than diffing.

--- a/apps/desktop/src/lib/useIntegrationConnect.ts
+++ b/apps/desktop/src/lib/useIntegrationConnect.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  IntegrationConnectCancelled,
+  useWorkspaceDesktop,
+} from "@/lib/workspaceDesktop";
+
+export type IntegrationConnectStatus =
+  | { kind: "idle" }
+  | { kind: "connecting" }
+  | { kind: "cancelled" }
+  | { kind: "error"; error: unknown }
+  | { kind: "done"; connectionId: string };
+
+export type IntegrationConnectOutcome =
+  | { kind: "done"; connectionId: string }
+  | { kind: "cancelled" }
+  | { kind: "error"; error: unknown };
+
+interface UseIntegrationConnectOptions {
+  /** Fires once the OAuth poll loop returns a finalized connection_id.
+   *  Useful for triggering follow-ups (rebind workspace apps, kick off
+   *  context fetch) without waiting on the consumer to inspect status. */
+  onDone?: (connectionId: string) => void | Promise<void>;
+}
+
+interface UseIntegrationConnectResult {
+  status: IntegrationConnectStatus;
+  isConnecting: boolean;
+  /** Initiates OAuth + polling. Aborts any prior in-flight attempt — a
+   *  retry click should not race with the abandoned one. */
+  connect: (params: {
+    provider: string;
+    accountLabel?: string | null;
+    whoami?: PendingIntegrationWhoami | null;
+  }) => Promise<IntegrationConnectOutcome>;
+  /** User-initiated cancel — aborts the AbortController so the
+   *  workspaceDesktop poll loop's `throwIfAborted` short-circuits the
+   *  ~5-minute timeout immediately. Safe to call when idle. */
+  cancel: () => void;
+  /** Reset to idle. Useful after handling a terminal error / cancellation
+   *  so the caller can re-arm the flow without re-instantiating the hook. */
+  reset: () => void;
+}
+
+/**
+ * Reusable OAuth connect flow with cancel + lifecycle abort.
+ *
+ * The native `connectIntegrationProvider` is a poll loop that can hang
+ * for ~5 minutes after the user closes the OAuth browser without
+ * authorizing. This hook wraps it with:
+ *   - AbortController per attempt so Cancel resolves instantly
+ *   - lifecycle abort on unmount so closed cards don't leak running polls
+ *   - tagged status state so the UI can render Connecting / Cancel / Done
+ *     / Error without ad-hoc boolean toggles
+ *
+ * Per-instance state — mount one hook per connect surface. Multi-toolkit
+ * parents that share a connect button across rows should still keep their
+ * own per-row controllers (this hook is single-flight).
+ */
+export function useIntegrationConnect(
+  options: UseIntegrationConnectOptions = {},
+): UseIntegrationConnectResult {
+  const { connectIntegrationProvider } = useWorkspaceDesktop();
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const onDoneRef = useRef(options.onDone);
+  const [status, setStatus] = useState<IntegrationConnectStatus>({
+    kind: "idle",
+  });
+
+  // Keep callback ref fresh without re-creating `connect` on every render.
+  useEffect(() => {
+    onDoneRef.current = options.onDone;
+  }, [options.onDone]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const cancel = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
+
+  const reset = useCallback(() => {
+    setStatus({ kind: "idle" });
+  }, []);
+
+  const connect = useCallback<UseIntegrationConnectResult["connect"]>(
+    async (params) => {
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      setStatus({ kind: "connecting" });
+      try {
+        const result = await connectIntegrationProvider({
+          ...params,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) {
+          setStatus({ kind: "cancelled" });
+          return { kind: "cancelled" };
+        }
+        await onDoneRef.current?.(result.connectionId);
+        setStatus({ kind: "done", connectionId: result.connectionId });
+        return { kind: "done", connectionId: result.connectionId };
+      } catch (error) {
+        if (
+          error instanceof IntegrationConnectCancelled ||
+          controller.signal.aborted
+        ) {
+          setStatus({ kind: "cancelled" });
+          return { kind: "cancelled" };
+        }
+        setStatus({ kind: "error", error });
+        return { kind: "error", error };
+      }
+    },
+    [connectIntegrationProvider],
+  );
+
+  return {
+    status,
+    isConnecting: status.kind === "connecting",
+    connect,
+    cancel,
+    reset,
+  };
+}

--- a/apps/desktop/src/lib/workspaceDesktop.tsx
+++ b/apps/desktop/src/lib/workspaceDesktop.tsx
@@ -95,6 +95,38 @@ export const COMPOSIO_POLL_MAX_TICKS = 100;
 export const COMPOSIO_POLL_TIMEOUT_MS =
   COMPOSIO_POLL_INTERVAL_MS * COMPOSIO_POLL_MAX_TICKS;
 
+/** Sleep for `ms` OR until the desktop window regains focus — whichever
+ *  comes first. Used by the OAuth poll loop so the moment the user
+ *  switches back from the browser after authorizing, we poll immediately
+ *  instead of waiting up to one full interval for the next tick. */
+function sleepUntilFocusOrTimeout(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const onAbort = () => finish();
+    const onFocus = () => finish();
+    const timer = setTimeout(() => finish(), ms);
+    function finish() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      window.removeEventListener("focus", onFocus);
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }
+    window.addEventListener("focus", onFocus, { once: true });
+    if (signal) {
+      if (signal.aborted) {
+        finish();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
 const ONBOARDING_ACTIVE_STATUSES = new Set(["pending", "awaiting_confirmation", "in_progress"]);
 const LOCAL_OSS_TEMPLATE_USER_ID = "local-oss";
 const DEFAULT_WORKSPACE_HARNESS: WorkspaceHarnessId = "pi";
@@ -1245,7 +1277,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
 
     let consecutiveErrors = 0;
     for (let tick = 0; tick < COMPOSIO_POLL_MAX_TICKS; tick++) {
-      await new Promise((r) => setTimeout(r, COMPOSIO_POLL_INTERVAL_MS));
+      await sleepUntilFocusOrTimeout(COMPOSIO_POLL_INTERVAL_MS, signal);
       throwIfAborted();
       let current;
       try {

--- a/apps/desktop/src/lib/workspaceDesktop.tsx
+++ b/apps/desktop/src/lib/workspaceDesktop.tsx
@@ -15,6 +15,7 @@ import { type AuthSession, useDesktopAuthSession } from "@/lib/auth/authClient";
 import { loadWorkspaceOnboardingPreference } from "@/features/workspace-onboarding/preferences";
 import { hydrateInstalledWorkspaceApps, type WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
+import { toolkitDisplayName } from "@/lib/toolkitDisplay";
 
 /**
  * Each app self-declares its integration provider in `app.runtime.yaml`,
@@ -94,6 +95,17 @@ export const COMPOSIO_POLL_INTERVAL_MS = 3000;
 export const COMPOSIO_POLL_MAX_TICKS = 100;
 export const COMPOSIO_POLL_TIMEOUT_MS =
   COMPOSIO_POLL_INTERVAL_MS * COMPOSIO_POLL_MAX_TICKS;
+
+// Progressive poll cadence — OAuth typically completes 5-30s after
+// open, so the first few polls hit at high density to catch fast
+// completions, then back off to the steady 3s baseline. Total tick
+// count still respects COMPOSIO_POLL_MAX_TICKS.
+const COMPOSIO_POLL_INTERVAL_PROGRESSION_MS = [800, 1200, 1800, 2400] as const;
+function composioPollIntervalForTick(tick: number): number {
+  return (
+    COMPOSIO_POLL_INTERVAL_PROGRESSION_MS[tick] ?? COMPOSIO_POLL_INTERVAL_MS
+  );
+}
 
 /** Sleep for `ms` OR until the desktop window regains focus — whichever
  *  comes first. Used by the OAuth poll loop so the moment the user
@@ -1248,23 +1260,21 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
 
     const MAX_CONSECUTIVE_ERRORS = 20;
 
-    const runtimeConfig = await window.electronAPI.runtime.getConfig();
+    // Parallelize the two independent pre-OAuth round-trips. Before this
+    // was serial — getConfig → snapshot → composioConnect — adding ~300-800ms
+    // of latency before the browser even opens. The snapshot only needs
+    // to complete before we start polling, not before composioConnect.
+    const toolkitSlug = composioToolkitSlugForProvider(provider);
+    const [runtimeConfig, beforeSnapshot] = await Promise.all([
+      window.electronAPI.runtime.getConfig(),
+      window.electronAPI.workspace
+        .composioListConnections()
+        .catch(() => ({ connections: [] as Array<{ id: string }> })),
+    ]);
     const userId = runtimeConfig.userId ?? (resolvedUserId || "local");
-
-    // Snapshot existing connection ids before initiating — see
-    // IntegrationsPane comment: poll the list and look for a new id,
-    // since the id from /link isn't reliably queryable.
-    let beforeIds = new Set<string>();
-    try {
-      const before =
-        await window.electronAPI.workspace.composioListConnections();
-      beforeIds = new Set(before.connections.map((c) => c.id));
-    } catch {
-      // tolerate snapshot failure
-    }
+    const beforeIds = new Set(beforeSnapshot.connections.map((c) => c.id));
 
     throwIfAborted();
-    const toolkitSlug = composioToolkitSlugForProvider(provider);
     const link = await window.electronAPI.workspace.composioConnect({
       provider: toolkitSlug,
       owner_user_id: userId,
@@ -1275,28 +1285,41 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
 
     await window.electronAPI.ui.openExternalUrl(link.redirect_url);
 
+    // Once we've found the new connection id, skip the full list call on
+    // subsequent ticks — we only need to poll its status. Halves per-tick
+    // round-trip cost during the INITIATED → ACTIVE window where Composio
+    // can take a few seconds to flip after the user clicks Allow.
+    let knownNewConnectionId: string | null = null;
     let consecutiveErrors = 0;
     for (let tick = 0; tick < COMPOSIO_POLL_MAX_TICKS; tick++) {
-      await sleepUntilFocusOrTimeout(COMPOSIO_POLL_INTERVAL_MS, signal);
-      throwIfAborted();
-      let current;
-      try {
-        current =
-          await window.electronAPI.workspace.composioListConnections();
-        consecutiveErrors = 0;
-      } catch (pollError) {
-        consecutiveErrors += 1;
-        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-          throw pollError;
-        }
-        continue;
-      }
-      const newConnection = current.connections.find(
-        (c) =>
-          !beforeIds.has(c.id) &&
-          composioToolkitMatchesProvider(c.toolkitSlug, provider),
+      await sleepUntilFocusOrTimeout(
+        composioPollIntervalForTick(tick),
+        signal,
       );
-      if (newConnection) {
+      throwIfAborted();
+      if (knownNewConnectionId === null) {
+        let current;
+        try {
+          current =
+            await window.electronAPI.workspace.composioListConnections();
+          consecutiveErrors = 0;
+        } catch (pollError) {
+          consecutiveErrors += 1;
+          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+            throw pollError;
+          }
+          continue;
+        }
+        const found = current.connections.find(
+          (c) =>
+            !beforeIds.has(c.id) &&
+            composioToolkitMatchesProvider(c.toolkitSlug, provider),
+        );
+        if (found) {
+          knownNewConnectionId = found.id;
+        }
+      }
+      if (knownNewConnectionId) {
         // Composio creates the row at /connect time in INITIATED state —
         // its mere presence in the list is NOT proof that OAuth completed.
         // Read the account's real status before finalizing.
@@ -1304,7 +1327,7 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
         try {
           accountStatus =
             await window.electronAPI.workspace.composioAccountStatus(
-              newConnection.id,
+              knownNewConnectionId,
               provider,
             );
         } catch {
@@ -1320,10 +1343,10 @@ export function WorkspaceDesktopProvider({ children }: { children: ReactNode }) 
           // to "integration connection ca_xxx not found" 404s the moment
           // anyone tried to bind the result.
           const finalized = await window.electronAPI.workspace.composioFinalize({
-            connected_account_id: newConnection.id,
+            connected_account_id: knownNewConnectionId,
             provider,
             owner_user_id: userId,
-            account_label: accountLabel ?? `${provider} (Managed)`,
+            account_label: accountLabel ?? toolkitDisplayName(provider),
           });
           throwIfAborted();
           return { connectionId: finalized.connection_id };

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -6,12 +6,15 @@
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-background text-foreground font-normal;
   }
+
   html {
     @apply font-sans;
   }
+
   strong {
     @apply font-medium;
   }
@@ -78,6 +81,7 @@ body {
 
 /* Narrow panels: clamp popouts and stack settings rows. */
 @container panel (max-width: 448px) {
+
   [data-popover-popup],
   [data-menu-popup],
   [data-select-popup] {
@@ -90,7 +94,8 @@ body {
     align-items: stretch;
     gap: 10px;
   }
-  [data-layout="settings-row"] > [data-layout="settings-control"] {
+
+  [data-layout="settings-row"]>[data-layout="settings-control"] {
     width: 100%;
     min-width: 0;
     flex-wrap: wrap;
@@ -103,6 +108,7 @@ body {
   container-type: inline-size;
   container-name: shell;
 }
+
 [data-container="panel"] {
   container-type: inline-size;
   container-name: panel;
@@ -114,9 +120,7 @@ body {
    0 specificity so utility classes can override individual properties.
    Opt out per-element with `data-no-focus-ring` (e.g. inputs nested in
    popovers/menus that already have their own active state). */
-:where(button, [role="button"], input, select, a, summary):not(
-    [data-no-focus-ring]
-  ):focus-visible {
+:where(button, [role="button"], input, select, a, summary):not([data-no-focus-ring]):focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring) 50%, transparent);
 }
@@ -152,21 +156,27 @@ webview {
 .border {
   border-width: 0.8px;
 }
+
 .border-x {
   border-inline-width: 0.8px;
 }
+
 .border-y {
   border-block-width: 0.8px;
 }
+
 .border-t {
   border-top-width: 0.8px;
 }
+
 .border-r {
   border-right-width: 0.8px;
 }
+
 .border-b {
   border-bottom-width: 0.8px;
 }
+
 .border-l {
   border-left-width: 0.8px;
 }
@@ -184,13 +194,16 @@ webview {
   width: 8px;
   height: 8px;
 }
+
 ::-webkit-scrollbar-track {
   background: transparent;
 }
+
 ::-webkit-scrollbar-thumb {
   background: var(--border);
   border-radius: 4px;
 }
+
 ::-webkit-scrollbar-thumb:hover {
   background: var(--muted-foreground);
 }
@@ -200,6 +213,7 @@ webview {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
@@ -210,9 +224,11 @@ webview {
   border-radius: 4px;
   transition: background 180ms ease;
 }
+
 .group:hover .scrollbar-ghost::-webkit-scrollbar-thumb {
   background: var(--border);
 }
+
 .group:hover .scrollbar-ghost::-webkit-scrollbar-thumb:hover {
   background: var(--muted-foreground);
 }
@@ -230,8 +246,7 @@ webview {
 
 .chat-scrollbar-thin {
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent)
-    transparent;
+  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent) transparent;
 }
 
 .chat-scrollbar-thin::-webkit-scrollbar {

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -63,23 +63,30 @@
   --color-foreground: var(--foreground);
   --color-background: var(--background);
   /* Radius scale — integer px steps off base 8px. */
-  --radius-sm: calc(var(--radius) * 0.5); /* 4px */
-  --radius-md: calc(var(--radius) * 0.75); /* 6px — button/menu-item */
-  --radius-lg: var(--radius); /* 8px — card/input */
-  --radius-xl: calc(var(--radius) * 1.25); /* 10px — popover/dropdown */
-  --radius-2xl: calc(var(--radius) * 1.5); /* 12px — panel inner */
-  --radius-3xl: calc(var(--radius) * 2); /* 16px */
-  --radius-4xl: calc(var(--radius) * 2.5); /* 20px */
+  --radius-sm: calc(var(--radius) * 0.5);
+  /* 4px */
+  --radius-md: calc(var(--radius) * 0.75);
+  /* 6px — button/menu-item */
+  --radius-lg: var(--radius);
+  /* 8px — card/input */
+  --radius-xl: calc(var(--radius) * 1.25);
+  /* 10px — popover/dropdown */
+  --radius-2xl: calc(var(--radius) * 1.5);
+  /* 12px — panel inner */
+  --radius-3xl: calc(var(--radius) * 2);
+  /* 16px */
+  --radius-4xl: calc(var(--radius) * 2.5);
+  /* 20px */
 
   /* Font weights — each step ~50 lighter than Tailwind default. */
   --font-weight-thin: 300;
   --font-weight-extralight: 325;
   --font-weight-light: 350;
   --font-weight-normal: 350;
-  --font-weight-medium: 400;
-  --font-weight-semibold: 450;
-  --font-weight-bold: 500;
-  --font-weight-extrabold: 550;
+  --font-weight-medium: 450;
+  --font-weight-semibold: 500;
+  --font-weight-bold: 550;
+  --font-weight-extrabold: 600;
   --font-weight-black: 600;
 
   /* Tight type scale — ~10-20% denser than Tailwind default. */
@@ -191,10 +198,12 @@
     opacity: 0;
     transform: scale(0.96) translateY(10px);
   }
+
   70% {
     opacity: 1;
     transform: scale(1.01) translateY(-2px);
   }
+
   100% {
     opacity: 1;
     transform: scale(1) translateY(0);
@@ -206,6 +215,7 @@
     opacity: 0;
     transform: translateY(5px);
   }
+
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -213,11 +223,13 @@
 }
 
 @keyframes holaboss-splash-halo {
+
   0%,
   100% {
     opacity: 0.35;
     transform: scale(1);
   }
+
   50% {
     opacity: 0.7;
     transform: scale(1.08);
@@ -225,11 +237,13 @@
 }
 
 @keyframes holaboss-splash-dot {
+
   0%,
   100% {
     opacity: 0.2;
     transform: translateY(0);
   }
+
   50% {
     opacity: 1;
     transform: translateY(-1.5px);
@@ -243,31 +257,37 @@
   inherits: true;
   initial-value: oklch(0.985 0.002 60);
 }
+
 @property --foreground {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.18 0.015 55);
 }
+
 @property --primary {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.68 0.21 37);
 }
+
 @property --info {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.62 0.17 240);
 }
+
 @property --success {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.58 0.16 148);
 }
+
 @property --destructive {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.55 0.24 18);
 }
+
 /* Surface palette — registered so theme switches interpolate the
    whole canvas instead of hard-cutting on most surfaces. Initial
    values mirror the holaos-light defaults. */
@@ -276,41 +296,49 @@
   inherits: true;
   initial-value: oklch(0.985 0.002 250);
 }
+
 @property --popover {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(1 0 0);
 }
+
 @property --muted {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.97 0.002 250);
 }
+
 @property --muted-foreground {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.56 0.005 250);
 }
+
 @property --accent {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.95 0.002 250);
 }
+
 @property --secondary {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.97 0.002 250);
 }
+
 @property --border {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.92 0.003 250);
 }
+
 @property --ring {
   syntax: "<color>";
   inherits: true;
   initial-value: oklch(0.624 0.229 32);
 }
+
 @property --sidebar {
   syntax: "<color>";
   inherits: true;
@@ -381,11 +409,9 @@
   --shadow-alpha: 0.07;
 
   /* Elevated bg for unfocused panels. */
-  --background-elevated: color-mix(
-    in srgb,
-    var(--foreground) 2%,
-    var(--background)
-  );
+  --background-elevated: color-mix(in srgb,
+      var(--foreground) 2%,
+      var(--background));
 
   /* Foreground-on-background opaque blends. Use --fg-N for tinted
      surfaces; Tailwind's bg-foreground/N for transparent overlays. */
@@ -404,11 +430,9 @@
 
   /* Status text — tinted toward foreground for labels on neutral bg. */
   --success-text: color-mix(in oklab, var(--success) 45%, var(--foreground));
-  --destructive-text: color-mix(
-    in oklab,
-    var(--destructive) 45%,
-    var(--foreground)
-  );
+  --destructive-text: color-mix(in oklab,
+      var(--destructive) 45%,
+      var(--foreground));
   --info-text: color-mix(in oklab, var(--info) 45%, var(--foreground));
 
   /* Workspace identity tint — neutral gray composed with --background /
@@ -416,16 +440,12 @@
      a separate theme override. */
   --workspace-color-gray: oklch(0.55 0.005 270);
 
-  --workspace-color-gray-bg: color-mix(
-    in srgb,
-    var(--workspace-color-gray) 14%,
-    var(--background)
-  );
-  --workspace-color-gray-fg: color-mix(
-    in oklab,
-    var(--workspace-color-gray) 65%,
-    var(--foreground)
-  );
+  --workspace-color-gray-bg: color-mix(in srgb,
+      var(--workspace-color-gray) 14%,
+      var(--background));
+  --workspace-color-gray-fg: color-mix(in oklab,
+      var(--workspace-color-gray) 65%,
+      var(--foreground));
 }
 
 .dark {

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -712,6 +712,16 @@ interface RuntimeNotificationListOptionsPayload {
     archived_at: string | null;
   }
 
+  interface ContinueBackgroundTaskPayload {
+    workspaceId: string;
+    subagentId: string;
+    ownerMainSessionId: string;
+    instruction: string;
+    title?: string | null;
+  }
+
+  type ContinueBackgroundTaskResponsePayload = Record<string, unknown>;
+
   interface MainSessionLegacyExportPayload {
     session_id: string;
     title: string | null;
@@ -1491,17 +1501,6 @@ interface RuntimeNotificationListOptionsPayload {
     usage: ConnectionWorkspaceUsageEntry[];
   }
 
-  interface ComposioToolkitCapability {
-    name: string;
-    description: string;
-    tool_slug: string;
-    read_only: boolean;
-  }
-
-  interface ComposioToolkitCapabilitiesPayload {
-    toolkits: Record<string, ComposioToolkitCapability[]>;
-  }
-
   interface IntegrationStoreCatalogEntry {
     slug: string;
     tier: "hero" | "supported";
@@ -2004,6 +2003,9 @@ interface RuntimeNotificationListOptionsPayload {
       archiveBackgroundTask: (
         payload: ArchiveBackgroundTaskPayload
       ) => Promise<ArchiveBackgroundTaskResponsePayload>;
+      continueBackgroundTask: (
+        payload: ContinueBackgroundTaskPayload
+      ) => Promise<ContinueBackgroundTaskResponsePayload>;
       acceptTaskProposal: (payload: TaskProposalAcceptPayload) => Promise<TaskProposalAcceptResponsePayload>;
       updateTaskProposalState: (
         workspaceId: string,
@@ -2079,7 +2081,6 @@ interface RuntimeNotificationListOptionsPayload {
       ) => Promise<IntegrationMergeConnectionsResult>;
       deleteIntegrationBinding: (bindingId: string, workspaceId: string) => Promise<{ deleted: boolean }>;
       listConnectionWorkspaceUsage: () => Promise<ConnectionWorkspaceUsagePayload>;
-      listComposioToolkitCapabilities: () => Promise<ComposioToolkitCapabilitiesPayload>;
       listIntegrationStoreCatalog: () => Promise<IntegrationStoreCatalogPayload>;
       listAllWorkspaceIntegrationOverrides: () => Promise<AllWorkspaceIntegrationOverridesPayload>;
       listWorkspaceIntegrations: (workspaceId: string) => Promise<WorkspaceIntegrationsListResponsePayload>;

--- a/docs/plans/2026-04-01-workspace-integration-auto-bind.md
+++ b/docs/plans/2026-04-01-workspace-integration-auto-bind.md
@@ -482,7 +482,7 @@ Add the "connect_integrations" view inside the return JSX, as a new branch in th
       <div className="mt-1 text-[20px] font-semibold text-text-main">
         This workspace needs access
       </div>
-      <div className="mt-2 text-[13px] leading-7 text-text-muted/84">
+      <div className="mt-2 text-[13px] text-text-muted/84">
         Connect the following accounts to continue.
       </div>
 

--- a/runtime/api-server/src/agent-capability-registry.ts
+++ b/runtime/api-server/src/agent-capability-registry.ts
@@ -1430,6 +1430,13 @@ export function renderCapabilityToolRoutingPromptSection(
     lines.push("When creating or updating cronjobs, put the executable task in `instruction` and keep `description` as a short display summary only.");
     lines.push("Do not repeat schedule wording such as 'every 5 minutes' inside the cronjob `instruction` unless the task itself genuinely requires saying that phrase.");
   }
+  if (manifest.runtime_tools.some((capability) => capability.id === "holaboss_workspace_integrations_propose_connect")) {
+    ensureHeading();
+    lines.push("Integration routing: when the user references their OWN account on a known third-party service (their Twitter posts, their Gmail inbox, their GitHub repos, their Notion pages, their Slack channels, etc.) and the provider's `<toolkit>_<verb>` tools are NOT in your current tool list, call `holaboss_workspace_integrations_propose_connect` for that toolkit FIRST. The chat UI renders a one-click Connect card from the result.");
+    lines.push("Do NOT open a browser to scrape an unauthenticated public page, ask the user to paste their `@handle` so you can read public data, or fall back to a manual workaround when a Connect card is the actual answer. That undersells what the agent can do post-connection.");
+    lines.push("Browser fallback for a third-party service is appropriate only when the user explicitly asks for a browser-based action, when the provider has no integration in the workspace catalog, or when the integration is already connected and the specific page or interaction genuinely cannot be reached through its surfaced tools.");
+    lines.push("Scope-error recovery: when a Composio `<toolkit>_<verb>` tool returns `[composio_error:forbidden:<slug>]`, `[composio_error:permission_denied:<slug>]`, or `[composio_error:insufficient_scope:<slug>]`, the user's OAuth grant lacks a required scope (most often Google's granular consent screen left a box unchecked). Call `holaboss_workspace_integrations_propose_connect` for that slug with a `reason` mentioning the missing access — do NOT switch to browser, web search, or ask the user to paste data manually. The Reconnect card is the recovery path.");
+  }
   if (manifest.runtime_tools.some((capability) => capability.id === "delegate_task")) {
     ensureHeading();
     lines.push("Delegation routing: keep work inline by default. Use `delegate_task` primarily for research and investigation work that benefits from a separate execution branch, or for creating apps and making substantial app modifications.");

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -136,7 +136,10 @@ import { resumePendingIntegrationInputs } from "./integration-proposal-gate.js";
 import { OAuthService } from "./oauth-service.js";
 import { ComposioService } from "./composio-service.js";
 import { ComposioMcpManager } from "./composio-mcp-manager.js";
-import { listAllToolkitCapabilities } from "./composio-tool-registry.js";
+import {
+  listAllToolkitCapabilities,
+  listAllToolkitCapabilitiesAsync,
+} from "./composio-tool-registry.js";
 import { listStoreCatalog } from "./integration-store-catalog.js";
 import { WorkspaceIntegrationsService } from "./workspace-integrations.js";
 import {
@@ -4865,8 +4868,61 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     return integrationService.getCatalog();
   });
 
+  // In-memory cache for the auto-discovered "Agent can" catalog. Each
+  // entry pulls ~30-50 Composio toolkit /tools fetches; without a cache
+  // the IntegrationsPane refresh fan-out would hammer Composio for every
+  // workspace switch. 10-minute TTL — toolkit tool lists are stable on
+  // the order of days, and Hono's own 24h cache already absorbs the
+  // upstream load, so this is mostly request-coalescing.
+  let composioCapabilitiesCache: {
+    expiresAt: number;
+    payload: Record<string, ReturnType<typeof listAllToolkitCapabilities>[string]>;
+  } | null = null;
+  const COMPOSIO_CAPABILITIES_TTL_MS = 10 * 60 * 1000;
+
   app.get("/api/v1/integrations/composio-capabilities", async () => {
-    return { toolkits: listAllToolkitCapabilities() };
+    const now = Date.now();
+    if (composioCapabilitiesCache && composioCapabilitiesCache.expiresAt > now) {
+      return { toolkits: composioCapabilitiesCache.payload };
+    }
+
+    // Without ComposioService we can't auto-discover — fall back to the
+    // hand-curated hero entries only. This keeps the runtime usable in
+    // local dev / test where the Composio bearer isn't wired, at the
+    // cost of the sparse "Agent can" panel the UI rewrite was meant to
+    // fix.
+    if (!composioService) {
+      const payload = listAllToolkitCapabilities();
+      composioCapabilitiesCache = {
+        expiresAt: now + COMPOSIO_CAPABILITIES_TTL_MS,
+        payload,
+      };
+      return { toolkits: payload };
+    }
+
+    // Union of every slug we'd plausibly advertise capabilities for:
+    // hand-curated hero entries (which may live outside the store
+    // catalog — e.g. early dev probes) + the curated store catalog
+    // (what the user can actually install via Settings → Integrations).
+    // Composio has 100+ toolkits; restricting to this union prevents
+    // each capabilities refresh from fanning out to all of them.
+    const slugs = Array.from(
+      new Set([
+        ...Object.keys(listAllToolkitCapabilities()),
+        ...listStoreCatalog().map((entry) => entry.slug.trim().toLowerCase()),
+      ]),
+    );
+
+    const payload = await listAllToolkitCapabilitiesAsync({
+      slugs,
+      fetchTools: (slug) => composioService.listToolkitTools(slug),
+      topN: 8,
+    });
+    composioCapabilitiesCache = {
+      expiresAt: now + COMPOSIO_CAPABILITIES_TTL_MS,
+      payload,
+    };
+    return { toolkits: payload };
   });
 
   // GET /integrations/store-catalog — the curated subset of Composio

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -136,10 +136,6 @@ import { resumePendingIntegrationInputs } from "./integration-proposal-gate.js";
 import { OAuthService } from "./oauth-service.js";
 import { ComposioService } from "./composio-service.js";
 import { ComposioMcpManager } from "./composio-mcp-manager.js";
-import {
-  listAllToolkitCapabilities,
-  listAllToolkitCapabilitiesAsync,
-} from "./composio-tool-registry.js";
 import { listStoreCatalog } from "./integration-store-catalog.js";
 import { WorkspaceIntegrationsService } from "./workspace-integrations.js";
 import {
@@ -4866,63 +4862,6 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
   app.get("/api/v1/integrations/catalog", async () => {
     return integrationService.getCatalog();
-  });
-
-  // In-memory cache for the auto-discovered "Agent can" catalog. Each
-  // entry pulls ~30-50 Composio toolkit /tools fetches; without a cache
-  // the IntegrationsPane refresh fan-out would hammer Composio for every
-  // workspace switch. 10-minute TTL — toolkit tool lists are stable on
-  // the order of days, and Hono's own 24h cache already absorbs the
-  // upstream load, so this is mostly request-coalescing.
-  let composioCapabilitiesCache: {
-    expiresAt: number;
-    payload: Record<string, ReturnType<typeof listAllToolkitCapabilities>[string]>;
-  } | null = null;
-  const COMPOSIO_CAPABILITIES_TTL_MS = 10 * 60 * 1000;
-
-  app.get("/api/v1/integrations/composio-capabilities", async () => {
-    const now = Date.now();
-    if (composioCapabilitiesCache && composioCapabilitiesCache.expiresAt > now) {
-      return { toolkits: composioCapabilitiesCache.payload };
-    }
-
-    // Without ComposioService we can't auto-discover — fall back to the
-    // hand-curated hero entries only. This keeps the runtime usable in
-    // local dev / test where the Composio bearer isn't wired, at the
-    // cost of the sparse "Agent can" panel the UI rewrite was meant to
-    // fix.
-    if (!composioService) {
-      const payload = listAllToolkitCapabilities();
-      composioCapabilitiesCache = {
-        expiresAt: now + COMPOSIO_CAPABILITIES_TTL_MS,
-        payload,
-      };
-      return { toolkits: payload };
-    }
-
-    // Union of every slug we'd plausibly advertise capabilities for:
-    // hand-curated hero entries (which may live outside the store
-    // catalog — e.g. early dev probes) + the curated store catalog
-    // (what the user can actually install via Settings → Integrations).
-    // Composio has 100+ toolkits; restricting to this union prevents
-    // each capabilities refresh from fanning out to all of them.
-    const slugs = Array.from(
-      new Set([
-        ...Object.keys(listAllToolkitCapabilities()),
-        ...listStoreCatalog().map((entry) => entry.slug.trim().toLowerCase()),
-      ]),
-    );
-
-    const payload = await listAllToolkitCapabilitiesAsync({
-      slugs,
-      fetchTools: (slug) => composioService.listToolkitTools(slug),
-      topN: 8,
-    });
-    composioCapabilitiesCache = {
-      expiresAt: now + COMPOSIO_CAPABILITIES_TTL_MS,
-      payload,
-    };
-    return { toolkits: payload };
   });
 
   // GET /integrations/store-catalog — the curated subset of Composio

--- a/runtime/api-server/src/composio-mcp-manager.test.ts
+++ b/runtime/api-server/src/composio-mcp-manager.test.ts
@@ -48,6 +48,13 @@ interface MockFetch {
 function mockFetch(handlers: {
   connections?: () => Response;
   execute?: () => Response;
+  /** Per-toolkit-slug tools-fetch handler. Returns a single Response shaped
+   *  like Composio's `/tools?toolkit_slug=...` payload. Used by every test
+   *  that needs `ensureRunning` to actually produce a non-empty catalog —
+   *  after the hand-curated hero tier was removed, ALL toolkits go through
+   *  the dynamic-discovery path, so any test that doesn't mock tools just
+   *  gets `skipped: no_tools_resolved`. */
+  tools?: (toolkitSlug: string) => Response;
 }): MockFetch {
   const calls: Array<{ url: string; method?: string }> = [];
   const handler: typeof fetch = async (input, init) => {
@@ -59,12 +66,75 @@ function mockFetch(handlers: {
     if (url.endsWith("/api/composio/execute") && handlers.execute) {
       return handlers.execute();
     }
+    const toolsMatch = url.match(/\/api\/composio\/tools\?toolkit_slug=([^&]+)/);
+    if (toolsMatch && handlers.tools) {
+      return handlers.tools(decodeURIComponent(toolsMatch[1]!));
+    }
     return new Response("not mocked", { status: 599 });
   };
   return { fetch: handler, calls };
 }
 
-test("ensureRunning bootstraps a host for the first ACTIVE Hero toolkit and writes the registry", async () => {
+// Sample tool entries shaped like Composio's `/tools?toolkit_slug=...`
+// response — enough to make `buildToolkitCatalogAsync` produce a non-
+// empty catalog so `ensureRunning` reaches its `started` branch. Each
+// helper includes at least one read-only entry that ranks ahead of a
+// write entry so the heuristic-pick is deterministic.
+function sampleGmailToolsResponse(): Response {
+  return jsonResponse({
+    tools: [
+      {
+        slug: "GMAIL_GET_PROFILE",
+        name: "Get profile",
+        description: "Read the authenticated Gmail user's profile.",
+        input_parameters: { type: "object", properties: {} },
+        tags: ["readOnlyHint"],
+        is_deprecated: false,
+      },
+      {
+        slug: "GMAIL_FETCH_EMAILS",
+        name: "Fetch emails",
+        description: "Read recent emails from the user's inbox.",
+        input_parameters: { type: "object", properties: {} },
+        tags: ["readOnlyHint"],
+        is_deprecated: false,
+      },
+      {
+        slug: "GMAIL_SEND_EMAIL",
+        name: "Send email",
+        description: "Send an email on behalf of the user.",
+        input_parameters: { type: "object", properties: {} },
+        tags: [],
+        is_deprecated: false,
+      },
+    ],
+  });
+}
+
+function sampleSlackToolsResponse(): Response {
+  return jsonResponse({
+    tools: [
+      {
+        slug: "SLACK_LIST_CHANNELS",
+        name: "List channels",
+        description: "List Slack channels the user can access.",
+        input_parameters: { type: "object", properties: {} },
+        tags: ["readOnlyHint"],
+        is_deprecated: false,
+      },
+      {
+        slug: "SLACK_SEND_MESSAGE",
+        name: "Send message",
+        description: "Send a message to a Slack channel.",
+        input_parameters: { type: "object", properties: {} },
+        tags: [],
+        is_deprecated: false,
+      },
+    ],
+  });
+}
+
+test("ensureRunning bootstraps a host for the first ACTIVE toolkit and writes the registry", async () => {
   const root = createTempRoot();
   try {
     makeWorkspace(root, "ws1");
@@ -76,6 +146,12 @@ test("ensureRunning bootstraps a host for the first ACTIVE Hero toolkit and writ
             { id: "ca_slack_active", status: "ACTIVE", toolkitSlug: "slack", userId: "u1" },
           ],
         }),
+      tools: (slug) =>
+        slug === "gmail"
+          ? sampleGmailToolsResponse()
+          : slug === "slack"
+            ? sampleSlackToolsResponse()
+            : jsonResponse({ tools: [] }),
     });
     const composio = new ComposioService({
       honoBaseUrl: "https://app.holaboss.test",
@@ -95,20 +171,24 @@ test("ensureRunning bootstraps a host for the first ACTIVE Hero toolkit and writ
       assert.equal(result.connected_account_id, "ca_gmail_active");
       assert.ok(
         (result.tool_names ?? []).includes("gmail_get_profile"),
-        "hero gmail tool should be present",
+        "gmail get_profile tool should be present after auto-discovery",
       );
       assert.match(result.url ?? "", /^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
 
-      // 1 for /connections + 1 for /tools?toolkit_slug=slack (slack is
-      // auto-discovered, gmail uses its hero entry and skips the fetch).
+      // /connections + one /tools per toolkit — both gmail and slack now
+      // go through auto-discovery (the hand-curated hero tier was removed).
       const urls = calls.map((c) => c.url);
       assert.ok(
         urls.includes("https://app.holaboss.test/api/composio/connections"),
         "connections endpoint should be hit",
       );
       assert.ok(
+        urls.some((u) => u.includes("/api/composio/tools?toolkit_slug=gmail")),
+        "tools endpoint should be hit for gmail",
+      );
+      assert.ok(
         urls.some((u) => u.includes("/api/composio/tools?toolkit_slug=slack")),
-        "tools endpoint should be hit for non-hero toolkit",
+        "tools endpoint should be hit for slack",
       );
 
       const running = manager.inspectRunning();
@@ -136,6 +216,9 @@ test("ensureRunning returns 'reused' on the second call and does not boot a seco
             { id: "ca_gmail", status: "ACTIVE", toolkitSlug: "gmail", userId: "u1" },
           ],
         });
+      }
+      if (url.includes("/api/composio/tools?toolkit_slug=gmail")) {
+        return sampleGmailToolsResponse();
       }
       return new Response("not mocked", { status: 599 });
     };
@@ -309,6 +392,9 @@ test("concurrent ensureRunning calls dedupe to one bootstrap (in-flight cache)",
           connections: [{ id: "ca_gmail", status: "ACTIVE", toolkitSlug: "gmail" }],
         });
       }
+      if (url.includes("/api/composio/tools?toolkit_slug=gmail")) {
+        return sampleGmailToolsResponse();
+      }
       return new Response("not mocked", { status: 599 });
     };
     const composio = new ComposioService({
@@ -346,6 +432,8 @@ test("stopAll closes every cached host and clears the cache", async () => {
         jsonResponse({
           connections: [{ id: "ca_gmail", status: "ACTIVE", toolkitSlug: "gmail" }],
         }),
+      tools: (slug) =>
+        slug === "gmail" ? sampleGmailToolsResponse() : jsonResponse({ tools: [] }),
     });
     const composio = new ComposioService({
       honoBaseUrl: "https://app.holaboss.test",
@@ -436,6 +524,8 @@ test('restart tears the host down and bootstraps a fresh one', async () => {
         jsonResponse({
           connections: [{ id: 'ca_gmail', status: 'ACTIVE', toolkitSlug: 'gmail' }],
         }),
+      tools: (slug) =>
+        slug === 'gmail' ? sampleGmailToolsResponse() : jsonResponse({ tools: [] }),
     });
     const composio = new ComposioService({
       honoBaseUrl: 'https://app.holaboss.test',

--- a/runtime/api-server/src/composio-tool-registry.test.ts
+++ b/runtime/api-server/src/composio-tool-registry.test.ts
@@ -10,7 +10,6 @@ import yaml from "js-yaml";
 
 import {
   bootstrapComposioMcpForWorkspace,
-  buildToolkitCatalog,
   COMPOSIO_REGISTRY_SERVER_ID,
   removeComposioMcpRegistryEntry,
   writeComposioMcpRegistryEntry,
@@ -246,7 +245,30 @@ test("bootstrapComposioMcpForWorkspace boots the host, writes the registry, and 
       workspaceDir,
       honoBaseUrl: "https://app.holaboss.test",
       authCookie: "hb_session=test",
-      catalog: buildToolkitCatalog("gmail", "ca_4vYjam9qHD46"),
+      catalog: [
+        {
+          name: "gmail_get_profile",
+          description:
+            "Read the authenticated Gmail user's profile (email address, message count, thread count). Read-only.",
+          toolkit_slug: "gmail",
+          tool_slug: "GMAIL_GET_PROFILE",
+          connected_account_id: "ca_4vYjam9qHD46",
+          input_schema: {
+            type: "object",
+            title: "GmailGetProfileRequest",
+            properties: {
+              user_id: {
+                type: "string",
+                default: "me",
+                description:
+                  "User identifier — 'me' for the authenticated user.",
+                examples: ["me", "user@example.com"],
+              },
+            },
+          },
+          annotations: { readOnlyHint: true },
+        },
+      ],
       composioService,
     });
 

--- a/runtime/api-server/src/composio-tool-registry.ts
+++ b/runtime/api-server/src/composio-tool-registry.ts
@@ -307,6 +307,72 @@ export function listAllToolkitCapabilities(): Record<string, ToolkitCapabilityEn
   return result;
 }
 
+/**
+ * Auto-discover variant of `listAllToolkitCapabilities`. For each requested
+ * toolkit slug:
+ *   1. Start with the hand-curated hero entries (zero or more).
+ *   2. Fall back to / fill in with Composio's full tool catalog, ranked by
+ *      `HEURISTIC_VERB_PATTERNS` (read/list/get verbs first; create/update
+ *      last) and capped at `topN`.
+ *   3. Skip any auto-discovered tool whose slug already appears in the
+ *      hero set so we don't render duplicates.
+ *
+ * This is what powers the UI's "Agent can" panel — without auto-discover
+ * the panel for Gmail shows the single `gmail_get_profile` entry the hero
+ * catalog defines, which dramatically undersells what the agent is wired
+ * to actually do via the composio-mcp host (it auto-discovers its own
+ * catalog via `buildToolkitCatalogAsync`). Now both layers read from the
+ * same Composio /tools surface.
+ */
+export async function listAllToolkitCapabilitiesAsync(params: {
+  slugs: ReadonlyArray<string>;
+  fetchTools: (toolkitSlug: string) => Promise<
+    Array<{
+      slug: string;
+      name: string;
+      description: string;
+      input_schema: Record<string, unknown>;
+      read_only: boolean;
+    }>
+  >;
+  topN?: number;
+}): Promise<Record<string, ToolkitCapabilityEntry[]>> {
+  const topN = params.topN ?? DEFAULT_HEURISTIC_TOP_N;
+  const result: Record<string, ToolkitCapabilityEntry[]> = {};
+
+  await Promise.all(
+    params.slugs.map(async (slug) => {
+      const hero = listToolkitCapabilities(slug);
+      let upstream: Awaited<ReturnType<typeof params.fetchTools>> = [];
+      try {
+        upstream = await params.fetchTools(slug);
+      } catch {
+        // Composio fetch is best-effort — fall back to hero only.
+      }
+      const heroSlugs = new Set(hero.map((entry) => entry.tool_slug));
+      const ranked = upstream
+        .filter((tool) => !heroSlugs.has(tool.slug))
+        .sort((a, b) => {
+          const ra = rankTool(a.slug);
+          const rb = rankTool(b.slug);
+          if (ra !== rb) return ra - rb;
+          return a.slug.localeCompare(b.slug);
+        })
+        .slice(0, Math.max(0, topN - hero.length))
+        .map((tool) => ({
+          name: `${slug}_${tool.slug
+            .replace(new RegExp(`^${slug.toUpperCase()}_`), "")
+            .toLowerCase()}`,
+          description: tool.description,
+          tool_slug: tool.slug,
+          read_only: tool.read_only,
+        }));
+      result[slug] = [...hero, ...ranked];
+    }),
+  );
+  return result;
+}
+
 export function buildToolkitCatalog(
   toolkitSlug: string,
   connectedAccountId: string,

--- a/runtime/api-server/src/composio-tool-registry.ts
+++ b/runtime/api-server/src/composio-tool-registry.ts
@@ -142,51 +142,12 @@ async function findFreePort(): Promise<number> {
   });
 }
 
-type ToolkitToolDefinition = Omit<ComposioMcpToolEntry, "connected_account_id" | "toolkit_slug">;
-
-// Add a row here to expose a new Composio toolkit to the agent.
-// Each entry is one toolkit; `tools` lists the verbs we expose for it.
-// The internal catalog plan (docs/plans/2026-05-19-agent-direct-integration-tools.md §5.5)
-// will replace this with a generated table fed by the Composio /tools endpoint.
-const TOOLKIT_CATALOG: Record<string, { tools: ToolkitToolDefinition[] }> = {
-  gmail: {
-    tools: [
-      {
-        name: "gmail_get_profile",
-        description:
-          "Read the authenticated Gmail user's profile (email address, message count, thread count). Read-only.",
-        tool_slug: "GMAIL_GET_PROFILE",
-        input_schema: {
-          type: "object",
-          title: "GmailGetProfileRequest",
-          properties: {
-            user_id: {
-              type: "string",
-              default: "me",
-              description: "User identifier — 'me' for the authenticated user.",
-              examples: ["me", "user@example.com"],
-            },
-          },
-        },
-        annotations: { readOnlyHint: true },
-      },
-    ],
-  },
-};
-
-/** Hero toolkits — manually curated entries get priority. */
-export function listHeroToolkitSlugs(): string[] {
-  return Object.keys(TOOLKIT_CATALOG);
-}
-
-/** @deprecated — use hasHeroEntry / listHeroToolkitSlugs. Kept so the old
- *  manager / mcp call sites that filtered to hero-only keep working. */
-export function listSupportedToolkitSlugs(): string[] {
-  return Object.keys(TOOLKIT_CATALOG);
-}
-
-export function hasHeroEntry(toolkitSlug: string): boolean {
-  return Boolean(TOOLKIT_CATALOG[toolkitSlug]);
+// Hand-curated tier was removed — capabilities are auto-discovered at MCP
+// boot via Composio's /tools endpoint (see buildToolkitCatalogAsync below
+// + composio-mcp-manager). `hasHeroEntry` is kept as a no-op so the one
+// external caller (workspace-integrations.ts) doesn't need to know.
+export function hasHeroEntry(_toolkitSlug: string): boolean {
+  return false;
 }
 
 // Pick top-N tools from a Composio toolkit when we don't have a Hero entry.
@@ -225,11 +186,9 @@ export function toolkitNameFromSlug(slug: string): string {
 }
 
 /**
- * Build the MCP tool entries for `toolkitSlug` × `connectedAccountId`.
- * Falls back to a Composio-tool-catalog-driven heuristic when we don't
- * have a Hero entry, so every active connection has _something_ usable
- * by the agent. Caller must provide a tool fetcher (closure over
- * ComposioService) when dynamic discovery is needed.
+ * Build the MCP tool entries for `toolkitSlug` × `connectedAccountId` by
+ * fetching Composio's tool catalog for the toolkit and ranking via
+ * HEURISTIC_VERB_PATTERNS (reads first). Returns at most `topN`.
  */
 export async function buildToolkitCatalogAsync(
   toolkitSlug: string,
@@ -245,14 +204,6 @@ export async function buildToolkitCatalogAsync(
   >,
   options: { topN?: number } = {},
 ): Promise<ComposioMcpToolEntry[]> {
-  const hero = TOOLKIT_CATALOG[toolkitSlug];
-  if (hero) {
-    return hero.tools.map((tool) => ({
-      ...tool,
-      toolkit_slug: toolkitSlug,
-      connected_account_id: connectedAccountId,
-    }));
-  }
   let upstream: Awaited<ReturnType<typeof fetchTools>>;
   try {
     upstream = await fetchTools(toolkitSlug);
@@ -278,113 +229,6 @@ export async function buildToolkitCatalogAsync(
     connected_account_id: connectedAccountId,
     input_schema: tool.input_schema,
     annotations: tool.read_only ? { readOnlyHint: true } : undefined,
-  }));
-}
-
-export interface ToolkitCapabilityEntry {
-  name: string;
-  description: string;
-  tool_slug: string;
-  read_only: boolean;
-}
-
-export function listToolkitCapabilities(toolkitSlug: string): ToolkitCapabilityEntry[] {
-  const entry = TOOLKIT_CATALOG[toolkitSlug];
-  if (!entry) return [];
-  return entry.tools.map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-    tool_slug: tool.tool_slug,
-    read_only: Boolean((tool.annotations as { readOnlyHint?: boolean } | undefined)?.readOnlyHint),
-  }));
-}
-
-export function listAllToolkitCapabilities(): Record<string, ToolkitCapabilityEntry[]> {
-  const result: Record<string, ToolkitCapabilityEntry[]> = {};
-  for (const slug of Object.keys(TOOLKIT_CATALOG)) {
-    result[slug] = listToolkitCapabilities(slug);
-  }
-  return result;
-}
-
-/**
- * Auto-discover variant of `listAllToolkitCapabilities`. For each requested
- * toolkit slug:
- *   1. Start with the hand-curated hero entries (zero or more).
- *   2. Fall back to / fill in with Composio's full tool catalog, ranked by
- *      `HEURISTIC_VERB_PATTERNS` (read/list/get verbs first; create/update
- *      last) and capped at `topN`.
- *   3. Skip any auto-discovered tool whose slug already appears in the
- *      hero set so we don't render duplicates.
- *
- * This is what powers the UI's "Agent can" panel — without auto-discover
- * the panel for Gmail shows the single `gmail_get_profile` entry the hero
- * catalog defines, which dramatically undersells what the agent is wired
- * to actually do via the composio-mcp host (it auto-discovers its own
- * catalog via `buildToolkitCatalogAsync`). Now both layers read from the
- * same Composio /tools surface.
- */
-export async function listAllToolkitCapabilitiesAsync(params: {
-  slugs: ReadonlyArray<string>;
-  fetchTools: (toolkitSlug: string) => Promise<
-    Array<{
-      slug: string;
-      name: string;
-      description: string;
-      input_schema: Record<string, unknown>;
-      read_only: boolean;
-    }>
-  >;
-  topN?: number;
-}): Promise<Record<string, ToolkitCapabilityEntry[]>> {
-  const topN = params.topN ?? DEFAULT_HEURISTIC_TOP_N;
-  const result: Record<string, ToolkitCapabilityEntry[]> = {};
-
-  await Promise.all(
-    params.slugs.map(async (slug) => {
-      const hero = listToolkitCapabilities(slug);
-      let upstream: Awaited<ReturnType<typeof params.fetchTools>> = [];
-      try {
-        upstream = await params.fetchTools(slug);
-      } catch {
-        // Composio fetch is best-effort — fall back to hero only.
-      }
-      const heroSlugs = new Set(hero.map((entry) => entry.tool_slug));
-      const ranked = upstream
-        .filter((tool) => !heroSlugs.has(tool.slug))
-        .sort((a, b) => {
-          const ra = rankTool(a.slug);
-          const rb = rankTool(b.slug);
-          if (ra !== rb) return ra - rb;
-          return a.slug.localeCompare(b.slug);
-        })
-        .slice(0, Math.max(0, topN - hero.length))
-        .map((tool) => ({
-          name: `${slug}_${tool.slug
-            .replace(new RegExp(`^${slug.toUpperCase()}_`), "")
-            .toLowerCase()}`,
-          description: tool.description,
-          tool_slug: tool.slug,
-          read_only: tool.read_only,
-        }));
-      result[slug] = [...hero, ...ranked];
-    }),
-  );
-  return result;
-}
-
-export function buildToolkitCatalog(
-  toolkitSlug: string,
-  connectedAccountId: string,
-): ComposioMcpToolEntry[] {
-  const entry = TOOLKIT_CATALOG[toolkitSlug];
-  if (!entry) {
-    return [];
-  }
-  return entry.tools.map((tool) => ({
-    ...tool,
-    toolkit_slug: toolkitSlug,
-    connected_account_id: connectedAccountId,
   }));
 }
 


### PR DESCRIPTION
## Summary

This branch started as two integration-binding follow-ups and grew into a broader pass on the integration UX across onboarding, the Settings → Integrations pane, and the sidebar. It includes a sibling merge from `upstream/main` for desktop auth + Windows release hardening that landed in parallel.

### Onboarding
- **Detect existing connections** and seed the hero tile to "Connected" with a Switch-account menu — no duplicate OAuth for users who already authorized Gmail/Notion/etc. in a previous workspace (`931be449`).
- **Persist bindings on Continue** via a new `bindConnectionToWorkspace` helper that wraps `set-default-account + rebind-apps-for-provider` — the same sequence IntegrationsPane and IntegrationProposalCard already do post-connect.
- **Switch-account actually switches** instead of popping a fresh OAuth (`f79c487e`).
- **Hero card menu items use `onClick`**, not `onSelect` — Base UI's `Menu.Item` doesn't dispatch `onSelect`, so "Add another account…" and account-switching were silently dead handlers (`3410bb78`).
- **Stop gating the connect spinner on background context fetch** — flip the tile to Connected as soon as Composio returns a connection_id; the long-running fetch becomes a separate "Importing…" lane (`e58b6831`).
- **Stabilize the Fetching view** + skip the empty Fetching panel when there are zero connections (`2ae46078`).
- **Start fetch for reused connections** so flow-through onboarding never lands in a "Connected but no context" state (`48b6a5e1`).
- **End-to-end polish** + drop the hand-curated capability path in favor of toolkit-driven discovery (`2e24da6f`).

### Settings → Integrations
- **Auto-discover toolkit capabilities** and group Read/Write in the UI (`b35e578d`).
- **Surface workspace default account**: inline "Default here" chip on the connection row for the currently-selected workspace, plus a per-workspace default-account dropdown in the Manage-expand section. Optimistic state update with revert-on-error so the controlled `<select>` doesn't bounce back during the in-flight PUT (`396fa5b1`).
- **Connect speed + cancel hook + scope-error recovery + "(Managed)" cleanup + agent routing** (`d1436f29`).

### Sidebar
- **Lift Settings out of the Home tab into a persistent sidebar footer** so it's reachable from any workspace, not just Home (`d1824877`).
- **Poll integration binding state** so agent-driven binds (from chat) surface in the sidebar without waiting for a remount. Chat-side bind goes runtime → main → state-store directly and never touches the renderer's `connect()` / `bind()` callbacks, so a poll is the only signal the renderer gets for out-of-band writes (`5c2edfc9`).

### Merge-in from upstream
- `671dc00c` harden desktop auth + Windows release flow + `745c2ff7` restore integration logo compat export, brought in via merge (`52dedbad`, `2b35fb99`).

## Validation

- [x] `tsc --noEmit` — pass
- [ ] manual: onboarding hero tile shows "Connected" with Switch-account menu when toolkit was previously authorized
- [ ] manual: clicking "Add another account…" pops a fresh OAuth
- [ ] manual: clicking Continue on onboarding actually persists bindings into the new workspace (agent sees the tools)
- [ ] manual: chat-side agent bind flips sidebar dot to ready within ~8s
- [ ] manual: Settings → Integrations → Manage shows the right default account per workspace, switching it persists

## Risks

- 8s poll on every mounted `useIntegrationBinding` — fine at typical scale (5-10 AppRows × 1-3 integrations); would need rework if IntegrationsPane ever renders this hook for hundreds of provider rows.
- `bindConnectionToWorkspace` swallows individual binding failures via `Promise.allSettled` — intentional so onboarding-continue doesn't block, but a silently-failing bind won't surface until the agent fails to call the tool.
- Workspace-default fetch is `workspaces × distinct-providers-with-connections` parallel calls in IntegrationsPane's `loadData` — small payloads, but worth keeping an eye on if the workspace × integration counts grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)