### PR TITLE
fix(new-shell): scope file tabs to current workspace + surface recent files in @ picker

### DIFF
--- a/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
+++ b/apps/desktop/src/components/layout/new-shell/NewAppShell.tsx
@@ -24,7 +24,10 @@ import { NotificationStack } from "./NotificationStack";
 import { Overlays } from "./Overlays";
 import { SearchDialog } from "./SearchDialog";
 import { Sidebar } from "./Sidebar";
-import { internalTabsAtom } from "./state/internalTabs";
+import {
+  activeInternalTabIdAtom,
+  internalTabsAtom,
+} from "./state/internalTabs";
 import {
   createWorkspaceOpenAtom,
   focusModeAtom,
@@ -67,6 +70,8 @@ function NewAppShellContent() {
   const workspaceMainViewMap = useAtomValue(workspaceMainViewModeMapAtom);
   const { browserState } = useWorkspaceBrowser("user");
   const internalTabs = useAtomValue(internalTabsAtom);
+  const setInternalTabs = useSetAtom(internalTabsAtom);
+  const setActiveInternalTabId = useSetAtom(activeInternalTabIdAtom);
   const totalTabs = browserState.tabs.length + internalTabs.length;
   const prevTotalTabsRef = useRef(totalTabs);
   const seededMainViewWorkspaceIdRef = useRef<string | null>(null);
@@ -93,6 +98,14 @@ function NewAppShellContent() {
     // Workspaces with no recorded preference (created before this feature
     // shipped) inherit whatever focusMode currently is — no surprises.
   }, [selectedWorkspaceId, workspaceMainViewMap, focusMode, setFocusMode]);
+
+  // Internal (file/image) tabs live in a global atom; clear on every
+  // workspace switch so a brand-new or freshly-selected workspace doesn't
+  // inherit the previous workspace's open file tabs.
+  useEffect(() => {
+    setInternalTabs([]);
+    setActiveInternalTabId(null);
+  }, [selectedWorkspaceId, setInternalTabs, setActiveInternalTabId]);
 
   // Auto-exit focus when a new tab appears (⌘T, chat link, sidebar app).
   // Opening a tab is an explicit "show me this" signal; staying hidden

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -97,6 +97,8 @@ import {
   resolveExplorerAttachmentKind,
 } from "@/lib/attachmentDrag";
 import { getExplorerAttachmentClipboardEntry } from "@/lib/appClipboard";
+import { useAtomValue } from "jotai";
+import { recentFilesAtom } from "@/components/layout/new-shell/state/recentFiles";
 import { CHAT_LAYOUT, chatScrollMaskImage } from "@/lib/chatLayout";
 import { ProviderBrandIcon } from "@/lib/providerBrandIcon";
 import { trackUmamiEvent } from "@/lib/analytics/umami";
@@ -3539,6 +3541,62 @@ export function ChatPane({
     };
   }, [selectedWorkspace?.id]);
 
+  // Recent file opens (renderer-side log persisted by file tabs). Drives
+  // the "recent" boost in the @ picker below — recently-opened files
+  // float to the top so users don't have to scroll past the alphabetical
+  // workspace tree to re-mention a file they just had open.
+  const allRecentFiles = useAtomValue(recentFilesAtom);
+  // Recent files as WorkspaceFileEntry-shaped rows, in most-recent-first
+  // order. Prefer the rich entry from the bounded workspace walk when
+  // available; otherwise synthesize one from filePath + label so files
+  // that listWorkspaceFiles skips (dotdirs like .holaboss, paths deeper
+  // than maxDepth=4, anything past the maxFiles=500 cap) still surface
+  // in the @ picker instead of vanishing silently.
+  const recentFileEntriesForWorkspace = useMemo<WorkspaceFileEntry[]>(() => {
+    const workspaceId = selectedWorkspace?.id ?? null;
+    if (!workspaceId) return [];
+
+    const byAbsolutePath = new Map<string, WorkspaceFileEntry>();
+    for (const entry of workspaceFiles) {
+      byAbsolutePath.set(entry.absolutePath, entry);
+    }
+
+    const rawWorkspacePath = selectedWorkspace?.workspace_path?.trim() ?? "";
+    const workspacePathPrefix = rawWorkspacePath
+      ? `${rawWorkspacePath.replace(/[\\/]+$/, "")}/`
+      : "";
+
+    const entries: WorkspaceFileEntry[] = [];
+    const seenAbsolutePaths = new Set<string>();
+    for (const recent of allRecentFiles) {
+      if (recent.workspaceId !== workspaceId) continue;
+      if (!recent.filePath || seenAbsolutePaths.has(recent.filePath)) continue;
+      seenAbsolutePaths.add(recent.filePath);
+
+      const fromWalk = byAbsolutePath.get(recent.filePath);
+      if (fromWalk) {
+        entries.push(fromWalk);
+        continue;
+      }
+      const relativePath =
+        workspacePathPrefix && recent.filePath.startsWith(workspacePathPrefix)
+          ? recent.filePath.slice(workspacePathPrefix.length)
+          : recent.label;
+      if (!relativePath) continue;
+      entries.push({
+        name: recent.label,
+        relativePath,
+        absolutePath: recent.filePath,
+      });
+    }
+    return entries;
+  }, [
+    allRecentFiles,
+    selectedWorkspace?.id,
+    selectedWorkspace?.workspace_path,
+    workspaceFiles,
+  ]);
+
   // `@` references content WITHIN the current workspace — files at
   // any depth + installed apps. Future kinds (sessions, memories,
   // skills) plug into the same array. Cross-workspace navigation is
