### PR TITLE
fix(new-shell): move CC close to top-right + restore window drag & Windows controls

### DIFF
--- a/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
+++ b/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
@@ -8,6 +8,7 @@ import { PublishScreen } from "@/components/publish/PublishScreen";
 import { WorkspaceOnboardingSurface } from "@/features/workspace-onboarding/WorkspaceOnboardingSurface";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
 import { useControlCenterCardSignals } from "@/lib/controlCenterLifecycle";
+import { useDesktopPlatform } from "@/lib/desktopPlatform";
 import { cn } from "@/lib/utils";
 import {
   useWorkspaceDesktop,
@@ -36,6 +37,7 @@ import {
 } from "./state/ui";
 import { TopChrome } from "./TopChrome";
 import { useChatLayout } from "./useChatLayout";
+import { WindowControls } from "./WindowControls";
 
 export function NewAppShell() {
   return (
@@ -212,18 +214,34 @@ function ControlCenterTakeover(props: {
     visibleWorkspaceIdsRef.current,
     true,
   );
+  const platform = useDesktopPlatform();
+  const isWin = platform === "win32";
 
   return (
-    <div className="relative flex min-w-0 flex-1 flex-col bg-background">
-      <button
-        type="button"
-        aria-label="Close all workspaces"
-        title="Close (Esc / ⌘0)"
-        onClick={props.onClose}
-        className="window-no-drag absolute top-3 left-3 z-10 grid size-7 place-items-center rounded-md text-foreground/55 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+    <div className="flex min-w-0 flex-1 flex-col bg-background">
+      {/* Mini top bar: drag region (so the frameless window remains
+          movable now that TopChrome is hidden) + close at top-right.
+          We pin close to the right because macOS traffic lights own the
+          top-left corner. On Windows the platform caption controls sit
+          flush right, with the CC close button just to their left. */}
+      <div
+        className={cn(
+          "window-drag flex h-10 shrink-0 items-center",
+          isWin ? "pr-0" : "pr-2",
+        )}
       >
-        <X className="size-3.5" />
-      </button>
+        <div className="flex-1" aria-hidden />
+        <button
+          type="button"
+          aria-label="Close all workspaces"
+          title="Close (Esc / ⌘0)"
+          onClick={props.onClose}
+          className="window-no-drag grid size-7 place-items-center rounded-md text-foreground/55 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+        {isWin ? <WindowControls /> : null}
+      </div>
       <WorkspaceControlCenter
         workspaces={props.workspaces}
         selectedWorkspaceId={props.selectedWorkspaceId}


### PR DESCRIPTION
## Summary
- The previous absolute `top-3 left-3` close button collided with the macOS traffic lights (fixed at x:14 y:16). Moves it to top-right where no native controls live.
- Restores window dragging while the Control Center takeover is active by giving the takeover its own `h-10 window-drag` header strip.
- On Windows the takeover renders `<WindowControls />` flush right, with the CC close button immediately to its left — without this, Windows users had no way to minimize / close the window while CC was open.

Stacks on top of #391 (which merged into `fix/agent-integration-followups`). Closes the "Layout 涉及需要考虑一下 windows 版本" Notion task.

## Test plan
- [ ] Open the Control Center on macOS — confirm the close button sits flush right, no overlap with traffic lights.
- [ ] Drag the header strip — confirm the window moves.
- [ ] Same on Windows — confirm `WindowControls` render flush right with the CC close button to their left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)