### PR TITLE
fix(new-shell): route link clicks inside markdown file previews

### DIFF
--- a/apps/desktop/src/components/layout/new-shell/FilePreviewPane.tsx
+++ b/apps/desktop/src/components/layout/new-shell/FilePreviewPane.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { useWorkspaceSelection } from "@/lib/workspaceSelection";
 import { fileNameFromPath } from "./state/internalTabs";
 import { removeRecentFileByPathAtom } from "./state/recentFiles";
+import { useOpenWorkspaceOutput } from "./useOpenWorkspaceOutput";
 
 interface FilePreviewPaneProps {
   filePath: string;
@@ -230,6 +231,7 @@ function MarkdownEditor({ preview, workspaceId, onUpdated }: EditorSurfaceProps)
     workspaceId,
     onUpdated,
   );
+  const { openUrlInBrowserTab, openFileInInternalTab } = useOpenWorkspaceOutput();
   const editable = preview.isEditable;
 
   return (
@@ -257,6 +259,8 @@ function MarkdownEditor({ preview, workspaceId, onUpdated }: EditorSurfaceProps)
             onChange={setDraft}
             readOnly={!editable}
             placeholder="Press / for commands…"
+            onLinkClick={(url) => void openUrlInBrowserTab(url)}
+            onLocalLinkClick={openFileInInternalTab}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -8135,6 +8135,7 @@ export function ChatPane({
             <SimpleMarkdown
               className="chat-markdown chat-assistant-markdown max-w-full text-foreground"
               onLinkClick={onOpenLinkInBrowser}
+              onLocalLinkClick={onOpenLocalLink}
             >
               {alignmentReportMarkdown}
             </SimpleMarkdown>
@@ -8231,6 +8232,7 @@ export function ChatPane({
             <SimpleMarkdown
               className="chat-markdown chat-assistant-markdown max-w-full text-foreground"
               onLinkClick={onOpenLinkInBrowser}
+              onLocalLinkClick={onOpenLocalLink}
             >
               {verificationReportMarkdown}
             </SimpleMarkdown>

--- a/apps/desktop/src/components/panes/InternalSurfacePane.tsx
+++ b/apps/desktop/src/components/panes/InternalSurfacePane.tsx
@@ -777,6 +777,8 @@ export function InternalSurfacePane({
                 readOnly={!preview.isEditable}
                 placeholder="Press / for commands…"
                 className="min-h-0 flex-1"
+                onLinkClick={openPreviewLink}
+                onLocalLinkClick={handleLocalLinkInPreview}
               />
             )
           ) : isHtmlPreview && textPreviewMode === "preview" ? (

--- a/sdk/editor/src/MarkdownEditor.tsx
+++ b/sdk/editor/src/MarkdownEditor.tsx
@@ -63,6 +63,18 @@ const bubbleShouldShow: NonNullable<BubbleMenuProps["shouldShow"]> = ({
 // matters later we can swap to a hand-picked subset.
 const lowlight = createLowlight(common);
 
+function normalizeHttpUrl(rawHref: string): string | null {
+  try {
+    const parsed = new URL(rawHref);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 export interface MarkdownEditorProps {
   /** The markdown source. Treated as the controlled value. */
   value: string;
@@ -78,6 +90,10 @@ export interface MarkdownEditorProps {
   className?: string;
   /** Notified once when the editor instance is created. Useful for parent toolbars. */
   onReady?: (editor: Editor) => void;
+  /** Called when the user clicks an http(s) link inside the editor. */
+  onLinkClick?: (url: string) => void;
+  /** Called when the user clicks a non-http link (relative path, file://, etc). */
+  onLocalLinkClick?: (href: string) => void;
 }
 
 export interface MarkdownEditorRef {
@@ -104,11 +120,25 @@ export const MarkdownEditor = forwardRef<
   MarkdownEditorRef,
   MarkdownEditorProps
 >(function MarkdownEditor(
-  { value, onChange, placeholder, readOnly = false, autoFocus, className, onReady },
+  {
+    value,
+    onChange,
+    placeholder,
+    readOnly = false,
+    autoFocus,
+    className,
+    onReady,
+    onLinkClick,
+    onLocalLinkClick,
+  },
   ref,
 ) {
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const onLinkClickRef = useRef(onLinkClick);
+  onLinkClickRef.current = onLinkClick;
+  const onLocalLinkClickRef = useRef(onLocalLinkClick);
+  onLocalLinkClickRef.current = onLocalLinkClick;
 
   const extensions = useMemo(
     () => [
@@ -167,6 +197,31 @@ export const MarkdownEditor = forwardRef<
     contentType: "markdown",
     editable: !readOnly,
     autofocus: autoFocus ?? false,
+    editorProps: {
+      handleDOMEvents: {
+        click: (_view, event) => {
+          const target = event.target as HTMLElement | null;
+          const anchor = target?.closest?.("a");
+          if (!anchor) return false;
+          const rawHref = (anchor.getAttribute("href") ?? "").trim();
+          if (!rawHref) return false;
+          const normalized = normalizeHttpUrl(rawHref);
+          if (normalized) {
+            const cb = onLinkClickRef.current;
+            if (!cb) return false;
+            event.preventDefault();
+            cb(normalized);
+            return true;
+          }
+          if (rawHref.startsWith("#")) return false;
+          const cb = onLocalLinkClickRef.current;
+          if (!cb) return false;
+          event.preventDefault();
+          cb(rawHref);
+          return true;
+        },
+      },
+    },
     onUpdate({ editor }) {
       onChangeRef.current?.(editor.getMarkdown());
     },


### PR DESCRIPTION
## Summary
- `@holaboss/editor` Tiptap `MarkdownEditor` was configured with `openOnClick: false` and no callback, so anchor clicks inside an opened `.md` file did nothing.
- Adds `onLinkClick` / `onLocalLinkClick` props to the editor (a ProseMirror `handleDOMEvents.click` interceptor classifies the href).
- Wires the new shell's `FilePreviewPane` markdown surface to `useOpenWorkspaceOutput`, so external links open as browser tabs and relative paths open as internal file tabs.
- Mirrors the same wiring in the legacy `InternalSurfacePane` edit mode for parity.
- Adds `onLocalLinkClick` to the alignment / verification report `SimpleMarkdown` blocks in `ChatPane` (pre-existing gap).

Closes the "也需要检查一下新版 layout 点击文件中的链接（外部和内部）会不会正确跳转" Notion task.

## Test plan
- [ ] Open a `.md` file with both http(s) and relative links in the new shell — confirm external opens a browser tab and relative opens an internal file tab.
- [ ] Same in legacy `InternalSurfacePane` Edit mode.
- [ ] In chat, click a relative link inside an alignment / verification report — confirm it opens an internal file tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)