### PR TITLE
feat(new-shell): restore Control Center entry (sidebar footer + ⌘0)

### DIFF
--- a/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
+++ b/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
@@ -1,10 +1,12 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
 import { FirstWorkspacePane } from "@/components/onboarding/FirstWorkspacePane";
+import { WorkspaceControlCenter } from "@/components/layout/WorkspaceControlCenter";
 import { useWorkspaceBrowser } from "@/components/panes/useWorkspaceBrowser";
 import { PublishScreen } from "@/components/publish/PublishScreen";
 import { WorkspaceOnboardingSurface } from "@/features/workspace-onboarding/WorkspaceOnboardingSurface";
 import { DesktopBillingProvider } from "@/lib/billing/useDesktopBilling";
+import { useControlCenterCardSignals } from "@/lib/controlCenterLifecycle";
 import { cn } from "@/lib/utils";
 import {
   useWorkspaceDesktop,
@@ -24,6 +26,7 @@ import { SearchDialog } from "./SearchDialog";
 import { Sidebar } from "./Sidebar";
 import { internalTabsAtom } from "./state/internalTabs";
 import {
+  controlCenterOpenAtom,
   createWorkspaceOpenAtom,
   focusModeAtom,
   newTabOpenAtom,
@@ -51,12 +54,16 @@ function NewAppShellContent() {
   const setNewTabOpen = useSetAtom(newTabOpenAtom);
   const setSearchOpen = useSetAtom(searchOpenAtom);
   const setSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
-  const { selectedWorkspaceId } = useWorkspaceSelection();
+  const { selectedWorkspaceId, setSelectedWorkspaceId } =
+    useWorkspaceSelection();
   const { onboardingModeActive, workspaces, hasHydratedWorkspaceList } =
     useWorkspaceDesktop();
   const [publishOpen, setPublishOpen] = useAtom(publishOpenAtom);
   const createWorkspaceOpen = useAtomValue(createWorkspaceOpenAtom);
   const setCreateWorkspaceOpen = useSetAtom(createWorkspaceOpenAtom);
+  const [controlCenterOpen, setControlCenterOpen] = useAtom(
+    controlCenterOpenAtom,
+  );
   const hasWorkspaces = workspaces.length > 0;
   const layout = useChatLayout();
   const [focusMode, setFocusMode] = useAtom(focusModeAtom);
@@ -108,11 +115,19 @@ function NewAppShellContent() {
       } else if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
         e.preventDefault();
         setSidebarCollapsed((prev) => !prev);
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "0") {
+        e.preventDefault();
+        setControlCenterOpen((prev) => !prev);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [setNewTabOpen, setSearchOpen, setSidebarCollapsed]);
+  }, [
+    setNewTabOpen,
+    setSearchOpen,
+    setSidebarCollapsed,
+    setControlCenterOpen,
+  ]);
 
   if (hasHydratedWorkspaceList && !hasWorkspaces) {
     return (
@@ -123,6 +138,7 @@ function NewAppShellContent() {
   }
 
   const showMiddle = layout === "split";
+  const showControlCenter = controlCenterOpen;
 
   return (
     <div className="flex h-screen w-screen overflow-hidden text-foreground antialiased">
@@ -131,6 +147,20 @@ function NewAppShellContent() {
         <div className="flex min-w-0 flex-1 flex-col bg-background">
           <ExperimentalWorkspaceOnboardingTakeover />
         </div>
+      ) : showControlCenter ? (
+        <ControlCenterTakeover
+          workspaces={workspaces}
+          selectedWorkspaceId={selectedWorkspaceId}
+          onSelectWorkspace={(id) => setSelectedWorkspaceId(id)}
+          onEnterWorkspace={(id) => {
+            setSelectedWorkspaceId(id);
+            setControlCenterOpen(false);
+          }}
+          onCreateWorkspace={() => {
+            setControlCenterOpen(false);
+            setCreateWorkspaceOpen(true);
+          }}
+        />
       ) : (
         <>
           <div
@@ -179,5 +209,53 @@ function ExperimentalWorkspaceOnboardingTakeover() {
         <WorkspaceOnboardingSurface />
       </div>
     </section>
+  );
+}
+
+// Wraps WorkspaceControlCenter for the new shell. Drag-reorder, density,
+// and completion highlights are deferred to a follow-up that lifts those
+// state slices out of legacy AppShell into shared atoms/hooks.
+function ControlCenterTakeover(props: {
+  workspaces: WorkspaceRecordPayload[];
+  selectedWorkspaceId: string | null;
+  onSelectWorkspace: (workspaceId: string) => void;
+  onEnterWorkspace: (workspaceId: string) => void;
+  onCreateWorkspace: () => void;
+}) {
+  const visibleWorkspaceIdsRef = useRef<string[]>([]);
+  const cardSignals = useControlCenterCardSignals(
+    visibleWorkspaceIdsRef.current,
+    true,
+  );
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col bg-background">
+      <WorkspaceControlCenter
+        workspaces={props.workspaces}
+        selectedWorkspaceId={props.selectedWorkspaceId}
+        cardsPerRow={3}
+        orderedWorkspaceIds={[]}
+        highlightedWorkspaceIds={[]}
+        cardSignals={cardSignals}
+        onOpenWorkspaceRunningTasks={props.onEnterWorkspace}
+        onOpenWorkspaceAppsExplorer={props.onEnterWorkspace}
+        onSelectWorkspace={props.onSelectWorkspace}
+        onEnterWorkspace={props.onEnterWorkspace}
+        onOpenOutput={(workspaceId) => props.onEnterWorkspace(workspaceId)}
+        onWorkspaceOrderChange={() => {
+          /* drag reorder deferred to a follow-up */
+        }}
+        onVisibleWorkspaceIdsChange={(ids) => {
+          visibleWorkspaceIdsRef.current = ids;
+        }}
+        onCardComposerSubmit={() => {
+          /* highlight suppression handled by AppShell; no-op here */
+        }}
+        onWorkspaceCompletion={() => {
+          /* completion highlights deferred to a follow-up */
+        }}
+        onCreateWorkspace={props.onCreateWorkspace}
+      />
+    </div>
   );
 }

--- a/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/new-shell/Sidebar.tsx
@@ -44,6 +44,7 @@ import {
   Home,
   LayoutDashboard,
   Inbox,
+  LayoutGrid,
   Link2,
   Loader2,
   MoreHorizontal,
@@ -79,6 +80,7 @@ import {
   appsExpandedAtom,
   automationsOpenAtom,
   chatComposerPrefillAtom,
+  controlCenterOpenAtom,
   createWorkspaceOpenAtom,
   focusModeAtom,
   newIssueOpenAtom,
@@ -420,8 +422,18 @@ function SidebarGlobalFooter() {
   const setSettingsOpen = useSetAtom(settingsOpenAtom);
   const setSettingsSection = useSetAtom(settingsSectionAtom);
   const settingsOpen = useAtomValue(settingsOpenAtom);
+  const [controlCenterOpen, setControlCenterOpen] = useAtom(
+    controlCenterOpenAtom,
+  );
   return (
     <div className="shrink-0 border-t border-sidebar-border px-2 py-1.5">
+      <NavItem
+        icon={<LayoutGrid />}
+        active={controlCenterOpen}
+        onClick={() => setControlCenterOpen((prev) => !prev)}
+      >
+        All workspaces
+      </NavItem>
       <NavItem
         icon={<Settings />}
         active={settingsOpen}

--- a/apps/desktop/src/components/layout/new-shell/state/ui.ts
+++ b/apps/desktop/src/components/layout/new-shell/state/ui.ts
@@ -64,6 +64,13 @@ export const settingsOpenAtom = atom(false);
 /** Is the Marketplace overlay open? */
 export const marketplaceOpenAtom = atom(false);
 
+/**
+ * Is the Control Center (full-screen workspace grid) open? Takes over
+ * the center + chat panel so the user sees the cross-workspace dashboard
+ * instead of the active workspace.
+ */
+export const controlCenterOpenAtom = atom(false);
+
 /** Is the Apps expandable group in the sidebar expanded? Persists. */
 export const appsExpandedAtom = atomWithStorage(
   "holaboss-new-shell-apps-expanded-v1",
@@ -163,6 +170,7 @@ export const browserViewSuspendedAtom = atom(
     get(automationsOpenAtom) ||
     get(settingsOpenAtom) ||
     get(marketplaceOpenAtom) ||
+    get(controlCenterOpenAtom) ||
     get(activeInternalTabIdAtom) !== null ||
     get(overlayOpenCountAtom) > 0,
 );


### PR DESCRIPTION
## Summary
- Brings the **"All workspaces"** NavItem (above Settings in the sidebar footer) and the **⌘0** Control Center takeover into `main`.
- Originally landed in #391, but that PR was merged into `fix/agent-integration-followups` (still ~15 commits ahead, 12 behind `main`) and never reached `main`. This is a clean cherry-pick of `c15b86b5` onto current `main`.

## What it does
- `NewAppShell` now mounts `WorkspaceControlCenter` via a `ControlCenterTakeover` — previously there was no way into the cross-workspace grid dashboard from the new shell; clicking workspaces in the sidebar popover only switched the active workspace.
- New `controlCenterOpenAtom` (jotai), wired into `browserViewSuspendedAtom` so the BrowserView detaches when the takeover is showing.
- `SidebarGlobalFooter`: "All workspaces" NavItem above Settings; both app-level entries are paired (both jump out of the current workspace).
- **⌘0** toggles the takeover; consistent with ⌘T / ⌘K / ⌘\ in `NewAppShell`.
- `enter`/`select` wire `selectedWorkspaceId`; `create` routes to the existing `createWorkspaceOpenAtom`.

Drag-reorder, density, and completion highlights are no-ops for v1 — they require lifting state out of legacy `AppShell` and are tracked as a follow-up.

## Test plan
- [ ] Launch desktop, open NewAppShell, confirm "All workspaces" appears above Settings in the sidebar footer
- [ ] Click it → Control Center grid takeover renders
- [ ] Press ⌘0 → takeover toggles open/closed
- [ ] Select a workspace in the grid → returns to that workspace
- [ ] Create-new from the takeover → opens the create-workspace flow
- [ ] BrowserView detaches while takeover is open (no overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)