### PR TITLE
feat: upgrade workspace memory retrieval and rebuild pipeline

### DIFF
--- a/runtime/api-server/src/integration-context-fetch.test.ts
+++ b/runtime/api-server/src/integration-context-fetch.test.ts
@@ -1172,10 +1172,16 @@ test("fetchIntegrationContextForConnection does not duplicate unchanged GitHub l
     connectionId: "conn-github-1",
     composioClient,
   });
+  const secondProgressLabels: string[] = [];
   const second = await fetchIntegrationContextForConnection({
     store,
     connectionId: "conn-github-1",
     composioClient,
+    onProgress(snapshot) {
+      if (snapshot.current_chunk_label) {
+        secondProgressLabels.push(snapshot.current_chunk_label);
+      }
+    },
   });
 
   assert.equal(first.leaves_created, 6);
@@ -1183,6 +1189,8 @@ test("fetchIntegrationContextForConnection does not duplicate unchanged GitHub l
   assert.equal(second.leaves_created, 0);
   assert.equal(second.leaves_superseding, 0);
   assert.equal(second.leaves_unchanged, 6);
+  const summaryLabels = secondProgressLabels.filter((label) => label.includes("GitHub context summary"));
+  assert.equal(summaryLabels.at(-1), "Reusing GitHub context summary");
 
   const trees = store.listIntegrationTrees({
     status: "active",

--- a/runtime/api-server/src/integration-context-fetch.ts
+++ b/runtime/api-server/src/integration-context-fetch.ts
@@ -8,7 +8,7 @@ import {
 import {
   countSummaryLikeSemanticIntegrationNodes,
   persistIntegrationCandidate,
-  rebuildIntegrationTree,
+  queueIntegrationTreeRebuild,
   type IntegrationLeafCandidate,
   type PersistedIntegrationLeafResult,
 } from "./integration-memory.js";
@@ -2576,6 +2576,50 @@ function retireIntegrationEntityLeaves(params: {
   return retired;
 }
 
+function integrationTreeHasSemanticState(params: {
+  store: RuntimeStateStore;
+  treeId: string;
+}): boolean {
+  return params.store.listSemanticMemoryNodes({
+    category: "integration",
+    treeId: params.treeId,
+    status: "active",
+    limit: 1,
+    offset: 0,
+  }).length > 0;
+}
+
+async function finalizeIntegrationContextSummary(params: {
+  store: RuntimeStateStore;
+  treeId: string | null;
+  providerLabel: string;
+  treeChanged: boolean;
+  syncProgress: (patch?: Partial<IntegrationContextFetchProgressSnapshot>) => void;
+}): Promise<number> {
+  if (!params.treeId) {
+    return 0;
+  }
+  const shouldRebuild = params.treeChanged || !integrationTreeHasSemanticState({
+    store: params.store,
+    treeId: params.treeId,
+  });
+  params.syncProgress({
+    current_chunk_label: `${shouldRebuild ? "Rebuilding" : "Reusing"} ${params.providerLabel} context summary`,
+  });
+  if (shouldRebuild) {
+    await queueIntegrationTreeRebuild({
+      store: params.store,
+      treeId: params.treeId,
+      embeddingClient: null,
+      debounceMs: 0,
+    });
+  }
+  return countSummaryLikeSemanticIntegrationNodes({
+    store: params.store,
+    treeId: params.treeId,
+  });
+}
+
 function resolveComposioClient(client?: ComposioExecuteClient | null): ComposioExecuteClient {
   if (client) {
     return client;
@@ -2808,17 +2852,14 @@ async function fetchGmailIntegrationContext(params: {
     });
   }
 
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Gmail",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Gmail context fetch complete" });
 
   return {
@@ -3225,18 +3266,14 @@ async function fetchGitHubIntegrationContext(params: {
     actions.push(`GITHUB_RETIRED_REPO_LEAVES:${retiredRepoLeaves}`);
   }
   chunksCompleted += 1;
-  syncProgress({ current_chunk_label: "Rebuilding GitHub context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "GitHub",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0 || retiredRepoLeaves > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "GitHub context fetch complete" });
 
   return {
@@ -3551,18 +3588,17 @@ async function fetchNotionIntegrationContext(params: {
   }
   chunksCompleted += 1;
 
-  syncProgress({ current_chunk_label: "Rebuilding Notion context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Notion",
+    treeChanged: persistStats.created > 0
+      || persistStats.superseding > 0
+      || retiredPages > 0
+      || retiredDatabases > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Notion context fetch complete" });
 
   return {
@@ -3735,18 +3771,14 @@ async function fetchGoogleDriveIntegrationContext(params: {
   }
   chunksCompleted += 1;
 
-  syncProgress({ current_chunk_label: "Rebuilding Google Drive context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Google Drive",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0 || retiredFiles > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Google Drive context fetch complete" });
 
   return {
@@ -3944,18 +3976,14 @@ async function fetchTwitterIntegrationContext(params: {
   }
   chunksCompleted += 1;
 
-  syncProgress({ current_chunk_label: "Rebuilding Twitter context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Twitter",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0 || retiredPosts > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Twitter context fetch complete" });
 
   return {
@@ -4183,18 +4211,14 @@ async function fetchGoogleCalendarIntegrationContext(params: {
   }
   chunksCompleted += 1;
 
-  syncProgress({ current_chunk_label: "Rebuilding Google Calendar context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Google Calendar",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0 || retiredCalendars > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Google Calendar context fetch complete" });
 
   return {
@@ -4304,21 +4328,14 @@ async function fetchLinkedInIntegrationContext(params: {
   updatePersistStats(profilePersist, persistStats);
   treeId = profilePersist.tree.treeId;
   chunksCompleted += 1;
-  syncProgress({
-    current_chunk_label: "Rebuilding LinkedIn context summary",
-  });
-
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "LinkedIn",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "LinkedIn context fetch complete" });
 
   return {
@@ -4541,18 +4558,14 @@ async function fetchSlackIntegrationContext(params: {
     }
   }
 
-  syncProgress({ current_chunk_label: "Rebuilding Slack context summary" });
-  await rebuildIntegrationTree({
+  summaryNodes = await finalizeIntegrationContextSummary({
     store: params.store,
     treeId,
-    embeddingClient: null,
+    providerLabel: "Slack",
+    treeChanged: persistStats.created > 0 || persistStats.superseding > 0,
+    syncProgress,
   });
   chunksCompleted += 1;
-
-  summaryNodes = countSummaryLikeSemanticIntegrationNodes({
-    store: params.store,
-    treeId,
-  });
   syncProgress({ current_chunk_label: "Slack context fetch complete" });
 
   return {

--- a/runtime/api-server/src/integration-memory.test.ts
+++ b/runtime/api-server/src/integration-memory.test.ts
@@ -132,6 +132,122 @@ test("rebuildIntegrationTree writes deterministic semantic summaries for integra
   }
 });
 
+test("retrieveIntegrationMemory recalls deep-body integration leaf terms through the semantic search index", async () => {
+  const root = makeTempDir("hb-integration-memory-fts-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    store.upsertIntegrationConnection({
+      connectionId: "github-1",
+      providerId: "github",
+      ownerUserId: "user-1",
+      accountLabel: "Release GitHub",
+      accountHandle: "release-github",
+      authMode: "composio",
+      grantedScopes: [],
+      status: "active",
+    });
+    store.upsertIntegrationTree({
+      treeId: "integration:github:acct-fts",
+      provider: "github",
+      ownerUserId: "user-1",
+      accountKey: "release-github",
+      accountLabel: "Release GitHub",
+      slug: "github-release-fts",
+      summary: "Release GitHub memory.",
+      status: "active",
+    });
+
+    const buriedToken = "orbitalfreeze88";
+    const leafId = "leaf-deep-body";
+    store.upsertIntegrationLeaf({
+      leafId,
+      treeId: "integration:github:acct-fts",
+      subjectKey: "repo:holaboss-ai/release:pr:fts",
+      entityKey: "repo:holaboss-ai/release",
+      entityLabel: "holaboss-ai/release",
+      branchKey: "pull_requests",
+      branchLabel: "Pull requests",
+      path: `integration/accounts/github-release-fts/leaves/${leafId}.md`,
+      title: "Release checksum gate",
+      summary: "Release approval depends on a checksum gate deep in the body.",
+      fingerprint: `fingerprint-${leafId}`,
+      bodySha256: `sha-${leafId}`,
+      tags: ["github", "release"],
+      sourceType: "github.pull_request",
+      sourceEventId: "evt-fts",
+      sourceMessageId: null,
+      externalObjectId: "9001",
+      externalObjectType: "pull_request",
+      admissionConfidence: 0.9,
+      observedAt: "2026-05-22T09:00:00.000Z",
+      supersedesLeafId: null,
+      status: "active",
+    });
+
+    const absolutePath = path.join(
+      globalMemoryDirForWorkspaceRoot(workspaceRoot),
+      "integration",
+      "accounts",
+      "github-release-fts",
+      "leaves",
+      `${leafId}.md`,
+    );
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(
+      absolutePath,
+      `# Release checksum gate\n\n${"filler ".repeat(90)}${buriedToken} must be green before merge.\n`,
+      "utf8",
+    );
+
+    await rebuildIntegrationTree({
+      store,
+      treeId: "integration:github:acct-fts",
+      embeddingClient: null,
+    });
+
+    const leafNode = store.listSemanticMemoryNodes({
+      category: "integration",
+      treeId: "integration:github:acct-fts",
+      nodeClass: "leaf",
+      status: "active",
+      limit: 10_000,
+      offset: 0,
+    })[0];
+    assert.ok(leafNode);
+
+    const indexedDoc = store.getSemanticMemorySearchDoc({
+      category: "integration",
+      treeId: "integration:github:acct-fts",
+      nodeId: leafNode!.nodeId,
+    });
+    assert.ok(indexedDoc);
+    assert.equal(indexedDoc?.bodyText.includes(buriedToken), true);
+    assert.equal(indexedDoc?.excerpt?.includes(buriedToken) ?? false, false);
+
+    const result = await retrieveIntegrationMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: buriedToken,
+      mode: "leaves",
+      treeId: "integration:github:acct-fts",
+      maxResults: 5,
+    });
+    assert.ok(result.hits.some((hit) => hit.title === "Release checksum gate"));
+  } finally {
+    store.close();
+  }
+});
+
 test("retrieveIntegrationMemory follows workspace override visibility without requiring integration bindings", async () => {
   const root = makeTempDir("hb-integration-memory-visibility-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/integration-memory.test.ts
+++ b/runtime/api-server/src/integration-memory.test.ts
@@ -248,6 +248,129 @@ test("retrieveIntegrationMemory recalls deep-body integration leaf terms through
   }
 });
 
+test("retrieveIntegrationMemory recalls matches across multiple visible integration trees", async () => {
+  const root = makeTempDir("hb-integration-memory-multi-tree-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    for (const account of [
+      { connectionId: "github-1", treeId: "integration:github:acct-a", slug: "github-acct-a", label: "Account A" },
+      { connectionId: "github-2", treeId: "integration:github:acct-b", slug: "github-acct-b", label: "Account B" },
+    ]) {
+      store.upsertIntegrationConnection({
+        connectionId: account.connectionId,
+        providerId: "github",
+        ownerUserId: "user-1",
+        accountLabel: account.label,
+        accountHandle: account.slug,
+        authMode: "composio",
+        grantedScopes: [],
+        status: "active",
+      });
+      store.upsertIntegrationTree({
+        treeId: account.treeId,
+        provider: "github",
+        ownerUserId: "user-1",
+        accountKey: account.slug,
+        accountLabel: account.label,
+        slug: account.slug,
+        summary: `${account.label} memory.`,
+        status: "active",
+      });
+    }
+
+    const buriedToken = "multitreeorbit77";
+    const seedLeaf = (params: {
+      treeId: string;
+      slug: string;
+      leafId: string;
+      title: string;
+      body: string;
+    }) => {
+      store.upsertIntegrationLeaf({
+        leafId: params.leafId,
+        treeId: params.treeId,
+        subjectKey: `repo:${params.slug}:${params.leafId}`,
+        entityKey: `repo:${params.slug}`,
+        entityLabel: params.slug,
+        branchKey: "pull_requests",
+        branchLabel: "Pull requests",
+        path: `integration/accounts/${params.slug}/leaves/${params.leafId}.md`,
+        title: params.title,
+        summary: `${params.title} summary.`,
+        fingerprint: `fingerprint-${params.leafId}`,
+        bodySha256: `sha-${params.leafId}`,
+        tags: ["github"],
+        sourceType: "github.pull_request",
+        sourceEventId: `evt-${params.leafId}`,
+        sourceMessageId: null,
+        externalObjectId: params.leafId,
+        externalObjectType: "pull_request",
+        admissionConfidence: 0.9,
+        observedAt: "2026-05-22T09:00:00.000Z",
+        supersedesLeafId: null,
+        status: "active",
+      });
+      const absolutePath = path.join(
+        globalMemoryDirForWorkspaceRoot(workspaceRoot),
+        "integration",
+        "accounts",
+        params.slug,
+        "leaves",
+        `${params.leafId}.md`,
+      );
+      fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+      fs.writeFileSync(absolutePath, params.body, "utf8");
+    };
+
+    seedLeaf({
+      treeId: "integration:github:acct-a",
+      slug: "github-acct-a",
+      leafId: "leaf-a",
+      title: "General release note",
+      body: "# General release note\n\nNormal release work.\n",
+    });
+    seedLeaf({
+      treeId: "integration:github:acct-b",
+      slug: "github-acct-b",
+      leafId: "leaf-b",
+      title: "Checksum gate",
+      body: `# Checksum gate\n\n${"filler ".repeat(90)}${buriedToken} must pass before merge.\n`,
+    });
+
+    await rebuildIntegrationTree({
+      store,
+      treeId: "integration:github:acct-a",
+      embeddingClient: null,
+    });
+    await rebuildIntegrationTree({
+      store,
+      treeId: "integration:github:acct-b",
+      embeddingClient: null,
+    });
+
+    const result = await retrieveIntegrationMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: buriedToken,
+      mode: "leaves",
+      maxResults: 5,
+    });
+    assert.ok(result.hits.some((hit) => hit.tree_id === "integration:github:acct-b" && hit.title === "Checksum gate"));
+  } finally {
+    store.close();
+  }
+});
+
 test("retrieveIntegrationMemory follows workspace override visibility without requiring integration bindings", async () => {
   const root = makeTempDir("hb-integration-memory-visibility-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/integration-memory.test.ts
+++ b/runtime/api-server/src/integration-memory.test.ts
@@ -294,6 +294,82 @@ test("retrieveIntegrationMemory recalls deep-body integration leaf terms through
   }
 });
 
+test("retrieveIntegrationMemory falls back to leaf summaries without reading markdown files", async () => {
+  const root = makeTempDir("hb-integration-memory-leaf-fallback-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    store.upsertIntegrationConnection({
+      connectionId: "github-1",
+      providerId: "github",
+      ownerUserId: "user-1",
+      accountLabel: "Release GitHub",
+      accountHandle: "release-github",
+      authMode: "composio",
+      grantedScopes: [],
+      status: "active",
+    });
+    store.upsertIntegrationTree({
+      treeId: "integration:github:acct-fallback",
+      provider: "github",
+      ownerUserId: "user-1",
+      accountKey: "release-github",
+      accountLabel: "Release GitHub",
+      slug: "github-release-fallback",
+      summary: "Release GitHub memory.",
+      status: "active",
+    });
+    store.upsertIntegrationLeaf({
+      leafId: "leaf-summary-fallback",
+      treeId: "integration:github:acct-fallback",
+      subjectKey: "repo:holaboss-ai/release:issue:summary-fallback",
+      entityKey: "repo:holaboss-ai/release",
+      entityLabel: "holaboss-ai/release",
+      branchKey: "issues",
+      branchLabel: "Issues",
+      path: "integration/accounts/github-release-fallback/leaves/leaf-summary-fallback.md",
+      title: "Release metrics backfill",
+      summary: "Backfill heliograph metrics after the rollout stabilizes.",
+      fingerprint: "fingerprint-leaf-summary-fallback",
+      bodySha256: "sha-leaf-summary-fallback",
+      tags: ["github", "release"],
+      sourceType: "github.issue",
+      sourceEventId: "evt-fallback",
+      sourceMessageId: null,
+      externalObjectId: "202",
+      externalObjectType: "issue",
+      admissionConfidence: 0.9,
+      observedAt: "2026-05-22T10:00:00.000Z",
+      supersedesLeafId: null,
+      status: "active",
+    });
+
+    const result = await retrieveIntegrationMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: "heliograph metrics",
+      mode: "leaves",
+      treeId: "integration:github:acct-fallback",
+      maxResults: 5,
+    });
+
+    assert.equal(result.hits.length, 1);
+    assert.equal(result.hits[0]?.title, "Release metrics backfill");
+    assert.match(result.hits[0]?.excerpt ?? "", /heliograph metrics/i);
+  } finally {
+    store.close();
+  }
+});
+
 test("retrieveIntegrationMemory adds vector-only semantic candidates that fall outside the recent doc window", async () => {
   const root = makeTempDir("hb-integration-memory-vector-topk-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/integration-memory.test.ts
+++ b/runtime/api-server/src/integration-memory.test.ts
@@ -13,9 +13,17 @@ import {
 } from "./integration-memory.js";
 import { globalMemoryDirForWorkspaceRoot } from "./workspace-bundle-paths.js";
 
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_RUNTIME_CONFIG_PATH = process.env.HOLABOSS_RUNTIME_CONFIG_PATH;
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_RUNTIME_CONFIG_PATH === undefined) {
+    delete process.env.HOLABOSS_RUNTIME_CONFIG_PATH;
+  } else {
+    process.env.HOLABOSS_RUNTIME_CONFIG_PATH = ORIGINAL_RUNTIME_CONFIG_PATH;
+  }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -25,6 +33,44 @@ function makeTempDir(prefix: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+function writeRecallEmbeddingRuntimeConfig(root: string): string {
+  const configPath = path.join(root, "runtime-config.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        runtime: {
+          sandbox_id: "sandbox-test",
+        },
+        providers: {
+          openai_direct: {
+            kind: "openai_compatible",
+            base_url: "https://api.openai.com/v1",
+            api_key: "sk-test-openai",
+          },
+        },
+        integrations: {
+          holaboss: {
+            auth_token: "hbmk.test-token",
+            sandbox_id: "sandbox-test",
+            user_id: "user-1",
+          },
+        },
+        holaboss: {
+          auth_token: "hbmk.test-token",
+          sandbox_id: "sandbox-test",
+          user_id: "user-1",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = configPath;
+  return configPath;
 }
 
 test("rebuildIntegrationTree writes deterministic semantic summaries for integration roots", async () => {
@@ -243,6 +289,115 @@ test("retrieveIntegrationMemory recalls deep-body integration leaf terms through
       maxResults: 5,
     });
     assert.ok(result.hits.some((hit) => hit.title === "Release checksum gate"));
+  } finally {
+    store.close();
+  }
+});
+
+test("retrieveIntegrationMemory adds vector-only semantic candidates that fall outside the recent doc window", async () => {
+  const root = makeTempDir("hb-integration-memory-vector-topk-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    assert.equal(store.supportsVectorIndex(), true);
+    writeRecallEmbeddingRuntimeConfig(root);
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    store.upsertIntegrationConnection({
+      connectionId: "github-vector",
+      providerId: "github",
+      ownerUserId: "user-1",
+      accountLabel: "Vector GitHub",
+      accountHandle: "vector-github",
+      authMode: "composio",
+      grantedScopes: [],
+      status: "active",
+    });
+    store.upsertIntegrationTree({
+      treeId: "integration:github:vector-topk",
+      provider: "github",
+      ownerUserId: "user-1",
+      accountKey: "vector-github",
+      accountLabel: "Vector GitHub",
+      slug: "github-vector-topk",
+      summary: "Vector GitHub memory.",
+      status: "active",
+    });
+
+    const relevantNodeId = "semantic:integration:integration:github:vector-topk:repo:archive-ledger";
+    const relevantVector = new Array<number>(1536).fill(0);
+    relevantVector[0] = 1;
+    globalThis.fetch = (async (input) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      assert.match(url, /\/embeddings$/);
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: relevantVector }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+
+    store.replaceSemanticMemorySearchDocs({
+      category: "integration",
+      treeId: "integration:github:vector-topk",
+      docs: [
+        ...Array.from({ length: 170 }, (_, index) => ({
+          nodeId: index === 169
+            ? relevantNodeId
+            : `semantic:integration:integration:github:vector-topk:filler-${index + 1}`,
+          nodeClass: "semantic" as const,
+          nodeKind: index === 169 ? "repo" : "overview",
+          path: index === 169
+            ? "semantic/integration/trees/github-vector-topk/repo-archive-ledger/content.md"
+            : `semantic/integration/trees/github-vector-topk/filler-${index + 1}/content.md`,
+          childCount: 0,
+          title: index === 169 ? "Archive ledger" : `Filler summary ${index + 1}`,
+          summary: index === 169
+            ? "Legacy rollout approvals are organized in the archive ledger."
+            : `Filler semantic summary ${index + 1}.`,
+          bodyText: index === 169
+            ? "Legacy rollout approvals are organized in the archive ledger."
+            : `Filler semantic summary ${index + 1}.`,
+          excerpt: index === 169 ? "Legacy rollout approvals are organized in the archive ledger." : null,
+          observedAt: `2026-05-20T00:${String(index % 60).padStart(2, "0")}:00.000Z`,
+          status: "active" as const,
+          updatedAt: index === 169 ? "2026-01-01T00:00:00.000Z" : "2026-05-31T00:00:00.000Z",
+        })),
+      ],
+    });
+    store.upsertIntegrationNodeEmbedding({
+      nodeKind: "summary",
+      nodeId: relevantNodeId,
+      treeId: "integration:github:vector-topk",
+      embeddingModel: "text-embedding-3-small",
+      contentFingerprint: "v".repeat(64),
+      dimensions: 1536,
+      vector: relevantVector,
+    });
+
+    const result = await retrieveIntegrationMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: "silentorbitvector42",
+      mode: "summaries",
+      maxResults: 5,
+    });
+    assert.ok(result.hits.some((hit) => hit.node_id === relevantNodeId && hit.title === "Archive ledger"));
   } finally {
     store.close();
   }

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -2338,6 +2338,32 @@ function readFileIfExists(filePath: string): string | null {
   }
 }
 
+function removeObsoleteFiles(rootDir: string, keepAbsolutePaths: Set<string>): void {
+  if (!fs.existsSync(rootDir)) {
+    return;
+  }
+  const walk = (currentPath: string): void => {
+    for (const childName of fs.readdirSync(currentPath)) {
+      const childPath = path.join(currentPath, childName);
+      const stats = fs.lstatSync(childPath);
+      if (stats.isDirectory()) {
+        walk(childPath);
+        if (fs.existsSync(childPath) && fs.readdirSync(childPath).length === 0) {
+          fs.rmdirSync(childPath);
+        }
+        continue;
+      }
+      if (!keepAbsolutePaths.has(path.resolve(childPath))) {
+        fs.rmSync(childPath, { force: true });
+      }
+    }
+  };
+  walk(rootDir);
+  if (fs.existsSync(rootDir) && fs.readdirSync(rootDir).length === 0) {
+    fs.rmdirSync(rootDir);
+  }
+}
+
 function markdownExcerpt(text: string, maxChars = EMBEDDING_EXCERPT_CHARS): string {
   const content = text
     .replace(/^\uFEFF/, "")
@@ -3901,10 +3927,6 @@ export async function rebuildIntegrationTree(params: {
     recursive: true,
     force: true,
   });
-  fs.rmSync(semanticIntegrationTreeDir(params.store.workspaceRoot, tree.slug), {
-    recursive: true,
-    force: true,
-  });
 
   const rewrittenLeaves: IntegrationLeafRecord[] = [];
   for (const leaf of activeLeaves) {
@@ -3977,6 +3999,14 @@ export async function rebuildIntegrationTree(params: {
         body,
       );
     }
+    removeObsoleteFiles(
+      semanticIntegrationTreeDir(params.store.workspaceRoot, tree.slug),
+      new Set(
+        [...semantic.bodiesByPath.keys()].map((relativePath) =>
+          path.resolve(absolutePathForRelative(params.store.workspaceRoot, relativePath))
+        ),
+      ),
+    );
     params.store.replaceSemanticMemoryTree({
       category: "integration",
       treeId: params.treeId,
@@ -4012,6 +4042,11 @@ export async function rebuildIntegrationTree(params: {
       docs: semanticSearchDocsForIntegrationTree({
         semantic,
       }),
+    });
+  } else {
+    fs.rmSync(semanticIntegrationTreeDir(params.store.workspaceRoot, tree.slug), {
+      recursive: true,
+      force: true,
     });
   }
   for (const node of semantic?.nodes ?? []) {

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -24,6 +24,7 @@ const RETRIEVAL_CANDIDATE_POOL_LIMIT = 320;
 const RETRIEVAL_FTS_CANDIDATE_LIMIT = 240;
 const RETRIEVAL_RECENT_CANDIDATE_LIMIT = 160;
 const RETRIEVAL_VECTOR_CANDIDATE_LIMIT = 120;
+const INTEGRATION_REBUILD_DEBOUNCE_MS = 75;
 const RETRIEVAL_QUERY_STOPWORDS = new Set([
   "a",
   "an",
@@ -69,6 +70,98 @@ export function countSummaryLikeSemanticIntegrationNodes(params: {
     limit: 10_000,
     offset: 0,
   }).filter((node) => node.nodeKind !== "connection").length;
+}
+
+export function queueIntegrationTreeRebuild(params: {
+  store: RuntimeStateStore;
+  treeId: string;
+  embeddingClient?: MemoryModelClientConfig | null;
+  debounceMs?: number;
+}): Promise<void> {
+  const key = params.treeId.trim();
+  let pending = pendingIntegrationTreeRebuilds.get(key) ?? null;
+  if (!pending) {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const settled = new Promise<void>((innerResolve, innerReject) => {
+      resolve = innerResolve;
+      reject = innerReject;
+    });
+    pending = {
+      key,
+      store: params.store,
+      treeId: params.treeId,
+      embeddingClient: params.embeddingClient ?? null,
+      debounceMs: Math.max(0, params.debounceMs ?? INTEGRATION_REBUILD_DEBOUNCE_MS),
+      timer: null,
+      running: false,
+      dirty: true,
+      settled,
+      resolve,
+      reject,
+    };
+    void settled.catch(() => undefined);
+    pendingIntegrationTreeRebuilds.set(key, pending);
+  } else {
+    pending.store = params.store;
+    pending.embeddingClient = params.embeddingClient ?? pending.embeddingClient ?? null;
+    pending.debounceMs = Math.max(0, params.debounceMs ?? pending.debounceMs);
+    pending.dirty = true;
+  }
+  if (!pending.running) {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+    pending.timer = setTimeout(() => {
+      pending!.timer = null;
+      void runQueuedIntegrationTreeRebuild(pending!);
+    }, pending.debounceMs);
+  }
+  return pending.settled;
+}
+
+async function runQueuedIntegrationTreeRebuild(pending: PendingIntegrationTreeRebuild): Promise<void> {
+  if (pending.running) {
+    return;
+  }
+  pending.running = true;
+  try {
+    while (pending.dirty) {
+      pending.dirty = false;
+      await rebuildIntegrationTree({
+        store: pending.store,
+        treeId: pending.treeId,
+        embeddingClient: pending.embeddingClient,
+      });
+    }
+    pending.resolve();
+  } catch (error) {
+    pending.reject(error);
+  } finally {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+    pending.running = false;
+    pendingIntegrationTreeRebuilds.delete(pending.key);
+  }
+}
+
+export async function waitForPendingIntegrationTreeRebuilds(params?: {
+  treeIds?: string[] | null;
+}): Promise<void> {
+  const normalizedTreeIds = params?.treeIds
+    ? new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))
+    : null;
+  while (true) {
+    const pending = [...pendingIntegrationTreeRebuilds.values()].filter((candidate) =>
+      !normalizedTreeIds || normalizedTreeIds.has(candidate.treeId)
+    );
+    if (pending.length === 0) {
+      return;
+    }
+    await Promise.all(pending.map((candidate) => candidate.settled));
+  }
 }
 
 export interface IntegrationLeafCandidate {
@@ -173,6 +266,22 @@ type IntegrationRelationInput = {
   relationType: string;
   metadata: Record<string, unknown>;
 };
+
+interface PendingIntegrationTreeRebuild {
+  key: string;
+  store: RuntimeStateStore;
+  treeId: string;
+  embeddingClient: MemoryModelClientConfig | null;
+  debounceMs: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  running: boolean;
+  dirty: boolean;
+  settled: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+const pendingIntegrationTreeRebuilds = new Map<string, PendingIntegrationTreeRebuild>();
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -4007,7 +4007,7 @@ export async function rebuildIntegrationTree(params: {
         ),
       ),
     );
-    params.store.replaceSemanticMemoryTree({
+    params.store.syncSemanticMemoryTree({
       category: "integration",
       treeId: params.treeId,
       nodes: semantic.nodes.map((node) => ({
@@ -4026,7 +4026,7 @@ export async function rebuildIntegrationTree(params: {
       })),
       edges: semantic.edges,
     });
-    params.store.replaceSemanticMemoryRelations({
+    params.store.syncSemanticMemoryRelations({
       category: "integration",
       treeId: params.treeId,
       relations: semantic.relations.map((relation) => ({
@@ -4036,7 +4036,7 @@ export async function rebuildIntegrationTree(params: {
         metadata: relation.metadata,
       })),
     });
-    params.store.replaceSemanticMemorySearchDocs({
+    params.store.syncSemanticMemorySearchDocs({
       category: "integration",
       treeId: params.treeId,
       docs: semanticSearchDocsForIntegrationTree({

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -20,6 +20,9 @@ import { globalMemoryDirForWorkspaceRoot } from "./workspace-bundle-paths.js";
 const INTEGRATION_BRANCH_FACTOR = 8;
 const MAX_RETRIEVE_RESULTS = 12;
 const EMBEDDING_EXCERPT_CHARS = 480;
+const RETRIEVAL_CANDIDATE_POOL_LIMIT = 320;
+const RETRIEVAL_FTS_CANDIDATE_LIMIT = 240;
+const RETRIEVAL_RECENT_CANDIDATE_LIMIT = 160;
 const RETRIEVAL_QUERY_STOPWORDS = new Set([
   "a",
   "an",
@@ -139,6 +142,8 @@ interface NodeCandidate {
   observedAt: string | null;
   updatedAt: string | null;
 }
+
+type SemanticSearchDoc = ReturnType<RuntimeStateStore["listSemanticMemorySearchDocs"]>[number];
 
 interface TempSummaryNode {
   tempId: string;
@@ -4221,6 +4226,16 @@ function semanticSearchDocsByNodeId(params: {
   );
 }
 
+function retrievalNodeClassForMode(mode: "mixed" | "summaries" | "leaves"): "leaf" | "semantic" | undefined {
+  if (mode === "leaves") {
+    return "leaf";
+  }
+  if (mode === "summaries") {
+    return "semantic";
+  }
+  return undefined;
+}
+
 function semanticLexicalRanksByNodeId(params: {
   store: RuntimeStateStore;
   query: string;
@@ -4232,17 +4247,15 @@ function semanticLexicalRanksByNodeId(params: {
     return new Map();
   }
   const dedupedTreeIds = [...new Set(params.treeIds)];
-  const hits = dedupedTreeIds.flatMap((treeId) =>
-    params.store.searchSemanticMemorySearchDocs({
-      category: "integration",
-      treeId,
-      nodeClass: params.mode === "leaves" ? "leaf" : params.mode === "summaries" ? "semantic" : undefined,
-      status: "active",
-      matchQuery,
-      limit: dedupedTreeIds.length > 1 ? 120 : 500,
-      offset: 0,
-    }),
-  );
+  const hits = params.store.searchSemanticMemorySearchDocs({
+    category: "integration",
+    treeIds: dedupedTreeIds,
+    nodeClass: retrievalNodeClassForMode(params.mode),
+    status: "active",
+    matchQuery,
+    limit: dedupedTreeIds.length > 1 ? 240 : 500,
+    offset: 0,
+  });
   hits.sort((left, right) =>
     left.bm25Score - right.bm25Score
     || right.updatedAt.localeCompare(left.updatedAt)
@@ -4255,6 +4268,55 @@ function semanticLexicalRanksByNodeId(params: {
     }
   }
   return ranks;
+}
+
+function listIntegrationCandidateSearchDocs(params: {
+  store: RuntimeStateStore;
+  query: string;
+  mode: "mixed" | "summaries" | "leaves";
+  treeIds: string[];
+  maxResults: number;
+}): SemanticSearchDoc[] {
+  const dedupedTreeIds = [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))];
+  if (dedupedTreeIds.length === 0) {
+    return [];
+  }
+  const nodeClass = retrievalNodeClassForMode(params.mode);
+  const poolLimit = Math.max(RETRIEVAL_CANDIDATE_POOL_LIMIT, params.maxResults * 24);
+  const recentLimit = Math.max(RETRIEVAL_RECENT_CANDIDATE_LIMIT, params.maxResults * 12);
+  const ftsLimit = Math.max(RETRIEVAL_FTS_CANDIDATE_LIMIT, params.maxResults * 20);
+  const docsByNodeId = new Map<string, SemanticSearchDoc>();
+  const addDocs = (docs: SemanticSearchDoc[]) => {
+    for (const doc of docs) {
+      if (!docsByNodeId.has(doc.nodeId)) {
+        docsByNodeId.set(doc.nodeId, doc);
+      }
+      if (docsByNodeId.size >= poolLimit) {
+        break;
+      }
+    }
+  };
+  const matchQuery = buildRetrievalFtsMatchQuery(params.query);
+  if (matchQuery) {
+    addDocs(params.store.searchSemanticMemorySearchDocs({
+      category: "integration",
+      treeIds: dedupedTreeIds,
+      nodeClass,
+      status: "active",
+      matchQuery,
+      limit: ftsLimit,
+      offset: 0,
+    }));
+  }
+  addDocs(params.store.listSemanticMemorySearchDocs({
+    category: "integration",
+    treeIds: dedupedTreeIds,
+    nodeClass,
+    status: "active",
+    limit: matchQuery ? recentLimit : poolLimit,
+    offset: 0,
+  }));
+  return [...docsByNodeId.values()];
 }
 
 function accessibleIntegrationTreesForWorkspace(params: {
@@ -4316,16 +4378,61 @@ function semanticNodeDepth(pathValue: string): number | null {
 function semanticCandidateKind(
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number],
 ): IntegrationRetrieveNodeKind {
-  if (node.nodeClass === "leaf") {
+  return semanticCandidateKindForParts(node.nodeClass, node.nodeKind);
+}
+
+function semanticCandidateKindForParts(
+  nodeClass: SemanticSearchDoc["nodeClass"],
+  nodeKind: SemanticSearchDoc["nodeKind"],
+): IntegrationRetrieveNodeKind {
+  if (nodeClass === "leaf") {
     return "leaf";
   }
-  if (node.nodeKind === "connection") {
+  if (nodeKind === "connection") {
     return "tree";
   }
-  if (new Set(["workspace", "repo", "thread", "page", "database", "contact", "file", "folder", "post", "calendar"]).has(node.nodeKind)) {
+  if (new Set(["workspace", "repo", "thread", "page", "database", "contact", "file", "folder", "post", "calendar"]).has(nodeKind)) {
     return "entity";
   }
   return "branch";
+}
+
+function buildSemanticCandidateFromSearchDoc(params: {
+  tree: IntegrationTreeRecord;
+  doc: SemanticSearchDoc;
+}): NodeCandidate {
+  return {
+    kind: semanticCandidateKindForParts(params.doc.nodeClass, params.doc.nodeKind),
+    id: params.doc.nodeId,
+    tree: params.tree,
+    title: params.doc.title,
+    summary: params.doc.summary,
+    excerpt: params.doc.excerpt,
+    path: params.doc.path,
+    level: semanticNodeDepth(params.doc.path),
+    childCount: params.doc.childCount,
+    observedAt: params.doc.observedAt,
+    updatedAt: params.doc.updatedAt,
+  };
+}
+
+function loadIntegrationEmbeddingsByCandidateKey(params: {
+  store: RuntimeStateStore;
+  embeddingModelId: string | null;
+  candidateIds: string[];
+}): Map<string, number[]> {
+  const normalizedCandidateIds = [...new Set(params.candidateIds.map((value) => value.trim()).filter(Boolean))];
+  if (!params.embeddingModelId || normalizedCandidateIds.length === 0) {
+    return new Map();
+  }
+  const embeddingByKey = new Map<string, number[]>();
+  for (const record of params.store.listIntegrationNodeEmbeddings({
+    embeddingModel: params.embeddingModelId,
+    nodeIds: normalizedCandidateIds,
+  })) {
+    embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
+  }
+  return embeddingByKey;
 }
 
 function buildSemanticCandidate(params: {
@@ -4457,7 +4564,6 @@ async function childHitsForNode(params: {
   mode: "mixed" | "summaries" | "leaves";
   embeddingModelId: string | null;
   queryVector: number[] | null;
-  embeddingByKey: Map<string, number[]>;
 }): Promise<IntegrationMemoryRetrieveHit[]> {
   const visibleTrees = accessibleIntegrationTreesForWorkspace({
     store: params.store,
@@ -4467,8 +4573,13 @@ async function childHitsForNode(params: {
     candidates: NodeCandidate[],
     lexicalRanksByNodeId: Map<string, number>,
     extraReason?: string,
-  ): IntegrationMemoryRetrieveHit[] =>
-    candidates
+  ): IntegrationMemoryRetrieveHit[] => {
+    const embeddingByKey = loadIntegrationEmbeddingsByCandidateKey({
+      store: params.store,
+      embeddingModelId: params.embeddingModelId,
+      candidateIds: candidates.map((candidate) => candidate.id),
+    });
+    return candidates
       .map((candidate) => {
         const scored = nodeScore({
           query: params.query,
@@ -4476,7 +4587,7 @@ async function childHitsForNode(params: {
           lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
           embeddingModelId: params.embeddingModelId,
           queryVector: params.queryVector,
-          embeddingByKey: params.embeddingByKey,
+          embeddingByKey,
           mode: params.mode,
         });
         return candidateToHit({
@@ -4486,6 +4597,7 @@ async function childHitsForNode(params: {
         });
       })
       .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path));
+  };
 
   const semanticTree = visibleTrees.find((candidateTree) =>
     params.parentNodeId.startsWith(`semantic:integration:${candidateTree.treeId}:`)
@@ -4594,14 +4706,6 @@ export async function retrieveIntegrationMemory(params: {
     selectedModel: params.selectedModel ?? null,
     query: params.query,
   });
-  const embeddingByKey = new Map<string, number[]>();
-  if (embeddingQuery) {
-    for (const record of params.store.listIntegrationNodeEmbeddings({
-      embeddingModel: embeddingQuery.modelId,
-    })) {
-      embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
-    }
-  }
   const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
     store: params.store,
     query: params.query,
@@ -4624,45 +4728,67 @@ export async function retrieveIntegrationMemory(params: {
         mode,
         embeddingModelId: embeddingQuery?.modelId ?? null,
         queryVector: embeddingQuery?.vector ?? null,
-        embeddingByKey,
       }),
     };
   }
 
-  const candidates: NodeCandidate[] = [];
-  for (const tree of trees) {
-    const searchDocsByNodeId = semanticSearchDocsByNodeId({
-      store: params.store,
-      treeId: tree.treeId,
-    });
-    const semanticNodes = params.store.listSemanticMemoryNodes({
-      category: "integration",
-      treeId: tree.treeId,
-      status: "active",
-      limit: 10_000,
-      offset: 0,
-    });
-    if (semanticNodes.length > 0) {
-      for (const node of semanticNodes) {
-        const kind = semanticCandidateKind(node);
-        if (kind === "tree") {
-          continue;
+  const treeById = new Map(trees.map((tree) => [tree.treeId, tree]));
+  const candidateDocs = listIntegrationCandidateSearchDocs({
+    store: params.store,
+    query: params.query,
+    mode,
+    treeIds: trees.map((tree) => tree.treeId),
+    maxResults,
+  });
+  let candidates = candidateDocs
+    .map((doc) => {
+      const tree = treeById.get(doc.treeId);
+      if (!tree) {
+        return null;
+      }
+      const candidate = buildSemanticCandidateFromSearchDoc({
+        tree,
+        doc,
+      });
+      if (candidate.kind === "tree") {
+        return null;
+      }
+      if (mode === "leaves" && candidate.kind !== "leaf") {
+        return null;
+      }
+      if (mode === "summaries" && candidate.kind === "leaf") {
+        return null;
+      }
+      return candidate;
+    })
+    .filter((candidate): candidate is NodeCandidate => Boolean(candidate));
+  if (candidates.length === 0 && mode !== "summaries") {
+    candidates = params.store
+      .listIntegrationLeaves({
+        treeId: params.treeId ?? undefined,
+        status: "active",
+        limit: Math.max(RETRIEVAL_RECENT_CANDIDATE_LIMIT, maxResults * 12),
+        offset: 0,
+      })
+      .map((leaf) => {
+        const tree = treeById.get(leaf.treeId);
+        if (!tree) {
+          return null;
         }
-        if (mode === "leaves" && kind !== "leaf") {
-          continue;
-        }
-        if (mode === "summaries" && kind === "leaf") {
-          continue;
-        }
-        candidates.push(buildSemanticCandidate({
+        return buildLeafCandidate({
           store: params.store,
           tree,
-          node,
-          searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
-        }));
-      }
-    }
+          leaf,
+        });
+      })
+      .filter((candidate): candidate is NodeCandidate => Boolean(candidate))
+      .filter((candidate) => mode === "mixed" || candidate.kind === "leaf");
   }
+  const embeddingByKey = loadIntegrationEmbeddingsByCandidateKey({
+    store: params.store,
+    embeddingModelId: embeddingQuery?.modelId ?? null,
+    candidateIds: candidates.map((candidate) => candidate.id),
+  });
 
   const hits = candidates
     .map((candidate) => {

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -23,6 +23,7 @@ const EMBEDDING_EXCERPT_CHARS = 480;
 const RETRIEVAL_CANDIDATE_POOL_LIMIT = 320;
 const RETRIEVAL_FTS_CANDIDATE_LIMIT = 240;
 const RETRIEVAL_RECENT_CANDIDATE_LIMIT = 160;
+const RETRIEVAL_VECTOR_CANDIDATE_LIMIT = 120;
 const RETRIEVAL_QUERY_STOPWORDS = new Set([
   "a",
   "an",
@@ -131,6 +132,7 @@ export interface IntegrationMemoryRetrieveResult {
 
 interface NodeCandidate {
   kind: IntegrationRetrieveNodeKind;
+  embeddingKind: InteractionTreeChildKind;
   id: string;
   tree: IntegrationTreeRecord;
   title: string;
@@ -4236,6 +4238,54 @@ function retrievalNodeClassForMode(mode: "mixed" | "summaries" | "leaves"): "lea
   return undefined;
 }
 
+function retrievalVectorNodeKindsForMode(mode: "mixed" | "summaries" | "leaves"): InteractionTreeChildKind[] {
+  if (mode === "leaves") {
+    return ["leaf"];
+  }
+  if (mode === "summaries") {
+    return ["summary"];
+  }
+  return ["leaf", "summary"];
+}
+
+function listIntegrationVectorCandidateSearchDocs(params: {
+  store: RuntimeStateStore;
+  mode: "mixed" | "summaries" | "leaves";
+  treeIds: string[];
+  embeddingModelId: string;
+  queryVector: number[];
+  maxResults: number;
+}): SemanticSearchDoc[] {
+  const dedupedTreeIds = [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))];
+  if (dedupedTreeIds.length === 0) {
+    return [];
+  }
+  const vectorHits = params.store.searchIntegrationNodeEmbeddingsByVector({
+    embedding: new Float32Array(params.queryVector),
+    embeddingModel: params.embeddingModelId,
+    limit: Math.max(RETRIEVAL_VECTOR_CANDIDATE_LIMIT, params.maxResults * 16),
+    treeIds: dedupedTreeIds,
+    nodeKinds: retrievalVectorNodeKindsForMode(params.mode),
+  });
+  if (vectorHits.length === 0) {
+    return [];
+  }
+  const docsByNodeId = new Map(
+    params.store.listSemanticMemorySearchDocs({
+      category: "integration",
+      treeIds: dedupedTreeIds,
+      nodeIds: vectorHits.map((hit) => hit.nodeId),
+      nodeClass: retrievalNodeClassForMode(params.mode),
+      status: "active",
+      limit: vectorHits.length,
+      offset: 0,
+    }).map((doc) => [doc.nodeId, doc]),
+  );
+  return vectorHits
+    .map((hit) => docsByNodeId.get(hit.nodeId) ?? null)
+    .filter((doc): doc is SemanticSearchDoc => Boolean(doc));
+}
+
 function semanticLexicalRanksByNodeId(params: {
   store: RuntimeStateStore;
   query: string;
@@ -4276,6 +4326,7 @@ function listIntegrationCandidateSearchDocs(params: {
   mode: "mixed" | "summaries" | "leaves";
   treeIds: string[];
   maxResults: number;
+  vectorDocs?: SemanticSearchDoc[];
 }): SemanticSearchDoc[] {
   const dedupedTreeIds = [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))];
   if (dedupedTreeIds.length === 0) {
@@ -4308,6 +4359,7 @@ function listIntegrationCandidateSearchDocs(params: {
       offset: 0,
     }));
   }
+  addDocs(params.vectorDocs ?? []);
   addDocs(params.store.listSemanticMemorySearchDocs({
     category: "integration",
     treeIds: dedupedTreeIds,
@@ -4343,6 +4395,7 @@ function buildLeafCandidate(params: {
   const body = readFileIfExists(filePath);
   return {
     kind: "leaf",
+    embeddingKind: "leaf",
     id: params.leaf.leafId,
     tree: params.tree,
     title: params.leaf.title,
@@ -4403,6 +4456,7 @@ function buildSemanticCandidateFromSearchDoc(params: {
 }): NodeCandidate {
   return {
     kind: semanticCandidateKindForParts(params.doc.nodeClass, params.doc.nodeKind),
+    embeddingKind: params.doc.nodeClass === "leaf" ? "leaf" : "summary",
     id: params.doc.nodeId,
     tree: params.tree,
     title: params.doc.title,
@@ -4451,6 +4505,7 @@ function buildSemanticCandidate(params: {
   })();
   return {
     kind: semanticCandidateKind(params.node),
+    embeddingKind: params.node.nodeClass === "leaf" ? "leaf" : "summary",
     id: params.node.nodeId,
     tree: params.tree,
     title: params.node.title,
@@ -4498,7 +4553,7 @@ function nodeScore(params: {
     reasons.push("fts_bm25");
   }
   if (params.embeddingModelId && params.queryVector) {
-    const embeddingKey = `${params.candidate.kind}:${params.candidate.id}:${params.embeddingModelId}`;
+    const embeddingKey = `${params.candidate.embeddingKind}:${params.candidate.id}:${params.embeddingModelId}`;
     const candidateVector = params.embeddingByKey.get(embeddingKey);
     if (candidateVector) {
       const similarity = cosineSimilarity(candidateVector, params.queryVector);
@@ -4733,12 +4788,23 @@ export async function retrieveIntegrationMemory(params: {
   }
 
   const treeById = new Map(trees.map((tree) => [tree.treeId, tree]));
+  const vectorCandidateDocs = embeddingQuery
+    ? listIntegrationVectorCandidateSearchDocs({
+        store: params.store,
+        mode,
+        treeIds: trees.map((tree) => tree.treeId),
+        embeddingModelId: embeddingQuery.modelId,
+        queryVector: embeddingQuery.vector,
+        maxResults,
+      })
+    : [];
   const candidateDocs = listIntegrationCandidateSearchDocs({
     store: params.store,
     query: params.query,
     mode,
     treeIds: trees.map((tree) => tree.treeId),
     maxResults,
+    vectorDocs: vectorCandidateDocs,
   });
   let candidates = candidateDocs
     .map((doc) => {

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -20,6 +20,37 @@ import { globalMemoryDirForWorkspaceRoot } from "./workspace-bundle-paths.js";
 const INTEGRATION_BRANCH_FACTOR = 8;
 const MAX_RETRIEVE_RESULTS = 12;
 const EMBEDDING_EXCERPT_CHARS = 480;
+const RETRIEVAL_QUERY_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "me",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+]);
 type IntegrationRetrieveNodeKind = "tree" | "entity" | "branch" | "summary" | "leaf";
 
 export function countSummaryLikeSemanticIntegrationNodes(params: {
@@ -177,6 +208,26 @@ function textScore(query: string, ...texts: Array<string | null | undefined>): n
     }
   }
   return score + hitCount / Math.max(1, tokens.length);
+}
+
+function buildRetrievalFtsMatchQuery(query: string): string | null {
+  const rawTokens = [...new Set(tokenize(query))];
+  if (rawTokens.length === 0) {
+    return null;
+  }
+  const filteredTokens = rawTokens.filter((token) => !RETRIEVAL_QUERY_STOPWORDS.has(token));
+  const tokens = filteredTokens.length > 0 ? filteredTokens : rawTokens;
+  if (tokens.length === 0) {
+    return null;
+  }
+  return tokens.map((token) => `${token}*`).join(" OR ");
+}
+
+function lexicalRankBoost(rank: number | null | undefined): number {
+  if (!rank || !Number.isFinite(rank) || rank < 1) {
+    return 0;
+  }
+  return 1.4 / Math.sqrt(rank);
 }
 
 function cosineSimilarity(left: number[], right: number[]): number {
@@ -2228,6 +2279,27 @@ function buildSemanticIntegrationTree(params: {
   }
 }
 
+function semanticSearchDocsForIntegrationTree(params: {
+  semantic: SemanticIntegrationTreeBuildResult;
+}) {
+  return params.semantic.nodes.map((node) => {
+    const bodyText = params.semantic.bodiesByPath.get(node.path) ?? "";
+    return {
+      nodeId: node.nodeId,
+      nodeClass: node.nodeClass,
+      nodeKind: node.nodeKind,
+      path: node.path,
+      childCount: node.childCount,
+      title: node.title,
+      summary: node.summary,
+      bodyText,
+      excerpt: bodyText ? markdownExcerpt(bodyText, 320) : null,
+      observedAt: node.observedAt ?? null,
+      status: "active" as const,
+    };
+  });
+}
+
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
@@ -3927,6 +3999,13 @@ export async function rebuildIntegrationTree(params: {
         metadata: relation.metadata,
       })),
     });
+    params.store.replaceSemanticMemorySearchDocs({
+      category: "integration",
+      treeId: params.treeId,
+      docs: semanticSearchDocsForIntegrationTree({
+        semantic,
+      }),
+    });
   }
   for (const node of semantic?.nodes ?? []) {
     if (node.nodeClass !== "semantic") {
@@ -3960,6 +4039,7 @@ export interface ClearedIntegrationMemoryResult {
   deleted_semantic_nodes: number;
   deleted_semantic_edges: number;
   deleted_semantic_relations: number;
+  deleted_semantic_search_docs: number;
   deleted_embeddings: number;
   deleted_files: number;
 }
@@ -4023,6 +4103,7 @@ export function clearIntegrationMemoryForConnection(params: {
   let deletedSemanticNodes = 0;
   let deletedSemanticEdges = 0;
   let deletedSemanticRelations = 0;
+  let deletedSemanticSearchDocs = 0;
   let deletedEmbeddings = 0;
   let deletedFiles = 0;
   for (const tree of trees) {
@@ -4043,6 +4124,7 @@ export function clearIntegrationMemoryForConnection(params: {
     deletedSemanticNodes += deleted.deletedSemanticNodes;
     deletedSemanticEdges += deleted.deletedSemanticEdges;
     deletedSemanticRelations += deleted.deletedSemanticRelations;
+    deletedSemanticSearchDocs += deleted.deletedSemanticSearchDocs;
     deletedEmbeddings += deleted.deletedEmbeddings;
   }
   return {
@@ -4056,6 +4138,7 @@ export function clearIntegrationMemoryForConnection(params: {
     deleted_semantic_nodes: deletedSemanticNodes,
     deleted_semantic_edges: deletedSemanticEdges,
     deleted_semantic_relations: deletedSemanticRelations,
+    deleted_semantic_search_docs: deletedSemanticSearchDocs,
     deleted_embeddings: deletedEmbeddings,
     deleted_files: deletedFiles,
   };
@@ -4121,6 +4204,57 @@ async function queryEmbeddingVector(params: {
     modelId: client.modelId,
     vector: Array.from(embedding),
   };
+}
+
+function semanticSearchDocsByNodeId(params: {
+  store: RuntimeStateStore;
+  treeId: string;
+}): Map<string, ReturnType<RuntimeStateStore["listSemanticMemorySearchDocs"]>[number]> {
+  return new Map(
+    params.store.listSemanticMemorySearchDocs({
+      category: "integration",
+      treeId: params.treeId,
+      status: "active",
+      limit: 10_000,
+      offset: 0,
+    }).map((doc) => [doc.nodeId, doc]),
+  );
+}
+
+function semanticLexicalRanksByNodeId(params: {
+  store: RuntimeStateStore;
+  query: string;
+  mode: "mixed" | "summaries" | "leaves";
+  treeIds: string[];
+}): Map<string, number> {
+  const matchQuery = buildRetrievalFtsMatchQuery(params.query);
+  if (!matchQuery || params.treeIds.length === 0) {
+    return new Map();
+  }
+  const dedupedTreeIds = [...new Set(params.treeIds)];
+  const hits = dedupedTreeIds.flatMap((treeId) =>
+    params.store.searchSemanticMemorySearchDocs({
+      category: "integration",
+      treeId,
+      nodeClass: params.mode === "leaves" ? "leaf" : params.mode === "summaries" ? "semantic" : undefined,
+      status: "active",
+      matchQuery,
+      limit: dedupedTreeIds.length > 1 ? 120 : 500,
+      offset: 0,
+    }),
+  );
+  hits.sort((left, right) =>
+    left.bm25Score - right.bm25Score
+    || right.updatedAt.localeCompare(left.updatedAt)
+    || left.path.localeCompare(right.path),
+  );
+  const ranks = new Map<string, number>();
+  for (const hit of hits) {
+    if (!ranks.has(hit.nodeId)) {
+      ranks.set(hit.nodeId, ranks.size + 1);
+    }
+  }
+  return ranks;
 }
 
 function accessibleIntegrationTreesForWorkspace(params: {
@@ -4198,19 +4332,23 @@ function buildSemanticCandidate(params: {
   store: RuntimeStateStore;
   tree: IntegrationTreeRecord;
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number];
+  searchDoc?: ReturnType<RuntimeStateStore["getSemanticMemorySearchDoc"]> | null;
 }): NodeCandidate {
-  const filePath = absolutePathForRelative(
-    params.store.workspaceRoot,
-    params.node.path,
-  );
-  const body = readFileIfExists(filePath);
+  const excerpt = params.searchDoc?.excerpt ?? (() => {
+    const filePath = absolutePathForRelative(
+      params.store.workspaceRoot,
+      params.node.path,
+    );
+    const body = readFileIfExists(filePath);
+    return body ? markdownExcerpt(body, 320) : null;
+  })();
   return {
     kind: semanticCandidateKind(params.node),
     id: params.node.nodeId,
     tree: params.tree,
     title: params.node.title,
     summary: params.node.summary,
-    excerpt: body ? markdownExcerpt(body, 320) : null,
+    excerpt,
     path: params.node.path,
     level: semanticNodeDepth(params.node.path),
     childCount: params.node.childCount,
@@ -4228,6 +4366,7 @@ function semanticGmailThreadNodeId(treeId: string, threadEntityKey: string): str
 function nodeScore(params: {
   query: string;
   candidate: NodeCandidate;
+  lexicalRank: number | null;
   embeddingModelId: string | null;
   queryVector: number[] | null;
   embeddingByKey: Map<string, number[]>;
@@ -4245,6 +4384,11 @@ function nodeScore(params: {
   );
   if (score > 0) {
     reasons.push("lexical_match");
+  }
+  const lexicalBoost = lexicalRankBoost(params.lexicalRank);
+  if (lexicalBoost > 0) {
+    score += lexicalBoost;
+    reasons.push("fts_bm25");
   }
   if (params.embeddingModelId && params.queryVector) {
     const embeddingKey = `${params.candidate.kind}:${params.candidate.id}:${params.embeddingModelId}`;
@@ -4319,12 +4463,17 @@ async function childHitsForNode(params: {
     store: params.store,
     workspaceId: params.workspaceId,
   });
-  const scoreCandidates = (candidates: NodeCandidate[], extraReason?: string): IntegrationMemoryRetrieveHit[] =>
+  const scoreCandidates = (
+    candidates: NodeCandidate[],
+    lexicalRanksByNodeId: Map<string, number>,
+    extraReason?: string,
+  ): IntegrationMemoryRetrieveHit[] =>
     candidates
       .map((candidate) => {
         const scored = nodeScore({
           query: params.query,
           candidate,
+          lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
           embeddingModelId: params.embeddingModelId,
           queryVector: params.queryVector,
           embeddingByKey: params.embeddingByKey,
@@ -4349,6 +4498,16 @@ async function childHitsForNode(params: {
     ),
   ) ?? null;
   if (semanticTree) {
+    const searchDocsByNodeId = semanticSearchDocsByNodeId({
+      store: params.store,
+      treeId: semanticTree.treeId,
+    });
+    const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
+      store: params.store,
+      query: params.query,
+      mode: params.mode,
+      treeIds: [semanticTree.treeId],
+    });
     const parentNode = params.store.getSemanticMemoryNode({
       category: "integration",
       treeId: semanticTree.treeId,
@@ -4375,6 +4534,7 @@ async function childHitsForNode(params: {
         store: params.store,
         tree: semanticTree,
         node,
+        searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
       }));
     const relationCandidates = params.store
       .listSemanticMemoryRelations({
@@ -4394,12 +4554,14 @@ async function childHitsForNode(params: {
         store: params.store,
         tree: semanticTree,
         node,
+        searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
       }));
 
     return scoreCandidates(
       [...candidates, ...relationCandidates].filter((candidate, index, bucket) =>
         bucket.findIndex((entry) => entry.id === candidate.id) === index,
       ),
+      lexicalRanksByNodeId,
     );
   }
   return [];
@@ -4440,6 +4602,12 @@ export async function retrieveIntegrationMemory(params: {
       embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
     }
   }
+  const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
+    store: params.store,
+    query: params.query,
+    mode,
+    treeIds: trees.map((tree) => tree.treeId),
+  });
 
   if (params.nodeId) {
     return {
@@ -4463,6 +4631,10 @@ export async function retrieveIntegrationMemory(params: {
 
   const candidates: NodeCandidate[] = [];
   for (const tree of trees) {
+    const searchDocsByNodeId = semanticSearchDocsByNodeId({
+      store: params.store,
+      treeId: tree.treeId,
+    });
     const semanticNodes = params.store.listSemanticMemoryNodes({
       category: "integration",
       treeId: tree.treeId,
@@ -4486,6 +4658,7 @@ export async function retrieveIntegrationMemory(params: {
           store: params.store,
           tree,
           node,
+          searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
         }));
       }
     }
@@ -4496,6 +4669,7 @@ export async function retrieveIntegrationMemory(params: {
       const scored = nodeScore({
         query: params.query,
         candidate,
+        lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
         embeddingModelId: embeddingQuery?.modelId ?? null,
         queryVector: embeddingQuery?.vector ?? null,
         embeddingByKey,

--- a/runtime/api-server/src/integration-memory.ts
+++ b/runtime/api-server/src/integration-memory.ts
@@ -4419,15 +4419,9 @@ function accessibleIntegrationTreesForWorkspace(params: {
 }
 
 function buildLeafCandidate(params: {
-  store: RuntimeStateStore;
   tree: IntegrationTreeRecord;
   leaf: IntegrationLeafRecord;
 }): NodeCandidate {
-  const filePath = absolutePathForRelative(
-    params.store.workspaceRoot,
-    params.leaf.path,
-  );
-  const body = readFileIfExists(filePath);
   return {
     kind: "leaf",
     embeddingKind: "leaf",
@@ -4435,7 +4429,7 @@ function buildLeafCandidate(params: {
     tree: params.tree,
     title: params.leaf.title,
     summary: params.leaf.summary,
-    excerpt: body ? markdownExcerpt(body, 320) : null,
+    excerpt: params.leaf.summary ? clipText(params.leaf.summary, 320) : null,
     path: params.leaf.path,
     level: null,
     childCount: null,
@@ -4525,19 +4519,11 @@ function loadIntegrationEmbeddingsByCandidateKey(params: {
 }
 
 function buildSemanticCandidate(params: {
-  store: RuntimeStateStore;
   tree: IntegrationTreeRecord;
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number];
   searchDoc?: ReturnType<RuntimeStateStore["getSemanticMemorySearchDoc"]> | null;
 }): NodeCandidate {
-  const excerpt = params.searchDoc?.excerpt ?? (() => {
-    const filePath = absolutePathForRelative(
-      params.store.workspaceRoot,
-      params.node.path,
-    );
-    const body = readFileIfExists(filePath);
-    return body ? markdownExcerpt(body, 320) : null;
-  })();
+  const excerpt = params.searchDoc?.excerpt ?? (params.node.summary ? clipText(params.node.summary, 320) : null);
   return {
     kind: semanticCandidateKind(params.node),
     embeddingKind: params.node.nodeClass === "leaf" ? "leaf" : "summary",
@@ -4733,7 +4719,6 @@ async function childHitsForNode(params: {
         }))
       .filter((node): node is NonNullable<typeof node> => Boolean(node))
       .map((node) => buildSemanticCandidate({
-        store: params.store,
         tree: semanticTree,
         node,
         searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
@@ -4753,7 +4738,6 @@ async function childHitsForNode(params: {
         }))
       .filter((node): node is NonNullable<typeof node> => Boolean(node))
       .map((node) => buildSemanticCandidate({
-        store: params.store,
         tree: semanticTree,
         node,
         searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
@@ -4877,7 +4861,6 @@ export async function retrieveIntegrationMemory(params: {
           return null;
         }
         return buildLeafCandidate({
-          store: params.store,
           tree,
           leaf,
         });

--- a/runtime/api-server/src/interaction-memory.test.ts
+++ b/runtime/api-server/src/interaction-memory.test.ts
@@ -691,6 +691,71 @@ test("retrieveInteractionMemory recalls deep-body leaf terms through the semanti
   }
 });
 
+test("retrieveInteractionMemory falls back to leaf summaries without reading markdown files", async () => {
+  const root = makeTempDir("hb-interaction-memory-leaf-fallback-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    store.upsertInteractionEntity({
+      workspaceId: "workspace-1",
+      entityId: "interaction:uncategorized",
+      entityType: "misc",
+      canonicalName: "Uncategorized",
+      slug: "uncategorized",
+      summary: "Fallback interaction tree.",
+      aliases: [],
+      isSystem: true,
+      status: "active",
+    });
+    store.upsertInteractionLeaf({
+      workspaceId: "workspace-1",
+      leafId: "leaf-summary-fallback",
+      entityId: "interaction:uncategorized",
+      subjectKey: "verification:summary-fallback",
+      path: "workspace/workspace-1/interaction/entities/uncategorized/leaves/leaf-summary-fallback.md",
+      title: "Verification command",
+      summary: "Use nebula verify to validate release bundles before shipping.",
+      fingerprint: "fingerprint-leaf-summary-fallback",
+      bodySha256: "sha-leaf-summary-fallback",
+      tags: ["verification"],
+      secondaryEntityIds: [],
+      sourceType: "manual",
+      sourceEventId: null,
+      sourceMessageId: null,
+      sourceTurnInputId: "input-seed",
+      admissionConfidence: 0.9,
+      entityConfidence: 0.9,
+      observedAt: "2026-05-22T10:00:00.000Z",
+      supersedesLeafId: null,
+      status: "active",
+    });
+
+    const result = await retrieveInteractionMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: "nebula verify",
+      mode: "leaves",
+      treeId: "interaction:uncategorized",
+      maxResults: 5,
+    });
+
+    assert.equal(result.hits.length, 1);
+    assert.equal(result.hits[0]?.title, "Verification command");
+    assert.match(result.hits[0]?.excerpt ?? "", /nebula verify/i);
+  } finally {
+    store.close();
+  }
+});
+
 test("retrieveInteractionMemory adds vector-only candidates that fall outside the recent semantic doc window", async () => {
   const root = makeTempDir("hb-interaction-memory-vector-topk-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/interaction-memory.test.ts
+++ b/runtime/api-server/src/interaction-memory.test.ts
@@ -381,6 +381,115 @@ test("rebuildInteractionEntityTree writes semantic interaction trees and retriev
   }
 });
 
+test("retrieveInteractionMemory recalls deep-body leaf terms through the semantic search index", async () => {
+  const root = makeTempDir("hb-interaction-memory-fts-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  store.upsertInteractionEntity({
+    workspaceId: "workspace-1",
+    entityId: "interaction:workflow:escalation-playbook",
+    entityType: "workflow",
+    canonicalName: "Escalation playbook",
+    slug: "workflow-escalation-playbook",
+    summary: "Escalation workflow memory.",
+    aliases: [],
+    isSystem: false,
+    status: "active",
+  });
+
+  const leafId = "leaf-deep-body";
+  const relativePath = `workspace/workspace-1/interaction/entities/workflow-escalation-playbook/leaves/${leafId}.md`;
+  const buriedToken = "zephyrchecksum42";
+  store.upsertInteractionLeaf({
+    workspaceId: "workspace-1",
+    leafId,
+    entityId: "interaction:workflow:escalation-playbook",
+    subjectKey: "procedure:escalation:timer",
+    path: relativePath,
+    title: "Escalation timer detail",
+    summary: "Escalations require a staging checksum before release approval.",
+    fingerprint: `fingerprint-${leafId}`,
+    bodySha256: `sha-${leafId}`,
+    tags: ["escalation", "release"],
+    secondaryEntityIds: [],
+    sourceType: "manual",
+    sourceEventId: null,
+    sourceMessageId: null,
+    sourceTurnInputId: "input-seed",
+    admissionConfidence: 0.9,
+    entityConfidence: 0.9,
+    observedAt: "2026-05-22T08:00:00.000Z",
+    supersedesLeafId: null,
+    status: "active",
+  });
+  const absolutePath = path.join(
+    workspaceMemoryDir(path.join(workspaceRoot, "workspace-1")),
+    "interaction",
+    "entities",
+    "workflow-escalation-playbook",
+    "leaves",
+    `${leafId}.md`,
+  );
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(
+    absolutePath,
+    `# Escalation timer detail\n\n${"filler ".repeat(90)}${buriedToken} must match before approval.\n`,
+    "utf8",
+  );
+
+  try {
+    await rebuildInteractionEntityTree({
+      store,
+      workspaceId: "workspace-1",
+      entityId: "interaction:workflow:escalation-playbook",
+      summaryModelClient: null,
+      embeddingClient: null,
+    });
+
+    const leafNode = store.listSemanticMemoryNodes({
+      category: "interaction",
+      workspaceId: "workspace-1",
+      treeId: "interaction:workflow:escalation-playbook",
+      nodeClass: "leaf",
+      status: "active",
+      limit: 10_000,
+      offset: 0,
+    })[0];
+    assert.ok(leafNode);
+
+    const indexedDoc = store.getSemanticMemorySearchDoc({
+      category: "interaction",
+      workspaceId: "workspace-1",
+      treeId: "interaction:workflow:escalation-playbook",
+      nodeId: leafNode!.nodeId,
+    });
+    assert.ok(indexedDoc);
+    assert.equal(indexedDoc?.bodyText.includes(buriedToken), true);
+    assert.equal(indexedDoc?.excerpt?.includes(buriedToken) ?? false, false);
+
+    const result = await retrieveInteractionMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: buriedToken,
+      mode: "leaves",
+      treeId: "interaction:workflow:escalation-playbook",
+      maxResults: 5,
+    });
+    assert.ok(result.hits.some((hit) => hit.title === "Escalation timer detail"));
+  } finally {
+    store.close();
+  }
+});
+
 test("persistInteractionCandidate no-ops when semantic dedupe classifies a candidate as the same memory", async () => {
   const root = makeTempDir("hb-interaction-memory-dedupe-same-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/interaction-memory.test.ts
+++ b/runtime/api-server/src/interaction-memory.test.ts
@@ -10,9 +10,17 @@ import { RuntimeStateStore } from "@holaboss/runtime-state-store";
 import { persistInteractionCandidate, rebuildInteractionEntityTree, retrieveInteractionMemory } from "./interaction-memory.js";
 import { workspaceMemoryDir } from "./workspace-bundle-paths.js";
 
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_RUNTIME_CONFIG_PATH = process.env.HOLABOSS_RUNTIME_CONFIG_PATH;
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_RUNTIME_CONFIG_PATH === undefined) {
+    delete process.env.HOLABOSS_RUNTIME_CONFIG_PATH;
+  } else {
+    process.env.HOLABOSS_RUNTIME_CONFIG_PATH = ORIGINAL_RUNTIME_CONFIG_PATH;
+  }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -22,6 +30,44 @@ function makeTempDir(prefix: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+function writeRecallEmbeddingRuntimeConfig(root: string): string {
+  const configPath = path.join(root, "runtime-config.json");
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        runtime: {
+          sandbox_id: "sandbox-test",
+        },
+        providers: {
+          openai_direct: {
+            kind: "openai_compatible",
+            base_url: "https://api.openai.com/v1",
+            api_key: "sk-test-openai",
+          },
+        },
+        integrations: {
+          holaboss: {
+            auth_token: "hbmk.test-token",
+            sandbox_id: "sandbox-test",
+            user_id: "user-1",
+          },
+        },
+        holaboss: {
+          auth_token: "hbmk.test-token",
+          sandbox_id: "sandbox-test",
+          user_id: "user-1",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = configPath;
+  return configPath;
 }
 
 async function withJsonResponseServer(params: {
@@ -485,6 +531,108 @@ test("retrieveInteractionMemory recalls deep-body leaf terms through the semanti
       maxResults: 5,
     });
     assert.ok(result.hits.some((hit) => hit.title === "Escalation timer detail"));
+  } finally {
+    store.close();
+  }
+});
+
+test("retrieveInteractionMemory adds vector-only candidates that fall outside the recent semantic doc window", async () => {
+  const root = makeTempDir("hb-interaction-memory-vector-topk-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  try {
+    assert.equal(store.supportsVectorIndex(), true);
+    writeRecallEmbeddingRuntimeConfig(root);
+    store.createWorkspace({
+      workspaceId: "workspace-1",
+      name: "Workspace 1",
+      harness: "pi",
+      status: "active",
+    });
+    store.upsertInteractionEntity({
+      workspaceId: "workspace-1",
+      entityId: "interaction:workflow:vector-playbook",
+      entityType: "workflow",
+      canonicalName: "Vector playbook",
+      slug: "workflow-vector-playbook",
+      summary: "Vector retrieval memory.",
+      aliases: [],
+      isSystem: false,
+      status: "active",
+    });
+
+    const relevantNodeId = "semantic:interaction:interaction:workflow:vector-playbook:archival-ledger";
+    const relevantVector = new Array<number>(1536).fill(0);
+    relevantVector[0] = 1;
+    globalThis.fetch = (async (input) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      assert.match(url, /\/embeddings$/);
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: relevantVector }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+
+    store.replaceSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: "workspace-1",
+      treeId: "interaction:workflow:vector-playbook",
+      docs: [
+        ...Array.from({ length: 170 }, (_, index) => ({
+          nodeId: index === 169
+            ? relevantNodeId
+            : `semantic:interaction:interaction:workflow:vector-playbook:filler-${index + 1}`,
+          nodeClass: "semantic" as const,
+          nodeKind: "overview",
+          path: index === 169
+            ? "semantic/interaction/trees/workflow-vector-playbook/archive-ledger/content.md"
+            : `semantic/interaction/trees/workflow-vector-playbook/filler-${index + 1}/content.md`,
+          childCount: 0,
+          title: index === 169 ? "Archival ledger" : `Filler summary ${index + 1}`,
+          summary: index === 169
+            ? "Legacy shipment approvals are tracked in the archival ledger."
+            : `Filler summary body ${index + 1}.`,
+          bodyText: index === 169
+            ? "Legacy shipment approvals are tracked in the archival ledger."
+            : `Filler summary body ${index + 1}.`,
+          excerpt: index === 169 ? "Legacy shipment approvals are tracked in the archival ledger." : null,
+          observedAt: `2026-05-20T00:${String(index % 60).padStart(2, "0")}:00.000Z`,
+          status: "active" as const,
+          updatedAt: index === 169 ? "2026-01-01T00:00:00.000Z" : "2026-05-31T00:00:00.000Z",
+        })),
+      ],
+    });
+    store.upsertInteractionNodeEmbedding({
+      workspaceId: "workspace-1",
+      nodeKind: "summary",
+      nodeId: relevantNodeId,
+      entityId: "interaction:workflow:vector-playbook",
+      embeddingModel: "text-embedding-3-small",
+      contentFingerprint: "v".repeat(64),
+      dimensions: 1536,
+      vector: relevantVector,
+    });
+
+    const result = await retrieveInteractionMemory({
+      store,
+      workspaceId: "workspace-1",
+      query: "silentorbitvector42",
+      mode: "summaries",
+      maxResults: 5,
+    });
+    assert.ok(result.hits.some((hit) => hit.node_id === relevantNodeId && hit.title === "Archival ledger"));
   } finally {
     store.close();
   }

--- a/runtime/api-server/src/interaction-memory.test.ts
+++ b/runtime/api-server/src/interaction-memory.test.ts
@@ -427,6 +427,161 @@ test("rebuildInteractionEntityTree writes semantic interaction trees and retriev
   }
 });
 
+test("rebuildInteractionEntityTree reuses unchanged semantic partitions and only recomputes affected subtrees", async () => {
+  const root = makeTempDir("hb-interaction-memory-incremental-");
+  const workspaceRoot = path.join(root, "workspace");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot,
+  });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  store.upsertInteractionEntity({
+    workspaceId: "workspace-1",
+    entityId: "interaction:workflow:incremental-playbook",
+    entityType: "workflow",
+    canonicalName: "Incremental playbook",
+    slug: "workflow-incremental-playbook",
+    summary: "Incremental rebuild memory.",
+    aliases: [],
+    isSystem: false,
+    status: "active",
+  });
+
+  const leafIds = Array.from({ length: 10 }, (_, index) => `leaf-${index + 1}`);
+  for (const [index, leafId] of leafIds.entries()) {
+    const relativePath = `workspace/workspace-1/interaction/entities/workflow-incremental-playbook/leaves/${leafId}.md`;
+    store.upsertInteractionLeaf({
+      workspaceId: "workspace-1",
+      leafId,
+      entityId: "interaction:workflow:incremental-playbook",
+      subjectKey: `procedure:incremental:${index + 1}`,
+      path: relativePath,
+      title: `Incremental step ${index + 1}`,
+      summary: `Summary for incremental step ${index + 1}.`,
+      fingerprint: `fingerprint-${leafId}`,
+      bodySha256: `sha-${leafId}`,
+      tags: ["incremental"],
+      secondaryEntityIds: [],
+      sourceType: "manual",
+      sourceEventId: null,
+      sourceMessageId: null,
+      sourceTurnInputId: "input-seed",
+      admissionConfidence: 0.9,
+      entityConfidence: 0.9,
+      observedAt: `2026-05-20T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      supersedesLeafId: null,
+      status: "active",
+    });
+    const absolutePath = path.join(
+      workspaceMemoryDir(path.join(workspaceRoot, "workspace-1")),
+      "interaction",
+      "entities",
+      "workflow-incremental-playbook",
+      "leaves",
+      `${leafId}.md`,
+    );
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(
+      absolutePath,
+      `# Incremental step ${index + 1}\n\nSummary for incremental step ${index + 1}.\n`,
+      "utf8",
+    );
+  }
+
+  try {
+    await withJsonResponseServer({
+      responses: Array.from({ length: 8 }, (_, index) => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                summary: `Incremental summary ${index + 1}.`,
+              }),
+            },
+          },
+        ],
+      })),
+      run: async (baseUrl, requests) => {
+        const summaryModelClient = {
+          baseUrl,
+          apiKey: "test-key",
+          modelId: "openai/gpt-4.1-mini",
+        };
+
+        await rebuildInteractionEntityTree({
+          store,
+          workspaceId: "workspace-1",
+          entityId: "interaction:workflow:incremental-playbook",
+          summaryModelClient,
+          embeddingClient: null,
+        });
+        assert.equal(requests.length, 3);
+
+        await rebuildInteractionEntityTree({
+          store,
+          workspaceId: "workspace-1",
+          entityId: "interaction:workflow:incremental-playbook",
+          summaryModelClient,
+          embeddingClient: null,
+        });
+        assert.equal(requests.length, 3);
+
+        const updatedLeafPath = path.join(
+          workspaceMemoryDir(path.join(workspaceRoot, "workspace-1")),
+          "interaction",
+          "entities",
+          "workflow-incremental-playbook",
+          "leaves",
+          "leaf-1.md",
+        );
+        fs.writeFileSync(
+          updatedLeafPath,
+          "# Incremental step 1\n\nSummary for incremental step 1 with a revised approval gate.\n",
+          "utf8",
+        );
+        store.upsertInteractionLeaf({
+          workspaceId: "workspace-1",
+          leafId: "leaf-1",
+          entityId: "interaction:workflow:incremental-playbook",
+          subjectKey: "procedure:incremental:1",
+          path: "workspace/workspace-1/interaction/entities/workflow-incremental-playbook/leaves/leaf-1.md",
+          title: "Incremental step 1",
+          summary: "Summary for incremental step 1 with a revised approval gate.",
+          fingerprint: "fingerprint-leaf-1-revised",
+          bodySha256: "sha-leaf-1-revised",
+          tags: ["incremental"],
+          secondaryEntityIds: [],
+          sourceType: "manual",
+          sourceEventId: null,
+          sourceMessageId: null,
+          sourceTurnInputId: "input-seed",
+          admissionConfidence: 0.9,
+          entityConfidence: 0.9,
+          observedAt: "2026-05-20T00:01:00.000Z",
+          supersedesLeafId: null,
+          status: "active",
+        });
+
+        await rebuildInteractionEntityTree({
+          store,
+          workspaceId: "workspace-1",
+          entityId: "interaction:workflow:incremental-playbook",
+          summaryModelClient,
+          embeddingClient: null,
+        });
+        assert.equal(requests.length, 5);
+      },
+    });
+  } finally {
+    store.close();
+  }
+});
+
 test("retrieveInteractionMemory recalls deep-body leaf terms through the semantic search index", async () => {
   const root = makeTempDir("hb-interaction-memory-fts-");
   const workspaceRoot = path.join(root, "workspace");

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -32,6 +32,7 @@ const ENTITY_CREATE_CONFIDENCE_THRESHOLD = 0.68;
 const ENTITY_MATCH_CONFIDENCE_THRESHOLD = 0.6;
 const SEMANTIC_DEDUPE_SHORTLIST_LIMIT = 6;
 const SEMANTIC_DEDUPE_SIMILARITY_THRESHOLD = 0.52;
+const INTERACTION_SUMMARY_INPUT_FINGERPRINT_VERSION = 1;
 const PROJECT_SUBJECT_TOKENS = new Set([
   "api",
   "app",
@@ -361,6 +362,11 @@ type SemanticInteractionDraftNode = {
   metadata: Record<string, unknown>;
 };
 
+type ExistingInteractionSummaryNode = {
+  node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number];
+  body: string;
+};
+
 interface SemanticDuplicateCandidate {
   leaf: InteractionLeafRecord;
   similarity: number;
@@ -601,6 +607,124 @@ function readFileIfExists(filePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function removeObsoleteFiles(rootDir: string, keepAbsolutePaths: Set<string>): void {
+  if (!fs.existsSync(rootDir)) {
+    return;
+  }
+  const walk = (currentPath: string): void => {
+    for (const childName of fs.readdirSync(currentPath)) {
+      const childPath = path.join(currentPath, childName);
+      const stats = fs.lstatSync(childPath);
+      if (stats.isDirectory()) {
+        walk(childPath);
+        if (fs.existsSync(childPath) && fs.readdirSync(childPath).length === 0) {
+          fs.rmdirSync(childPath);
+        }
+        continue;
+      }
+      if (!keepAbsolutePaths.has(path.resolve(childPath))) {
+        fs.rmSync(childPath, { force: true });
+      }
+    }
+  };
+  walk(rootDir);
+  if (fs.existsSync(rootDir) && fs.readdirSync(rootDir).length === 0) {
+    fs.rmdirSync(rootDir);
+  }
+}
+
+function metadataString(metadata: Record<string, unknown> | null | undefined, key: string): string | null {
+  const value = metadata?.[key];
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function interactionSummaryInputFingerprint(params: {
+  entity: InteractionEntityRecord;
+  nodeKind: "tree" | "partition";
+  title: string;
+  depthFromLeaves: number;
+  ordinal: number;
+  children: Array<{
+    kind: InteractionTreeChildKind;
+    id: string;
+    title: string;
+    summary: string;
+    excerpt: string | null;
+  }>;
+}): string {
+  return sha256(JSON.stringify({
+    version: INTERACTION_SUMMARY_INPUT_FINGERPRINT_VERSION,
+    entityId: params.entity.entityId,
+    entityName: params.entity.canonicalName,
+    entityType: params.entity.entityType,
+    entitySummary: params.entity.summary ?? null,
+    nodeKind: params.nodeKind,
+    title: params.title,
+    depthFromLeaves: params.depthFromLeaves,
+    ordinal: params.ordinal,
+    children: params.children.map((child) => ({
+      kind: child.kind,
+      id: child.id,
+      title: child.title,
+      summary: child.summary,
+      excerpt: child.excerpt ? clipText(child.excerpt, 280) : null,
+    })),
+  }));
+}
+
+function existingInteractionSummaryNode(params: {
+  cache: Map<string, ExistingInteractionSummaryNode>;
+  nodeId: string;
+  inputFingerprint: string;
+}): ExistingInteractionSummaryNode | null {
+  const existing = params.cache.get(params.nodeId);
+  if (!existing) {
+    return null;
+  }
+  return metadataString(existing.node.metadata, "summary_input_fingerprint") === params.inputFingerprint
+    ? existing
+    : null;
+}
+
+function loadExistingInteractionSummaryNodes(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  entity: InteractionEntityRecord;
+}): Map<string, ExistingInteractionSummaryNode> {
+  const docsByNodeId = new Map(
+    params.store.listSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: params.workspaceId,
+      treeId: params.entity.entityId,
+      status: "active",
+      limit: 10_000,
+      offset: 0,
+    }).map((doc) => [doc.nodeId, doc]),
+  );
+  const existing = new Map<string, ExistingInteractionSummaryNode>();
+  for (const node of params.store.listSemanticMemoryNodes({
+    category: "interaction",
+    workspaceId: params.workspaceId,
+    treeId: params.entity.entityId,
+    nodeClass: "semantic",
+    status: "active",
+    limit: 10_000,
+    offset: 0,
+  })) {
+    const body = docsByNodeId.get(node.nodeId)?.bodyText
+      ?? readFileIfExists(absolutePathForRelative(params.store.workspaceDir(params.workspaceId), node.path));
+    if (!body) {
+      continue;
+    }
+    existing.set(node.nodeId, { node, body });
+  }
+  return existing;
 }
 
 function markdownExcerpt(text: string, maxChars = EMBEDDING_EXCERPT_CHARS): string {
@@ -1470,12 +1594,35 @@ async function buildSemanticInteractionPartitionNode(params: {
   depthFromLeaves: number;
   ordinal: number;
   modelClient: MemoryModelClientConfig | null;
+  existingSummaryByNodeId: Map<string, ExistingInteractionSummaryNode>;
 }): Promise<{
   node: SemanticInteractionDraftNode;
   body: string;
   child: SemanticInteractionDraftChild;
 }> {
-  const summary = await generateSummaryText({
+  const childIdentity = params.children.map((child) => `${child.kind}:${child.id}`).join("|");
+  const nodeId = `semantic:interaction:${params.entity.entityId}:partition:L${params.depthFromLeaves}:${sha256(childIdentity).slice(0, 16)}`;
+  const title = `Slice ${params.ordinal}`;
+  const inputFingerprint = interactionSummaryInputFingerprint({
+    entity: params.entity,
+    nodeKind: "partition",
+    title,
+    depthFromLeaves: params.depthFromLeaves,
+    ordinal: params.ordinal,
+    children: params.children.map((child) => ({
+      kind: child.kind,
+      id: child.id,
+      title: child.title,
+      summary: child.summary,
+      excerpt: child.excerpt,
+    })),
+  });
+  const reused = existingInteractionSummaryNode({
+    cache: params.existingSummaryByNodeId,
+    nodeId,
+    inputFingerprint,
+  });
+  const summary = reused?.node.summary ?? await generateSummaryText({
     entity: params.entity,
     children: params.children.map((child) => ({
       kind: child.kind,
@@ -1488,14 +1635,11 @@ async function buildSemanticInteractionPartitionNode(params: {
     ordinal: params.ordinal,
     modelClient: params.modelClient,
   });
-  const childIdentity = params.children.map((child) => `${child.kind}:${child.id}`).join("|");
-  const nodeId = `semantic:interaction:${params.entity.entityId}:partition:L${params.depthFromLeaves}:${sha256(childIdentity).slice(0, 16)}`;
-  const title = `Slice ${params.ordinal}`;
   const path = semanticInteractionChildRelativePath(
     params.rootPath,
     `slice-l${params.depthFromLeaves}-${String(params.ordinal).padStart(2, "0")}-${nodeId.slice(-6)}`,
   );
-  const body = semanticInteractionNodeBody({
+  const body = reused?.body ?? semanticInteractionNodeBody({
     entity: params.entity,
     nodeKind: "partition",
     title,
@@ -1526,6 +1670,8 @@ async function buildSemanticInteractionPartitionNode(params: {
       metadata: {
         depth_from_leaves: params.depthFromLeaves,
         ordinal: params.ordinal,
+        source: "interaction_summary",
+        summary_input_fingerprint: inputFingerprint,
       },
     },
     body,
@@ -1546,6 +1692,7 @@ async function buildSemanticInteractionTree(params: {
   leaves: InteractionLeafRecord[];
   leafBodies: Map<string, string>;
   modelClient: MemoryModelClientConfig | null;
+  existingSummaryByNodeId: Map<string, ExistingInteractionSummaryNode>;
 }): Promise<{
   nodes: SemanticInteractionDraftNode[];
   edges: Array<{
@@ -1620,6 +1767,7 @@ async function buildSemanticInteractionTree(params: {
           depthFromLeaves,
           ordinal: index + 1,
           modelClient: params.modelClient,
+          existingSummaryByNodeId: params.existingSummaryByNodeId,
         })),
     );
     for (const [index, partition] of layer.entries()) {
@@ -1649,7 +1797,26 @@ async function buildSemanticInteractionTree(params: {
     depthFromLeaves += 1;
   }
 
-  const rootSummary = currentChildren.length > 0
+  const rootInputFingerprint = interactionSummaryInputFingerprint({
+    entity: params.entity,
+    nodeKind: "tree",
+    title: params.entity.canonicalName,
+    depthFromLeaves,
+    ordinal: 1,
+    children: currentChildren.map((child) => ({
+      kind: child.kind,
+      id: child.id,
+      title: child.title,
+      summary: child.summary,
+      excerpt: child.excerpt,
+    })),
+  });
+  const reusedRoot = existingInteractionSummaryNode({
+    cache: params.existingSummaryByNodeId,
+    nodeId: rootNodeId,
+    inputFingerprint: rootInputFingerprint,
+  });
+  const rootSummary = reusedRoot?.node.summary ?? (currentChildren.length > 0
     ? await generateSummaryText({
         entity: params.entity,
         children: currentChildren.map((child) => ({
@@ -1663,8 +1830,8 @@ async function buildSemanticInteractionTree(params: {
         ordinal: 1,
         modelClient: params.modelClient,
       })
-    : (params.entity.summary?.trim() || `${params.entity.canonicalName} interaction memory.`);
-  const rootBody = semanticInteractionNodeBody({
+    : (params.entity.summary?.trim() || `${params.entity.canonicalName} interaction memory.`));
+  const rootBody = reusedRoot?.body ?? semanticInteractionNodeBody({
     entity: params.entity,
     nodeKind: "tree",
     title: params.entity.canonicalName,
@@ -1693,6 +1860,8 @@ async function buildSemanticInteractionTree(params: {
       entity_id: params.entity.entityId,
       entity_type: params.entity.entityType,
       entity_slug: params.entity.slug,
+      source: "interaction_summary",
+      summary_input_fingerprint: rootInputFingerprint,
     },
   });
   currentChildren.forEach((child, index) => {
@@ -1949,8 +2118,12 @@ export async function rebuildInteractionEntityTree(params: {
   const entityDir = interactionEntityDir(workspaceDir, entity.slug);
   const semanticTreeDir = semanticInteractionTreeDir(workspaceDir, entity.slug);
   const summariesDir = path.join(entityDir, "summaries");
+  const existingSummaryByNodeId = loadExistingInteractionSummaryNodes({
+    store: params.store,
+    workspaceId: params.workspaceId,
+    entity,
+  });
   fs.rmSync(summariesDir, { recursive: true, force: true });
-  fs.rmSync(semanticTreeDir, { recursive: true, force: true });
   fs.rmSync(
     absolutePathForRelative(
       workspaceDir,
@@ -1991,10 +2164,19 @@ export async function rebuildInteractionEntityTree(params: {
     leaves: activeLeaves,
     leafBodies,
     modelClient: params.summaryModelClient ?? null,
+    existingSummaryByNodeId,
   });
   for (const [relativePath, body] of semantic.bodiesByPath) {
     writeFileIfChanged(absolutePathForRelative(workspaceDir, relativePath), body);
   }
+  removeObsoleteFiles(
+    semanticTreeDir,
+    new Set(
+      [...semantic.bodiesByPath.keys()].map((relativePath) =>
+        path.resolve(absolutePathForRelative(workspaceDir, relativePath))
+      ),
+    ),
+  );
   params.store.replaceSemanticMemoryTree({
     category: "interaction",
     workspaceId: params.workspaceId,

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -21,6 +21,9 @@ const INTERACTION_BRANCH_FACTOR = 8;
 const MAX_ENTITY_SHORTLIST = 24;
 const MAX_RETRIEVE_RESULTS = 12;
 const EMBEDDING_EXCERPT_CHARS = 480;
+const RETRIEVAL_CANDIDATE_POOL_LIMIT = 320;
+const RETRIEVAL_FTS_CANDIDATE_LIMIT = 240;
+const RETRIEVAL_RECENT_CANDIDATE_LIMIT = 160;
 const INTERACTION_UNCATEGORIZED_ENTITY_ID = "interaction:uncategorized";
 const INTERACTION_UNCATEGORIZED_SLUG = "uncategorized";
 const INTERACTION_UNCATEGORIZED_NAME = "Uncategorized";
@@ -314,6 +317,8 @@ interface NodeCandidate {
   observedAt: string | null;
   updatedAt: string | null;
 }
+
+type SemanticSearchDoc = ReturnType<RuntimeStateStore["listSemanticMemorySearchDocs"]>[number];
 
 interface TempSummaryNode {
   tempId: string;
@@ -2130,6 +2135,16 @@ function semanticSearchDocsByNodeId(params: {
   );
 }
 
+function retrievalNodeClassForMode(mode: "mixed" | "summaries" | "leaves"): "leaf" | "semantic" | undefined {
+  if (mode === "leaves") {
+    return "leaf";
+  }
+  if (mode === "summaries") {
+    return "semantic";
+  }
+  return undefined;
+}
+
 function semanticLexicalRanksByNodeId(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -2145,13 +2160,61 @@ function semanticLexicalRanksByNodeId(params: {
     category: "interaction",
     workspaceId: params.workspaceId,
     treeId: params.treeId ?? undefined,
-    nodeClass: params.mode === "leaves" ? "leaf" : params.mode === "summaries" ? "semantic" : undefined,
+    nodeClass: retrievalNodeClassForMode(params.mode),
     status: "active",
     matchQuery,
     limit: 500,
     offset: 0,
   });
   return new Map(hits.map((hit, index) => [hit.nodeId, index + 1]));
+}
+
+function listInteractionCandidateSearchDocs(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  query: string;
+  mode: "mixed" | "summaries" | "leaves";
+  treeId?: string | null;
+  maxResults: number;
+}): SemanticSearchDoc[] {
+  const nodeClass = retrievalNodeClassForMode(params.mode);
+  const poolLimit = Math.max(RETRIEVAL_CANDIDATE_POOL_LIMIT, params.maxResults * 24);
+  const recentLimit = Math.max(RETRIEVAL_RECENT_CANDIDATE_LIMIT, params.maxResults * 12);
+  const ftsLimit = Math.max(RETRIEVAL_FTS_CANDIDATE_LIMIT, params.maxResults * 20);
+  const docsByNodeId = new Map<string, SemanticSearchDoc>();
+  const addDocs = (docs: SemanticSearchDoc[]) => {
+    for (const doc of docs) {
+      if (!docsByNodeId.has(doc.nodeId)) {
+        docsByNodeId.set(doc.nodeId, doc);
+      }
+      if (docsByNodeId.size >= poolLimit) {
+        break;
+      }
+    }
+  };
+  const matchQuery = buildRetrievalFtsMatchQuery(params.query);
+  if (matchQuery) {
+    addDocs(params.store.searchSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: params.workspaceId,
+      treeId: params.treeId ?? undefined,
+      nodeClass,
+      status: "active",
+      matchQuery,
+      limit: ftsLimit,
+      offset: 0,
+    }));
+  }
+  addDocs(params.store.listSemanticMemorySearchDocs({
+    category: "interaction",
+    workspaceId: params.workspaceId,
+    treeId: params.treeId ?? undefined,
+    nodeClass,
+    status: "active",
+    limit: matchQuery ? recentLimit : poolLimit,
+    offset: 0,
+  }));
+  return [...docsByNodeId.values()];
 }
 
 function buildLeafCandidate(params: {
@@ -2186,6 +2249,12 @@ function semanticInteractionCandidateKind(
   return node.nodeClass === "leaf" ? "leaf" : "summary";
 }
 
+function semanticInteractionCandidateKindForDoc(
+  doc: Pick<SemanticSearchDoc, "nodeClass">,
+): InteractionTreeChildKind {
+  return doc.nodeClass === "leaf" ? "leaf" : "summary";
+}
+
 function isSummaryLikeSemanticInteractionNode(
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number],
 ): boolean {
@@ -2203,6 +2272,19 @@ function semanticInteractionNodeLevel(
     return null;
   }
   return node.nodeKind === "tree" ? 1 : nodesDepth + 1;
+}
+
+function semanticInteractionNodeLevelForDoc(
+  doc: Pick<SemanticSearchDoc, "nodeClass" | "nodeKind" | "path">,
+): number | null {
+  if (doc.nodeClass === "leaf") {
+    return null;
+  }
+  const nodesDepth = semanticTreePathDepth(doc.path, ["semantic", "interaction", "trees"]);
+  if (nodesDepth === null) {
+    return null;
+  }
+  return doc.nodeKind === "tree" ? 1 : nodesDepth + 1;
 }
 
 function buildSemanticCandidate(params: {
@@ -2233,6 +2315,46 @@ function buildSemanticCandidate(params: {
     observedAt: params.node.observedAt,
     updatedAt: params.node.updatedAt,
   };
+}
+
+function buildSemanticCandidateFromSearchDoc(params: {
+  entity: InteractionEntityRecord;
+  doc: SemanticSearchDoc;
+}): NodeCandidate {
+  return {
+    kind: semanticInteractionCandidateKindForDoc(params.doc),
+    id: params.doc.nodeId,
+    entity: params.entity,
+    title: params.doc.title,
+    summary: params.doc.summary,
+    excerpt: params.doc.excerpt,
+    path: params.doc.path,
+    level: semanticInteractionNodeLevelForDoc(params.doc),
+    childCount: params.doc.childCount,
+    observedAt: params.doc.observedAt,
+    updatedAt: params.doc.updatedAt,
+  };
+}
+
+function loadInteractionEmbeddingsByCandidateKey(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  embeddingModelId: string | null;
+  candidateIds: string[];
+}): Map<string, number[]> {
+  const normalizedCandidateIds = [...new Set(params.candidateIds.map((value) => value.trim()).filter(Boolean))];
+  if (!params.embeddingModelId || normalizedCandidateIds.length === 0) {
+    return new Map();
+  }
+  const embeddingByKey = new Map<string, number[]>();
+  for (const record of params.store.listInteractionNodeEmbeddings({
+    workspaceId: params.workspaceId,
+    embeddingModel: params.embeddingModelId,
+    nodeIds: normalizedCandidateIds,
+  })) {
+    embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
+  }
+  return embeddingByKey;
 }
 
 function nodeScore(params: {
@@ -2326,7 +2448,6 @@ async function childHitsForNode(params: {
   mode: "mixed" | "summaries" | "leaves";
   embeddingModelId: string | null;
   queryVector: number[] | null;
-  embeddingByKey: Map<string, number[]>;
 }): Promise<InteractionMemoryRetrieveHit[]> {
   const semanticEntity = params.store.listInteractionEntities({
     workspaceId: params.workspaceId,
@@ -2382,6 +2503,12 @@ async function childHitsForNode(params: {
         }))
       .filter((candidate) => params.mode === "mixed"
         || (params.mode === "leaves" ? candidate.kind === "leaf" : candidate.kind === "summary"));
+    const embeddingByKey = loadInteractionEmbeddingsByCandidateKey({
+      store: params.store,
+      workspaceId: params.workspaceId,
+      embeddingModelId: params.embeddingModelId,
+      candidateIds: candidates.map((candidate) => candidate.id),
+    });
     return candidates
       .map((candidate) => {
         const scored = nodeScore({
@@ -2390,7 +2517,7 @@ async function childHitsForNode(params: {
           lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
           embeddingModelId: params.embeddingModelId,
           queryVector: params.queryVector,
-          embeddingByKey: params.embeddingByKey,
+          embeddingByKey,
           mode: params.mode,
         });
         return candidateToHit({
@@ -2441,15 +2568,6 @@ export async function retrieveInteractionMemory(params: {
     selectedModel: params.selectedModel ?? null,
     query: params.query,
   });
-  const embeddingByKey = new Map<string, number[]>();
-  if (embeddingQuery) {
-    for (const record of params.store.listInteractionNodeEmbeddings({
-      workspaceId: params.workspaceId,
-      embeddingModel: embeddingQuery.modelId,
-    })) {
-      embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
-    }
-  }
   const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
     store: params.store,
     workspaceId: params.workspaceId,
@@ -2473,45 +2591,61 @@ export async function retrieveInteractionMemory(params: {
         mode,
         embeddingModelId: embeddingQuery?.modelId ?? null,
         queryVector: embeddingQuery?.vector ?? null,
-        embeddingByKey,
       }),
     };
   }
 
-  const candidates: NodeCandidate[] = [];
-  for (const entity of entities) {
-    const searchDocsByNodeId = semanticSearchDocsByNodeId({
-      store: params.store,
-      workspaceId: params.workspaceId,
-      treeId: entity.entityId,
-    });
-    const semanticNodes = params.store.listSemanticMemoryNodes({
-      category: "interaction",
-      workspaceId: params.workspaceId,
-      treeId: entity.entityId,
-      status: "active",
-      limit: 10_000,
-      offset: 0,
-    });
-    if (semanticNodes.length > 0) {
-      for (const node of semanticNodes) {
-        const candidate = buildSemanticCandidate({
+  const entityById = new Map(entities.map((entity) => [entity.entityId, entity]));
+  const candidateDocs = listInteractionCandidateSearchDocs({
+    store: params.store,
+    workspaceId: params.workspaceId,
+    query: params.query,
+    mode,
+    treeId: params.treeId ?? null,
+    maxResults,
+  });
+  let candidates = candidateDocs
+    .map((doc) => {
+      const entity = entityById.get(doc.treeId);
+      if (!entity) {
+        return null;
+      }
+      return buildSemanticCandidateFromSearchDoc({
+        entity,
+        doc,
+      });
+    })
+    .filter((candidate): candidate is NodeCandidate => Boolean(candidate));
+  if (candidates.length === 0 && mode !== "summaries") {
+    candidates = params.store
+      .listInteractionLeaves({
+        workspaceId: params.workspaceId,
+        entityId: params.treeId ?? undefined,
+        status: "active",
+        limit: Math.max(RETRIEVAL_RECENT_CANDIDATE_LIMIT, maxResults * 12),
+        offset: 0,
+      })
+      .map((leaf) => {
+        const entity = entityById.get(leaf.entityId);
+        if (!entity) {
+          return null;
+        }
+        return buildLeafCandidate({
           store: params.store,
           workspaceId: params.workspaceId,
           entity,
-          node,
-          searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
+          leaf,
         });
-        if (mode === "leaves" && candidate.kind !== "leaf") {
-          continue;
-        }
-        if (mode === "summaries" && candidate.kind !== "summary") {
-          continue;
-        }
-        candidates.push(candidate);
-      }
-    }
+      })
+      .filter((candidate): candidate is NodeCandidate => Boolean(candidate))
+      .filter((candidate) => mode === "mixed" || candidate.kind === "leaf");
   }
+  const embeddingByKey = loadInteractionEmbeddingsByCandidateKey({
+    store: params.store,
+    workspaceId: params.workspaceId,
+    embeddingModelId: embeddingQuery?.modelId ?? null,
+    candidateIds: candidates.map((candidate) => candidate.id),
+  });
 
   const hits = candidates
     .map((candidate) => {

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -2177,20 +2177,20 @@ export async function rebuildInteractionEntityTree(params: {
       ),
     ),
   );
-  params.store.replaceSemanticMemoryTree({
+  params.store.syncSemanticMemoryTree({
     category: "interaction",
     workspaceId: params.workspaceId,
     treeId: params.entityId,
     nodes: semantic.nodes,
     edges: semantic.edges,
   });
-  params.store.replaceSemanticMemoryRelations({
+  params.store.syncSemanticMemoryRelations({
     category: "interaction",
     workspaceId: params.workspaceId,
     treeId: params.entityId,
     relations: [],
   });
-  params.store.replaceSemanticMemorySearchDocs({
+  params.store.syncSemanticMemorySearchDocs({
     category: "interaction",
     workspaceId: params.workspaceId,
     treeId: params.entityId,

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -2450,23 +2450,16 @@ function listInteractionCandidateSearchDocs(params: {
 }
 
 function buildLeafCandidate(params: {
-  store: RuntimeStateStore;
-  workspaceId: string;
   entity: InteractionEntityRecord;
   leaf: InteractionLeafRecord;
 }): NodeCandidate {
-  const filePath = absolutePathForRelative(
-    params.store.workspaceDir(params.workspaceId),
-    params.leaf.path,
-  );
-  const body = readFileIfExists(filePath);
   return {
     kind: "leaf",
     id: params.leaf.leafId,
     entity: params.entity,
     title: params.leaf.title,
     summary: params.leaf.summary,
-    excerpt: body ? markdownExcerpt(body, 320) : null,
+    excerpt: params.leaf.summary ? clipText(params.leaf.summary, 320) : null,
     path: params.leaf.path,
     level: null,
     childCount: null,
@@ -2520,20 +2513,11 @@ function semanticInteractionNodeLevelForDoc(
 }
 
 function buildSemanticCandidate(params: {
-  store: RuntimeStateStore;
-  workspaceId: string;
   entity: InteractionEntityRecord;
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number];
   searchDoc?: ReturnType<RuntimeStateStore["getSemanticMemorySearchDoc"]> | null;
 }): NodeCandidate {
-  const excerpt = params.searchDoc?.excerpt ?? (() => {
-    const filePath = absolutePathForRelative(
-      params.store.workspaceDir(params.workspaceId),
-      params.node.path,
-    );
-    const body = readFileIfExists(filePath);
-    return body ? markdownExcerpt(body, 320) : null;
-  })();
+  const excerpt = params.searchDoc?.excerpt ?? (params.node.summary ? clipText(params.node.summary, 320) : null);
   return {
     kind: semanticInteractionCandidateKind(params.node),
     id: params.node.nodeId,
@@ -2727,8 +2711,6 @@ async function childHitsForNode(params: {
       .filter((node): node is NonNullable<typeof node> => Boolean(node))
       .map((node) =>
         buildSemanticCandidate({
-          store: params.store,
-          workspaceId: params.workspaceId,
           entity: semanticEntity,
           node,
           searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
@@ -2875,8 +2857,6 @@ export async function retrieveInteractionMemory(params: {
           return null;
         }
         return buildLeafCandidate({
-          store: params.store,
-          workspaceId: params.workspaceId,
           entity,
           leaf,
         });

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -24,6 +24,7 @@ const EMBEDDING_EXCERPT_CHARS = 480;
 const RETRIEVAL_CANDIDATE_POOL_LIMIT = 320;
 const RETRIEVAL_FTS_CANDIDATE_LIMIT = 240;
 const RETRIEVAL_RECENT_CANDIDATE_LIMIT = 160;
+const RETRIEVAL_VECTOR_CANDIDATE_LIMIT = 120;
 const INTERACTION_UNCATEGORIZED_ENTITY_ID = "interaction:uncategorized";
 const INTERACTION_UNCATEGORIZED_SLUG = "uncategorized";
 const INTERACTION_UNCATEGORIZED_NAME = "Uncategorized";
@@ -2145,6 +2146,53 @@ function retrievalNodeClassForMode(mode: "mixed" | "summaries" | "leaves"): "lea
   return undefined;
 }
 
+function retrievalVectorNodeKindsForMode(mode: "mixed" | "summaries" | "leaves"): InteractionTreeChildKind[] {
+  if (mode === "leaves") {
+    return ["leaf"];
+  }
+  if (mode === "summaries") {
+    return ["summary"];
+  }
+  return ["leaf", "summary"];
+}
+
+function listInteractionVectorCandidateSearchDocs(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  mode: "mixed" | "summaries" | "leaves";
+  treeId?: string | null;
+  embeddingModelId: string;
+  queryVector: number[];
+  maxResults: number;
+}): SemanticSearchDoc[] {
+  const vectorHits = params.store.searchInteractionNodeEmbeddingsByVector({
+    workspaceId: params.workspaceId,
+    embedding: new Float32Array(params.queryVector),
+    embeddingModel: params.embeddingModelId,
+    limit: Math.max(RETRIEVAL_VECTOR_CANDIDATE_LIMIT, params.maxResults * 16),
+    entityIds: params.treeId ? [params.treeId] : undefined,
+    nodeKinds: retrievalVectorNodeKindsForMode(params.mode),
+  });
+  if (vectorHits.length === 0) {
+    return [];
+  }
+  const docsByNodeId = new Map(
+    params.store.listSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: params.workspaceId,
+      treeId: params.treeId ?? undefined,
+      nodeIds: vectorHits.map((hit) => hit.nodeId),
+      nodeClass: retrievalNodeClassForMode(params.mode),
+      status: "active",
+      limit: vectorHits.length,
+      offset: 0,
+    }).map((doc) => [doc.nodeId, doc]),
+  );
+  return vectorHits
+    .map((hit) => docsByNodeId.get(hit.nodeId) ?? null)
+    .filter((doc): doc is SemanticSearchDoc => Boolean(doc));
+}
+
 function semanticLexicalRanksByNodeId(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -2176,6 +2224,7 @@ function listInteractionCandidateSearchDocs(params: {
   mode: "mixed" | "summaries" | "leaves";
   treeId?: string | null;
   maxResults: number;
+  vectorDocs?: SemanticSearchDoc[];
 }): SemanticSearchDoc[] {
   const nodeClass = retrievalNodeClassForMode(params.mode);
   const poolLimit = Math.max(RETRIEVAL_CANDIDATE_POOL_LIMIT, params.maxResults * 24);
@@ -2205,6 +2254,7 @@ function listInteractionCandidateSearchDocs(params: {
       offset: 0,
     }));
   }
+  addDocs(params.vectorDocs ?? []);
   addDocs(params.store.listSemanticMemorySearchDocs({
     category: "interaction",
     workspaceId: params.workspaceId,
@@ -2596,6 +2646,17 @@ export async function retrieveInteractionMemory(params: {
   }
 
   const entityById = new Map(entities.map((entity) => [entity.entityId, entity]));
+  const vectorCandidateDocs = embeddingQuery
+    ? listInteractionVectorCandidateSearchDocs({
+        store: params.store,
+        workspaceId: params.workspaceId,
+        mode,
+        treeId: params.treeId ?? null,
+        embeddingModelId: embeddingQuery.modelId,
+        queryVector: embeddingQuery.vector,
+        maxResults,
+      })
+    : [];
   const candidateDocs = listInteractionCandidateSearchDocs({
     store: params.store,
     workspaceId: params.workspaceId,
@@ -2603,6 +2664,7 @@ export async function retrieveInteractionMemory(params: {
     mode,
     treeId: params.treeId ?? null,
     maxResults,
+    vectorDocs: vectorCandidateDocs,
   });
   let candidates = candidateDocs
     .map((doc) => {

--- a/runtime/api-server/src/interaction-memory.ts
+++ b/runtime/api-server/src/interaction-memory.ts
@@ -200,6 +200,37 @@ const PROJECT_SIGNAL_TOKENS = new Set([
   "staging",
   "verification",
 ]);
+const RETRIEVAL_QUERY_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "me",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+]);
 
 const INTERACTION_ENTITY_TYPES = new Set<InteractionEntityType>([
   "project",
@@ -640,6 +671,26 @@ function textScore(query: string, ...texts: Array<string | null | undefined>): n
     }
   }
   return score + hitCount / Math.max(1, tokens.length);
+}
+
+function buildRetrievalFtsMatchQuery(query: string): string | null {
+  const rawTokens = [...new Set(tokenize(query))];
+  if (rawTokens.length === 0) {
+    return null;
+  }
+  const filteredTokens = rawTokens.filter((token) => !RETRIEVAL_QUERY_STOPWORDS.has(token));
+  const tokens = filteredTokens.length > 0 ? filteredTokens : rawTokens;
+  if (tokens.length === 0) {
+    return null;
+  }
+  return tokens.map((token) => `${token}*`).join(" OR ");
+}
+
+function lexicalRankBoost(rank: number | null | undefined): number {
+  if (!rank || !Number.isFinite(rank) || rank < 1) {
+    return 0;
+  }
+  return 1.4 / Math.sqrt(rank);
 }
 
 function cosineSimilarity(left: number[], right: number[]): number {
@@ -1664,6 +1715,28 @@ async function buildSemanticInteractionTree(params: {
   };
 }
 
+function semanticSearchDocsForInteractionTree(params: {
+  nodes: Awaited<ReturnType<typeof buildSemanticInteractionTree>>["nodes"];
+  bodiesByPath: Awaited<ReturnType<typeof buildSemanticInteractionTree>>["bodiesByPath"];
+}) {
+  return params.nodes.map((node) => {
+    const bodyText = params.bodiesByPath.get(node.path) ?? "";
+    return {
+      nodeId: node.nodeId,
+      nodeClass: node.nodeClass,
+      nodeKind: node.nodeKind,
+      path: node.path,
+      childCount: node.childCount,
+      title: node.title,
+      summary: node.summary,
+      bodyText,
+      excerpt: bodyText ? markdownExcerpt(bodyText, 320) : null,
+      observedAt: node.observedAt ?? null,
+      status: "active" as const,
+    };
+  });
+}
+
 async function syncNodeEmbedding(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -1929,6 +2002,15 @@ export async function rebuildInteractionEntityTree(params: {
     treeId: params.entityId,
     relations: [],
   });
+  params.store.replaceSemanticMemorySearchDocs({
+    category: "interaction",
+    workspaceId: params.workspaceId,
+    treeId: params.entityId,
+    docs: semanticSearchDocsForInteractionTree({
+      nodes: semantic.nodes,
+      bodiesByPath: semantic.bodiesByPath,
+    }),
+  });
   for (const node of semantic.nodes) {
     if (node.nodeClass !== "semantic") {
       continue;
@@ -2031,6 +2113,47 @@ async function queryEmbeddingVector(params: {
   };
 }
 
+function semanticSearchDocsByNodeId(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  treeId: string;
+}): Map<string, ReturnType<RuntimeStateStore["listSemanticMemorySearchDocs"]>[number]> {
+  return new Map(
+    params.store.listSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: params.workspaceId,
+      treeId: params.treeId,
+      status: "active",
+      limit: 10_000,
+      offset: 0,
+    }).map((doc) => [doc.nodeId, doc]),
+  );
+}
+
+function semanticLexicalRanksByNodeId(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  query: string;
+  mode: "mixed" | "summaries" | "leaves";
+  treeId?: string | null;
+}): Map<string, number> {
+  const matchQuery = buildRetrievalFtsMatchQuery(params.query);
+  if (!matchQuery) {
+    return new Map();
+  }
+  const hits = params.store.searchSemanticMemorySearchDocs({
+    category: "interaction",
+    workspaceId: params.workspaceId,
+    treeId: params.treeId ?? undefined,
+    nodeClass: params.mode === "leaves" ? "leaf" : params.mode === "summaries" ? "semantic" : undefined,
+    status: "active",
+    matchQuery,
+    limit: 500,
+    offset: 0,
+  });
+  return new Map(hits.map((hit, index) => [hit.nodeId, index + 1]));
+}
+
 function buildLeafCandidate(params: {
   store: RuntimeStateStore;
   workspaceId: string;
@@ -2087,19 +2210,23 @@ function buildSemanticCandidate(params: {
   workspaceId: string;
   entity: InteractionEntityRecord;
   node: ReturnType<RuntimeStateStore["listSemanticMemoryNodes"]>[number];
+  searchDoc?: ReturnType<RuntimeStateStore["getSemanticMemorySearchDoc"]> | null;
 }): NodeCandidate {
-  const filePath = absolutePathForRelative(
-    params.store.workspaceDir(params.workspaceId),
-    params.node.path,
-  );
-  const body = readFileIfExists(filePath);
+  const excerpt = params.searchDoc?.excerpt ?? (() => {
+    const filePath = absolutePathForRelative(
+      params.store.workspaceDir(params.workspaceId),
+      params.node.path,
+    );
+    const body = readFileIfExists(filePath);
+    return body ? markdownExcerpt(body, 320) : null;
+  })();
   return {
     kind: semanticInteractionCandidateKind(params.node),
     id: params.node.nodeId,
     entity: params.entity,
     title: params.node.title,
     summary: params.node.summary,
-    excerpt: body ? markdownExcerpt(body, 320) : null,
+    excerpt,
     path: params.node.path,
     level: semanticInteractionNodeLevel(params.node),
     childCount: params.node.childCount,
@@ -2111,6 +2238,7 @@ function buildSemanticCandidate(params: {
 function nodeScore(params: {
   query: string;
   candidate: NodeCandidate;
+  lexicalRank: number | null;
   embeddingModelId: string | null;
   queryVector: number[] | null;
   embeddingByKey: Map<string, number[]>;
@@ -2127,6 +2255,11 @@ function nodeScore(params: {
   );
   if (score > 0) {
     reasons.push("lexical_match");
+  }
+  const lexicalBoost = lexicalRankBoost(params.lexicalRank);
+  if (lexicalBoost > 0) {
+    score += lexicalBoost;
+    reasons.push("fts_bm25");
   }
   if (params.embeddingModelId && params.queryVector) {
     const embeddingKey = `${params.candidate.kind}:${params.candidate.id}:${params.embeddingModelId}`;
@@ -2212,6 +2345,18 @@ async function childHitsForNode(params: {
     ),
   ) ?? null;
   if (semanticEntity) {
+    const searchDocsByNodeId = semanticSearchDocsByNodeId({
+      store: params.store,
+      workspaceId: params.workspaceId,
+      treeId: semanticEntity.entityId,
+    });
+    const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
+      store: params.store,
+      workspaceId: params.workspaceId,
+      query: params.query,
+      mode: params.mode,
+      treeId: semanticEntity.entityId,
+    });
     const candidates = params.store
       .listSemanticMemoryChildren({
         category: "interaction",
@@ -2233,6 +2378,7 @@ async function childHitsForNode(params: {
           workspaceId: params.workspaceId,
           entity: semanticEntity,
           node,
+          searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
         }))
       .filter((candidate) => params.mode === "mixed"
         || (params.mode === "leaves" ? candidate.kind === "leaf" : candidate.kind === "summary"));
@@ -2241,6 +2387,7 @@ async function childHitsForNode(params: {
         const scored = nodeScore({
           query: params.query,
           candidate,
+          lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
           embeddingModelId: params.embeddingModelId,
           queryVector: params.queryVector,
           embeddingByKey: params.embeddingByKey,
@@ -2303,6 +2450,13 @@ export async function retrieveInteractionMemory(params: {
       embeddingByKey.set(`${record.nodeKind}:${record.nodeId}:${record.embeddingModel}`, record.vector);
     }
   }
+  const lexicalRanksByNodeId = semanticLexicalRanksByNodeId({
+    store: params.store,
+    workspaceId: params.workspaceId,
+    query: params.query,
+    mode,
+    treeId: params.treeId ?? null,
+  });
 
   if (params.nodeId) {
     return {
@@ -2326,6 +2480,11 @@ export async function retrieveInteractionMemory(params: {
 
   const candidates: NodeCandidate[] = [];
   for (const entity of entities) {
+    const searchDocsByNodeId = semanticSearchDocsByNodeId({
+      store: params.store,
+      workspaceId: params.workspaceId,
+      treeId: entity.entityId,
+    });
     const semanticNodes = params.store.listSemanticMemoryNodes({
       category: "interaction",
       workspaceId: params.workspaceId,
@@ -2341,6 +2500,7 @@ export async function retrieveInteractionMemory(params: {
           workspaceId: params.workspaceId,
           entity,
           node,
+          searchDoc: searchDocsByNodeId.get(node.nodeId) ?? null,
         });
         if (mode === "leaves" && candidate.kind !== "leaf") {
           continue;
@@ -2358,6 +2518,7 @@ export async function retrieveInteractionMemory(params: {
       const scored = nodeScore({
         query: params.query,
         candidate,
+        lexicalRank: lexicalRanksByNodeId.get(candidate.id) ?? null,
         embeddingModelId: embeddingQuery?.modelId ?? null,
         queryVector: embeddingQuery?.vector ?? null,
         embeddingByKey,

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -2808,9 +2808,11 @@ test("runTsRunnerCli uses the default recall embedding model even when backgroun
   );
 
   assert.equal(exitCode, 0);
-  assert.equal(recallRequests.length, 1);
-  assert.equal(recallRequests[0]?.model, "text-embedding-3-small");
-  assert.match(String(recallRequests[0]?.input), /how do i deploy/i);
+  const embeddingRequests = recallRequests.filter((request) =>
+    request.model === "text-embedding-3-small",
+  );
+  assert.equal(embeddingRequests.length, 1);
+  assert.match(String(embeddingRequests[0]?.input), /how do i deploy/i);
 });
 
 test("runTsRunnerCli loads pending user memory proposals into prompt context for the same input", async () => {

--- a/runtime/api-server/src/turn-memory-writeback.test.ts
+++ b/runtime/api-server/src/turn-memory-writeback.test.ts
@@ -14,13 +14,15 @@ import {
 } from "./workspace-bundle-paths.js";
 import {
   refreshMemoryIndexes,
+  waitForPendingInteractionEntityRebuilds,
   writeTurnDurableMemory,
   type TurnMemoryWritebackModelContext,
 } from "./turn-memory-writeback.js";
 
 const tempDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
+  await waitForPendingInteractionEntityRebuilds();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -147,6 +149,7 @@ function listActiveInteractionEntities(store: RuntimeStateStore, workspaceId: st
 async function withModelExtractionResponse(params: {
   memories: Array<Record<string, unknown>>;
   onRequest?: (body: string) => void;
+  waitForRebuilds?: boolean;
   run: (modelContext: TurnMemoryWritebackModelContext) => Promise<void>;
 }): Promise<void> {
   await withModelExtractionResponses({
@@ -167,6 +170,7 @@ async function withModelExtractionResponse(params: {
       },
     ],
     onRequest: params.onRequest,
+    waitForRebuilds: params.waitForRebuilds,
     run: params.run,
   });
 }
@@ -178,6 +182,7 @@ async function withModelExtractionResponses(params: {
     delayMs?: number;
   }>;
   onRequest?: (body: string, index: number) => void;
+  waitForRebuilds?: boolean;
   run: (modelContext: TurnMemoryWritebackModelContext) => Promise<void>;
 }): Promise<void> {
   const server = http.createServer((request, response) => {
@@ -227,6 +232,9 @@ async function withModelExtractionResponses(params: {
       instruction: "extract durable memory candidates",
     };
     await params.run(modelContext);
+    if (params.waitForRebuilds !== false) {
+      await waitForPendingInteractionEntityRebuilds({ workspaceId: "workspace-1" });
+    }
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -462,6 +470,82 @@ test("writeTurnDurableMemory waits for a full three-turn batch and does not repl
   assert.match(files[blockerLeaf.path], /Recurring deploy policy blocker/);
   assert.match(files[blockerLeaf.path], /blocked by workspace policy/i);
   assert.equal(interactionBatchCursor(store), "3");
+
+  store.close();
+});
+
+test("writeTurnDurableMemory schedules semantic rebuilds in the background after persisting leaves", async () => {
+  const { store, memoryService, workspaceRoot } = makeRuntimeState("hb-turn-memory-background-rebuild-");
+  seedWorkspace(store);
+  const [, , turnResult] = seedCompletedTurns({
+    store,
+    turns: [
+      {
+        userText: "Remember the release verification command.",
+        assistantText: "I will remember the release verification command.",
+      },
+      {
+        userText: "It should stay durable for future runs.",
+        assistantText: "Understood.",
+      },
+      {
+        userText: "For release verification, use `npm run test:ci`.",
+        assistantText: "Captured the release verification command.",
+      },
+    ],
+  });
+
+  await withModelExtractionResponse({
+    waitForRebuilds: false,
+    memories: [
+      {
+        scope: "workspace",
+        memory_type: "fact",
+        subject_key: "release-verification-command",
+        title: "Release verification command",
+        summary: "Use `npm run test:ci` to verify release changes in this workspace.",
+        tags: ["verification", "command"],
+        evidence: "The current turn explicitly instructs the agent to use `npm run test:ci` as durable release verification guidance.",
+        confidence: 0.97,
+      },
+    ],
+    run: async (modelContext) => {
+      await writeTurnDurableMemory({
+        store,
+        memoryService,
+        turnResult,
+        modelContext,
+      });
+    },
+  });
+
+  const immediateLeaves = listActiveInteractionLeaves(store, "workspace-1");
+  const immediateSummaries = listSummaryLikeSemanticInteractionNodes(store, "workspace-1");
+  const immediateFiles = snapshotMemoryFiles(workspaceRoot, "workspace-1");
+
+  assert.equal(interactionBatchCursor(store), "3");
+  assert.equal(immediateLeaves.length, 1);
+  assert.deepEqual(immediateSummaries, []);
+  assert.equal(
+    Object.keys(immediateFiles).some((filePath) => filePath.includes("/semantic/interaction/trees/")),
+    false,
+  );
+
+  await waitForPendingInteractionEntityRebuilds({ workspaceId: "workspace-1" });
+
+  const rebuiltSemanticNodes = store.listSemanticMemoryNodes({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:uncategorized",
+    nodeClass: "semantic",
+    status: "active",
+    limit: 10_000,
+    offset: 0,
+  });
+  const rebuiltFiles = snapshotMemoryFiles(workspaceRoot, "workspace-1");
+
+  assert.equal(rebuiltSemanticNodes.length, 1);
+  assert.ok(rebuiltFiles["workspace/workspace-1/semantic/interaction/trees/uncategorized/content.md"]);
 
   store.close();
 });

--- a/runtime/api-server/src/turn-memory-writeback.test.ts
+++ b/runtime/api-server/src/turn-memory-writeback.test.ts
@@ -1372,6 +1372,139 @@ test("refreshMemoryIndexes rebuilds large interaction trees without truncation",
   store.close();
 });
 
+test("refreshMemoryIndexes can target specific interaction entities", async () => {
+  const { store, memoryService, workspaceRoot } = makeRuntimeState("hb-turn-memory-targeted-index-refresh-");
+  seedWorkspace(store);
+
+  store.upsertInteractionEntity({
+    workspaceId: "workspace-1",
+    entityId: "interaction:customer:redwood-care",
+    entityType: "customer",
+    canonicalName: "Redwood Care",
+    slug: "customer-redwood-care",
+    summary: "Customer memory.",
+    aliases: [],
+    isSystem: false,
+    status: "active",
+  });
+  store.upsertInteractionEntity({
+    workspaceId: "workspace-1",
+    entityId: "interaction:workflow:deploy-procedure",
+    entityType: "workflow",
+    canonicalName: "Deploy procedure",
+    slug: "workflow-deploy-procedure",
+    summary: "Workflow memory.",
+    aliases: [],
+    isSystem: false,
+    status: "active",
+  });
+
+  const seedLeaf = async (params: {
+    entityId: string;
+    slug: string;
+    leafId: string;
+    title: string;
+    summary: string;
+  }) => {
+    const leafPath = `workspace/workspace-1/interaction/entities/${params.slug}/leaves/${params.leafId}.md`;
+    store.upsertInteractionLeaf({
+      workspaceId: "workspace-1",
+      leafId: params.leafId,
+      entityId: params.entityId,
+      subjectKey: `seed:${params.leafId}`,
+      path: leafPath,
+      title: params.title,
+      summary: params.summary,
+      fingerprint: `fingerprint-${params.leafId}`,
+      bodySha256: `sha-${params.leafId}`,
+      tags: ["seed"],
+      secondaryEntityIds: [],
+      sourceType: "manual",
+      sourceEventId: null,
+      sourceMessageId: null,
+      sourceTurnInputId: "input-seed",
+      admissionConfidence: 0.9,
+      entityConfidence: 0.9,
+      observedAt: "2026-04-09T10:00:00.000Z",
+      supersedesLeafId: null,
+      status: "active",
+    });
+    await memoryService.upsert({
+      workspace_id: "workspace-1",
+      path: leafPath,
+      content: `# ${params.title}\n\n${params.summary}\n`,
+      append: false,
+    });
+  };
+
+  await seedLeaf({
+    entityId: "interaction:customer:redwood-care",
+    slug: "customer-redwood-care",
+    leafId: "leaf-customer",
+    title: "Redwood escalation owner",
+    summary: "Route severe billing issues to Alicia Park.",
+  });
+  await seedLeaf({
+    entityId: "interaction:customer:redwood-care",
+    slug: "customer-redwood-care",
+    leafId: "leaf-customer-2",
+    title: "Redwood billing backup",
+    summary: "Escalate backup billing issues to Jordan Lee.",
+  });
+  await seedLeaf({
+    entityId: "interaction:workflow:deploy-procedure",
+    slug: "workflow-deploy-procedure",
+    leafId: "leaf-workflow",
+    title: "Deploy verification",
+    summary: "Run smoke tests before release.",
+  });
+
+  await refreshMemoryIndexes({
+    store,
+    memoryService,
+    workspaceId: "workspace-1",
+  });
+
+  const workspaceDir = workspaceMemoryDir(path.join(workspaceRoot, "workspace-1"));
+  const customerSummaryPath = path.join(
+    workspaceDir,
+    "semantic",
+    "interaction",
+    "trees",
+    "customer-redwood-care",
+    "content.md",
+  );
+  const workflowSummaryPath = path.join(
+    workspaceDir,
+    "semantic",
+    "interaction",
+    "trees",
+    "workflow-deploy-procedure",
+    "content.md",
+  );
+  assert.equal(fs.existsSync(customerSummaryPath), true);
+  assert.equal(fs.existsSync(workflowSummaryPath), true);
+
+  fs.rmSync(path.dirname(customerSummaryPath), { recursive: true, force: true });
+  fs.rmSync(path.dirname(workflowSummaryPath), { recursive: true, force: true });
+  assert.equal(fs.existsSync(customerSummaryPath), false);
+  assert.equal(fs.existsSync(workflowSummaryPath), false);
+
+  const restoredPaths = await refreshMemoryIndexes({
+    store,
+    memoryService,
+    workspaceId: "workspace-1",
+    entityIds: ["interaction:customer:redwood-care"],
+  });
+
+  assert.ok(restoredPaths.length > 0);
+  assert.ok(restoredPaths.every((entry) => entry.includes("customer-redwood-care")));
+  assert.equal(fs.existsSync(customerSummaryPath), true);
+  assert.equal(fs.existsSync(workflowSummaryPath), false);
+
+  store.close();
+});
+
 test("writeTurnDurableMemory rebuilds interaction summaries after new leaves are added", async () => {
   const { store, memoryService, workspaceRoot } = makeRuntimeState("hb-turn-memory-incremental-indexes-");
   seedWorkspace(store);

--- a/runtime/api-server/src/turn-memory-writeback.ts
+++ b/runtime/api-server/src/turn-memory-writeback.ts
@@ -121,6 +121,139 @@ export interface TurnMemoryWritebackModelContext {
   instruction?: string | null;
 }
 
+const INTERACTION_REBUILD_DEBOUNCE_MS = 75;
+
+interface PendingInteractionEntityRebuild {
+  key: string;
+  store: RuntimeStateStore;
+  workspaceId: string;
+  entityId: string;
+  summaryModelClient: MemoryModelClientConfig | null;
+  embeddingClient: MemoryModelClientConfig | null;
+  debounceMs: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  running: boolean;
+  dirty: boolean;
+  settled: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+const pendingInteractionEntityRebuilds = new Map<string, PendingInteractionEntityRebuild>();
+
+function interactionEntityRebuildKey(workspaceId: string, entityId: string): string {
+  return `${workspaceId}::${entityId}`;
+}
+
+function queueInteractionEntityRebuild(params: {
+  store: RuntimeStateStore;
+  workspaceId: string;
+  entityId: string;
+  summaryModelClient?: MemoryModelClientConfig | null;
+  embeddingClient?: MemoryModelClientConfig | null;
+  debounceMs?: number;
+}): Promise<void> {
+  const key = interactionEntityRebuildKey(params.workspaceId, params.entityId);
+  let pending = pendingInteractionEntityRebuilds.get(key) ?? null;
+  if (!pending) {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const settled = new Promise<void>((innerResolve, innerReject) => {
+      resolve = innerResolve;
+      reject = innerReject;
+    });
+    pending = {
+      key,
+      store: params.store,
+      workspaceId: params.workspaceId,
+      entityId: params.entityId,
+      summaryModelClient: params.summaryModelClient ?? null,
+      embeddingClient: params.embeddingClient ?? null,
+      debounceMs: Math.max(0, params.debounceMs ?? INTERACTION_REBUILD_DEBOUNCE_MS),
+      timer: null,
+      running: false,
+      dirty: true,
+      settled,
+      resolve,
+      reject,
+    };
+    // Swallow unhandled rejections for fire-and-forget background callers while
+    // still allowing explicit awaiters to observe the same rejection.
+    void settled.catch(() => undefined);
+    pendingInteractionEntityRebuilds.set(key, pending);
+  } else {
+    pending.store = params.store;
+    pending.summaryModelClient = params.summaryModelClient ?? pending.summaryModelClient ?? null;
+    pending.embeddingClient = params.embeddingClient ?? pending.embeddingClient ?? null;
+    pending.debounceMs = Math.max(0, params.debounceMs ?? pending.debounceMs);
+    pending.dirty = true;
+  }
+
+  if (!pending.running) {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+    pending.timer = setTimeout(() => {
+      pending!.timer = null;
+      void runQueuedInteractionEntityRebuild(pending!);
+    }, pending.debounceMs);
+  }
+  return pending.settled;
+}
+
+async function runQueuedInteractionEntityRebuild(pending: PendingInteractionEntityRebuild): Promise<void> {
+  if (pending.running) {
+    return;
+  }
+  pending.running = true;
+  try {
+    while (pending.dirty) {
+      pending.dirty = false;
+      await rebuildInteractionEntityTree({
+        store: pending.store,
+        workspaceId: pending.workspaceId,
+        entityId: pending.entityId,
+        summaryModelClient: pending.summaryModelClient,
+        embeddingClient: pending.embeddingClient,
+      });
+    }
+    pending.resolve();
+  } catch (error) {
+    pending.reject(error);
+  } finally {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+    pending.running = false;
+    pendingInteractionEntityRebuilds.delete(pending.key);
+  }
+}
+
+export async function waitForPendingInteractionEntityRebuilds(params?: {
+  workspaceId?: string | null;
+  entityIds?: string[] | null;
+}): Promise<void> {
+  const normalizedEntityIds = params?.entityIds
+    ? new Set(params.entityIds.map((value) => value.trim()).filter(Boolean))
+    : null;
+  while (true) {
+    const pending = [...pendingInteractionEntityRebuilds.values()].filter((candidate) => {
+      if (params?.workspaceId && candidate.workspaceId !== params.workspaceId) {
+        return false;
+      }
+      if (normalizedEntityIds && !normalizedEntityIds.has(candidate.entityId)) {
+        return false;
+      }
+      return true;
+    });
+    if (pending.length === 0) {
+      return;
+    }
+    await Promise.all(pending.map((candidate) => candidate.settled));
+  }
+}
+
 const TURN_BATCH_SIZE = 3;
 const BATCH_CURSOR_KEY_PREFIX = "interaction_memory_batch_processed_count:";
 const BATCH_STATE_KEY_PREFIX = "interaction_memory_batch_state:";
@@ -813,7 +946,7 @@ export async function persistDurableMemoryCandidate(params: {
     modelClient: null,
     embeddingClient,
   });
-  await rebuildInteractionEntityTree({
+  void queueInteractionEntityRebuild({
     store: params.store,
     workspaceId: params.workspaceId,
     entityId: result.entity.entityId,
@@ -850,12 +983,17 @@ export async function refreshMemoryIndexes(params: {
     });
   if (requestedEntityIds.length > 0) {
     for (const entity of targetEntities) {
-      await rebuildInteractionEntityTree({
+      void queueInteractionEntityRebuild({
         store: params.store,
         workspaceId: params.workspaceId,
         entityId: entity.entityId,
+        debounceMs: 0,
       });
     }
+    await waitForPendingInteractionEntityRebuilds({
+      workspaceId: params.workspaceId,
+      entityIds: targetEntities.map((entity) => entity.entityId),
+    });
   } else {
     await rebuildAllInteractionTrees({
       store: params.store,
@@ -1070,20 +1208,14 @@ export async function writeTurnDurableMemory(params: {
           value: String(processedTurnCount),
         });
         const rebuildStartedAt = Date.now();
-        try {
-          for (const entityId of touchedEntityIds) {
-            await rebuildInteractionEntityTree({
-              store: params.store,
-              workspaceId: batchLastTurn.workspaceId,
-              entityId,
-              summaryModelClient,
-              embeddingClient,
-            });
-          }
-        } catch (error) {
-          rebuildFailureReason = error instanceof Error && error.message
-            ? error.message
-            : "summary_rebuild_failed";
+        for (const entityId of touchedEntityIds) {
+          void queueInteractionEntityRebuild({
+            store: params.store,
+            workspaceId: batchLastTurn.workspaceId,
+            entityId,
+            summaryModelClient,
+            embeddingClient,
+          });
         }
         rebuildMs = Date.now() - rebuildStartedAt;
       } else {

--- a/runtime/api-server/src/turn-memory-writeback.ts
+++ b/runtime/api-server/src/turn-memory-writeback.ts
@@ -827,20 +827,42 @@ export async function refreshMemoryIndexes(params: {
   store: RuntimeStateStore;
   memoryService: MemoryServiceLike;
   workspaceId: string;
+  entityIds?: string[] | null;
 }): Promise<string[]> {
   void params.memoryService;
-  await rebuildAllInteractionTrees({
-    store: params.store,
-    workspaceId: params.workspaceId,
-  });
-  const semanticPaths = params.store
-    .listInteractionEntities({
+  const requestedEntityIds = params.entityIds
+    ? [...new Set(params.entityIds.map((value) => value.trim()).filter(Boolean))]
+    : [];
+  const targetEntities = requestedEntityIds.length > 0
+    ? requestedEntityIds
+      .map((entityId) =>
+        params.store.getInteractionEntity({
+          workspaceId: params.workspaceId,
+          entityId,
+        }))
+      .filter((entity): entity is NonNullable<typeof entity> => Boolean(entity))
+    : params.store.listInteractionEntities({
       workspaceId: params.workspaceId,
       status: "active",
       includeSystem: true,
       limit: 10_000,
       offset: 0,
-    })
+    });
+  if (requestedEntityIds.length > 0) {
+    for (const entity of targetEntities) {
+      await rebuildInteractionEntityTree({
+        store: params.store,
+        workspaceId: params.workspaceId,
+        entityId: entity.entityId,
+      });
+    }
+  } else {
+    await rebuildAllInteractionTrees({
+      store: params.store,
+      workspaceId: params.workspaceId,
+    });
+  }
+  const semanticPaths = targetEntities
     .flatMap((entity) =>
       params.store.listSemanticMemoryNodes({
         category: "interaction",
@@ -850,8 +872,7 @@ export async function refreshMemoryIndexes(params: {
         status: "active",
         limit: 10_000,
         offset: 0,
-      }),
-    )
+      }))
     .filter((node) => isSummaryLikeSemanticInteractionNode(node))
     .map((node) => node.path);
   return semanticPaths;

--- a/runtime/api-server/src/workspace-memory.test.ts
+++ b/runtime/api-server/src/workspace-memory.test.ts
@@ -195,6 +195,73 @@ function makeStoreFixture(root: string): RuntimeStateStore {
     [`interaction:${interactionEntity.entityId}:${interactionNode.nodeId}`, interactionNode],
     [`integration:${integrationTree.treeId}:${integrationNode.nodeId}`, integrationNode],
   ]);
+  const semanticSearchDocs = [
+    {
+      workspaceId,
+      category: "interaction" as const,
+      treeId: interactionEntity.entityId,
+      nodeId: interactionNode.nodeId,
+      nodeClass: interactionNode.nodeClass,
+      nodeKind: interactionNode.nodeKind,
+      path: interactionNode.path,
+      childCount: interactionNode.childCount,
+      title: interactionNode.title,
+      summary: interactionNode.summary,
+      bodyText: "Deploy approver Maya owns release approvals.",
+      excerpt: "Deploy approver Maya owns release approvals.",
+      observedAt: interactionNode.observedAt,
+      status: interactionNode.status,
+      updatedAt: interactionNode.updatedAt,
+    },
+    {
+      workspaceId: null,
+      category: "integration" as const,
+      treeId: integrationTree.treeId,
+      nodeId: integrationNode.nodeId,
+      nodeClass: integrationNode.nodeClass,
+      nodeKind: integrationNode.nodeKind,
+      path: integrationNode.path,
+      childCount: integrationNode.childCount,
+      title: integrationNode.title,
+      summary: integrationNode.summary,
+      bodyText: "Customer escalation waiting on reply before Friday.",
+      excerpt: "Customer escalation waiting on reply before Friday.",
+      observedAt: integrationNode.observedAt,
+      status: integrationNode.status,
+      updatedAt: integrationNode.updatedAt,
+    },
+  ];
+  const searchDocsFor = (params: {
+    category: "interaction" | "integration";
+    workspaceId?: string | null;
+    treeId?: string | null;
+    treeIds?: string[] | null;
+    nodeIds?: string[] | null;
+    nodeClass?: string | null;
+    status?: string | null;
+    matchQuery?: string | null;
+  }) => {
+    const normalizedTreeIds = params.treeIds
+      ? new Set(params.treeIds.filter(Boolean))
+      : null;
+    const normalizedNodeIds = params.nodeIds
+      ? new Set(params.nodeIds.filter(Boolean))
+      : null;
+    const query = (params.matchQuery ?? "").toLowerCase();
+    return semanticSearchDocs
+      .filter((doc) => doc.category === params.category)
+      .filter((doc) => params.workspaceId === undefined || doc.workspaceId === params.workspaceId)
+      .filter((doc) => params.treeId === undefined || doc.treeId === params.treeId)
+      .filter((doc) => !normalizedTreeIds || normalizedTreeIds.has(doc.treeId))
+      .filter((doc) => !normalizedNodeIds || normalizedNodeIds.has(doc.nodeId))
+      .filter((doc) => params.nodeClass == null || doc.nodeClass === params.nodeClass)
+      .filter((doc) => params.status == null || doc.status === params.status)
+      .filter((doc) => !query
+        || doc.title.toLowerCase().includes(query)
+        || doc.summary.toLowerCase().includes(query)
+        || doc.bodyText.toLowerCase().includes(query)
+        || doc.excerpt?.toLowerCase().includes(query));
+  };
 
   return {
     workspaceRoot,
@@ -209,22 +276,51 @@ function makeStoreFixture(root: string): RuntimeStateStore {
         ? interactionEntity
         : null;
     },
-    listInteractionNodeEmbeddings(params: { workspaceId: string; embeddingModel?: string | null }) {
+    listInteractionNodeEmbeddings(params: { workspaceId: string; embeddingModel?: string | null; nodeIds?: string[] | null }) {
+      const normalizedNodeIds = params.nodeIds ? new Set(params.nodeIds.filter(Boolean)) : null;
       return interactionEmbeddings.filter((record) =>
         record.workspaceId === params.workspaceId
         && (params.embeddingModel == null || record.embeddingModel === params.embeddingModel)
+        && (!normalizedNodeIds || normalizedNodeIds.has(record.nodeId))
       );
     },
-    listIntegrationNodeEmbeddings(params: { embeddingModel?: string | null }) {
+    listIntegrationNodeEmbeddings(params: { embeddingModel?: string | null; nodeIds?: string[] | null }) {
+      const normalizedNodeIds = params.nodeIds ? new Set(params.nodeIds.filter(Boolean)) : null;
       return integrationEmbeddings.filter((record) =>
         params.embeddingModel == null || record.embeddingModel === params.embeddingModel
-      );
+      ).filter((record) => !normalizedNodeIds || normalizedNodeIds.has(record.nodeId));
     },
     getSemanticMemoryNode(params: { category: "interaction" | "integration"; treeId: string; nodeId: string; workspaceId?: string | null }) {
       return semanticNodes.get(`${params.category}:${params.treeId}:${params.nodeId}`) ?? null;
     },
     listSemanticMemoryNodes(params: { category: "interaction" | "integration"; treeId: string }) {
       return [...semanticNodes.values()].filter((node) => node.category === params.category && node.treeId === params.treeId);
+    },
+    listSemanticMemorySearchDocs(params: {
+      category: "interaction" | "integration";
+      workspaceId?: string | null;
+      treeId?: string | null;
+      treeIds?: string[] | null;
+      nodeIds?: string[] | null;
+      nodeClass?: string | null;
+      status?: string | null;
+    }) {
+      return searchDocsFor(params);
+    },
+    searchSemanticMemorySearchDocs(params: {
+      category: "interaction" | "integration";
+      workspaceId?: string | null;
+      treeId?: string | null;
+      treeIds?: string[] | null;
+      nodeClass?: string | null;
+      status?: string | null;
+      matchQuery: string;
+    }) {
+      return searchDocsFor(params)
+        .map((doc, index) => ({
+          ...doc,
+          bm25Score: index + 1,
+        }));
     },
     listIntegrationConnections() {
       return [integrationConnection];

--- a/runtime/state-store/src/index.ts
+++ b/runtime/state-store/src/index.ts
@@ -44,6 +44,8 @@ export {
   type SemanticMemoryNodeClass,
   type SemanticMemoryNodeRecord,
   type SemanticMemoryRelationRecord,
+  type SemanticMemorySearchDocRecord,
+  type SemanticMemorySearchHitRecord,
   type MemoryNodeKind,
   type MemoryNodeStatus,
   type MemoryUpdateProposalKind,

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -4750,3 +4750,793 @@ test("semantic memory substrate round trips for interaction and integration cate
   );
   reopened.close();
 });
+
+test("sync semantic memory substrate patches interaction scope without rewriting unchanged rows", () => {
+  const root = makeTempDir("hb-state-store-semantic-sync-interaction-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const store = new RuntimeStateStore({ dbPath, workspaceRoot });
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Acme",
+    harness: "pi",
+    status: "active",
+  });
+
+  store.replaceSemanticMemoryTree({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodes: [
+      {
+        nodeId: "interaction-root",
+        nodeClass: "semantic",
+        nodeKind: "workflow",
+        path: "memory/interaction/release-playbook/content.md",
+        title: "Release playbook",
+        summary: "Root release workflow.",
+        bodySha256: "sha-root-v1",
+        childCount: 1,
+        metadata: { owner: "ops" },
+        createdAt: "2026-05-24T10:00:00.000Z",
+        updatedAt: "2026-05-24T10:00:00.000Z",
+      },
+      {
+        nodeId: "interaction-section",
+        nodeClass: "semantic",
+        nodeKind: "section",
+        path: "memory/interaction/release-playbook/checklist/content.md",
+        title: "Checklist",
+        summary: "Release checklist.",
+        bodySha256: "sha-section-v1",
+        childCount: 1,
+        isMaterialized: true,
+        metadata: { partition: "current" },
+        createdAt: "2026-05-24T10:01:00.000Z",
+        updatedAt: "2026-05-24T10:01:00.000Z",
+      },
+      {
+        nodeId: "interaction-leaf-1",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        sourceLeafId: "leaf-release-1",
+        path: "memory/interaction/release-playbook/checklist/step-1.md",
+        title: "Run migration",
+        summary: "Apply the migration before restarting workers.",
+        bodySha256: "sha-leaf-1",
+        observedAt: "2026-05-24T09:59:00.000Z",
+        metadata: { source: "interaction_leaf" },
+        createdAt: "2026-05-24T10:02:00.000Z",
+        updatedAt: "2026-05-24T10:02:00.000Z",
+      },
+    ],
+    edges: [
+      {
+        parentNodeId: "interaction-root",
+        childNodeId: "interaction-section",
+        position: 1,
+        createdAt: "2026-05-24T10:03:00.000Z",
+      },
+      {
+        parentNodeId: "interaction-section",
+        childNodeId: "interaction-leaf-1",
+        position: 1,
+        createdAt: "2026-05-24T10:04:00.000Z",
+      },
+    ],
+  });
+  store.replaceSemanticMemorySearchDocs({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    docs: [
+      {
+        nodeId: "interaction-root",
+        nodeClass: "semantic",
+        nodeKind: "workflow",
+        path: "memory/interaction/release-playbook/content.md",
+        childCount: 1,
+        title: "Release playbook",
+        summary: "Root release workflow.",
+        bodyText: "Release playbook root body.",
+        excerpt: "Release playbook root body.",
+        updatedAt: "2026-05-24T10:05:00.000Z",
+      },
+      {
+        nodeId: "interaction-section",
+        nodeClass: "semantic",
+        nodeKind: "section",
+        path: "memory/interaction/release-playbook/checklist/content.md",
+        childCount: 1,
+        title: "Checklist",
+        summary: "Release checklist.",
+        bodyText: "Checklist body covering migration sequencing.",
+        excerpt: "Checklist body covering migration sequencing.",
+        updatedAt: "2026-05-24T10:06:00.000Z",
+      },
+      {
+        nodeId: "interaction-leaf-1",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        path: "memory/interaction/release-playbook/checklist/step-1.md",
+        title: "Run migration",
+        summary: "Apply the migration before restarting workers.",
+        bodyText: "Run the migration and restart the workers after it finishes.",
+        excerpt: "Run the migration and restart the workers.",
+        observedAt: "2026-05-24T09:59:00.000Z",
+        updatedAt: "2026-05-24T10:07:00.000Z",
+      },
+    ],
+  });
+  store.replaceSemanticMemoryRelations({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    relations: [
+      {
+        fromNodeId: "interaction-root",
+        toNodeId: "interaction-leaf-1",
+        relationType: "references",
+        metadata: { note: "original critical step" },
+        createdAt: "2026-05-24T10:08:00.000Z",
+        updatedAt: "2026-05-24T10:08:00.000Z",
+      },
+    ],
+  });
+
+  const rootBefore = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-root",
+  });
+  const sectionBefore = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-section",
+  });
+  const rootDocBefore = store.getSemanticMemorySearchDoc({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-root",
+  });
+  const rootEdgeBefore = store.listSemanticMemoryChildren({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    parentNodeId: "interaction-root",
+  })[0];
+
+  assert.ok(rootBefore);
+  assert.ok(sectionBefore);
+  assert.ok(rootDocBefore);
+  assert.ok(rootEdgeBefore);
+
+  store.syncSemanticMemoryTree({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodes: [
+      {
+        nodeId: "interaction-root",
+        nodeClass: "semantic",
+        nodeKind: "workflow",
+        path: "memory/interaction/release-playbook/content.md",
+        title: "Release playbook",
+        summary: "Root release workflow.",
+        bodySha256: "sha-root-v1",
+        childCount: 1,
+        metadata: { owner: "ops" },
+        createdAt: "2099-01-01T00:00:00.000Z",
+        updatedAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        nodeId: "interaction-section",
+        nodeClass: "semantic",
+        nodeKind: "section",
+        path: "memory/interaction/release-playbook/checklist/content.md",
+        title: "Checklist",
+        summary: "Release checklist and restart order.",
+        bodySha256: "sha-section-v2",
+        childCount: 1,
+        isMaterialized: true,
+        metadata: { partition: "current", owner: "release-eng" },
+        createdAt: "2099-01-01T00:00:00.000Z",
+        updatedAt: "2026-05-25T10:01:00.000Z",
+      },
+      {
+        nodeId: "interaction-leaf-2",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        sourceLeafId: "leaf-release-2",
+        path: "memory/interaction/release-playbook/checklist/step-2.md",
+        title: "Warm caches",
+        summary: "Warm the cache after the rollout finishes.",
+        bodySha256: "sha-leaf-2",
+        observedAt: "2026-05-25T09:59:00.000Z",
+        metadata: { source: "interaction_leaf" },
+        createdAt: "2026-05-25T10:02:00.000Z",
+        updatedAt: "2026-05-25T10:02:00.000Z",
+      },
+    ],
+    edges: [
+      {
+        parentNodeId: "interaction-root",
+        childNodeId: "interaction-section",
+        position: 1,
+        createdAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        parentNodeId: "interaction-section",
+        childNodeId: "interaction-leaf-2",
+        position: 1,
+        createdAt: "2026-05-25T10:03:00.000Z",
+      },
+    ],
+  });
+  store.syncSemanticMemorySearchDocs({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    docs: [
+      {
+        nodeId: "interaction-root",
+        nodeClass: "semantic",
+        nodeKind: "workflow",
+        path: "memory/interaction/release-playbook/content.md",
+        childCount: 1,
+        title: "Release playbook",
+        summary: "Root release workflow.",
+        bodyText: "Release playbook root body.",
+        excerpt: "Release playbook root body.",
+        updatedAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        nodeId: "interaction-section",
+        nodeClass: "semantic",
+        nodeKind: "section",
+        path: "memory/interaction/release-playbook/checklist/content.md",
+        childCount: 1,
+        title: "Checklist",
+        summary: "Release checklist and restart order.",
+        bodyText: "Checklist body covering restart sequencing and cache warmup.",
+        excerpt: "Checklist body covering restart sequencing.",
+        updatedAt: "2026-05-25T10:04:00.000Z",
+      },
+      {
+        nodeId: "interaction-leaf-2",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        path: "memory/interaction/release-playbook/checklist/step-2.md",
+        title: "Warm caches",
+        summary: "Warm the cache after the rollout finishes.",
+        bodyText: "Run the runbook cache warmer after the rollout settles.",
+        excerpt: "Run the runbook cache warmer.",
+        observedAt: "2026-05-25T09:59:00.000Z",
+        updatedAt: "2026-05-25T10:05:00.000Z",
+      },
+    ],
+  });
+  store.syncSemanticMemoryRelations({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    relations: [
+      {
+        fromNodeId: "interaction-root",
+        toNodeId: "interaction-leaf-2",
+        relationType: "references",
+        metadata: { note: "updated critical step" },
+        createdAt: "2026-05-25T10:06:00.000Z",
+        updatedAt: "2026-05-25T10:06:00.000Z",
+      },
+    ],
+  });
+
+  const rootAfter = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-root",
+  });
+  const sectionAfter = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-section",
+  });
+  const leaf1After = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-leaf-1",
+  });
+  const leaf2After = store.getSemanticMemoryNode({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-leaf-2",
+  });
+  const rootDocAfter = store.getSemanticMemorySearchDoc({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-root",
+  });
+  const sectionDocAfter = store.getSemanticMemorySearchDoc({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-section",
+  });
+  const leaf1DocAfter = store.getSemanticMemorySearchDoc({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-leaf-1",
+  });
+  const leaf2DocAfter = store.getSemanticMemorySearchDoc({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    nodeId: "interaction-leaf-2",
+  });
+  const rootEdgeAfter = store.listSemanticMemoryChildren({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    parentNodeId: "interaction-root",
+  });
+  const sectionEdgeAfter = store.listSemanticMemoryChildren({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    parentNodeId: "interaction-section",
+  });
+  const relationsAfter = store.listSemanticMemoryRelations({
+    category: "interaction",
+    workspaceId: "workspace-1",
+    treeId: "interaction:release-playbook",
+    fromNodeId: "interaction-root",
+  });
+
+  assert.ok(rootAfter);
+  assert.ok(sectionAfter);
+  assert.equal(leaf1After, null);
+  assert.ok(leaf2After);
+  assert.ok(rootDocAfter);
+  assert.ok(sectionDocAfter);
+  assert.equal(leaf1DocAfter, null);
+  assert.ok(leaf2DocAfter);
+  assert.equal(rootAfter.createdAt, rootBefore.createdAt);
+  assert.equal(rootAfter.updatedAt, rootBefore.updatedAt);
+  assert.equal(sectionAfter.createdAt, sectionBefore.createdAt);
+  assert.equal(sectionAfter.updatedAt, "2026-05-25T10:01:00.000Z");
+  assert.equal(sectionAfter.summary, "Release checklist and restart order.");
+  assert.deepEqual(sectionAfter.metadata, { partition: "current", owner: "release-eng" });
+  assert.equal(leaf2After.createdAt, "2026-05-25T10:02:00.000Z");
+  assert.equal(rootDocAfter.updatedAt, rootDocBefore.updatedAt);
+  assert.equal(sectionDocAfter.updatedAt, "2026-05-25T10:04:00.000Z");
+  assert.equal(leaf2DocAfter.updatedAt, "2026-05-25T10:05:00.000Z");
+  assert.equal(rootEdgeAfter.length, 1);
+  assert.equal(rootEdgeAfter[0]?.childNodeId, "interaction-section");
+  assert.equal(rootEdgeAfter[0]?.createdAt, rootEdgeBefore.createdAt);
+  assert.deepEqual(
+    sectionEdgeAfter.map((edge) => ({
+      childNodeId: edge.childNodeId,
+      createdAt: edge.createdAt,
+    })),
+    [{ childNodeId: "interaction-leaf-2", createdAt: "2026-05-25T10:03:00.000Z" }],
+  );
+  assert.deepEqual(
+    relationsAfter.map((relation) => ({
+      toNodeId: relation.toNodeId,
+      relationType: relation.relationType,
+      note: relation.metadata.note,
+      createdAt: relation.createdAt,
+    })),
+    [{
+      toNodeId: "interaction-leaf-2",
+      relationType: "references",
+      note: "updated critical step",
+      createdAt: "2026-05-25T10:06:00.000Z",
+    }],
+  );
+  assert.deepEqual(
+    store.searchSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: "workspace-1",
+      treeId: "interaction:release-playbook",
+      matchQuery: "runbook",
+    }).map((hit) => hit.nodeId),
+    ["interaction-leaf-2"],
+  );
+  assert.equal(
+    store.searchSemanticMemorySearchDocs({
+      category: "interaction",
+      workspaceId: "workspace-1",
+      treeId: "interaction:release-playbook",
+      matchQuery: "migration",
+    }).some((hit) => hit.nodeId === "interaction-leaf-1"),
+    false,
+  );
+
+  store.close();
+});
+
+test("sync semantic memory substrate patches integration scope without rewriting unchanged rows", () => {
+  const root = makeTempDir("hb-state-store-semantic-sync-integration-");
+  const dbPath = path.join(root, "runtime.db");
+  const workspaceRoot = path.join(root, "workspace");
+
+  const store = new RuntimeStateStore({ dbPath, workspaceRoot });
+
+  store.replaceSemanticMemoryTree({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodes: [
+      {
+        nodeId: "integration-root",
+        nodeClass: "semantic",
+        nodeKind: "repo",
+        path: "memory/integration/github/holaboss-ai-holaOS/content.md",
+        title: "holaboss-ai/holaOS",
+        summary: "Repository memory.",
+        bodySha256: "sha-integration-root-v1",
+        childCount: 1,
+        metadata: { provider: "github" },
+        createdAt: "2026-05-24T11:00:00.000Z",
+        updatedAt: "2026-05-24T11:00:00.000Z",
+      },
+      {
+        nodeId: "integration-issues",
+        nodeClass: "semantic",
+        nodeKind: "facet",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/content.md",
+        title: "Issues",
+        summary: "Open issues.",
+        bodySha256: "sha-integration-issues-v1",
+        childCount: 1,
+        createdAt: "2026-05-24T11:01:00.000Z",
+        updatedAt: "2026-05-24T11:01:00.000Z",
+      },
+      {
+        nodeId: "integration-issue-101",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        sourceLeafId: "issue-101",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/101.md",
+        title: "Issue #101",
+        summary: "Fix layout mismatch.",
+        bodySha256: "sha-integration-leaf-101",
+        observedAt: "2026-05-24T10:59:00.000Z",
+        metadata: { source: "integration_leaf" },
+        createdAt: "2026-05-24T11:02:00.000Z",
+        updatedAt: "2026-05-24T11:02:00.000Z",
+      },
+    ],
+    edges: [
+      {
+        parentNodeId: "integration-root",
+        childNodeId: "integration-issues",
+        position: 1,
+        createdAt: "2026-05-24T11:03:00.000Z",
+      },
+      {
+        parentNodeId: "integration-issues",
+        childNodeId: "integration-issue-101",
+        position: 1,
+        createdAt: "2026-05-24T11:04:00.000Z",
+      },
+    ],
+  });
+  store.replaceSemanticMemorySearchDocs({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    docs: [
+      {
+        nodeId: "integration-root",
+        nodeClass: "semantic",
+        nodeKind: "repo",
+        path: "memory/integration/github/holaboss-ai-holaOS/content.md",
+        childCount: 1,
+        title: "holaboss-ai/holaOS",
+        summary: "Repository memory.",
+        bodyText: "Repository memory root body.",
+        excerpt: "Repository memory root body.",
+        updatedAt: "2026-05-24T11:05:00.000Z",
+      },
+      {
+        nodeId: "integration-issues",
+        nodeClass: "semantic",
+        nodeKind: "facet",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/content.md",
+        childCount: 1,
+        title: "Issues",
+        summary: "Open issues.",
+        bodyText: "Issue list body for layout bugs.",
+        excerpt: "Issue list body for layout bugs.",
+        updatedAt: "2026-05-24T11:06:00.000Z",
+      },
+      {
+        nodeId: "integration-issue-101",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/101.md",
+        title: "Issue #101",
+        summary: "Fix layout mismatch.",
+        bodyText: "Layout mismatch appears in the memory browser.",
+        excerpt: "Layout mismatch appears in the memory browser.",
+        observedAt: "2026-05-24T10:59:00.000Z",
+        updatedAt: "2026-05-24T11:07:00.000Z",
+      },
+    ],
+  });
+  store.replaceSemanticMemoryRelations({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    relations: [
+      {
+        fromNodeId: "integration-root",
+        toNodeId: "integration-issue-101",
+        relationType: "tracks",
+        metadata: { priority: "medium" },
+        createdAt: "2026-05-24T11:08:00.000Z",
+        updatedAt: "2026-05-24T11:08:00.000Z",
+      },
+    ],
+  });
+
+  const issuesBefore = store.getSemanticMemoryNode({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issues",
+  });
+  const issuesDocBefore = store.getSemanticMemorySearchDoc({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issues",
+  });
+  const rootEdgeBefore = store.listSemanticMemoryChildren({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    parentNodeId: "integration-root",
+  })[0];
+
+  assert.ok(issuesBefore);
+  assert.ok(issuesDocBefore);
+  assert.ok(rootEdgeBefore);
+
+  store.syncSemanticMemoryTree({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodes: [
+      {
+        nodeId: "integration-root",
+        nodeClass: "semantic",
+        nodeKind: "repo",
+        path: "memory/integration/github/holaboss-ai-holaOS/content.md",
+        title: "holaboss-ai/holaOS",
+        summary: "Repository memory with release issues.",
+        bodySha256: "sha-integration-root-v2",
+        childCount: 1,
+        metadata: { provider: "github", owner: "holaboss-ai" },
+        createdAt: "2099-01-01T00:00:00.000Z",
+        updatedAt: "2026-05-25T11:00:00.000Z",
+      },
+      {
+        nodeId: "integration-issues",
+        nodeClass: "semantic",
+        nodeKind: "facet",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/content.md",
+        title: "Issues",
+        summary: "Open issues.",
+        bodySha256: "sha-integration-issues-v1",
+        childCount: 1,
+        createdAt: "2099-01-01T00:00:00.000Z",
+        updatedAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        nodeId: "integration-issue-202",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        sourceLeafId: "issue-202",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/202.md",
+        title: "Issue #202",
+        summary: "Backfill release metrics after rollout.",
+        bodySha256: "sha-integration-leaf-202",
+        observedAt: "2026-05-25T10:59:00.000Z",
+        metadata: { source: "integration_leaf" },
+        createdAt: "2026-05-25T11:01:00.000Z",
+        updatedAt: "2026-05-25T11:01:00.000Z",
+      },
+    ],
+    edges: [
+      {
+        parentNodeId: "integration-root",
+        childNodeId: "integration-issues",
+        position: 1,
+        createdAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        parentNodeId: "integration-issues",
+        childNodeId: "integration-issue-202",
+        position: 1,
+        createdAt: "2026-05-25T11:02:00.000Z",
+      },
+    ],
+  });
+  store.syncSemanticMemorySearchDocs({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    docs: [
+      {
+        nodeId: "integration-root",
+        nodeClass: "semantic",
+        nodeKind: "repo",
+        path: "memory/integration/github/holaboss-ai-holaOS/content.md",
+        childCount: 1,
+        title: "holaboss-ai/holaOS",
+        summary: "Repository memory with release issues.",
+        bodyText: "Repository memory root body with release issues.",
+        excerpt: "Repository memory root body with release issues.",
+        updatedAt: "2026-05-25T11:03:00.000Z",
+      },
+      {
+        nodeId: "integration-issues",
+        nodeClass: "semantic",
+        nodeKind: "facet",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/content.md",
+        childCount: 1,
+        title: "Issues",
+        summary: "Open issues.",
+        bodyText: "Issue list body for layout bugs.",
+        excerpt: "Issue list body for layout bugs.",
+        updatedAt: "2099-01-01T00:00:00.000Z",
+      },
+      {
+        nodeId: "integration-issue-202",
+        nodeClass: "leaf",
+        nodeKind: "leaf",
+        path: "memory/integration/github/holaboss-ai-holaOS/issues/202.md",
+        title: "Issue #202",
+        summary: "Backfill release metrics after rollout.",
+        bodyText: "Release metrics backfill should start after the rollout settles.",
+        excerpt: "Release metrics backfill should start after the rollout settles.",
+        observedAt: "2026-05-25T10:59:00.000Z",
+        updatedAt: "2026-05-25T11:04:00.000Z",
+      },
+    ],
+  });
+  store.syncSemanticMemoryRelations({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    relations: [
+      {
+        fromNodeId: "integration-root",
+        toNodeId: "integration-issue-202",
+        relationType: "tracks",
+        metadata: { priority: "high" },
+        createdAt: "2026-05-25T11:05:00.000Z",
+        updatedAt: "2026-05-25T11:05:00.000Z",
+      },
+    ],
+  });
+
+  const rootAfter = store.getSemanticMemoryNode({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-root",
+  });
+  const issuesAfter = store.getSemanticMemoryNode({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issues",
+  });
+  const issue101After = store.getSemanticMemoryNode({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issue-101",
+  });
+  const issue202After = store.getSemanticMemoryNode({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issue-202",
+  });
+  const rootDocAfter = store.getSemanticMemorySearchDoc({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-root",
+  });
+  const issuesDocAfter = store.getSemanticMemorySearchDoc({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issues",
+  });
+  const issue101DocAfter = store.getSemanticMemorySearchDoc({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issue-101",
+  });
+  const issue202DocAfter = store.getSemanticMemorySearchDoc({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    nodeId: "integration-issue-202",
+  });
+  const rootEdgeAfter = store.listSemanticMemoryChildren({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    parentNodeId: "integration-root",
+  });
+  const issueEdgesAfter = store.listSemanticMemoryChildren({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    parentNodeId: "integration-issues",
+  });
+  const relationsAfter = store.listSemanticMemoryRelations({
+    category: "integration",
+    treeId: "integration:github:conn-1",
+    fromNodeId: "integration-root",
+  });
+
+  assert.ok(rootAfter);
+  assert.ok(issuesAfter);
+  assert.equal(issue101After, null);
+  assert.ok(issue202After);
+  assert.ok(rootDocAfter);
+  assert.ok(issuesDocAfter);
+  assert.equal(issue101DocAfter, null);
+  assert.ok(issue202DocAfter);
+  assert.equal(rootAfter.createdAt, "2026-05-24T11:00:00.000Z");
+  assert.equal(rootAfter.updatedAt, "2026-05-25T11:00:00.000Z");
+  assert.equal(issuesAfter.createdAt, issuesBefore.createdAt);
+  assert.equal(issuesAfter.updatedAt, issuesBefore.updatedAt);
+  assert.deepEqual(rootAfter.metadata, { provider: "github", owner: "holaboss-ai" });
+  assert.equal(issue202After.createdAt, "2026-05-25T11:01:00.000Z");
+  assert.equal(rootDocAfter.updatedAt, "2026-05-25T11:03:00.000Z");
+  assert.equal(issuesDocAfter.updatedAt, issuesDocBefore.updatedAt);
+  assert.equal(issue202DocAfter.updatedAt, "2026-05-25T11:04:00.000Z");
+  assert.equal(rootEdgeAfter[0]?.createdAt, rootEdgeBefore.createdAt);
+  assert.deepEqual(
+    issueEdgesAfter.map((edge) => ({
+      childNodeId: edge.childNodeId,
+      createdAt: edge.createdAt,
+    })),
+    [{ childNodeId: "integration-issue-202", createdAt: "2026-05-25T11:02:00.000Z" }],
+  );
+  assert.deepEqual(
+    relationsAfter.map((relation) => ({
+      toNodeId: relation.toNodeId,
+      relationType: relation.relationType,
+      priority: relation.metadata.priority,
+      createdAt: relation.createdAt,
+    })),
+    [{
+      toNodeId: "integration-issue-202",
+      relationType: "tracks",
+      priority: "high",
+      createdAt: "2026-05-25T11:05:00.000Z",
+    }],
+  );
+  assert.deepEqual(
+    store.searchSemanticMemorySearchDocs({
+      category: "integration",
+      treeId: "integration:github:conn-1",
+      matchQuery: "backfill",
+    }).map((hit) => hit.nodeId),
+    ["integration-issue-202"],
+  );
+  assert.equal(
+    store.searchSemanticMemorySearchDocs({
+      category: "integration",
+      treeId: "integration:github:conn-1",
+      matchQuery: "mismatch",
+    }).some((hit) => hit.nodeId === "integration-issue-101"),
+    false,
+  );
+
+  store.close();
+});

--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -3064,6 +3064,124 @@ test("memory embedding index supports vector replacement, search, and delete", (
   store.close();
 });
 
+test("node embedding vector indexes support interaction and integration top-k search", () => {
+  const root = makeTempDir("hb-state-store-node-vec-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+
+  assert.equal(store.supportsVectorIndex(), true);
+  store.createWorkspace({
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+
+  const primaryVector = new Float32Array(1536).fill(0);
+  primaryVector[0] = 1;
+  const secondaryVector = new Float32Array(1536).fill(0);
+  secondaryVector[1] = 1;
+
+  store.upsertInteractionNodeEmbedding({
+    workspaceId: "workspace-1",
+    nodeKind: "summary",
+    nodeId: "semantic:interaction:vector-primary",
+    entityId: "interaction:workflow:vector-primary",
+    embeddingModel: "text-embedding-3-small",
+    contentFingerprint: "c".repeat(64),
+    dimensions: 1536,
+    vector: Array.from(primaryVector),
+  });
+  store.upsertInteractionNodeEmbedding({
+    workspaceId: "workspace-1",
+    nodeKind: "summary",
+    nodeId: "semantic:interaction:vector-secondary",
+    entityId: "interaction:workflow:vector-primary",
+    embeddingModel: "text-embedding-3-small",
+    contentFingerprint: "d".repeat(64),
+    dimensions: 1536,
+    vector: Array.from(secondaryVector),
+  });
+
+  const interactionResults = store.searchInteractionNodeEmbeddingsByVector({
+    workspaceId: "workspace-1",
+    embedding: primaryVector,
+    embeddingModel: "text-embedding-3-small",
+    limit: 2,
+    entityIds: ["interaction:workflow:vector-primary"],
+    nodeKinds: ["summary"],
+  });
+  assert.equal(interactionResults[0]?.nodeId, "semantic:interaction:vector-primary");
+
+  const treeId = "integration:github:vector-primary";
+  store.upsertIntegrationTree({
+    treeId,
+    provider: "github",
+    ownerUserId: "user-1",
+    accountKey: "vector-github",
+    accountLabel: "Vector GitHub",
+    slug: "github-vector-primary",
+    summary: "Vector GitHub memory.",
+    status: "active",
+  });
+  store.upsertIntegrationNodeEmbedding({
+    nodeKind: "summary",
+    nodeId: "semantic:integration:vector-primary",
+    treeId,
+    embeddingModel: "text-embedding-3-small",
+    contentFingerprint: "e".repeat(64),
+    dimensions: 1536,
+    vector: Array.from(primaryVector),
+  });
+  store.upsertIntegrationNodeEmbedding({
+    nodeKind: "summary",
+    nodeId: "semantic:integration:vector-secondary",
+    treeId,
+    embeddingModel: "text-embedding-3-small",
+    contentFingerprint: "f".repeat(64),
+    dimensions: 1536,
+    vector: Array.from(secondaryVector),
+  });
+
+  const integrationResults = store.searchIntegrationNodeEmbeddingsByVector({
+    embedding: primaryVector,
+    embeddingModel: "text-embedding-3-small",
+    limit: 2,
+    treeIds: [treeId],
+    nodeKinds: ["summary"],
+  });
+  assert.equal(integrationResults[0]?.nodeId, "semantic:integration:vector-primary");
+
+  const vecRowid = integrationResults[0]?.vecRowid ?? null;
+  store.deleteIntegrationTreeMemory({ treeId });
+  assert.equal(
+    store.searchIntegrationNodeEmbeddingsByVector({
+      embedding: primaryVector,
+      embeddingModel: "text-embedding-3-small",
+      limit: 2,
+      treeIds: [treeId],
+      nodeKinds: ["summary"],
+    }).length,
+    0,
+  );
+  if (vecRowid !== null) {
+    const db = new Database(store.controlPlaneDbPath, { readonly: true });
+    sqliteVec.load(db as unknown as { loadExtension(file: string, entrypoint?: string | undefined): void });
+    const remaining = Number(
+      (
+        db.prepare<[number], { count: number }>("SELECT COUNT(*) AS count FROM integration_node_embedding_vec WHERE vec_rowid = ?")
+          .get(vecRowid) as { count: number }
+      ).count,
+    );
+    db.close();
+    assert.equal(remaining, 0);
+  }
+
+  store.close();
+});
+
 test("app build status round trip supports upsert, lookup, and delete", () => {
   const root = makeTempDir("hb-state-store-");
   const store = new RuntimeStateStore({

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -571,6 +571,16 @@ export interface InteractionNodeEmbeddingRecord {
   updatedAt: string;
 }
 
+export interface InteractionNodeEmbeddingVectorSearchResult {
+  vecRowid: number;
+  distance: number;
+  workspaceId: string;
+  nodeKind: InteractionTreeChildKind;
+  nodeId: string;
+  entityId: string;
+  embeddingModel: string;
+}
+
 export interface IntegrationTreeRecord {
   treeId: string;
   provider: string;
@@ -622,6 +632,15 @@ export interface IntegrationNodeEmbeddingRecord {
   vector: number[];
   createdAt: string;
   updatedAt: string;
+}
+
+export interface IntegrationNodeEmbeddingVectorSearchResult {
+  vecRowid: number;
+  distance: number;
+  nodeKind: InteractionTreeChildKind;
+  nodeId: string;
+  treeId: string;
+  embeddingModel: string;
 }
 
 export interface SemanticMemoryNodeRecord {
@@ -6218,6 +6237,13 @@ export class RuntimeStateStore {
     if (!record) {
       throw new Error("interaction embedding row not found after upsert");
     }
+    this.replaceInteractionNodeEmbeddingVector({
+      workspaceId: params.workspaceId,
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+      embedding: new Float32Array(params.vector),
+    });
     return record;
   }
 
@@ -6241,6 +6267,159 @@ export class RuntimeStateStore {
       )
       .get(params.workspaceId, params.nodeKind, params.nodeId, params.embeddingModel);
     return row ? this.rowToInteractionNodeEmbedding(row) : null;
+  }
+
+  private interactionNodeEmbeddingRowid(params: {
+    workspaceId: string;
+    nodeKind: InteractionTreeChildKind;
+    nodeId: string;
+    embeddingModel: string;
+  }): number | null {
+    const row = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare<
+        [string, string, string, string],
+        { vec_rowid?: number | bigint | null }
+      >(
+        `
+          SELECT rowid AS vec_rowid
+          FROM interaction_node_embeddings
+          WHERE workspace_id = ?
+            AND node_kind = ?
+            AND node_id = ?
+            AND embedding_model = ?
+          LIMIT 1
+        `,
+      )
+      .get(params.workspaceId, params.nodeKind, params.nodeId, params.embeddingModel);
+    if (!row?.vec_rowid) {
+      return null;
+    }
+    return Number(row.vec_rowid);
+  }
+
+  replaceInteractionNodeEmbeddingVector(params: {
+    workspaceId: string;
+    nodeKind: InteractionTreeChildKind;
+    nodeId: string;
+    embeddingModel: string;
+    embedding: Float32Array;
+  }): void {
+    if (!this.#vectorIndexSupported || params.embedding.length !== 1536) {
+      return;
+    }
+    const record = this.getInteractionNodeEmbedding({
+      workspaceId: params.workspaceId,
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+    });
+    if (!record) {
+      return;
+    }
+    const vecRowid = this.interactionNodeEmbeddingRowid({
+      workspaceId: params.workspaceId,
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+    });
+    if (!Number.isFinite(vecRowid)) {
+      return;
+    }
+    const db = this.workspaceRuntimeDb(params.workspaceId);
+    db.prepare("DELETE FROM interaction_node_embedding_vec WHERE vec_rowid = ?").run(vecRowid);
+    db
+      .prepare(`
+        INSERT INTO interaction_node_embedding_vec (vec_rowid, embedding, entity_id, node_kind, embedding_model)
+        VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+      `)
+      .run(
+        vecRowid,
+        params.embedding,
+        record.entityId,
+        record.nodeKind,
+        record.embeddingModel,
+      );
+  }
+
+  private backfillInteractionNodeEmbeddingVectors(params: {
+    workspaceId: string;
+    embeddingModel: string;
+    entityIds?: string[] | null;
+    nodeKinds?: InteractionTreeChildKind[] | null;
+  }): void {
+    if (!this.#vectorIndexSupported) {
+      return;
+    }
+    const normalizedEntityIds = params.entityIds
+      ? [...new Set(params.entityIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    const normalizedNodeKinds = params.nodeKinds
+      ? [...new Set(params.nodeKinds.map((value) => value.trim()).filter(Boolean) as InteractionTreeChildKind[])]
+      : null;
+    const db = this.workspaceRuntimeDb(params.workspaceId);
+    let query = `
+      SELECT rowid AS vec_rowid, vector_json, entity_id, node_kind, embedding_model
+      FROM interaction_node_embeddings
+      WHERE workspace_id = ?
+        AND embedding_model = ?
+        AND dimensions = 1536
+    `;
+    const values: Array<string | number> = [params.workspaceId, params.embeddingModel];
+    if (normalizedEntityIds && normalizedEntityIds.length > 0) {
+      query += ` AND entity_id IN (${normalizedEntityIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedEntityIds);
+    }
+    if (normalizedNodeKinds && normalizedNodeKinds.length > 0) {
+      query += ` AND node_kind IN (${normalizedNodeKinds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeKinds);
+    }
+    const sourceRows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+    if (sourceRows.length === 0) {
+      return;
+    }
+    const rowIds = sourceRows
+      .map((row) => Number(row.vec_rowid))
+      .filter((value) => Number.isFinite(value));
+    if (rowIds.length === 0) {
+      return;
+    }
+    const existingRowIds = new Set<number>(
+      (
+        db.prepare(`
+          SELECT vec_rowid
+          FROM interaction_node_embedding_vec
+          WHERE vec_rowid IN (${rowIds.map(() => "?").join(", ")})
+        `).all(...rowIds) as Array<{ vec_rowid: number | bigint }>
+      )
+        .map((row) => Number(row.vec_rowid))
+        .filter((value) => Number.isFinite(value)),
+    );
+    const insert = db.prepare(`
+      INSERT INTO interaction_node_embedding_vec (vec_rowid, embedding, entity_id, node_kind, embedding_model)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+    `);
+    const insertMany = db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        const vecRowid = Number(row.vec_rowid);
+        if (!Number.isFinite(vecRowid) || existingRowIds.has(vecRowid)) {
+          continue;
+        }
+        const vector = this.parseJsonList(row.vector_json)
+          .map((value) => (typeof value === "number" ? value : Number(value)))
+          .filter((value) => Number.isFinite(value));
+        if (vector.length !== 1536) {
+          continue;
+        }
+        insert.run(
+          vecRowid,
+          new Float32Array(vector),
+          String(row.entity_id),
+          String(row.node_kind),
+          String(row.embedding_model),
+        );
+      }
+    });
+    insertMany(sourceRows);
   }
 
   listInteractionNodeEmbeddings(params: {
@@ -6284,6 +6463,99 @@ export class RuntimeStateStore {
     query += " ORDER BY updated_at DESC, created_at DESC, node_id ASC";
     const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToInteractionNodeEmbedding(row));
+  }
+
+  searchInteractionNodeEmbeddingsByVector(params: {
+    workspaceId: string;
+    embedding: Float32Array;
+    embeddingModel: string;
+    limit: number;
+    entityIds?: string[] | null;
+    nodeKinds?: InteractionTreeChildKind[] | null;
+  }): InteractionNodeEmbeddingVectorSearchResult[] {
+    if (!this.#vectorIndexSupported || params.embedding.length !== 1536) {
+      return [];
+    }
+    const normalizedLimit = Math.max(1, Math.trunc(params.limit));
+    const normalizedEntityIds = params.entityIds
+      ? [...new Set(params.entityIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    const normalizedNodeKinds = params.nodeKinds
+      ? [...new Set(params.nodeKinds.map((value) => value.trim()).filter(Boolean) as InteractionTreeChildKind[])]
+      : null;
+    this.backfillInteractionNodeEmbeddingVectors({
+      workspaceId: params.workspaceId,
+      embeddingModel: params.embeddingModel,
+      entityIds: normalizedEntityIds,
+      nodeKinds: normalizedNodeKinds,
+    });
+    let query = `
+      SELECT vec_rowid, distance
+      FROM interaction_node_embedding_vec
+      WHERE embedding MATCH ?
+        AND k = ?
+        AND embedding_model = ?
+    `;
+    const values: Array<string | number | Float32Array> = [params.embedding, normalizedLimit, params.embeddingModel];
+    if (normalizedEntityIds && normalizedEntityIds.length > 0) {
+      query += ` AND entity_id IN (${normalizedEntityIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedEntityIds);
+    }
+    if (normalizedNodeKinds && normalizedNodeKinds.length > 0) {
+      query += ` AND node_kind IN (${normalizedNodeKinds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeKinds);
+    }
+    const rows = this.workspaceRuntimeDb(params.workspaceId)
+      .prepare(query)
+      .all(...values) as Array<{ vec_rowid: number; distance: number }>;
+    return this.interactionEmbeddingVectorResultsForRows(params.workspaceId, rows);
+  }
+
+  private interactionEmbeddingVectorResultsForRows(
+    workspaceId: string,
+    rows: Array<{ vec_rowid: number; distance: number }>
+  ): InteractionNodeEmbeddingVectorSearchResult[] {
+    if (rows.length === 0) {
+      return [];
+    }
+    const rowIds = rows.map((row) => Number(row.vec_rowid)).filter((value) => Number.isFinite(value));
+    if (rowIds.length === 0) {
+      return [];
+    }
+    const db = this.workspaceRuntimeDb(workspaceId);
+    const mappingRows = db
+      .prepare(`
+        SELECT rowid AS vec_rowid, *
+        FROM interaction_node_embeddings
+        WHERE workspace_id = ?
+          AND rowid IN (${rowIds.map(() => "?").join(", ")})
+      `)
+      .all(workspaceId, ...rowIds) as Array<Record<string, unknown>>;
+    const byRowId = new Map<number, InteractionNodeEmbeddingRecord>();
+    for (const row of mappingRows) {
+      const vecRowid = Number(row.vec_rowid);
+      if (!Number.isFinite(vecRowid)) {
+        continue;
+      }
+      byRowId.set(vecRowid, this.rowToInteractionNodeEmbedding(row));
+    }
+    const results: InteractionNodeEmbeddingVectorSearchResult[] = [];
+    for (const row of rows) {
+      const mapping = byRowId.get(Number(row.vec_rowid));
+      if (!mapping) {
+        continue;
+      }
+      results.push({
+        vecRowid: Number(row.vec_rowid),
+        distance: Number(row.distance),
+        workspaceId: mapping.workspaceId,
+        nodeKind: mapping.nodeKind,
+        nodeId: mapping.nodeId,
+        entityId: mapping.entityId,
+        embeddingModel: mapping.embeddingModel,
+      });
+    }
+    return results;
   }
 
   upsertIntegrationTree(params: {
@@ -7114,6 +7386,7 @@ export class RuntimeStateStore {
     treeId?: string | null;
     treeIds?: string[] | null;
     nodeId?: string | null;
+    nodeIds?: string[] | null;
     nodeClass?: SemanticMemoryNodeClass | null;
     nodeKind?: string | null;
     status?: MemoryNodeStatus | null;
@@ -7123,7 +7396,13 @@ export class RuntimeStateStore {
     const normalizedTreeIds = params.treeIds
       ? [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))]
       : null;
+    const normalizedNodeIds = params.nodeIds
+      ? [...new Set(params.nodeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
     if (params.treeIds && normalizedTreeIds && normalizedTreeIds.length === 0) {
+      return [];
+    }
+    if (params.nodeIds && normalizedNodeIds && normalizedNodeIds.length === 0) {
       return [];
     }
     const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
@@ -7155,6 +7434,9 @@ export class RuntimeStateStore {
         query += " AND node_id = ?";
         values.push(params.nodeId);
       }
+    } else if (normalizedNodeIds) {
+      query += ` AND node_id IN (${normalizedNodeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeIds);
     }
     if (params.nodeClass !== undefined) {
       if (params.nodeClass === null) {
@@ -7638,11 +7920,30 @@ export class RuntimeStateStore {
           )
           .get(params.treeId) as { count?: number } | undefined)?.count ?? 0,
       );
+      const embeddingRowIds = (
+        db
+          .prepare<[string], { vec_rowid: number | bigint }>(
+            `
+              SELECT rowid AS vec_rowid
+              FROM integration_node_embeddings
+              WHERE tree_id = ?
+            `,
+          )
+          .all(params.treeId) as Array<{ vec_rowid: number | bigint }>
+      )
+        .map((row) => Number(row.vec_rowid))
+        .filter((value) => Number.isFinite(value));
 
       db.prepare(`
         DELETE FROM integration_node_embeddings
         WHERE tree_id = ?
       `).run(params.treeId);
+      if (this.#vectorIndexSupported && embeddingRowIds.length > 0) {
+        db.prepare(`
+          DELETE FROM integration_node_embedding_vec
+          WHERE vec_rowid IN (${embeddingRowIds.map(() => "?").join(", ")})
+        `).run(...embeddingRowIds);
+      }
       db.prepare(`
         DELETE FROM semantic_memory_search_fts
         WHERE category = 'integration' AND tree_id = ?
@@ -7748,6 +8049,12 @@ export class RuntimeStateStore {
     if (!record) {
       throw new Error("integration embedding row not found after upsert");
     }
+    this.replaceIntegrationNodeEmbeddingVector({
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+      embedding: new Float32Array(params.vector),
+    });
     return record;
   }
 
@@ -7769,6 +8076,152 @@ export class RuntimeStateStore {
       )
       .get(params.nodeKind, params.nodeId, params.embeddingModel);
     return row ? this.rowToIntegrationNodeEmbedding(row) : null;
+  }
+
+  private integrationNodeEmbeddingRowid(params: {
+    nodeKind: InteractionTreeChildKind;
+    nodeId: string;
+    embeddingModel: string;
+  }): number | null {
+    const row = this.controlPlaneDb()
+      .prepare<
+        [string, string, string],
+        { vec_rowid?: number | bigint | null }
+      >(
+        `
+          SELECT rowid AS vec_rowid
+          FROM integration_node_embeddings
+          WHERE node_kind = ?
+            AND node_id = ?
+            AND embedding_model = ?
+          LIMIT 1
+        `,
+      )
+      .get(params.nodeKind, params.nodeId, params.embeddingModel);
+    if (!row?.vec_rowid) {
+      return null;
+    }
+    return Number(row.vec_rowid);
+  }
+
+  replaceIntegrationNodeEmbeddingVector(params: {
+    nodeKind: InteractionTreeChildKind;
+    nodeId: string;
+    embeddingModel: string;
+    embedding: Float32Array;
+  }): void {
+    if (!this.#vectorIndexSupported || params.embedding.length !== 1536) {
+      return;
+    }
+    const record = this.getIntegrationNodeEmbedding({
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+    });
+    if (!record) {
+      return;
+    }
+    const vecRowid = this.integrationNodeEmbeddingRowid({
+      nodeKind: params.nodeKind,
+      nodeId: params.nodeId,
+      embeddingModel: params.embeddingModel,
+    });
+    if (!Number.isFinite(vecRowid)) {
+      return;
+    }
+    const db = this.controlPlaneDb();
+    db.prepare("DELETE FROM integration_node_embedding_vec WHERE vec_rowid = ?").run(vecRowid);
+    db
+      .prepare(`
+        INSERT INTO integration_node_embedding_vec (vec_rowid, embedding, tree_id, node_kind, embedding_model)
+        VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+      `)
+      .run(
+        vecRowid,
+        params.embedding,
+        record.treeId,
+        record.nodeKind,
+        record.embeddingModel,
+      );
+  }
+
+  private backfillIntegrationNodeEmbeddingVectors(params: {
+    embeddingModel: string;
+    treeIds?: string[] | null;
+    nodeKinds?: InteractionTreeChildKind[] | null;
+  }): void {
+    if (!this.#vectorIndexSupported) {
+      return;
+    }
+    const normalizedTreeIds = params.treeIds
+      ? [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    const normalizedNodeKinds = params.nodeKinds
+      ? [...new Set(params.nodeKinds.map((value) => value.trim()).filter(Boolean) as InteractionTreeChildKind[])]
+      : null;
+    const db = this.controlPlaneDb();
+    let query = `
+      SELECT rowid AS vec_rowid, vector_json, tree_id, node_kind, embedding_model
+      FROM integration_node_embeddings
+      WHERE embedding_model = ?
+        AND dimensions = 1536
+    `;
+    const values: Array<string | number> = [params.embeddingModel];
+    if (normalizedTreeIds && normalizedTreeIds.length > 0) {
+      query += ` AND tree_id IN (${normalizedTreeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedTreeIds);
+    }
+    if (normalizedNodeKinds && normalizedNodeKinds.length > 0) {
+      query += ` AND node_kind IN (${normalizedNodeKinds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeKinds);
+    }
+    const sourceRows = db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+    if (sourceRows.length === 0) {
+      return;
+    }
+    const rowIds = sourceRows
+      .map((row) => Number(row.vec_rowid))
+      .filter((value) => Number.isFinite(value));
+    if (rowIds.length === 0) {
+      return;
+    }
+    const existingRowIds = new Set<number>(
+      (
+        db.prepare(`
+          SELECT vec_rowid
+          FROM integration_node_embedding_vec
+          WHERE vec_rowid IN (${rowIds.map(() => "?").join(", ")})
+        `).all(...rowIds) as Array<{ vec_rowid: number | bigint }>
+      )
+        .map((row) => Number(row.vec_rowid))
+        .filter((value) => Number.isFinite(value)),
+    );
+    const insert = db.prepare(`
+      INSERT INTO integration_node_embedding_vec (vec_rowid, embedding, tree_id, node_kind, embedding_model)
+      VALUES (CAST(? AS INTEGER), ?, ?, ?, ?)
+    `);
+    const insertMany = db.transaction((items: Array<Record<string, unknown>>) => {
+      for (const row of items) {
+        const vecRowid = Number(row.vec_rowid);
+        if (!Number.isFinite(vecRowid) || existingRowIds.has(vecRowid)) {
+          continue;
+        }
+        const vector = this.parseJsonList(row.vector_json)
+          .map((value) => (typeof value === "number" ? value : Number(value)))
+          .filter((value) => Number.isFinite(value));
+        if (vector.length !== 1536) {
+          continue;
+        }
+        insert.run(
+          vecRowid,
+          new Float32Array(vector),
+          String(row.tree_id),
+          String(row.node_kind),
+          String(row.embedding_model),
+        );
+      }
+    });
+    insertMany(sourceRows);
   }
 
   listIntegrationNodeEmbeddings(params: {
@@ -7811,6 +8264,94 @@ export class RuntimeStateStore {
     query += " ORDER BY updated_at DESC, created_at DESC, node_id ASC";
     const rows = this.controlPlaneDb().prepare(query).all(...values) as Array<Record<string, unknown>>;
     return rows.map((row) => this.rowToIntegrationNodeEmbedding(row));
+  }
+
+  searchIntegrationNodeEmbeddingsByVector(params: {
+    embedding: Float32Array;
+    embeddingModel: string;
+    limit: number;
+    treeIds?: string[] | null;
+    nodeKinds?: InteractionTreeChildKind[] | null;
+  }): IntegrationNodeEmbeddingVectorSearchResult[] {
+    if (!this.#vectorIndexSupported || params.embedding.length !== 1536) {
+      return [];
+    }
+    const normalizedLimit = Math.max(1, Math.trunc(params.limit));
+    const normalizedTreeIds = params.treeIds
+      ? [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    const normalizedNodeKinds = params.nodeKinds
+      ? [...new Set(params.nodeKinds.map((value) => value.trim()).filter(Boolean) as InteractionTreeChildKind[])]
+      : null;
+    this.backfillIntegrationNodeEmbeddingVectors({
+      embeddingModel: params.embeddingModel,
+      treeIds: normalizedTreeIds,
+      nodeKinds: normalizedNodeKinds,
+    });
+    let query = `
+      SELECT vec_rowid, distance
+      FROM integration_node_embedding_vec
+      WHERE embedding MATCH ?
+        AND k = ?
+        AND embedding_model = ?
+    `;
+    const values: Array<string | number | Float32Array> = [params.embedding, normalizedLimit, params.embeddingModel];
+    if (normalizedTreeIds && normalizedTreeIds.length > 0) {
+      query += ` AND tree_id IN (${normalizedTreeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedTreeIds);
+    }
+    if (normalizedNodeKinds && normalizedNodeKinds.length > 0) {
+      query += ` AND node_kind IN (${normalizedNodeKinds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeKinds);
+    }
+    const rows = this.controlPlaneDb()
+      .prepare(query)
+      .all(...values) as Array<{ vec_rowid: number; distance: number }>;
+    return this.integrationEmbeddingVectorResultsForRows(rows);
+  }
+
+  private integrationEmbeddingVectorResultsForRows(
+    rows: Array<{ vec_rowid: number; distance: number }>
+  ): IntegrationNodeEmbeddingVectorSearchResult[] {
+    if (rows.length === 0) {
+      return [];
+    }
+    const rowIds = rows.map((row) => Number(row.vec_rowid)).filter((value) => Number.isFinite(value));
+    if (rowIds.length === 0) {
+      return [];
+    }
+    const db = this.controlPlaneDb();
+    const mappingRows = db
+      .prepare(`
+        SELECT rowid AS vec_rowid, *
+        FROM integration_node_embeddings
+        WHERE rowid IN (${rowIds.map(() => "?").join(", ")})
+      `)
+      .all(...rowIds) as Array<Record<string, unknown>>;
+    const byRowId = new Map<number, IntegrationNodeEmbeddingRecord>();
+    for (const row of mappingRows) {
+      const vecRowid = Number(row.vec_rowid);
+      if (!Number.isFinite(vecRowid)) {
+        continue;
+      }
+      byRowId.set(vecRowid, this.rowToIntegrationNodeEmbedding(row));
+    }
+    const results: IntegrationNodeEmbeddingVectorSearchResult[] = [];
+    for (const row of rows) {
+      const mapping = byRowId.get(Number(row.vec_rowid));
+      if (!mapping) {
+        continue;
+      }
+      results.push({
+        vecRowid: Number(row.vec_rowid),
+        distance: Number(row.distance),
+        nodeKind: mapping.nodeKind,
+        nodeId: mapping.nodeId,
+        treeId: mapping.treeId,
+        embeddingModel: mapping.embeddingModel,
+      });
+    }
+    return results;
   }
 
   getMemoryEmbeddingIndexByMemoryId(params: {
@@ -10496,6 +11037,17 @@ export class RuntimeStateStore {
     this.ensureIntegrationLeavesTableSchema(db);
     this.ensureSemanticMemoryTableSchema({ db, workspaceScoped: false });
     this.ensureSemanticMemorySearchTableSchema({ db, workspaceScoped: false });
+    if (this.#vectorIndexSupported) {
+      db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS integration_node_embedding_vec USING vec0(
+            vec_rowid INTEGER PRIMARY KEY,
+            embedding float[1536],
+            tree_id TEXT,
+            node_kind TEXT,
+            embedding_model TEXT
+        );
+      `);
+    }
     this.migrateIntegrationConnectionIdentityColumns(db);
     this.migrateAppCatalogProviderColumns(db);
   }
@@ -11193,6 +11745,17 @@ export class RuntimeStateStore {
     this.ensureConversationBindingsTableSchema(db);
     this.ensureSemanticMemoryTableSchema({ db, workspaceScoped: true });
     this.ensureSemanticMemorySearchTableSchema({ db, workspaceScoped: true });
+    if (this.#vectorIndexSupported) {
+      db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS interaction_node_embedding_vec USING vec0(
+            vec_rowid INTEGER PRIMARY KEY,
+            embedding float[1536],
+            entity_id TEXT,
+            node_kind TEXT,
+            embedding_model TEXT
+        );
+      `);
+    }
     this.migrateLegacyMainSessionLabels(db);
     this.ensureSubagentRunsTableSchema(db);
     this.ensureSessionRuntimeStateTableSchema(db);

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -6247,7 +6247,14 @@ export class RuntimeStateStore {
     workspaceId: string;
     entityId?: string | null;
     embeddingModel?: string | null;
+    nodeIds?: string[] | null;
   }): InteractionNodeEmbeddingRecord[] {
+    const normalizedNodeIds = params.nodeIds
+      ? [...new Set(params.nodeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    if (params.nodeIds && normalizedNodeIds && normalizedNodeIds.length === 0) {
+      return [];
+    }
     let query = `
       SELECT *
       FROM interaction_node_embeddings
@@ -6269,6 +6276,10 @@ export class RuntimeStateStore {
         query += " AND embedding_model = ?";
         values.push(params.embeddingModel);
       }
+    }
+    if (normalizedNodeIds) {
+      query += ` AND node_id IN (${normalizedNodeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeIds);
     }
     query += " ORDER BY updated_at DESC, created_at DESC, node_id ASC";
     const rows = this.workspaceRuntimeDb(params.workspaceId).prepare(query).all(...values) as Array<Record<string, unknown>>;
@@ -7101,6 +7112,7 @@ export class RuntimeStateStore {
     category: SemanticMemoryCategory;
     workspaceId?: string | null;
     treeId?: string | null;
+    treeIds?: string[] | null;
     nodeId?: string | null;
     nodeClass?: SemanticMemoryNodeClass | null;
     nodeKind?: string | null;
@@ -7108,6 +7120,12 @@ export class RuntimeStateStore {
     limit?: number;
     offset?: number;
   }): SemanticMemorySearchDocRecord[] {
+    const normalizedTreeIds = params.treeIds
+      ? [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    if (params.treeIds && normalizedTreeIds && normalizedTreeIds.length === 0) {
+      return [];
+    }
     const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
     let query = `
       SELECT *
@@ -7119,7 +7137,10 @@ export class RuntimeStateStore {
       query += " AND workspace_id = ?";
       values.push(scope.workspaceId);
     }
-    if (params.treeId !== undefined) {
+    if (normalizedTreeIds) {
+      query += ` AND tree_id IN (${normalizedTreeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedTreeIds);
+    } else if (params.treeId !== undefined) {
       if (params.treeId === null) {
         query += " AND tree_id IS NULL";
       } else {
@@ -7173,6 +7194,7 @@ export class RuntimeStateStore {
     workspaceId?: string | null;
     matchQuery: string;
     treeId?: string | null;
+    treeIds?: string[] | null;
     nodeClass?: SemanticMemoryNodeClass | null;
     nodeKind?: string | null;
     status?: MemoryNodeStatus | null;
@@ -7181,6 +7203,12 @@ export class RuntimeStateStore {
   }): SemanticMemorySearchHitRecord[] {
     const matchQuery = params.matchQuery.trim();
     if (!matchQuery) {
+      return [];
+    }
+    const normalizedTreeIds = params.treeIds
+      ? [...new Set(params.treeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    if (params.treeIds && normalizedTreeIds && normalizedTreeIds.length === 0) {
       return [];
     }
     const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
@@ -7197,7 +7225,10 @@ export class RuntimeStateStore {
     }
     query += " AND category = ?";
     values.push(params.category);
-    if (params.treeId !== undefined) {
+    if (normalizedTreeIds) {
+      query += ` AND tree_id IN (${normalizedTreeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedTreeIds);
+    } else if (params.treeId !== undefined) {
       if (params.treeId === null) {
         query += " AND tree_id IS NULL";
       } else {
@@ -7743,7 +7774,14 @@ export class RuntimeStateStore {
   listIntegrationNodeEmbeddings(params: {
     treeId?: string | null;
     embeddingModel?: string | null;
+    nodeIds?: string[] | null;
   } = {}): IntegrationNodeEmbeddingRecord[] {
+    const normalizedNodeIds = params.nodeIds
+      ? [...new Set(params.nodeIds.map((value) => value.trim()).filter(Boolean))]
+      : null;
+    if (params.nodeIds && normalizedNodeIds && normalizedNodeIds.length === 0) {
+      return [];
+    }
     let query = `
       SELECT *
       FROM integration_node_embeddings
@@ -7765,6 +7803,10 @@ export class RuntimeStateStore {
         query += " AND embedding_model = ?";
         values.push(params.embeddingModel);
       }
+    }
+    if (normalizedNodeIds) {
+      query += ` AND node_id IN (${normalizedNodeIds.map(() => "?").join(", ")})`;
+      values.push(...normalizedNodeIds);
     }
     query += " ORDER BY updated_at DESC, created_at DESC, node_id ASC";
     const rows = this.controlPlaneDb().prepare(query).all(...values) as Array<Record<string, unknown>>;

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -7138,6 +7138,302 @@ export class RuntimeStateStore {
     });
   }
 
+  syncSemanticMemoryTree(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+    nodes: Array<{
+      nodeId: string;
+      nodeClass: SemanticMemoryNodeClass;
+      nodeKind: string;
+      sourceLeafId?: string | null;
+      path: string;
+      title: string;
+      summary: string;
+      bodySha256: string;
+      childCount?: number;
+      observedAt?: string | null;
+      status?: MemoryNodeStatus;
+      isMaterialized?: boolean;
+      metadata?: Record<string, unknown> | null;
+      createdAt?: string;
+      updatedAt?: string;
+    }>;
+    edges: Array<{
+      parentNodeId: string;
+      childNodeId: string;
+      position: number;
+      createdAt?: string;
+    }>;
+  }): SemanticMemoryNodeRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    const sync = scope.db.transaction(() => {
+      const now = utcNowIso();
+      const existingNodes = this.listSemanticMemoryNodes({
+        category: params.category,
+        workspaceId: scope.workspaceId,
+        treeId: params.treeId,
+        limit: 10_000,
+        offset: 0,
+      });
+      const existingNodesById = new Map(existingNodes.map((node) => [node.nodeId, node]));
+      const desiredNodeIds = new Set(params.nodes.map((node) => node.nodeId));
+      const upsertNode = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            INSERT INTO semantic_memory_nodes (
+              workspace_id,
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              source_leaf_id,
+              path,
+              title,
+              summary,
+              body_sha256,
+              child_count,
+              observed_at,
+              status,
+              is_materialized,
+              metadata,
+              created_at,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(workspace_id, category, tree_id, node_id) DO UPDATE SET
+              node_class = excluded.node_class,
+              node_kind = excluded.node_kind,
+              source_leaf_id = excluded.source_leaf_id,
+              path = excluded.path,
+              title = excluded.title,
+              summary = excluded.summary,
+              body_sha256 = excluded.body_sha256,
+              child_count = excluded.child_count,
+              observed_at = excluded.observed_at,
+              status = excluded.status,
+              is_materialized = excluded.is_materialized,
+              metadata = excluded.metadata,
+              updated_at = excluded.updated_at
+          `)
+        : scope.db.prepare(`
+            INSERT INTO semantic_memory_nodes (
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              source_leaf_id,
+              path,
+              title,
+              summary,
+              body_sha256,
+              child_count,
+              observed_at,
+              status,
+              is_materialized,
+              metadata,
+              created_at,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(category, tree_id, node_id) DO UPDATE SET
+              node_class = excluded.node_class,
+              node_kind = excluded.node_kind,
+              source_leaf_id = excluded.source_leaf_id,
+              path = excluded.path,
+              title = excluded.title,
+              summary = excluded.summary,
+              body_sha256 = excluded.body_sha256,
+              child_count = excluded.child_count,
+              observed_at = excluded.observed_at,
+              status = excluded.status,
+              is_materialized = excluded.is_materialized,
+              metadata = excluded.metadata,
+              updated_at = excluded.updated_at
+          `);
+      for (const node of params.nodes) {
+        const existing = existingNodesById.get(node.nodeId) ?? null;
+        if (existing && this.semanticMemoryNodeMatches(existing, node)) {
+          continue;
+        }
+        const createdAt = existing?.createdAt ?? node.createdAt ?? now;
+        const updatedAt = node.updatedAt ?? now;
+        const metadataJson = JSON.stringify(node.metadata ?? {});
+        if (scope.workspaceId !== null) {
+          upsertNode.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            node.nodeId,
+            node.nodeClass,
+            node.nodeKind,
+            node.sourceLeafId ?? null,
+            node.path,
+            node.title,
+            node.summary,
+            node.bodySha256,
+            node.childCount ?? 0,
+            node.observedAt ?? null,
+            node.status ?? "active",
+            node.isMaterialized ? 1 : 0,
+            metadataJson,
+            createdAt,
+            updatedAt,
+          );
+          continue;
+        }
+        upsertNode.run(
+          params.category,
+          params.treeId,
+          node.nodeId,
+          node.nodeClass,
+          node.nodeKind,
+          node.sourceLeafId ?? null,
+          node.path,
+          node.title,
+          node.summary,
+          node.bodySha256,
+          node.childCount ?? 0,
+          node.observedAt ?? null,
+          node.status ?? "active",
+          node.isMaterialized ? 1 : 0,
+          metadataJson,
+          createdAt,
+          updatedAt,
+        );
+      }
+
+      const existingEdges = this.listAllSemanticMemoryEdgesForTree({
+        category: params.category,
+        workspaceId: scope.workspaceId,
+        treeId: params.treeId,
+      });
+      const existingEdgesByParent = new Map<string, SemanticMemoryContainmentEdgeRecord[]>();
+      for (const edge of existingEdges) {
+        const bucket = existingEdgesByParent.get(edge.parentNodeId);
+        if (bucket) {
+          bucket.push(edge);
+        } else {
+          existingEdgesByParent.set(edge.parentNodeId, [edge]);
+        }
+      }
+      const desiredEdgesByParent = new Map<string, Array<{
+        parentNodeId: string;
+        childNodeId: string;
+        position: number;
+        createdAt?: string;
+      }>>();
+      for (const edge of params.edges) {
+        const bucket = desiredEdgesByParent.get(edge.parentNodeId);
+        if (bucket) {
+          bucket.push(edge);
+        } else {
+          desiredEdgesByParent.set(edge.parentNodeId, [edge]);
+        }
+      }
+      const deleteParentEdges = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            DELETE FROM semantic_memory_edges
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND parent_node_id = ?
+          `)
+        : scope.db.prepare(`
+            DELETE FROM semantic_memory_edges
+            WHERE category = ? AND tree_id = ? AND parent_node_id = ?
+          `);
+      const insertEdge = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            INSERT INTO semantic_memory_edges (
+              workspace_id,
+              category,
+              tree_id,
+              parent_node_id,
+              child_node_id,
+              position,
+              created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+          `)
+        : scope.db.prepare(`
+            INSERT INTO semantic_memory_edges (
+              category,
+              tree_id,
+              parent_node_id,
+              child_node_id,
+              position,
+              created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+          `);
+      const parentIds = new Set([
+        ...existingEdgesByParent.keys(),
+        ...desiredEdgesByParent.keys(),
+      ]);
+      for (const parentNodeId of parentIds) {
+        const existingBucket = [...(existingEdgesByParent.get(parentNodeId) ?? [])]
+          .sort((left, right) => left.position - right.position || left.childNodeId.localeCompare(right.childNodeId));
+        const desiredBucket = [...(desiredEdgesByParent.get(parentNodeId) ?? [])]
+          .sort((left, right) => left.position - right.position || left.childNodeId.localeCompare(right.childNodeId));
+        if (this.semanticMemoryEdgesMatch(existingBucket, desiredBucket)) {
+          continue;
+        }
+        if (scope.workspaceId !== null) {
+          deleteParentEdges.run(scope.workspaceId, params.category, params.treeId, parentNodeId);
+        } else {
+          deleteParentEdges.run(params.category, params.treeId, parentNodeId);
+        }
+        for (const edge of desiredBucket) {
+          const existingEdge = existingBucket.find((candidate) => candidate.childNodeId === edge.childNodeId) ?? null;
+          const createdAt = existingEdge?.createdAt ?? edge.createdAt ?? now;
+          if (scope.workspaceId !== null) {
+            insertEdge.run(
+              scope.workspaceId,
+              params.category,
+              params.treeId,
+              edge.parentNodeId,
+              edge.childNodeId,
+              edge.position,
+              createdAt,
+            );
+            continue;
+          }
+          insertEdge.run(
+            params.category,
+            params.treeId,
+            edge.parentNodeId,
+            edge.childNodeId,
+            edge.position,
+            createdAt,
+          );
+        }
+      }
+
+      const deleteNode = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            DELETE FROM semantic_memory_nodes
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND node_id = ?
+          `)
+        : scope.db.prepare(`
+            DELETE FROM semantic_memory_nodes
+            WHERE category = ? AND tree_id = ? AND node_id = ?
+          `);
+      for (const node of existingNodes) {
+        if (desiredNodeIds.has(node.nodeId)) {
+          continue;
+        }
+        if (scope.workspaceId !== null) {
+          deleteNode.run(scope.workspaceId, params.category, params.treeId, node.nodeId);
+        } else {
+          deleteNode.run(params.category, params.treeId, node.nodeId);
+        }
+      }
+    });
+    sync();
+    return this.listSemanticMemoryNodes({
+      category: params.category,
+      workspaceId: scope.workspaceId,
+      treeId: params.treeId,
+      status: "active",
+      limit: Math.max(200, params.nodes.length + 10),
+    });
+  }
+
   replaceSemanticMemorySearchDocs(params: {
     category: SemanticMemoryCategory;
     workspaceId?: string | null;
@@ -7338,6 +7634,260 @@ export class RuntimeStateStore {
       }
     });
     replace();
+    return this.listSemanticMemorySearchDocs({
+      category: params.category,
+      workspaceId: scope.workspaceId,
+      treeId: params.treeId,
+      status: "active",
+      limit: Math.max(200, params.docs.length + 10),
+    });
+  }
+
+  syncSemanticMemorySearchDocs(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+    docs: Array<{
+      nodeId: string;
+      nodeClass: SemanticMemoryNodeClass;
+      nodeKind: string;
+      path: string;
+      childCount?: number;
+      title: string;
+      summary: string;
+      bodyText: string;
+      excerpt?: string | null;
+      observedAt?: string | null;
+      status?: MemoryNodeStatus;
+      updatedAt?: string;
+    }>;
+  }): SemanticMemorySearchDocRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    const sync = scope.db.transaction(() => {
+      const now = utcNowIso();
+      const existingDocs = this.listSemanticMemorySearchDocs({
+        category: params.category,
+        workspaceId: scope.workspaceId,
+        treeId: params.treeId,
+        limit: 10_000,
+        offset: 0,
+      });
+      const existingDocsById = new Map(existingDocs.map((doc) => [doc.nodeId, doc]));
+      const desiredNodeIds = new Set(params.docs.map((doc) => doc.nodeId));
+      const upsertDoc = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            INSERT INTO semantic_memory_search_docs (
+              workspace_id,
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              path,
+              child_count,
+              title,
+              summary,
+              body_text,
+              excerpt,
+              observed_at,
+              status,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(workspace_id, category, tree_id, node_id) DO UPDATE SET
+              node_class = excluded.node_class,
+              node_kind = excluded.node_kind,
+              path = excluded.path,
+              child_count = excluded.child_count,
+              title = excluded.title,
+              summary = excluded.summary,
+              body_text = excluded.body_text,
+              excerpt = excluded.excerpt,
+              observed_at = excluded.observed_at,
+              status = excluded.status,
+              updated_at = excluded.updated_at
+          `)
+        : scope.db.prepare(`
+            INSERT INTO semantic_memory_search_docs (
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              path,
+              child_count,
+              title,
+              summary,
+              body_text,
+              excerpt,
+              observed_at,
+              status,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(category, tree_id, node_id) DO UPDATE SET
+              node_class = excluded.node_class,
+              node_kind = excluded.node_kind,
+              path = excluded.path,
+              child_count = excluded.child_count,
+              title = excluded.title,
+              summary = excluded.summary,
+              body_text = excluded.body_text,
+              excerpt = excluded.excerpt,
+              observed_at = excluded.observed_at,
+              status = excluded.status,
+              updated_at = excluded.updated_at
+          `);
+      const deleteDoc = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            DELETE FROM semantic_memory_search_docs
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND node_id = ?
+          `)
+        : scope.db.prepare(`
+            DELETE FROM semantic_memory_search_docs
+            WHERE category = ? AND tree_id = ? AND node_id = ?
+          `);
+      const deleteFtsByNode = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            DELETE FROM semantic_memory_search_fts
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND node_id = ?
+          `)
+        : scope.db.prepare(`
+            DELETE FROM semantic_memory_search_fts
+            WHERE category = ? AND tree_id = ? AND node_id = ?
+          `);
+      const insertFts = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            INSERT INTO semantic_memory_search_fts (
+              workspace_id,
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              path,
+              child_count,
+              title,
+              summary,
+              body_text,
+              excerpt,
+              observed_at,
+              status,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `)
+        : scope.db.prepare(`
+            INSERT INTO semantic_memory_search_fts (
+              category,
+              tree_id,
+              node_id,
+              node_class,
+              node_kind,
+              path,
+              child_count,
+              title,
+              summary,
+              body_text,
+              excerpt,
+              observed_at,
+              status,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `);
+      for (const existing of existingDocs) {
+        if (desiredNodeIds.has(existing.nodeId)) {
+          continue;
+        }
+        if (scope.workspaceId !== null) {
+          deleteDoc.run(scope.workspaceId, params.category, params.treeId, existing.nodeId);
+          deleteFtsByNode.run(scope.workspaceId, params.category, params.treeId, existing.nodeId);
+        } else {
+          deleteDoc.run(params.category, params.treeId, existing.nodeId);
+          deleteFtsByNode.run(params.category, params.treeId, existing.nodeId);
+        }
+      }
+      for (const doc of params.docs) {
+        const existing = existingDocsById.get(doc.nodeId) ?? null;
+        if (existing && this.semanticMemorySearchDocMatches(existing, doc)) {
+          continue;
+        }
+        const updatedAt = doc.updatedAt ?? now;
+        const childCount = doc.childCount ?? 0;
+        const excerpt = doc.excerpt ?? null;
+        const observedAt = doc.observedAt ?? null;
+        const status = doc.status ?? "active";
+        if (scope.workspaceId !== null) {
+          upsertDoc.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            doc.nodeId,
+            doc.nodeClass,
+            doc.nodeKind,
+            doc.path,
+            childCount,
+            doc.title,
+            doc.summary,
+            doc.bodyText,
+            excerpt,
+            observedAt,
+            status,
+            updatedAt,
+          );
+          deleteFtsByNode.run(scope.workspaceId, params.category, params.treeId, doc.nodeId);
+          insertFts.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            doc.nodeId,
+            doc.nodeClass,
+            doc.nodeKind,
+            doc.path,
+            childCount,
+            doc.title,
+            doc.summary,
+            doc.bodyText,
+            excerpt,
+            observedAt,
+            status,
+            updatedAt,
+          );
+          continue;
+        }
+        upsertDoc.run(
+          params.category,
+          params.treeId,
+          doc.nodeId,
+          doc.nodeClass,
+          doc.nodeKind,
+          doc.path,
+          childCount,
+          doc.title,
+          doc.summary,
+          doc.bodyText,
+          excerpt,
+          observedAt,
+          status,
+          updatedAt,
+        );
+        deleteFtsByNode.run(params.category, params.treeId, doc.nodeId);
+        insertFts.run(
+          params.category,
+          params.treeId,
+          doc.nodeId,
+          doc.nodeClass,
+          doc.nodeKind,
+          doc.path,
+          childCount,
+          doc.title,
+          doc.summary,
+          doc.bodyText,
+          excerpt,
+          observedAt,
+          status,
+          updatedAt,
+        );
+      }
+    });
+    sync();
     return this.listSemanticMemorySearchDocs({
       category: params.category,
       workspaceId: scope.workspaceId,
@@ -7793,6 +8343,145 @@ export class RuntimeStateStore {
       }
     });
     replace();
+    return this.listSemanticMemoryRelations({
+      category: params.category,
+      workspaceId: scope.workspaceId,
+      treeId: params.treeId,
+      limit: Math.max(200, params.relations.length + 10),
+    });
+  }
+
+  syncSemanticMemoryRelations(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+    relations: Array<{
+      fromNodeId: string;
+      toNodeId: string;
+      relationType: string;
+      metadata?: Record<string, unknown> | null;
+      createdAt?: string;
+      updatedAt?: string;
+    }>;
+  }): SemanticMemoryRelationRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    const sync = scope.db.transaction(() => {
+      const now = utcNowIso();
+      const existingRelations = this.listSemanticMemoryRelations({
+        category: params.category,
+        workspaceId: scope.workspaceId,
+        treeId: params.treeId,
+        limit: 10_000,
+        offset: 0,
+      });
+      const existingByKey = new Map(existingRelations.map((relation) => [
+        `${relation.fromNodeId}|${relation.toNodeId}|${relation.relationType}`,
+        relation,
+      ]));
+      const desiredKeys = new Set(
+        params.relations.map((relation) => `${relation.fromNodeId}|${relation.toNodeId}|${relation.relationType}`),
+      );
+      const deleteRelation = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            DELETE FROM semantic_memory_relations
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND from_node_id = ? AND to_node_id = ? AND relation_type = ?
+          `)
+        : scope.db.prepare(`
+            DELETE FROM semantic_memory_relations
+            WHERE category = ? AND tree_id = ? AND from_node_id = ? AND to_node_id = ? AND relation_type = ?
+          `);
+      for (const existing of existingRelations) {
+        const key = `${existing.fromNodeId}|${existing.toNodeId}|${existing.relationType}`;
+        if (desiredKeys.has(key)) {
+          continue;
+        }
+        if (scope.workspaceId !== null) {
+          deleteRelation.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            existing.fromNodeId,
+            existing.toNodeId,
+            existing.relationType,
+          );
+        } else {
+          deleteRelation.run(
+            params.category,
+            params.treeId,
+            existing.fromNodeId,
+            existing.toNodeId,
+            existing.relationType,
+          );
+        }
+      }
+      const upsertRelation = scope.workspaceId !== null
+        ? scope.db.prepare(`
+            INSERT INTO semantic_memory_relations (
+              workspace_id,
+              category,
+              tree_id,
+              from_node_id,
+              to_node_id,
+              relation_type,
+              metadata,
+              created_at,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(workspace_id, category, tree_id, from_node_id, to_node_id, relation_type) DO UPDATE SET
+              metadata = excluded.metadata,
+              updated_at = excluded.updated_at
+          `)
+        : scope.db.prepare(`
+            INSERT INTO semantic_memory_relations (
+              category,
+              tree_id,
+              from_node_id,
+              to_node_id,
+              relation_type,
+              metadata,
+              created_at,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(category, tree_id, from_node_id, to_node_id, relation_type) DO UPDATE SET
+              metadata = excluded.metadata,
+              updated_at = excluded.updated_at
+          `);
+      for (const relation of params.relations) {
+        const key = `${relation.fromNodeId}|${relation.toNodeId}|${relation.relationType}`;
+        const existing = existingByKey.get(key) ?? null;
+        if (existing && this.semanticMemoryRelationMatches(existing, relation)) {
+          continue;
+        }
+        const createdAt = existing?.createdAt ?? relation.createdAt ?? now;
+        const updatedAt = relation.updatedAt ?? now;
+        const metadataJson = JSON.stringify(relation.metadata ?? {});
+        if (scope.workspaceId !== null) {
+          upsertRelation.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            relation.fromNodeId,
+            relation.toNodeId,
+            relation.relationType,
+            metadataJson,
+            createdAt,
+            updatedAt,
+          );
+          continue;
+        }
+        upsertRelation.run(
+          params.category,
+          params.treeId,
+          relation.fromNodeId,
+          relation.toNodeId,
+          relation.relationType,
+          metadataJson,
+          createdAt,
+          updatedAt,
+        );
+      }
+    });
+    sync();
     return this.listSemanticMemoryRelations({
       category: params.category,
       workspaceId: scope.workspaceId,
@@ -13782,6 +14471,123 @@ export class RuntimeStateStore {
       createdAt: String(row.created_at),
       updatedAt: String(row.updated_at),
     };
+  }
+
+  private listAllSemanticMemoryEdgesForTree(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+  }): SemanticMemoryContainmentEdgeRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    if (scope.workspaceId !== null) {
+      const rows = scope.db
+        .prepare<[string, string, string], Record<string, unknown>>(
+          `
+            SELECT *
+            FROM semantic_memory_edges
+            WHERE workspace_id = ? AND category = ? AND tree_id = ?
+            ORDER BY parent_node_id ASC, position ASC, child_node_id ASC
+          `,
+        )
+        .all(scope.workspaceId, params.category, params.treeId) as Array<Record<string, unknown>>;
+      return rows.map((row) => this.rowToSemanticMemoryContainmentEdge(row));
+    }
+    const rows = scope.db
+      .prepare<[string, string], Record<string, unknown>>(
+        `
+          SELECT *
+          FROM semantic_memory_edges
+          WHERE category = ? AND tree_id = ?
+          ORDER BY parent_node_id ASC, position ASC, child_node_id ASC
+        `,
+      )
+      .all(params.category, params.treeId) as Array<Record<string, unknown>>;
+    return rows.map((row) => this.rowToSemanticMemoryContainmentEdge(row));
+  }
+
+  private semanticMemoryNodeMatches(
+    existing: SemanticMemoryNodeRecord,
+    desired: {
+      nodeClass: SemanticMemoryNodeClass;
+      nodeKind: string;
+      sourceLeafId?: string | null;
+      path: string;
+      title: string;
+      summary: string;
+      bodySha256: string;
+      childCount?: number;
+      observedAt?: string | null;
+      status?: MemoryNodeStatus;
+      isMaterialized?: boolean;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): boolean {
+    return existing.nodeClass === desired.nodeClass
+      && existing.nodeKind === desired.nodeKind
+      && existing.sourceLeafId === (desired.sourceLeafId ?? null)
+      && existing.path === desired.path
+      && existing.title === desired.title
+      && existing.summary === desired.summary
+      && existing.bodySha256 === desired.bodySha256
+      && existing.childCount === (desired.childCount ?? 0)
+      && existing.observedAt === (desired.observedAt ?? null)
+      && existing.status === (desired.status ?? "active")
+      && existing.isMaterialized === Boolean(desired.isMaterialized)
+      && JSON.stringify(existing.metadata ?? {}) === JSON.stringify(desired.metadata ?? {});
+  }
+
+  private semanticMemoryEdgesMatch(
+    existing: SemanticMemoryContainmentEdgeRecord[],
+    desired: Array<{ childNodeId: string; position: number }>
+  ): boolean {
+    if (existing.length !== desired.length) {
+      return false;
+    }
+    for (let index = 0; index < existing.length; index += 1) {
+      if (existing[index]?.childNodeId !== desired[index]?.childNodeId) {
+        return false;
+      }
+      if (existing[index]?.position !== desired[index]?.position) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private semanticMemorySearchDocMatches(
+    existing: SemanticMemorySearchDocRecord,
+    desired: {
+      nodeClass: SemanticMemoryNodeClass;
+      nodeKind: string;
+      path: string;
+      childCount?: number;
+      title: string;
+      summary: string;
+      bodyText: string;
+      excerpt?: string | null;
+      observedAt?: string | null;
+      status?: MemoryNodeStatus;
+    },
+  ): boolean {
+    return existing.nodeClass === desired.nodeClass
+      && existing.nodeKind === desired.nodeKind
+      && existing.path === desired.path
+      && existing.childCount === (desired.childCount ?? 0)
+      && existing.title === desired.title
+      && existing.summary === desired.summary
+      && existing.bodyText === desired.bodyText
+      && existing.excerpt === (desired.excerpt ?? null)
+      && existing.observedAt === (desired.observedAt ?? null)
+      && existing.status === (desired.status ?? "active");
+  }
+
+  private semanticMemoryRelationMatches(
+    existing: SemanticMemoryRelationRecord,
+    desired: {
+      metadata?: Record<string, unknown> | null;
+    },
+  ): boolean {
+    return JSON.stringify(existing.metadata ?? {}) === JSON.stringify(desired.metadata ?? {});
   }
 
   private rowToSemanticMemoryNode(row: Record<string, unknown>): SemanticMemoryNodeRecord {

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -667,6 +667,28 @@ export interface SemanticMemoryRelationRecord {
   updatedAt: string;
 }
 
+export interface SemanticMemorySearchDocRecord {
+  workspaceId: string | null;
+  category: SemanticMemoryCategory;
+  treeId: string;
+  nodeId: string;
+  nodeClass: SemanticMemoryNodeClass;
+  nodeKind: string;
+  path: string;
+  childCount: number;
+  title: string;
+  summary: string;
+  bodyText: string;
+  excerpt: string | null;
+  observedAt: string | null;
+  status: MemoryNodeStatus;
+  updatedAt: string;
+}
+
+export interface SemanticMemorySearchHitRecord extends SemanticMemorySearchDocRecord {
+  bm25Score: number;
+}
+
 export interface OutputFolderRecord {
   id: string;
   workspaceId: string;
@@ -6833,6 +6855,389 @@ export class RuntimeStateStore {
     });
   }
 
+  replaceSemanticMemorySearchDocs(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+    docs: Array<{
+      nodeId: string;
+      nodeClass: SemanticMemoryNodeClass;
+      nodeKind: string;
+      path: string;
+      childCount?: number;
+      title: string;
+      summary: string;
+      bodyText: string;
+      excerpt?: string | null;
+      observedAt?: string | null;
+      status?: MemoryNodeStatus;
+      updatedAt?: string;
+    }>;
+  }): SemanticMemorySearchDocRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    const replace = scope.db.transaction(() => {
+      const now = utcNowIso();
+      if (scope.workspaceId !== null) {
+        scope.db.prepare(`
+          DELETE FROM semantic_memory_search_docs
+          WHERE workspace_id = ? AND category = ? AND tree_id = ?
+        `).run(scope.workspaceId, params.category, params.treeId);
+        scope.db.prepare(`
+          DELETE FROM semantic_memory_search_fts
+          WHERE workspace_id = ? AND category = ? AND tree_id = ?
+        `).run(scope.workspaceId, params.category, params.treeId);
+
+        const insertDoc = scope.db.prepare(`
+          INSERT INTO semantic_memory_search_docs (
+            workspace_id,
+            category,
+            tree_id,
+            node_id,
+            node_class,
+            node_kind,
+            path,
+            child_count,
+            title,
+            summary,
+            body_text,
+            excerpt,
+            observed_at,
+            status,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        const insertFts = scope.db.prepare(`
+          INSERT INTO semantic_memory_search_fts (
+            workspace_id,
+            category,
+            tree_id,
+            node_id,
+            node_class,
+            node_kind,
+            path,
+            child_count,
+            title,
+            summary,
+            body_text,
+            excerpt,
+            observed_at,
+            status,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const doc of params.docs) {
+          const updatedAt = doc.updatedAt ?? now;
+          const childCount = doc.childCount ?? 0;
+          const excerpt = doc.excerpt ?? null;
+          const observedAt = doc.observedAt ?? null;
+          const status = doc.status ?? "active";
+          insertDoc.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            doc.nodeId,
+            doc.nodeClass,
+            doc.nodeKind,
+            doc.path,
+            childCount,
+            doc.title,
+            doc.summary,
+            doc.bodyText,
+            excerpt,
+            observedAt,
+            status,
+            updatedAt,
+          );
+          insertFts.run(
+            scope.workspaceId,
+            params.category,
+            params.treeId,
+            doc.nodeId,
+            doc.nodeClass,
+            doc.nodeKind,
+            doc.path,
+            childCount,
+            doc.title,
+            doc.summary,
+            doc.bodyText,
+            excerpt,
+            observedAt,
+            status,
+            updatedAt,
+          );
+        }
+        return;
+      }
+
+      scope.db.prepare(`
+        DELETE FROM semantic_memory_search_docs
+        WHERE category = ? AND tree_id = ?
+      `).run(params.category, params.treeId);
+      scope.db.prepare(`
+        DELETE FROM semantic_memory_search_fts
+        WHERE category = ? AND tree_id = ?
+      `).run(params.category, params.treeId);
+
+      const insertDoc = scope.db.prepare(`
+        INSERT INTO semantic_memory_search_docs (
+          category,
+          tree_id,
+          node_id,
+          node_class,
+          node_kind,
+          path,
+          child_count,
+          title,
+          summary,
+          body_text,
+          excerpt,
+          observed_at,
+          status,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      const insertFts = scope.db.prepare(`
+        INSERT INTO semantic_memory_search_fts (
+          category,
+          tree_id,
+          node_id,
+          node_class,
+          node_kind,
+          path,
+          child_count,
+          title,
+          summary,
+          body_text,
+          excerpt,
+          observed_at,
+          status,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const doc of params.docs) {
+        const updatedAt = doc.updatedAt ?? now;
+        const childCount = doc.childCount ?? 0;
+        const excerpt = doc.excerpt ?? null;
+        const observedAt = doc.observedAt ?? null;
+        const status = doc.status ?? "active";
+        insertDoc.run(
+          params.category,
+          params.treeId,
+          doc.nodeId,
+          doc.nodeClass,
+          doc.nodeKind,
+          doc.path,
+          childCount,
+          doc.title,
+          doc.summary,
+          doc.bodyText,
+          excerpt,
+          observedAt,
+          status,
+          updatedAt,
+        );
+        insertFts.run(
+          params.category,
+          params.treeId,
+          doc.nodeId,
+          doc.nodeClass,
+          doc.nodeKind,
+          doc.path,
+          childCount,
+          doc.title,
+          doc.summary,
+          doc.bodyText,
+          excerpt,
+          observedAt,
+          status,
+          updatedAt,
+        );
+      }
+    });
+    replace();
+    return this.listSemanticMemorySearchDocs({
+      category: params.category,
+      workspaceId: scope.workspaceId,
+      treeId: params.treeId,
+      status: "active",
+      limit: Math.max(200, params.docs.length + 10),
+    });
+  }
+
+  getSemanticMemorySearchDoc(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId: string;
+    nodeId: string;
+  }): SemanticMemorySearchDocRecord | null {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    if (scope.workspaceId !== null) {
+      const row = scope.db
+        .prepare<[string, string, string, string], Record<string, unknown>>(
+          `
+            SELECT *
+            FROM semantic_memory_search_docs
+            WHERE workspace_id = ? AND category = ? AND tree_id = ? AND node_id = ?
+            LIMIT 1
+          `,
+        )
+        .get(scope.workspaceId, params.category, params.treeId, params.nodeId);
+      return row ? this.rowToSemanticMemorySearchDoc(row) : null;
+    }
+    const row = scope.db
+      .prepare<[string, string, string], Record<string, unknown>>(
+        `
+          SELECT *
+          FROM semantic_memory_search_docs
+          WHERE category = ? AND tree_id = ? AND node_id = ?
+          LIMIT 1
+        `,
+      )
+      .get(params.category, params.treeId, params.nodeId);
+    return row ? this.rowToSemanticMemorySearchDoc(row) : null;
+  }
+
+  listSemanticMemorySearchDocs(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    treeId?: string | null;
+    nodeId?: string | null;
+    nodeClass?: SemanticMemoryNodeClass | null;
+    nodeKind?: string | null;
+    status?: MemoryNodeStatus | null;
+    limit?: number;
+    offset?: number;
+  }): SemanticMemorySearchDocRecord[] {
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    let query = `
+      SELECT *
+      FROM semantic_memory_search_docs
+      WHERE category = ?
+    `;
+    const values: Array<string | number> = [params.category];
+    if (scope.workspaceId !== null) {
+      query += " AND workspace_id = ?";
+      values.push(scope.workspaceId);
+    }
+    if (params.treeId !== undefined) {
+      if (params.treeId === null) {
+        query += " AND tree_id IS NULL";
+      } else {
+        query += " AND tree_id = ?";
+        values.push(params.treeId);
+      }
+    }
+    if (params.nodeId !== undefined) {
+      if (params.nodeId === null) {
+        query += " AND node_id IS NULL";
+      } else {
+        query += " AND node_id = ?";
+        values.push(params.nodeId);
+      }
+    }
+    if (params.nodeClass !== undefined) {
+      if (params.nodeClass === null) {
+        query += " AND node_class IS NULL";
+      } else {
+        query += " AND node_class = ?";
+        values.push(params.nodeClass);
+      }
+    }
+    if (params.nodeKind !== undefined) {
+      if (params.nodeKind === null) {
+        query += " AND node_kind IS NULL";
+      } else {
+        query += " AND node_kind = ?";
+        values.push(params.nodeKind);
+      }
+    }
+    if (params.status !== undefined) {
+      if (params.status === null) {
+        query += " AND status IS NULL";
+      } else {
+        query += " AND status = ?";
+        values.push(params.status);
+      }
+    }
+    query += `
+      ORDER BY updated_at DESC, path ASC, node_id ASC
+      LIMIT ? OFFSET ?
+    `;
+    values.push(params.limit ?? 500, params.offset ?? 0);
+    const rows = scope.db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+    return rows.map((row) => this.rowToSemanticMemorySearchDoc(row));
+  }
+
+  searchSemanticMemorySearchDocs(params: {
+    category: SemanticMemoryCategory;
+    workspaceId?: string | null;
+    matchQuery: string;
+    treeId?: string | null;
+    nodeClass?: SemanticMemoryNodeClass | null;
+    nodeKind?: string | null;
+    status?: MemoryNodeStatus | null;
+    limit?: number;
+    offset?: number;
+  }): SemanticMemorySearchHitRecord[] {
+    const matchQuery = params.matchQuery.trim();
+    if (!matchQuery) {
+      return [];
+    }
+    const scope = this.resolveSemanticMemoryScope(params.category, params.workspaceId ?? null);
+    let query = `
+      SELECT *,
+             bm25(semantic_memory_search_fts, 4.0, 2.0, 1.0) AS bm25_score
+      FROM semantic_memory_search_fts
+      WHERE semantic_memory_search_fts MATCH ?
+    `;
+    const values: Array<string | number> = [matchQuery];
+    if (scope.workspaceId !== null) {
+      query += " AND workspace_id = ?";
+      values.push(scope.workspaceId);
+    }
+    query += " AND category = ?";
+    values.push(params.category);
+    if (params.treeId !== undefined) {
+      if (params.treeId === null) {
+        query += " AND tree_id IS NULL";
+      } else {
+        query += " AND tree_id = ?";
+        values.push(params.treeId);
+      }
+    }
+    if (params.nodeClass !== undefined) {
+      if (params.nodeClass === null) {
+        query += " AND node_class IS NULL";
+      } else {
+        query += " AND node_class = ?";
+        values.push(params.nodeClass);
+      }
+    }
+    if (params.nodeKind !== undefined) {
+      if (params.nodeKind === null) {
+        query += " AND node_kind IS NULL";
+      } else {
+        query += " AND node_kind = ?";
+        values.push(params.nodeKind);
+      }
+    }
+    if (params.status !== undefined) {
+      if (params.status === null) {
+        query += " AND status IS NULL";
+      } else {
+        query += " AND status = ?";
+        values.push(params.status);
+      }
+    }
+    query += `
+      ORDER BY bm25_score ASC, updated_at DESC, path ASC, node_id ASC
+      LIMIT ? OFFSET ?
+    `;
+    values.push(params.limit ?? 100, params.offset ?? 0);
+    const rows = scope.db.prepare(query).all(...values) as Array<Record<string, unknown>>;
+    return rows.map((row) => this.rowToSemanticMemorySearchHit(row));
+  }
+
   getSemanticMemoryNode(params: {
     category: SemanticMemoryCategory;
     workspaceId?: string | null;
@@ -7145,6 +7550,7 @@ export class RuntimeStateStore {
     deletedSemanticNodes: number;
     deletedSemanticEdges: number;
     deletedSemanticRelations: number;
+    deletedSemanticSearchDocs: number;
     deletedEmbeddings: number;
   } {
     const db = this.controlPlaneDb();
@@ -7190,10 +7596,25 @@ export class RuntimeStateStore {
           )
           .get(params.treeId) as { count?: number } | undefined)?.count ?? 0,
       );
+      const deletedSemanticSearchDocs = Number(
+        (db
+          .prepare(
+            `
+              SELECT COUNT(*) AS count
+              FROM semantic_memory_search_docs
+              WHERE category = 'integration' AND tree_id = ?
+            `,
+          )
+          .get(params.treeId) as { count?: number } | undefined)?.count ?? 0,
+      );
 
       db.prepare(`
         DELETE FROM integration_node_embeddings
         WHERE tree_id = ?
+      `).run(params.treeId);
+      db.prepare(`
+        DELETE FROM semantic_memory_search_fts
+        WHERE category = 'integration' AND tree_id = ?
       `).run(params.treeId);
       db.prepare(`
         DELETE FROM semantic_memory_edges
@@ -7205,6 +7626,10 @@ export class RuntimeStateStore {
       `).run(params.treeId);
       db.prepare(`
         DELETE FROM semantic_memory_nodes
+        WHERE category = 'integration' AND tree_id = ?
+      `).run(params.treeId);
+      db.prepare(`
+        DELETE FROM semantic_memory_search_docs
         WHERE category = 'integration' AND tree_id = ?
       `).run(params.treeId);
       db.prepare(`
@@ -7221,12 +7646,14 @@ export class RuntimeStateStore {
           || deletedSemanticNodes > 0
           || deletedSemanticRelations > 0
           || deletedSemanticEdges > 0
+          || deletedSemanticSearchDocs > 0
           || deletedEmbeddings > 0,
         deletedTree,
         deletedLeaves,
         deletedSemanticNodes,
         deletedSemanticEdges,
         deletedSemanticRelations,
+        deletedSemanticSearchDocs,
         deletedEmbeddings,
       };
     });
@@ -10026,6 +10453,7 @@ export class RuntimeStateStore {
     this.ensureMemoryEmbeddingIndexSchema(db);
     this.ensureIntegrationLeavesTableSchema(db);
     this.ensureSemanticMemoryTableSchema({ db, workspaceScoped: false });
+    this.ensureSemanticMemorySearchTableSchema({ db, workspaceScoped: false });
     this.migrateIntegrationConnectionIdentityColumns(db);
     this.migrateAppCatalogProviderColumns(db);
   }
@@ -10722,6 +11150,7 @@ export class RuntimeStateStore {
     this.ensureSessionMessagesTableSchema(db);
     this.ensureConversationBindingsTableSchema(db);
     this.ensureSemanticMemoryTableSchema({ db, workspaceScoped: true });
+    this.ensureSemanticMemorySearchTableSchema({ db, workspaceScoped: true });
     this.migrateLegacyMainSessionLabels(db);
     this.ensureSubagentRunsTableSchema(db);
     this.ensureSessionRuntimeStateTableSchema(db);
@@ -10885,6 +11314,61 @@ export class RuntimeStateStore {
 
       CREATE INDEX IF NOT EXISTS idx_semantic_memory_relations_tree_from_type
           ON semantic_memory_relations (${workspaceIdPrefix}category, tree_id, from_node_id, relation_type, updated_at DESC);
+    `);
+  }
+
+  private ensureSemanticMemorySearchTableSchema(params: {
+    db: Database.Database;
+    workspaceScoped: boolean;
+  }): void {
+    const prefix = params.workspaceScoped
+      ? `
+          workspace_id TEXT NOT NULL,
+      `
+      : "";
+    const workspaceIdPrefix = params.workspaceScoped ? "workspace_id, " : "";
+    params.db.exec(`
+      CREATE TABLE IF NOT EXISTS semantic_memory_search_docs (
+          ${prefix}category TEXT NOT NULL,
+          tree_id TEXT NOT NULL,
+          node_id TEXT NOT NULL,
+          node_class TEXT NOT NULL,
+          node_kind TEXT NOT NULL,
+          path TEXT NOT NULL,
+          child_count INTEGER NOT NULL DEFAULT 0,
+          title TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          body_text TEXT NOT NULL,
+          excerpt TEXT,
+          observed_at TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (${workspaceIdPrefix}category, tree_id, node_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_semantic_memory_search_docs_tree_status
+          ON semantic_memory_search_docs (${workspaceIdPrefix}category, tree_id, status, updated_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_semantic_memory_search_docs_tree_kind
+          ON semantic_memory_search_docs (${workspaceIdPrefix}category, tree_id, node_class, node_kind, updated_at DESC);
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS semantic_memory_search_fts USING fts5(
+          ${params.workspaceScoped ? "workspace_id UNINDEXED,\n" : ""}category UNINDEXED,
+          tree_id UNINDEXED,
+          node_id UNINDEXED,
+          node_class UNINDEXED,
+          node_kind UNINDEXED,
+          path UNINDEXED,
+          child_count UNINDEXED,
+          title,
+          summary,
+          body_text,
+          excerpt UNINDEXED,
+          observed_at UNINDEXED,
+          status UNINDEXED,
+          updated_at UNINDEXED,
+          tokenize = 'unicode61 remove_diacritics 2'
+      );
     `);
   }
 
@@ -12715,6 +13199,37 @@ export class RuntimeStateStore {
       metadata: this.parseJsonDict(row.metadata),
       createdAt: String(row.created_at),
       updatedAt: String(row.updated_at),
+    };
+  }
+
+  private rowToSemanticMemorySearchDoc(
+    row: Record<string, unknown>,
+  ): SemanticMemorySearchDocRecord {
+    return {
+      workspaceId: row.workspace_id == null ? null : String(row.workspace_id),
+      category: String(row.category) as SemanticMemoryCategory,
+      treeId: String(row.tree_id),
+      nodeId: String(row.node_id),
+      nodeClass: String(row.node_class) as SemanticMemoryNodeClass,
+      nodeKind: String(row.node_kind),
+      path: String(row.path),
+      childCount: Number(row.child_count ?? 0),
+      title: String(row.title),
+      summary: String(row.summary),
+      bodyText: String(row.body_text ?? ""),
+      excerpt: row.excerpt == null ? null : String(row.excerpt),
+      observedAt: row.observed_at == null ? null : String(row.observed_at),
+      status: String(row.status) as MemoryNodeStatus,
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private rowToSemanticMemorySearchHit(
+    row: Record<string, unknown>,
+  ): SemanticMemorySearchHitRecord {
+    return {
+      ...this.rowToSemanticMemorySearchDoc(row),
+      bm25Score: Number(row.bm25_score),
     };
   }
 


### PR DESCRIPTION
## Context

This branch upgrades the workspace memory backend around retrieval quality, rebuild cost, and integration synchronization behavior.

## What Changed

- add hybrid semantic retrieval built on FTS/BM25-style lexical indexing plus vector candidate search for interaction and integration memory
- narrow retrieval to bounded candidate pools, remove hot-path markdown reads, and replace full embedding scans with vector-side top-k lookup
- incrementalize semantic tree rebuilds with subtree reuse, partial tree patching, and targeted search-doc / relation syncing instead of full rewrites
- debounce interaction rebuild work into a background queue and skip unchanged integration summary rebuilds after provider syncs
- add store and runtime coverage for the new retrieval, patching, rebuild, and integration scheduling behavior
- remove superseded experimental retrieval modules now replaced by the tree-native hybrid path

## Validation

- `bun --filter=@holaboss/runtime-state-store run typecheck`
- `bun --filter=@holaboss/runtime-api-server run typecheck`
- `node --import tsx --test --test-force-exit src/store.test.ts`
- `node --import tsx --test --test-force-exit src/interaction-memory.test.ts src/integration-memory.test.ts`
- `node --import tsx --test --test-force-exit src/turn-memory-writeback.test.ts`
- `node --import tsx --test --test-force-exit src/integration-context-fetch.test.ts src/integration-context-fetch-manager.test.ts src/integration-memory.test.ts`

## Notes

- local Node test execution required `npm rebuild better-sqlite3` before the integration fetch test suite because of a native module ABI mismatch
