### PR TITLE
fix(new-shell): Windows caption controls + platform-aware titlebar padding

### DIFF
--- a/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/panes/ChatPane/ArtifactBrowserModal";
 import type { ArtifactBrowserFilter } from "@/components/panes/ChatPane/types";
 import { FileTypeIcon } from "@/lib/fileIcon";
+import { useDesktopPlatform } from "@/lib/desktopPlatform";
 import { useIntegrationBinding } from "@/lib/useIntegrationBinding";
 import { cn } from "@/lib/utils";
 import type { WorkspaceInstalledAppDefinition } from "@/lib/workspaceApps";
@@ -1899,11 +1900,18 @@ function RecentFileRow({ entry }: { entry: RecentFile }) {
 // Used to pull the popover leftward so it aligns with the sidebar's
 // inner edge instead of starting from the trigger button — keeping
 // the popover entirely within the sidebar so it never overflows onto
-// the BrowserView.
-const WORKSPACE_POPOVER_LEFT_INSET = 72;
+// the BrowserView. On Windows there are no traffic lights, so the
+// trigger sits at the natural left edge and needs no offset.
+const WORKSPACE_POPOVER_LEFT_INSET_MAC = 72;
+const WORKSPACE_POPOVER_LEFT_INSET_DEFAULT = 0;
 
 function WorkspaceSwitcher() {
   const sidebarWidth = useAtomValue(sidebarWidthAtom);
+  const platform = useDesktopPlatform();
+  const isMac = platform === "darwin";
+  const popoverLeftInset = isMac
+    ? WORKSPACE_POPOVER_LEFT_INSET_MAC
+    : WORKSPACE_POPOVER_LEFT_INSET_DEFAULT;
   const { selectedWorkspaceId, setSelectedWorkspaceId } =
     useWorkspaceSelection();
   const {
@@ -1953,7 +1961,12 @@ function WorkspaceSwitcher() {
   };
 
   return (
-    <div className="window-drag flex h-10 shrink-0 items-center px-2 pl-20">
+    <div
+      className={cn(
+        "window-drag flex h-10 shrink-0 items-center px-2",
+        isMac && "pl-20",
+      )}
+    >
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <PopoverTrigger
           render={
@@ -1983,7 +1996,7 @@ function WorkspaceSwitcher() {
         />
         <PopoverContent
           align="start"
-          alignOffset={-WORKSPACE_POPOVER_LEFT_INSET}
+          alignOffset={-popoverLeftInset}
           sideOffset={6}
           className="gap-0 p-2"
           style={{

--- a/apps/desktop/src/components/layout/new-shell/TopChrome.tsx
+++ b/apps/desktop/src/components/layout/new-shell/TopChrome.tsx
@@ -20,6 +20,7 @@ import {
   SuspendingPopover as Popover,
 } from "./overlay-presence";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
+import { useDesktopPlatform } from "@/lib/desktopPlatform";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import { cn } from "@/lib/utils";
 import {
@@ -28,6 +29,7 @@ import {
 } from "./state/internalTabs";
 import { removeRecentFileByPathAtom } from "./state/recentFiles";
 import { newTabOpenAtom, sidebarCollapsedAtom } from "./state/ui";
+import { WindowControls } from "./WindowControls";
 
 export function TopChrome() {
   const openNewTab = useSetAtom(newTabOpenAtom);
@@ -35,6 +37,9 @@ export function TopChrome() {
   const { browserState } = useWorkspaceBrowser("user");
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const setSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
+  const platform = useDesktopPlatform();
+  const isMac = platform === "darwin";
+  const isWin = platform === "win32";
   const [internalTabs, setInternalTabs] = useAtom(internalTabsAtom);
   const [activeInternalTabId, setActiveInternalTabId] = useAtom(
     activeInternalTabIdAtom,
@@ -170,11 +175,19 @@ export function TopChrome() {
 
   const agentTabCount = browserState.tabCounts.agent;
 
+  // macOS reserves space for the fixed-position traffic lights when the
+  // sidebar is collapsed; Windows draws its caption controls on the right
+  // side (see <WindowControls />) so the left edge stays flush.
+  const collapsedPadLeft = isMac ? "5rem" : "0.5rem";
+
   return (
     <header
-      className="window-drag flex h-10 shrink-0 items-center gap-1 border-b border-border pr-3 transition-[padding-left] duration-stride ease-out-expo"
+      className={cn(
+        "window-drag flex h-10 shrink-0 items-center gap-1 border-b border-border transition-[padding-left] duration-stride ease-out-expo",
+        isWin ? "pr-0" : "pr-3",
+      )}
       style={{
-        paddingLeft: sidebarCollapsed ? "5rem" : "0.5rem",
+        paddingLeft: sidebarCollapsed ? collapsedPadLeft : "0.5rem",
       }}
     >
       <button
@@ -231,6 +244,12 @@ export function TopChrome() {
       >
         <Plus className="size-3.5" strokeWidth={1.75} />
       </Button>
+      {isWin ? (
+        <>
+          <div className="flex-1" aria-hidden />
+          <WindowControls />
+        </>
+      ) : null}
     </header>
   );
 }

--- a/apps/desktop/src/components/layout/new-shell/WindowControls.tsx
+++ b/apps/desktop/src/components/layout/new-shell/WindowControls.tsx
@@ -1,0 +1,66 @@
+import { Copy, Minus, Square, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const BUTTON_CLASSES =
+  "window-no-drag grid h-7 w-11 shrink-0 place-items-center text-foreground/55 transition-colors duration-150 hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:bg-foreground/[0.06]";
+
+export function WindowControls() {
+  const [state, setState] = useState<DesktopWindowStatePayload>({
+    isFullScreen: false,
+    isMaximized: false,
+    isMinimized: false,
+  });
+
+  useEffect(() => {
+    let mounted = true;
+    void window.electronAPI.ui.getWindowState().then((next) => {
+      if (mounted) setState(next);
+    });
+    const unsubscribe = window.electronAPI.ui.onWindowStateChange((next) => {
+      if (mounted) setState(next);
+    });
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const isRestored = state.isMaximized || state.isFullScreen;
+
+  return (
+    <div className="window-no-drag flex h-full shrink-0 items-stretch">
+      <button
+        type="button"
+        aria-label="Minimize window"
+        className={BUTTON_CLASSES}
+        onClick={() => void window.electronAPI.ui.minimizeWindow()}
+      >
+        <Minus className="size-3.5" strokeWidth={2.1} />
+      </button>
+      <button
+        type="button"
+        aria-label={isRestored ? "Restore window" : "Maximize window"}
+        className={BUTTON_CLASSES}
+        onClick={() => void window.electronAPI.ui.toggleWindowSize()}
+      >
+        {isRestored ? (
+          <Copy className="size-3.5" strokeWidth={1.9} />
+        ) : (
+          <Square className="size-3" strokeWidth={1.9} />
+        )}
+      </button>
+      <button
+        type="button"
+        aria-label="Close window"
+        className={cn(
+          BUTTON_CLASSES,
+          "hover:bg-destructive/15 hover:text-destructive",
+        )}
+        onClick={() => void window.electronAPI.ui.closeWindow()}
+      >
+        <X className="size-3.5" strokeWidth={2.1} />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/desktopPlatform.ts
+++ b/apps/desktop/src/lib/desktopPlatform.ts
@@ -1,0 +1,11 @@
+export type DesktopPlatform = "darwin" | "win32" | "linux" | "other";
+
+export function getDesktopPlatform(): DesktopPlatform {
+  const raw = window.electronAPI?.platform ?? "";
+  if (raw === "darwin" || raw === "win32" || raw === "linux") return raw;
+  return "other";
+}
+
+export function useDesktopPlatform(): DesktopPlatform {
+  return getDesktopPlatform();
+}


### PR DESCRIPTION
## Summary
- NewAppShell only padded for macOS traffic lights and never drew Windows min/max/close, so on Windows the frameless window had no way to close and ~80px on the left was wasted.
- Add a small \`useDesktopPlatform()\` helper, render a \`<WindowControls />\` on win32 (uses the existing \`ui.minimizeWindow / toggleWindowSize / closeWindow\` IPC and subscribes to \`onWindowStateChange\` for the maximize/restore icon swap), and drop the macOS-only padding when not on darwin.
- Sidebar workspace switcher: \`pl-20\` only on darwin; popover \`alignOffset\` recomputed so it still sits flush with the sidebar's inner edge on Windows.

## Why this targets \`fix/agent-integration-followups\`
\`apps/desktop/src/components/layout/new-shell/\` does not exist on \`main\` yet — it lives on \`feat/integration-store-unified\` (PR #387 series) and downstream branches. Targeting the active downstream so the diff stays focused on just the Windows fix. Re-target to \`main\` once new-shell lands.

## Test plan
- [ ] macOS: traffic lights still uncovered; no extra right-side controls; sidebar collapsed → ⌘\\ shows correct left padding
- [ ] Windows: min / maximize ↔ restore (icon swap) / close all work; double-click on the drag area still maximizes; sidebar header no longer has 80px gap
- [ ] Linux: window has its native title bar; new components do not render
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)