### PR TITLE
ci(release): mirror release assets to Cloudflare R2 (phase 1 dual-publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1063,3 +1063,79 @@ jobs:
             --notes-file "${notes_path}" \
             "${prerelease_flag[@]}" \
             "${upload_paths[@]}"
+
+      # Phase 1 of the GitHub → R2 migration: mirror every binary that
+      # the previous step pushed to holaOS-releases up to a Cloudflare
+      # R2 bucket so we can validate global download throughput before
+      # flipping electron-updater away from `provider: "github"`.
+      # GitHub Releases stay authoritative for now — installed clients
+      # ignore R2 entirely until a future release flips the
+      # `electron-builder.config.cjs` publish config.
+      #
+      # Soft-gated: missing R2 secrets log a warning and exit 0 so this
+      # workflow stays mergeable before the bucket + GH secrets land.
+      - name: Mirror release assets to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # R2 ignores region but the AWS SDK insists on having one set;
+          # `auto` is the documented value.
+          AWS_DEFAULT_REGION: auto
+          # Full endpoint URL — e.g. https://<account-id>.r2.cloudflarestorage.com
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          # Bucket name — e.g. holaos-releases
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
+              || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] \
+              || [ -z "${R2_ENDPOINT_URL:-}" ] \
+              || [ -z "${R2_BUCKET:-}" ]; then
+            echo "::warning::R2_* secrets not configured — skipping R2 mirror"
+            exit 0
+          fi
+
+          # Re-derive the asset list by walking release-assets/. We
+          # intentionally don't reuse the previous step's
+          # ${upload_paths[@]} array — running a fresh `find` keeps the
+          # mirror step self-contained and easy to re-run in isolation.
+          mapfile -t assets < <(
+            find release-assets -type f \
+              \( -name '*.dmg' \
+                 -o -name '*.zip' \
+                 -o -name '*.exe' \
+                 -o -name '*.tar.gz' \
+                 -o -name '*.sha256' \
+                 -o -name '*.blockmap' \
+                 -o -name '*.yml' \
+                 -o -name '*.json' \
+              \) -print
+          )
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "::error::no release assets found under release-assets/ — nothing to mirror"
+            exit 1
+          fi
+
+          echo "Mirroring ${#assets[@]} asset(s) to R2 bucket: ${R2_BUCKET}"
+          for asset in "${assets[@]}"; do
+            name="$(basename "${asset}")"
+            # Manifests (latest*.yml / beta*.yml / runtime json) drive
+            # auto-updater — must be revalidated each check. Binaries
+            # carry version in filename, so safe to cache for a year.
+            case "${name}" in
+              *.yml|*.json|*.sha256)
+                cache_control="public, max-age=60, must-revalidate"
+                ;;
+              *)
+                cache_control="public, max-age=31536000, immutable"
+                ;;
+            esac
+            echo "  → ${name}"
+            aws s3 cp "${asset}" "s3://${R2_BUCKET}/${name}" \
+              --endpoint-url "${R2_ENDPOINT_URL}" \
+              --cache-control "${cache_control}" \
+              --only-show-errors
+          done
+
+          echo "Mirror complete — bucket: ${R2_BUCKET}, ${#assets[@]} files uploaded."


### PR DESCRIPTION
## Summary

