### PR TITLE
feat(new-shell): restore Control Center entry (sidebar footer + ⌘0)

### DIFF
--- a/apps/desktop/src/components/layout/WorkspaceControlCenter.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceControlCenter.tsx
@@ -67,6 +67,20 @@ interface RunningSubTaskPreview {
 const SUB_TASK_PREVIEW_HISTORY_LIMIT = 6;
 const SUB_TASK_PREVIEW_TEXT_LIMIT = 160;
 
+interface WorkspaceCardSnapshot {
+  mainSession: AgentSessionRecordPayload | null;
+  messages: PreviewChatMessage[];
+  runtimeState: SessionRuntimeRecordPayload | null;
+  runtimeCardState: RuntimeCardState;
+  runningSubTasks: RunningSubTaskPreview[];
+}
+
+// Module-level cache so each WorkspaceCard can rehydrate instantly when the
+// Control Center re-opens. Keeps last-seen snapshot per workspace across
+// mounts; without this, every CC reopen flashes a loading spinner before
+// the same content paints in. Cache size is bounded by the workspace count.
+const workspaceCardSnapshotCache = new Map<string, WorkspaceCardSnapshot>();
+
 interface WorkspaceControlCenterProps {
   workspaces: WorkspaceRecordPayload[];
   selectedWorkspaceId: string | null;
@@ -447,16 +461,22 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
 }: WorkspaceCardProps) {
   const workspaceId = workspace.id;
   const workspaceFallbackActivityAt = fallbackWorkspaceActivityAt(workspace);
+  const cachedSnapshot = workspaceCardSnapshotCache.get(workspaceId) ?? null;
   const [mainSession, setMainSession] = useState<AgentSessionRecordPayload | null>(
-    null,
+    () => cachedSnapshot?.mainSession ?? null,
   );
-  const [messages, setMessages] = useState<PreviewChatMessage[]>([]);
+  const [messages, setMessages] = useState<PreviewChatMessage[]>(
+    () => cachedSnapshot?.messages ?? [],
+  );
   const [runtimeState, setRuntimeState] =
-    useState<SessionRuntimeRecordPayload | null>(null);
-  const [runtimeCardState, setRuntimeCardState] =
-    useState<RuntimeCardState>("idle");
+    useState<SessionRuntimeRecordPayload | null>(
+      () => cachedSnapshot?.runtimeState ?? null,
+    );
+  const [runtimeCardState, setRuntimeCardState] = useState<RuntimeCardState>(
+    () => cachedSnapshot?.runtimeCardState ?? "idle",
+  );
   const [errorMessage, setErrorMessage] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(() => cachedSnapshot === null);
   const [isResponding, setIsResponding] = useState(false);
   const [liveAssistantText, setLiveAssistantText] = useState("");
   const [liveAgentStatus, setLiveAgentStatus] = useState("");
@@ -468,7 +488,7 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
   >([]);
   const [runningSubTasks, setRunningSubTasks] = useState<
     RunningSubTaskPreview[]
-  >([]);
+  >(() => cachedSnapshot?.runningSubTasks ?? []);
   const previewScrollerRef = useRef<HTMLDivElement | null>(null);
   const messagesRef = useRef<PreviewChatMessage[]>([]);
   const shouldStickToBottomRef = useRef(true);
@@ -764,6 +784,13 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
       setRuntimeState(nextRuntimeState);
       setRuntimeCardState(nextRuntimeCardState);
       setRunningSubTasks(nextSubTaskPreviews);
+      workspaceCardSnapshotCache.set(workspaceId, {
+        mainSession: session,
+        messages: nextRenderedMessages,
+        runtimeState: nextRuntimeState,
+        runtimeCardState: nextRuntimeCardState,
+        runningSubTasks: nextSubTaskPreviews,
+      });
       setIsResponding(
         nextRuntimeCardState === "queued" || nextRuntimeCardState === "working",
       );
@@ -820,7 +847,11 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
 
   useEffect(() => {
     disposedRef.current = false;
-    void refreshSnapshot({ attachStream: true, showLoading: true }).catch(
+    // Skip the loading spinner when we already have a cached snapshot for
+    // this workspace — the cached data is on screen, the background refresh
+    // will just replace it when it lands.
+    const showLoading = !workspaceCardSnapshotCache.has(workspaceId);
+    void refreshSnapshot({ attachStream: true, showLoading }).catch(
       (error) => {
         if (disposedRef.current) {
           return;
@@ -839,7 +870,12 @@ const WorkspaceControlCenterCard = memo(function WorkspaceControlCenterCard({
       clearScheduledTerminalRefreshes();
       void closeActiveStream("control_center_card_unmounted");
     };
-  }, [clearScheduledTerminalRefreshes, closeActiveStream, refreshSnapshot]);
+  }, [
+    clearScheduledTerminalRefreshes,
+    closeActiveStream,
+    refreshSnapshot,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     messagesRef.current = messages;

--- a/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
+++ b/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
@@ -1,10 +1,12 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
 import { FirstWorkspacePane } from "@/components/onboarding/FirstWorkspacePane";
+import { WorkspaceControlCenter } from "@/components/layout/WorkspaceControlCenter";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 import { PublishScreen } from "@/components/publish/PublishScreen";
 import { WorkspaceOnboardingSurface } from "@/features/workspace-onboarding/WorkspaceOnboardingSurface";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
+import { useControlCenterCardSignals } from "@/lib/controlCenterLifecycle";
 import { cn } from "@/lib/utils";
 import {
   useWorkspaceDesktop,
@@ -23,6 +25,7 @@ import { SearchDialog } from "./SearchDialog";
 import { Sidebar } from "./Sidebar";
 import { internalTabsAtom } from "./state/internalTabs";
 import {
+  controlCenterOpenAtom,
   createWorkspaceOpenAtom,
   focusModeAtom,
   newTabOpenAtom,
@@ -49,12 +52,16 @@ function NewAppShellContent() {
   const setNewTabOpen = useSetAtom(newTabOpenAtom);
   const setSearchOpen = useSetAtom(searchOpenAtom);
   const setSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
-  const { selectedWorkspaceId } = useWorkspaceSelection();
+  const { selectedWorkspaceId, setSelectedWorkspaceId } =
+    useWorkspaceSelection();
   const { onboardingModeActive, workspaces, hasHydratedWorkspaceList } =
     useWorkspaceDesktop();
   const [publishOpen, setPublishOpen] = useAtom(publishOpenAtom);
   const createWorkspaceOpen = useAtomValue(createWorkspaceOpenAtom);
   const setCreateWorkspaceOpen = useSetAtom(createWorkspaceOpenAtom);
+  const [controlCenterOpen, setControlCenterOpen] = useAtom(
+    controlCenterOpenAtom,
+  );
   const hasWorkspaces = workspaces.length > 0;
   const layout = useChatLayout();
   const [focusMode, setFocusMode] = useAtom(focusModeAtom);
@@ -84,11 +91,19 @@ function NewAppShellContent() {
       } else if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
         e.preventDefault();
         setSidebarCollapsed((prev) => !prev);
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "0") {
+        e.preventDefault();
+        setControlCenterOpen((prev) => !prev);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [setNewTabOpen, setSearchOpen, setSidebarCollapsed]);
+  }, [
+    setNewTabOpen,
+    setSearchOpen,
+    setSidebarCollapsed,
+    setControlCenterOpen,
+  ]);
 
   if (hasHydratedWorkspaceList && !hasWorkspaces) {
     return (
@@ -99,6 +114,7 @@ function NewAppShellContent() {
   }
 
   const showMiddle = layout === "split";
+  const showControlCenter = controlCenterOpen;
 
   return (
     <div className="flex h-screen w-screen overflow-hidden text-foreground antialiased">
@@ -107,6 +123,20 @@ function NewAppShellContent() {
         <div className="flex min-w-0 flex-1 flex-col bg-background">
           <ExperimentalWorkspaceOnboardingTakeover />
         </div>
+      ) : showControlCenter ? (
+        <ControlCenterTakeover
+          workspaces={workspaces}
+          selectedWorkspaceId={selectedWorkspaceId}
+          onSelectWorkspace={(id) => setSelectedWorkspaceId(id)}
+          onEnterWorkspace={(id) => {
+            setSelectedWorkspaceId(id);
+            setControlCenterOpen(false);
+          }}
+          onCreateWorkspace={() => {
+            setControlCenterOpen(false);
+            setCreateWorkspaceOpen(true);
+          }}
+        />
       ) : (
         <>
           <div
@@ -154,5 +184,53 @@ function ExperimentalWorkspaceOnboardingTakeover() {
         <WorkspaceOnboardingSurface />
       </div>
     </section>
+  );
+}
+
+// Wraps WorkspaceControlCenter for the new shell. Drag-reorder, density,
+// and completion highlights are deferred to a follow-up that lifts those
+// state slices out of legacy AppShell into shared atoms/hooks.
+function ControlCenterTakeover(props: {
+  workspaces: WorkspaceRecordPayload[];
+  selectedWorkspaceId: string | null;
+  onSelectWorkspace: (workspaceId: string) => void;
+  onEnterWorkspace: (workspaceId: string) => void;
+  onCreateWorkspace: () => void;
+}) {
+  const visibleWorkspaceIdsRef = useRef<string[]>([]);
+  const cardSignals = useControlCenterCardSignals(
+    visibleWorkspaceIdsRef.current,
+    true,
+  );
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col bg-background">
+      <WorkspaceControlCenter
+        workspaces={props.workspaces}
+        selectedWorkspaceId={props.selectedWorkspaceId}
+        cardsPerRow={3}
+        orderedWorkspaceIds={[]}
+        highlightedWorkspaceIds={[]}
+        cardSignals={cardSignals}
+        onOpenWorkspaceRunningTasks={props.onEnterWorkspace}
+        onOpenWorkspaceAppsExplorer={props.onEnterWorkspace}
+        onSelectWorkspace={props.onSelectWorkspace}
+        onEnterWorkspace={props.onEnterWorkspace}
+        onOpenOutput={(workspaceId) => props.onEnterWorkspace(workspaceId)}
+        onWorkspaceOrderChange={() => {
+          /* drag reorder deferred to a follow-up */
+        }}
+        onVisibleWorkspaceIdsChange={(ids) => {
+          visibleWorkspaceIdsRef.current = ids;
+        }}
+        onCardComposerSubmit={() => {
+          /* highlight suppression handled by AppShell; no-op here */
+        }}
+        onWorkspaceCompletion={() => {
+          /* completion highlights deferred to a follow-up */
+        }}
+        onCreateWorkspace={props.onCreateWorkspace}
+      />
+    </div>
   );
 }

--- a/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
+++ b/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
@@ -1,4 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { X } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { FirstWorkspacePane } from "@/components/onboarding/FirstWorkspacePane";
 import { WorkspaceControlCenter } from "@/components/layout/WorkspaceControlCenter";
@@ -94,6 +95,13 @@ function NewAppShellContent() {
       } else if ((e.metaKey || e.ctrlKey) && e.key === "0") {
         e.preventDefault();
         setControlCenterOpen((prev) => !prev);
+      } else if (e.key === "Escape") {
+        // Only swallow Escape when CC is open; other consumers (composers,
+        // dialogs) keep their own ESC handling intact.
+        setControlCenterOpen((prev) => {
+          if (prev) return false;
+          return prev;
+        });
       }
     };
     window.addEventListener("keydown", handler);
@@ -118,7 +126,7 @@ function NewAppShellContent() {
 
   return (
     <div className="flex h-screen w-screen overflow-hidden text-foreground antialiased">
-      <Sidebar />
+      {showControlCenter ? null : <Sidebar />}
       {onboardingModeActive ? (
         <div className="flex min-w-0 flex-1 flex-col bg-background">
           <ExperimentalWorkspaceOnboardingTakeover />
@@ -127,6 +135,7 @@ function NewAppShellContent() {
         <ControlCenterTakeover
           workspaces={workspaces}
           selectedWorkspaceId={selectedWorkspaceId}
+          onClose={() => setControlCenterOpen(false)}
           onSelectWorkspace={(id) => setSelectedWorkspaceId(id)}
           onEnterWorkspace={(id) => {
             setSelectedWorkspaceId(id);
@@ -193,6 +202,7 @@ function ExperimentalWorkspaceOnboardingTakeover() {
 function ControlCenterTakeover(props: {
   workspaces: WorkspaceRecordPayload[];
   selectedWorkspaceId: string | null;
+  onClose: () => void;
   onSelectWorkspace: (workspaceId: string) => void;
   onEnterWorkspace: (workspaceId: string) => void;
   onCreateWorkspace: () => void;
@@ -204,7 +214,16 @@ function ControlCenterTakeover(props: {
   );
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col bg-background">
+    <div className="relative flex min-w-0 flex-1 flex-col bg-background">
+      <button
+        type="button"
+        aria-label="Close all workspaces"
+        title="Close (Esc / ⌘0)"
+        onClick={props.onClose}
+        className="window-no-drag absolute top-3 left-3 z-10 grid size-7 place-items-center rounded-md text-foreground/55 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+      >
+        <X className="size-3.5" />
+      </button>
       <WorkspaceControlCenter
         workspaces={props.workspaces}
         selectedWorkspaceId={props.selectedWorkspaceId}

--- a/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
@@ -42,6 +42,7 @@ import {
   Globe,
   Home,
   Inbox,
+  LayoutGrid,
   Link2,
   Loader2,
   MoreHorizontal,
@@ -74,6 +75,7 @@ import {
   appsExpandedAtom,
   automationsOpenAtom,
   chatComposerPrefillAtom,
+  controlCenterOpenAtom,
   createWorkspaceOpenAtom,
   focusModeAtom,
   publishOpenAtom,
@@ -411,8 +413,18 @@ function SidebarGlobalFooter() {
   const setSettingsOpen = useSetAtom(settingsOpenAtom);
   const setSettingsSection = useSetAtom(settingsSectionAtom);
   const settingsOpen = useAtomValue(settingsOpenAtom);
+  const [controlCenterOpen, setControlCenterOpen] = useAtom(
+    controlCenterOpenAtom,
+  );
   return (
     <div className="shrink-0 border-t border-sidebar-border px-2 py-1.5">
+      <NavItem
+        icon={<LayoutGrid />}
+        active={controlCenterOpen}
+        onClick={() => setControlCenterOpen((prev) => !prev)}
+      >
+        All workspaces
+      </NavItem>
       <NavItem
         icon={<Settings />}
         active={settingsOpen}

--- a/apps/desktop/src/components/layout/new-shell/state/ui.ts
+++ b/apps/desktop/src/components/layout/new-shell/state/ui.ts
@@ -56,6 +56,13 @@ export const settingsOpenAtom = atom(false);
 /** Is the Marketplace overlay open? */
 export const marketplaceOpenAtom = atom(false);
 
+/**
+ * Is the Control Center (full-screen workspace grid) open? Takes over
+ * the center + chat panel so the user sees the cross-workspace dashboard
+ * instead of the active workspace.
+ */
+export const controlCenterOpenAtom = atom(false);
+
 /** Is the Apps expandable group in the sidebar expanded? Persists. */
 export const appsExpandedAtom = atomWithStorage(
   "holaboss-new-shell-apps-expanded-v1",
@@ -126,6 +133,7 @@ export const browserViewSuspendedAtom = atom(
     get(automationsOpenAtom) ||
     get(settingsOpenAtom) ||
     get(marketplaceOpenAtom) ||
+    get(controlCenterOpenAtom) ||
     get(activeInternalTabIdAtom) !== null ||
     get(overlayOpenCountAtom) > 0,
 );


### PR DESCRIPTION
## Summary
- \`NewAppShell\` never mounted \`WorkspaceControlCenter\`, so the cross-workspace grid dashboard had no way in. Clicking workspaces in the sidebar popover just switched the active workspace; there was no overview view at all.
- New entry: an "All workspaces" \`NavItem\` in \`SidebarGlobalFooter\` (paired with Settings — both are app-level / jump-out-of-workspace actions). \`⌘0\` toggles the takeover from anywhere (covers the sidebar-collapsed case).
- New \`controlCenterOpenAtom\` is added to \`browserViewSuspendedAtom\` so the native \`BrowserView\` detaches while the grid is up.
- \`ControlCenterTakeover\` wraps \`WorkspaceControlCenter\` with minimal props. Enter/select wire \`selectedWorkspaceId\`; create routes to the existing \`createWorkspaceOpenAtom\` panel.

## Why this targets \`fix/agent-integration-followups\`
\`apps/desktop/src/components/layout/new-shell/\` does not exist on \`main\` yet — it lives on \`feat/integration-store-unified\` (PR #387) and downstream branches. Targeting the active downstream so the diff stays focused. Re-target to \`main\` once new-shell lands.

## Follow-ups (deferred from v1)
- Drag-reorder of workspace cards (\`onWorkspaceOrderChange\`) — needs the localStorage-backed order atom lifted out of legacy \`AppShell.tsx\`.
- Card density picker (\`cardsPerRow\`) — currently hardcoded to 3.
- "Completion highlight" pulse when a backgrounded workspace finishes (\`highlightedWorkspaceIds\` + \`onWorkspaceCompletion\`) — needs the same lift.
- Routing \`onOpenWorkspaceRunningTasks\` / \`onOpenWorkspaceAppsExplorer\` / \`onOpenOutput\` to the new shell's equivalents (today they all just enter the workspace).

## Test plan
- [ ] Click "All workspaces" in sidebar footer → grid appears, BrowserView hidden
- [ ] \`⌘0\` toggles in/out of grid from any sidebar section
- [ ] Click a workspace card → enters workspace, returns to chat/canvas
- [ ] "+ Create workspace" from inside the grid → grid closes, FirstWorkspacePane opens
- [ ] Sidebar collapsed (\`⌘\\\`) → only \`⌘0\` works; footer entry is correctly hidden
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)