### PR TITLE
Refresh MiniMax M3 defaults

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5491,7 +5491,7 @@ const PROVIDER_DEFAULT_BASE_URL: Record<string, string> = {
   anthropic_direct: "https://api.anthropic.com",
   openrouter_direct: "https://openrouter.ai/api",
   gemini_direct: "https://generativelanguage.googleapis.com/v1beta/openai",
-  minimax: "https://api.minimaxi.chat",
+  minimax: "https://api.minimax.io/v1",
   ollama_local: "http://localhost:11434",
 };
 

--- a/apps/desktop/electron/runtime-provider-models.test.mjs
+++ b/apps/desktop/electron/runtime-provider-models.test.mjs
@@ -12,11 +12,13 @@ const chatPaneSourcePath = path.join(
   "src",
   "components",
   "panes",
-  "ChatPane.tsx",
+  "ChatPane",
+  "index.tsx",
 );
 const sharedCatalogPath = path.join(__dirname, "..", "shared", "model-catalog.ts");
 const modelRoutingPath = path.join(
   __dirname,
+  "..",
   "..",
   "..",
   "runtime",
@@ -51,11 +53,26 @@ test("desktop runtime normalizes stale direct-provider model aliases for Anthrop
   assert.match(source, /function upsertRuntimeProviderModel\(/);
 });
 
-test("desktop runtime recognizes minimax provider label and strips minimax token prefix", async () => {
+test("desktop runtime recognizes minimax provider label, base URL, and strips minimax token prefix", async () => {
   const source = await readFile(mainSourcePath, "utf8");
 
+  assert.match(source, /minimax:\s*"https:\/\/api\.minimax\.io\/v1"/);
   assert.match(source, /normalized\.includes\("minimax"\)[\s\S]*?return "MiniMax"/);
   assert.match(source, /normalizedPrefix\.includes\("minimax"\)/);
+});
+
+test("desktop model catalog carries refreshed MiniMax M3 defaults", async () => {
+  const [mainSource, sharedCatalogSource, modelRoutingSource] = await Promise.all([
+    readFile(mainSourcePath, "utf8"),
+    readFile(sharedCatalogPath, "utf8"),
+    readFile(modelRoutingPath, "utf8"),
+  ]);
+
+  assert.match(mainSource, /minimax:\s*"https:\/\/api\.minimax\.io\/v1"/);
+  assert.match(sharedCatalogSource, /minimax_direct:\s*\{[\s\S]*"MiniMax-M3"[\s\S]*context_window: 1_000_000/);
+  assert.match(sharedCatalogSource, /pricing_usd_per_million_tokens:\s*\{[\s\S]*input: 0\.6[\s\S]*output: 2\.4[\s\S]*cache_read: 0\.12[\s\S]*cache_write: null/);
+  assert.match(modelRoutingSource, /entry\?\.contextWindow \?\? entry\?\.context_window/);
+  assert.match(modelRoutingSource, /entry\?\.pricing_usd_per_million_tokens/);
 });
 
 test("desktop model catalog carries reasoning metadata and the composer persists thinking preferences", async () => {
@@ -67,6 +84,7 @@ test("desktop model catalog carries reasoning metadata and the composer persists
 
   assert.match(sharedCatalogSource, /export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = \{/);
   assert.match(sharedCatalogSource, /openai_codex:\s*\{[\s\S]*"gpt-5\.5"/);
+  assert.match(sharedCatalogSource, /minimax_direct:\s*\{[\s\S]*"MiniMax-M3"[\s\S]*reasoning: true[\s\S]*thinking_values: \[\.\.\.MINIMAX_THINKING_VALUES\]/);
   assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"qwen\/qwen3\.6-plus"/);
   assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"xiaomi\/mimo-v2-pro"/);
   assert.match(sharedCatalogSource, /openrouter_direct:\s*\{[\s\S]*"z-ai\/glm-5-turbo"/);
@@ -76,7 +94,7 @@ test("desktop model catalog carries reasoning metadata and the composer persists
   assert.match(mainSource, /function runtimeModelMetadataFromPayload\(/);
   assert.match(chatPaneSource, /CHAT_THINKING_STORAGE_KEY/);
   assert.match(chatPaneSource, /thinking_value: effectiveThinkingValue/);
-  assert.match(chatPaneSource, /function ThinkingValueSelect\(/);
+  assert.match(chatPaneSource, /function runtimeModelThinkingValues\(/);
 });
 
 test("desktop codex wiring includes GPT-5.5 defaults and Codex-specific routing budgets", async () => {

--- a/apps/desktop/shared/model-catalog.ts
+++ b/apps/desktop/shared/model-catalog.ts
@@ -7,6 +7,13 @@ export interface ModelCatalogEntry {
   thinking_values: string[];
   default_thinking_value?: string | null;
   input_modalities: ModelCatalogInputModality[];
+  context_window?: number;
+  pricing_usd_per_million_tokens?: {
+    input: number;
+    output: number;
+    cache_read: number;
+    cache_write?: number | null;
+  };
 }
 
 export interface ProviderCatalogEntry {
@@ -71,6 +78,7 @@ const GEMINI_FLASH_THINKING_VALUES = [
   "8192",
   "24576",
 ] as const;
+const MINIMAX_THINKING_VALUES = ["adaptive", "disabled"] as const;
 
 export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = {
   holaboss_model_proxy: {
@@ -252,18 +260,19 @@ export const PROVIDER_MODEL_CATALOG: ProviderModelCatalog = {
     source: "local",
     models: [
       {
-        model_id: "MiniMax-M2.7",
-        label: "MiniMax M2.7",
-        reasoning: false,
-        thinking_values: [],
+        model_id: "MiniMax-M3",
+        label: "MiniMax M3",
+        reasoning: true,
+        thinking_values: [...MINIMAX_THINKING_VALUES],
+        default_thinking_value: "adaptive",
         input_modalities: ["text"],
-      },
-      {
-        model_id: "MiniMax-M2.7-highspeed",
-        label: "MiniMax M2.7 Highspeed",
-        reasoning: false,
-        thinking_values: [],
-        input_modalities: ["text"],
+        context_window: 1_000_000,
+        pricing_usd_per_million_tokens: {
+          input: 0.6,
+          output: 2.4,
+          cache_read: 0.12,
+          cache_write: null,
+        },
       },
     ],
   },
@@ -400,5 +409,15 @@ export function catalogConfigShapeForProviderModel(
       ? { default_thinking_value: entry.default_thinking_value }
       : {}),
     input_modalities: [...entry.input_modalities],
+    ...(entry.context_window !== undefined
+      ? { context_window: entry.context_window }
+      : {}),
+    ...(entry.pricing_usd_per_million_tokens
+      ? {
+          pricing_usd_per_million_tokens: {
+            ...entry.pricing_usd_per_million_tokens,
+          },
+        }
+      : {}),
   };
 }

--- a/runtime/harnesses/src/model-routing.ts
+++ b/runtime/harnesses/src/model-routing.ts
@@ -36,12 +36,22 @@ export interface HarnessOpenAiCompat {
 
 export interface HarnessCatalogModelEntry {
   contextWindow?: unknown;
+  context_window?: unknown;
   maxTokens?: unknown;
+  max_tokens?: unknown;
   cost?: {
     input?: unknown;
     output?: unknown;
     cacheRead?: unknown;
+    cache_read?: unknown;
     cacheWrite?: unknown;
+    cache_write?: unknown;
+  };
+  pricing_usd_per_million_tokens?: {
+    input?: unknown;
+    output?: unknown;
+    cache_read?: unknown;
+    cache_write?: unknown;
   };
 }
 
@@ -494,48 +504,53 @@ function catalogModelIdCandidates(request: Pick<HarnessModelRoutingRequest, "mod
   return candidates;
 }
 
-function modelBudgetFromCatalogEntry(entry: {
-  contextWindow?: unknown;
-  maxTokens?: unknown;
-} | null | undefined): HarnessModelBudget | null {
+function modelBudgetFromCatalogEntry(entry: HarnessCatalogModelEntry | null | undefined): HarnessModelBudget | null {
+  const contextWindow = entry?.contextWindow ?? entry?.context_window;
+  const maxTokens = entry?.maxTokens ?? entry?.max_tokens ?? UNIFORM_MODEL_MAX_TOKENS;
   if (
-    typeof entry?.contextWindow !== "number" ||
-    !Number.isFinite(entry.contextWindow) ||
-    entry.contextWindow <= 0 ||
-    typeof entry.maxTokens !== "number" ||
-    !Number.isFinite(entry.maxTokens) ||
-    entry.maxTokens <= 0
+    typeof contextWindow !== "number" ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= 0 ||
+    typeof maxTokens !== "number" ||
+    !Number.isFinite(maxTokens) ||
+    maxTokens <= 0
   ) {
     return null;
   }
   return {
-    contextWindow: entry.contextWindow,
-    maxTokens: entry.maxTokens,
+    contextWindow,
+    maxTokens,
   };
 }
 
 function modelCostFromCatalogEntry(entry: HarnessCatalogModelEntry | null | undefined): HarnessModelCost | null {
+  const cost = entry?.cost;
+  const pricing = entry?.pricing_usd_per_million_tokens;
+  const input = cost?.input ?? pricing?.input;
+  const output = cost?.output ?? pricing?.output;
+  const cacheRead = cost?.cacheRead ?? cost?.cache_read ?? pricing?.cache_read;
+  const cacheWrite = cost?.cacheWrite ?? cost?.cache_write ?? pricing?.cache_write ?? 0;
   if (
-    typeof entry?.cost?.input !== "number" ||
-    !Number.isFinite(entry.cost.input) ||
-    entry.cost.input < 0 ||
-    typeof entry.cost.output !== "number" ||
-    !Number.isFinite(entry.cost.output) ||
-    entry.cost.output < 0 ||
-    typeof entry.cost.cacheRead !== "number" ||
-    !Number.isFinite(entry.cost.cacheRead) ||
-    entry.cost.cacheRead < 0 ||
-    typeof entry.cost.cacheWrite !== "number" ||
-    !Number.isFinite(entry.cost.cacheWrite) ||
-    entry.cost.cacheWrite < 0
+    typeof input !== "number" ||
+    !Number.isFinite(input) ||
+    input < 0 ||
+    typeof output !== "number" ||
+    !Number.isFinite(output) ||
+    output < 0 ||
+    typeof cacheRead !== "number" ||
+    !Number.isFinite(cacheRead) ||
+    cacheRead < 0 ||
+    typeof cacheWrite !== "number" ||
+    !Number.isFinite(cacheWrite) ||
+    cacheWrite < 0
   ) {
     return null;
   }
   return {
-    input: entry.cost.input,
-    output: entry.cost.output,
-    cacheRead: entry.cost.cacheRead,
-    cacheWrite: entry.cost.cacheWrite,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
   };
 }
 


### PR DESCRIPTION
Reason: refresh target model defaults against current official parameters

## Summary
- Refresh MiniMax desktop defaults to MiniMax M3 with the current OpenAI-compatible endpoint.
- Add MiniMax M3 context window, pricing, and thinking metadata to the shared model catalog.
- Teach runtime harness routing to consume snake_case catalog budget and pricing fields.

## Test plan
- [x] node --test apps/desktop/electron/runtime-provider-models.test.mjs
- [x] git diff --check
- [x] secret scan against current diff
- [ ] bun --filter=holaboss-local run typecheck (bun unavailable in worker environment)
- [ ] npm --prefix apps/desktop run typecheck (blocked: tsdown dependency unavailable)