**Phase 1** of the GitHub → R2 distribution migration. After the existing \`Publish validated GitHub release\` step pushes the artifacts to \`holaboss-ai/holaOS-releases\`, a new \`Mirror release assets to Cloudflare R2\` step copies the same binaries + manifests to an R2 bucket via the S3 API (\`aws s3 cp\`).

Why: GitHub Releases CDN can be slow in some regions and lacks the egress economics for big binaries (~400 MB DMG, ~250 MB EXE, plus blockmap differentials on every release). R2 gives us global Cloudflare CDN + 0 egress cost. This PR is the **observability step** — mirror first, validate throughput, then later flip electron-updater off GitHub.

What this PR does **not** do (yet):
- Does **not** change \`electron-builder.config.cjs\` — installed clients keep updating from \`holaOS-releases\` until a future PR flips \`provider: \"github\"\` to \`provider: \"generic\"\`.
- Does **not** add a custom domain — uploads land in the R2 bucket root using the bucket's default \`https://<account-id>.r2.cloudflarestorage.com/...\` URL.

## Required secrets (Settings → Secrets and variables → Actions)

| Secret | Value |
|---|---|
| \`R2_ACCESS_KEY_ID\` | R2 access key (Cloudflare dashboard → R2 → Manage API Tokens) |
| \`R2_SECRET_ACCESS_KEY\` | R2 secret access key |
| \`R2_ENDPOINT_URL\` | \`https://<account-id>.r2.cloudflarestorage.com\` |
| \`R2_BUCKET\` | bucket name, e.g. \`holaos-releases\` |

\`AWS_DEFAULT_REGION=auto\` is hardcoded in the step (R2 ignores region but the AWS SDK requires the env to be set).

## Soft-gated

The step **always runs** but checks for the secrets up front:

\`\`\`bash
if [ -z \"\${AWS_ACCESS_KEY_ID:-}\" ] \\
    || [ -z \"\${AWS_SECRET_ACCESS_KEY:-}\" ] \\
    || [ -z \"\${R2_ENDPOINT_URL:-}\" ] \\
    || [ -z \"\${R2_BUCKET:-}\" ]; then
  echo \"::warning::R2_* secrets not configured — skipping R2 mirror\"
  exit 0
fi
\`\`\`

So this PR is safe to merge **before** the bucket + secrets land. The first release after the secrets are configured starts mirroring automatically with no further code change.

## Implementation notes

- **Asset discovery**: re-walks \`release-assets/\` with \`find\` instead of inheriting the previous step's \`\${upload_paths[@]}\` bash array. Keeps the mirror step self-contained and easy to re-run in isolation.
- **What gets mirrored**: \`*.dmg\`, \`*.zip\`, \`*.exe\`, \`*.tar.gz\`, \`*.sha256\`, \`*.blockmap\`, \`*.yml\`, \`*.json\`. Same set the GitHub release uses, plus the manifest files electron-updater's \`generic\` provider will need in Phase 2 (\`latest.yml\`, \`latest-mac.yml\`, \`beta.yml\`, \`beta-mac.yml\`).
- **Layout**: flat — everything goes to the bucket root (\`s3://\$BUCKET/<filename>\`). Matches what electron-updater's \`generic\` provider expects without extra config.
- **Cache-Control**:
  - \`*.yml\` / \`*.json\` / \`*.sha256\` → \`public, max-age=60, must-revalidate\` (updater always picks up new versions promptly)
  - everything else → \`public, max-age=31536000, immutable\` (binaries have version baked into the filename)
- **AWS CLI**: pre-installed on \`ubuntu-latest\` runners — no extra setup step needed.

## Test plan

- [ ] Merge this PR with the soft-gate in place (no secrets yet).
- [ ] On the next manual release: confirm the step runs, logs the warning, and exits cleanly (workflow stays green).
- [ ] Create the R2 bucket + provision the 4 secrets in repo settings.
- [ ] On the release after that: confirm the step actually mirrors. Spot-check 2-3 files in the bucket UI (sizes match GitHub Release), and \`curl -I\` a yml to verify the \`Cache-Control\` header.
- [ ] Compare download throughput vs GitHub Release for a few representative regions (US east, EU, APAC, CN).
- [ ] Once happy, follow up with **Phase 2** PR that flips \`apps/desktop/electron-builder.config.cjs\` publish provider to \`generic\` and points at \`https://updates.holaos.ai/\` (or whatever custom domain we settle on).

## Files

- \`.github/workflows/ci.yml\` — adds one step (76 lines) at the end of \`publish-release\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)