### PR TITLE
feat(desktop): push integration updates via Composio SSE channel

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8224,6 +8224,7 @@ function emitAuthAuthenticated(user: AuthUserPayload) {
   for (const listener of gatewayAuthCallbackListeners) {
     listener();
   }
+  startComposioEventsSubscription();
 }
 
 function emitAuthUserUpdated(user: AuthUserPayload | null) {
@@ -8242,6 +8243,9 @@ function emitAuthUserUpdated(user: AuthUserPayload | null) {
     for (const listener of gatewayAuthCallbackListeners) {
       listener();
     }
+    startComposioEventsSubscription();
+  } else {
+    stopComposioEventsSubscription();
   }
 }
 
@@ -16309,6 +16313,103 @@ function emitSessionStreamEvent(payload: HolabossSessionStreamEventPayload) {
   }
 }
 
+// Hono fans out Composio webhook events (composio.connected_account.*) on
+// a per-user SSE channel. Subscribing here turns OAuth-completion latency
+// from "next 60s heartbeat or focus tick in useIntegrationBinding" into
+// "Composio fires webhook → ~50ms network → renderer refresh".
+let composioEventsAbort: AbortController | null = null;
+let composioEventsRetryTimer: NodeJS.Timeout | null = null;
+let composioEventsBackoffMs = 1000;
+const COMPOSIO_EVENTS_BACKOFF_MAX_MS = 30_000;
+
+function emitIntegrationUpdated(payload: unknown) {
+  const windows = BrowserWindow.getAllWindows().filter(
+    (win) => !win.isDestroyed(),
+  );
+  for (const win of windows) {
+    try {
+      win.webContents.send("integration:updated", payload);
+    } catch {
+      // renderer destroyed between filter and send — ignore.
+    }
+  }
+}
+
+function startComposioEventsSubscription() {
+  if (composioEventsAbort) return;
+  if (!AUTH_BASE_URL) return;
+  const cookie = authCookieHeader();
+  if (!cookie) return;
+
+  const controller = new AbortController();
+  composioEventsAbort = controller;
+
+  void (async () => {
+    try {
+      const url = `${AUTH_BASE_URL.replace(/\/+$/, "")}/api/composio/events`;
+      const response = await fetch(url, {
+        headers: {
+          Accept: "text/event-stream",
+          "Cache-Control": "no-cache",
+          Cookie: cookie,
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`composio events stream ${response.status}`);
+      }
+      composioEventsBackoffMs = 1000;
+      const stream = Readable.fromWeb(
+        response.body as unknown as Parameters<typeof Readable.fromWeb>[0],
+      );
+      for await (const event of iterSseEvents(stream)) {
+        if (controller.signal.aborted) break;
+        let parsed: unknown = event.data;
+        try {
+          parsed = JSON.parse(event.data);
+        } catch {
+          continue;
+        }
+        emitIntegrationUpdated(parsed);
+      }
+    } catch (error) {
+      if ((error as { name?: string })?.name === "AbortError") return;
+      // fall through to reconnect
+    }
+    if (composioEventsAbort === controller) {
+      composioEventsAbort = null;
+      if (!controller.signal.aborted) {
+        scheduleComposioEventsReconnect();
+      }
+    }
+  })();
+}
+
+function scheduleComposioEventsReconnect() {
+  if (composioEventsRetryTimer) return;
+  const delay = composioEventsBackoffMs;
+  composioEventsBackoffMs = Math.min(
+    delay * 2,
+    COMPOSIO_EVENTS_BACKOFF_MAX_MS,
+  );
+  composioEventsRetryTimer = setTimeout(() => {
+    composioEventsRetryTimer = null;
+    startComposioEventsSubscription();
+  }, delay);
+}
+
+function stopComposioEventsSubscription() {
+  if (composioEventsRetryTimer) {
+    clearTimeout(composioEventsRetryTimer);
+    composioEventsRetryTimer = null;
+  }
+  if (composioEventsAbort) {
+    composioEventsAbort.abort();
+    composioEventsAbort = null;
+  }
+  composioEventsBackoffMs = 1000;
+}
+
 async function openSessionOutputStream(
   payload: HolabossStreamSessionOutputsPayload,
 ): Promise<HolabossSessionStreamHandlePayload> {
@@ -17165,6 +17266,7 @@ async function ensureAppQuitCleanup(): Promise<void> {
   if (appQuitCleanupFinished) {
     return;
   }
+  stopComposioEventsSubscription();
   if (!appQuitCleanupPromise) {
     // Block the final Electron quit until embedded services have been torn down.
     appQuitCleanupPromise = Promise.allSettled([

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1782,6 +1782,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
       return () => ipcRenderer.removeListener("auth:error", wrapped);
     }
   },
+  integration: {
+    onUpdated: (listener: (payload: unknown) => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, payload: unknown) => listener(payload);
+      ipcRenderer.on("integration:updated", wrapped);
+      return () => ipcRenderer.removeListener("integration:updated", wrapped);
+    },
+  },
   tabs: {
     showContextMenu: (opts: {
       canCloseLeft: boolean;

--- a/apps/desktop/src/lib/useIntegrationBinding.ts
+++ b/apps/desktop/src/lib/useIntegrationBinding.ts
@@ -182,6 +182,19 @@ export function useIntegrationBinding({
     return () => clearInterval(id);
   }, [selectedWorkspaceId, trimmedProvider, trimmedAppId, refresh]);
 
+  // Push path: main subscribes to Hono's per-user Composio SSE channel
+  // (composio.connected_account.* webhooks). When Composio flips a
+  // connection ACTIVE on their side, we refresh in ~50ms — not on the
+  // next heartbeat or focus tick.
+  useEffect(() => {
+    if (!selectedWorkspaceId || !trimmedProvider || !trimmedAppId) return;
+    const unsubscribe = window.electronAPI.integration.onUpdated(() => {
+      void refresh();
+    });
+    return unsubscribe;
+  }, [selectedWorkspaceId, trimmedProvider, trimmedAppId, refresh]);
+
+
   // The running app captured HOLABOSS_APP_GRANT at boot in its bridge
   // transport. Any bind change is invisible until the app process cycles —
   // unconditional restart is cheaper than diffing.

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -2224,6 +2224,9 @@ interface RuntimeNotificationListOptionsPayload {
       onUserUpdated: (callback: (user: AuthUserPayload | null) => unknown) => () => void;
       onError: (callback: (context: AuthErrorPayload) => unknown) => () => void;
     };
+    integration: {
+      onUpdated: (listener: (payload: unknown) => void) => () => void;
+    };
     tabs: {
       showContextMenu: (opts: {
         canCloseLeft: boolean;


### PR DESCRIPTION
## Summary
- Subscribes the Electron main process to Hono's per-user `/api/composio/events` SSE stream once the user is authenticated.
- Fans out `integration:updated` to all renderer windows over IPC.
- `useIntegrationBinding` re-runs `refresh()` when that signal arrives, so OAuth completions surface in ~50ms instead of waiting for the next 8s heartbeat.

Closes the "Integration 链接从 composio 回来还要等很久（avg 1 min)" Notion task.

## Test plan
- [ ] Sign in on desktop, connect a Composio integration (e.g. Notion) from the marketplace flow.
- [ ] After completing OAuth in the browser, confirm the integration status flips to active in under 1s without manually focusing the window.
- [ ] Sign out, confirm the SSE subscription stops (no further `integration:updated` traffic).
- [ ] Kill the SSE stream server-side, confirm the main process reconnects with backoff (1s → 30s cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)