### PR TITLE
feat(analytics): umami event when user picks work-mode in onboarding

### DIFF
--- a/apps/desktop/src/components/onboarding/FirstWorkspacePane.tsx
+++ b/apps/desktop/src/components/onboarding/FirstWorkspacePane.tsx
@@ -123,6 +123,16 @@ export function FirstWorkspacePane({
     setStep("layout");
   }
 
+  function handleSelectMainViewMode(next: MainViewMode) {
+    if (next === mainViewMode) return;
+    trackUmamiEvent("first_workspace_main_view_selected", {
+      main_view_mode: next,
+      previous_main_view_mode: mainViewMode,
+      variant: isPanelVariant ? "panel" : "full",
+    });
+    setMainViewMode(next);
+  }
+
   function handleCreateWorkspace() {
     if (createDisabled) {
       return;
@@ -308,14 +318,14 @@ export function FirstWorkspacePane({
               <WorkModeOption
                 active={mainViewMode === "workspace"}
                 description="Tabs and chat side by side."
-                onSelect={() => setMainViewMode("workspace")}
+                onSelect={() => handleSelectMainViewMode("workspace")}
                 preview={<WorkspaceModePreview />}
                 title="Workspace mode"
               />
               <WorkModeOption
                 active={mainViewMode === "chat"}
                 description="Chat fills the canvas, tabs tucked away."
-                onSelect={() => setMainViewMode("chat")}
+                onSelect={() => handleSelectMainViewMode("chat")}
                 preview={<ChatModePreview />}
                 title="Chat mode"
               />


### PR DESCRIPTION
## Summary

Follow-up to #403. \`first_workspace_create_started\` / \`_created\` already track the final \`main_view_mode\` at submit time — good for the chat-vs-workspace split, but doesn't say whether the user accepted the workspace default or actively switched, nor how often they toggle before committing.

Adds \`first_workspace_main_view_selected\` on every real toggle in the picker (skipped when re-clicking the already-active card), with:
- \`main_view_mode\` — the chosen mode
- \`previous_main_view_mode\` — what was active before
- \`variant\` — \`panel\` or \`full\` (matches the existing \`onboarding_step_viewed\` shape)

## Test plan
- [ ] Open the create-workspace flow, advance to "Pick your work mode". In dev verify the event fires only when the selection actually changes (Umami devtools / network).
- [ ] Toggle Workspace → Chat → Workspace, confirm two events, each with the right \`previous_main_view_mode\`.
- [ ] Re-click the active option: no event fires.