@@ -3546,8 +3604,9 @@ export function ChatPane({
   const composerMentionableItems = useMemo<ChatComposerMentionItem[]>(() => {
     const items: ChatComposerMentionItem[] = [];
 
-    // Files first — typically the more frequent reference target.
-    for (const entry of workspaceFiles) {
+    const fileEntryToItem = (
+      entry: WorkspaceFileEntry,
+    ): ChatComposerMentionItem | null => {
       // Slugify each path segment so the inserted token round-trips
       // through findActiveMentionRange. Unicode letters / digits are
       // preserved so CJK-named files (e.g. `产品方案.md`) survive
@@ -3562,14 +3621,35 @@ export function ChatPane({
         )
         .filter(Boolean)
         .join("/");
-      if (!handle) continue;
-      items.push({
+      if (!handle) return null;
+      return {
         id: `file:${entry.relativePath}`,
         handle,
         label: entry.relativePath,
         kindIcon: <FileIcon className="size-3.5" />,
         keywords: [entry.name, entry.relativePath, handle],
-      });
+      };
+    };
+
+    // Recent files first, in most-recent-first order — when the user
+    // types `@` with no query, this is what shows up at the top. The
+    // dedupe set guards against duplicate items when we fall through
+    // to the alphabetical workspace listing below.
+    const emittedRelativePaths = new Set<string>();
+    for (const entry of recentFileEntriesForWorkspace) {
+      const item = fileEntryToItem(entry);
+      if (!item) continue;
+      items.push(item);
+      emittedRelativePaths.add(entry.relativePath);
+    }
+
+    // Remaining files — alphabetical (as listWorkspaceFiles sorts), skip
+    // anything already emitted via the recents boost.
+    for (const entry of workspaceFiles) {
+      if (emittedRelativePaths.has(entry.relativePath)) continue;
+      const item = fileEntryToItem(entry);
+      if (!item) continue;
+      items.push(item);
     }
 
     // Apps next.
@@ -3587,7 +3667,7 @@ export function ChatPane({
     }
 
     return items;
-  }, [installedApps, workspaceFiles]);
+  }, [installedApps, recentFileEntriesForWorkspace, workspaceFiles]);
 
   // handle → workspace-file entry map. Built from the same slug logic
   // as composerMentionableItems above so a `@<handle>` typed by the
@@ -3597,8 +3677,8 @@ export function ChatPane({
   // not be picked up by file-read tools.
   const mentionableFilesByHandle = useMemo(() => {
     const byHandle = new Map<string, WorkspaceFileEntry>();
-    for (const entry of workspaceFiles) {
-      const handle = entry.relativePath
+    const slugifyEntry = (entry: WorkspaceFileEntry) =>
+      entry.relativePath
         .split("/")
         .map((segment) =>
           segment
@@ -3608,11 +3688,21 @@ export function ChatPane({
         )
         .filter(Boolean)
         .join("/");
+    for (const entry of workspaceFiles) {
+      const handle = slugifyEntry(entry);
       if (!handle) continue;
       byHandle.set(handle, entry);
     }
+    // Synthesized recent entries (those not in the bounded walk) also
+    // need a handle so `@<file>` send-time staging can resolve them.
+    for (const entry of recentFileEntriesForWorkspace) {
+      const handle = slugifyEntry(entry);
+      if (!handle) continue;
+      if (byHandle.has(handle)) continue;
+      byHandle.set(handle, entry);
+    }
     return byHandle;
-  }, [workspaceFiles]);
+  }, [recentFileEntriesForWorkspace, workspaceFiles]);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sessionOutputs, setSessionOutputs] = useState<


### PR DESCRIPTION
## Summary

Two independent new-shell papercuts a user hit back-to-back:

1. **Internal file tabs leaked across workspaces.** Open `README.md` in workspace A, switch to / create workspace B → the README tab was still sitting in TopChrome. Browser tabs reset properly via `useWorkspaceBrowser`, but the `internalTabsAtom` (file/image preview tabs) had no reset wired to `selectedWorkspaceId`. Add a `useEffect` in `NewAppShellContent` that clears `internalTabsAtom` + `activeInternalTabIdAtom` on every workspace switch.

2. **Composer `@` picker never showed recent files.** Specifically, files outside the bounded workspace walk vanished — `listWorkspaceFiles` caps at `maxDepth=4` / `maxFiles=500` and skips dotdirs (`.holaboss`, `.git`, `node_modules`, etc.), so recents like `.holaboss/notes/foo.md` had to be hand-typed. Now the `@` picker lists recent files first (most-recent-first), preferring the walk's rich entry when present and synthesizing a `WorkspaceFileEntry` from `selectedWorkspace.workspace_path` + the recent's absolute path otherwise. `mentionableFilesByHandle` also picks up the synthesized entries so send-time `stageSessionAttachmentPaths` can still resolve them.

## Test plan

- [ ] Open a file tab in workspace A → switch to workspace B → file tab is gone (and the chat-only fallback / welcome surface kicks in if B has no tabs)
- [ ] Create a brand-new workspace from a workspace that has open file tabs → TopChrome is empty in the new workspace
- [ ] In `@` picker, an empty query shows recent files at the top in most-recent-first order, then alphabetical workspace files, then installed apps (no duplicates)
- [ ] Open a file in a path the walk skips (e.g. `.holaboss/scratch/foo.md` or 5+ levels deep) → `@` picker still surfaces it
- [ ] Select that synthesized recent file in `@`, send the message → confirm the file is staged as an attachment (not left as plain text)
- [ ] Switch to a workspace that has no recents for that workspace → `@` only shows that workspace's files (recents stay partitioned per workspace as `c20aa66f` set up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)