### PR TITLE
refactor(desktop): automations report every outcome as a toast

### DIFF
--- a/apps/desktop/src/components/panes/AutomationsPane.test.mjs
+++ b/apps/desktop/src/components/panes/AutomationsPane.test.mjs
@@ -33,12 +33,34 @@ test("run-now can jump directly into the spawned scheduled session", async () =>
   );
 });
 
-test("post-action refresh preserves the current banner and suppresses transient refresh errors", async () => {
+test("every outcome is a toast — no in-page status banner survives", async () => {
   const source = await readFile(sourcePath, "utf8");
 
-  assert.match(source, /interface RefreshDataOptions \{\s*preserveStatusMessage\?: boolean;\s*suppressErrors\?: boolean;\s*\}/);
-  assert.match(source, /if \(!preserveStatusMessage\) \{\s*setStatusMessage\(""\);\s*\}/);
-  assert.match(source, /void refreshData\(\{\s*preserveStatusMessage: true,\s*suppressErrors: true,\s*\}\);/);
+  // The banner and its tone plumbing are gone; sonner is the only channel.
+  assert.doesNotMatch(source, /statusMessage|statusTone|statusBarClassName/);
+  for (const call of [
+    /toast\.success\(`Deleted "\$\{jobTitle\(job\)\}"`\)/,
+    /toast\.success\(`Created "\$\{draft\.name \|\| "automation"\}"`\)/,
+    /toast\.error\("Couldn't load automations", \{/,
+    /toast\.error\("Couldn't delete automation", \{/,
+    /toast\.error\("Couldn't save automation", \{/,
+    /toast\.error\("Couldn't update automation", \{/,
+  ]) {
+    assert.match(source, call);
+  }
+});
+
+test("a post-action refresh still swallows its own transient errors", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  // Background refreshes fire after an action that already reported its own
+  // outcome — a failure there must not stack a second toast on top of it.
+  assert.match(source, /interface RefreshDataOptions \{\s*suppressErrors\?: boolean;\s*\}/);
+  assert.match(source, /void refreshData\(\{ suppressErrors: true \}\);/);
+  assert.match(
+    source,
+    /if \(!suppressErrors\) \{\s*toast\.error\("Couldn't load automations", \{/,
+  );
 });
 
 test("empty state keeps the decorated icon and offers both creation paths as peer links", async () => {

--- a/apps/desktop/src/components/panes/AutomationsPane.tsx
+++ b/apps/desktop/src/components/panes/AutomationsPane.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   CalendarClock,
   Check,
-  CheckCircle2,
   Bot,
   ChevronDown,
   Clock3,
@@ -102,7 +101,6 @@ interface AutomationsPaneProps {
 }
 
 interface RefreshDataOptions {
-  preserveStatusMessage?: boolean;
   suppressErrors?: boolean;
 }
 
@@ -315,10 +313,6 @@ export function AutomationsPane({
   );
   const [isLoading, setIsLoading] = useState(false);
   const [busyJobId, setBusyJobId] = useState<string | null>(null);
-  const [statusMessage, setStatusMessage] = useState("");
-  const [statusTone, setStatusTone] = useState<"info" | "success" | "error">(
-    "info",
-  );
 
   const { projects } = useWorkspaceProjects(activeWorkspaceId || null);
   const projectNameById = useMemo(() => {
@@ -420,28 +414,8 @@ export function AutomationsPane({
     ? (cronjobs.find((job) => job.id === editJobId) ?? null)
     : null;
 
-  const statusBarClassName =
-    statusTone === "success"
-      ? "border-b border-success/20 bg-success/8 text-success"
-      : statusTone === "error"
-        ? "border-b border-destructive/20 bg-destructive/5 text-destructive"
-        : "border-b border-border bg-fg-2 text-muted-foreground";
-
-  // Auto-dismiss success messages after a moment so the banner doesn't
-  // linger forever after a save. Errors stay until the user replaces them
-  // (or another action overwrites) — they need acknowledgement. Info
-  // also persists since it's used for "open in chat" affordance hints.
-  useEffect(() => {
-    if (statusTone !== "success" || !statusMessage) return;
-    const timeoutId = window.setTimeout(() => {
-      setStatusMessage("");
-    }, 3500);
-    return () => window.clearTimeout(timeoutId);
-  }, [statusMessage, statusTone]);
-
   const refreshData = useCallback(
     async (options?: RefreshDataOptions) => {
-      const preserveStatusMessage = options?.preserveStatusMessage ?? false;
       const suppressErrors = options?.suppressErrors ?? false;
 
       if (!activeWorkspaceId) {
@@ -455,14 +429,11 @@ export function AutomationsPane({
         });
 
         setCronjobs(cronjobsResponse.jobs);
-
-        if (!preserveStatusMessage) {
-          setStatusMessage("");
-        }
       } catch (error) {
         if (!suppressErrors) {
-          setStatusTone("error");
-          setStatusMessage(normalizeErrorMessage(error));
+          toast.error("Couldn't load automations", {
+            description: normalizeErrorMessage(error),
+          });
         }
       } finally {
         setIsLoading(false);
@@ -477,7 +448,6 @@ export function AutomationsPane({
 
   const handleDelete = async (job: CronjobRecordPayload) => {
     setBusyJobId(job.id);
-    setStatusMessage("");
     try {
       await remoteApi.cronjobs.delete({
         jobId: job.id,
@@ -488,15 +458,12 @@ export function AutomationsPane({
           ? { mode: "index" }
           : current,
       );
-      setStatusTone("success");
-      setStatusMessage(`Deleted "${jobTitle(job)}".`);
-      void refreshData({
-        preserveStatusMessage: true,
-        suppressErrors: true,
-      });
+      toast.success(`Deleted "${jobTitle(job)}"`);
+      void refreshData({ suppressErrors: true });
     } catch (error) {
-      setStatusTone("error");
-      setStatusMessage(normalizeErrorMessage(error));
+      toast.error("Couldn't delete automation", {
+        description: normalizeErrorMessage(error),
+      });
     } finally {
       setBusyJobId(null);
     }
@@ -509,7 +476,6 @@ export function AutomationsPane({
       successMessage: string,
     ) => {
       setBusyJobId(job.id);
-      setStatusMessage("");
       try {
         const updated = await remoteApi.cronjobs.update({
           jobId: job.id,
@@ -518,15 +484,12 @@ export function AutomationsPane({
         setCronjobs((previous) =>
           previous.map((item) => (item.id === updated.id ? updated : item)),
         );
-        setStatusTone("success");
-        setStatusMessage(successMessage);
-        void refreshData({
-          preserveStatusMessage: true,
-          suppressErrors: true,
-        });
+        toast.success(successMessage);
+        void refreshData({ suppressErrors: true });
       } catch (error) {
-        setStatusTone("error");
-        setStatusMessage(normalizeErrorMessage(error));
+        toast.error("Couldn't save automation", {
+          description: normalizeErrorMessage(error),
+        });
         // Re-throw so the edit dialog can keep itself open and let the user
         // retry without losing their draft.
         throw error;
@@ -539,7 +502,6 @@ export function AutomationsPane({
 
   const handleToggleEnabled = async (job: CronjobRecordPayload) => {
     setBusyJobId(job.id);
-    setStatusMessage("");
     try {
       const updated = await remoteApi.cronjobs.update({
         jobId: job.id,
@@ -548,17 +510,14 @@ export function AutomationsPane({
       setCronjobs((previous) =>
         previous.map((item) => (item.id === updated.id ? updated : item)),
       );
-      setStatusTone("success");
-      setStatusMessage(
-        `${updated.enabled ? "Enabled" : "Paused"} "${jobTitle(updated)}".`,
+      toast.success(
+        `${updated.enabled ? "Enabled" : "Paused"} "${jobTitle(updated)}"`,
       );
-      void refreshData({
-        preserveStatusMessage: true,
-        suppressErrors: true,
-      });
+      void refreshData({ suppressErrors: true });
     } catch (error) {
-      setStatusTone("error");
-      setStatusMessage(normalizeErrorMessage(error));
+      toast.error("Couldn't update automation", {
+        description: normalizeErrorMessage(error),
+      });
     } finally {
       setBusyJobId(null);
     }
@@ -566,7 +525,6 @@ export function AutomationsPane({
 
   const handleRunNow = async (job: CronjobRecordPayload) => {
     setBusyJobId(job.id);
-    setStatusMessage("");
     try {
       const response = await remoteApi.cronjobs.runNow({
         jobId: job.id,
@@ -577,7 +535,6 @@ export function AutomationsPane({
           item.id === response.cronjob.id ? response.cronjob : item,
         ),
       );
-      // Run-now feedback lives in the toast alone — no status banner.
       toast.success(`Running "${jobTitle(response.cronjob)}" now`, {
         description: "Track it from the running task in chat.",
       });
@@ -589,10 +546,7 @@ export function AutomationsPane({
         onRunNow(response.cronjob);
         return;
       }
-      void refreshData({
-        preserveStatusMessage: true,
-        suppressErrors: true,
-      });
+      void refreshData({ suppressErrors: true });
     } catch (error) {
       toast.error("Couldn't run automation", {
         description: normalizeErrorMessage(error),
@@ -652,9 +606,8 @@ export function AutomationsPane({
           ...(draft.model ? { selected_model: draft.model } : {}),
         },
       });
-      setStatusTone("success");
-      setStatusMessage(`Created "${draft.name || "automation"}".`);
-      await refreshData({ preserveStatusMessage: true, suppressErrors: true });
+      toast.success(`Created "${draft.name || "automation"}"`);
+      await refreshData({ suppressErrors: true });
     },
     [activeWorkspaceId, refreshData],
   );
@@ -681,7 +634,7 @@ export function AutomationsPane({
           cron: draft.cron,
           metadata,
         },
-        `Updated "${draft.name || jobTitle(job)}".`,
+        `Updated "${draft.name || jobTitle(job)}"`,
       );
     },
     [handleUpdateCronjobField],
@@ -853,23 +806,6 @@ export function AutomationsPane({
           setPendingDelete(null);
         }}
       />
-
-      {statusMessage ? (
-        <div
-          key={`${statusTone}:${statusMessage}`}
-          className={cn(
-            "mx-auto flex w-full max-w-5xl shrink-0 items-center gap-1.5 px-6 py-1.5 text-xs font-medium duration-snappy ease-out-expo animate-in fade-in-0",
-            statusBarClassName,
-          )}
-        >
-          {statusTone === "success" ? (
-            <CheckCircle2 className="size-3.5 shrink-0" />
-          ) : statusTone === "error" ? (
-            <AlertTriangle className="size-3.5 shrink-0" />
-          ) : null}
-          <span className="min-w-0 truncate">{statusMessage}</span>
-        </div>
-      ) : null}
 
       <div className="min-h-0 w-full flex-1 overflow-y-auto [&>*]:mx-auto [&>*]:w-full [&>*]:max-w-5xl">
         {!activeWorkspaceId ? (


### PR DESCRIPTION
## What

The automations pane had two feedback channels for the same class of event: run-now used a sonner toast, while delete, save, enable/pause, create and list-refresh wrote to an in-page banner. This routes everything through toast.

| Action | Toast |
|---|---|
| Delete | `Deleted "X"` / `Couldn't delete automation` |
| Save edit | `Updated "X"` / `Couldn't save automation` |
| Enable / pause | `Enabled "X"` · `Paused "X"` / `Couldn't update automation` |
| Create | `Created "X"` |
| List load | `Couldn't load automations` |
| Run now | unchanged — already a toast |

Keeps the shape already in the file: a short headline for what happened, the raw error as the description. Success strings lose their trailing period to match `Running "X" now`.

## Why this is more than a style change

The banner rendered as a `shrink-0` row *above* the scroll area. With a long list, acting on a job further down put the outcome off-screen — the user got no feedback at all.

## What went with it

Removing the banner removed the machinery that existed only to serve it: the tone→classname map, the 3.5s auto-dismiss timer, and the `preserveStatusMessage` option threaded through `refreshData` (its only job was stopping a background refresh from wiping the banner mid-read). Net −64 lines in the pane.

`suppressErrors` stays. A refresh fires right after an action that already reported its own outcome, so a failure there must not stack a second toast on top.

## Tests

The test asserting the banner mechanism is replaced by two: one asserts the banner identifiers are gone entirely and all six toast calls are present, the other pins the `suppressErrors` behaviour.

- `desktop:typecheck` clean
- `AutomationsPane.test.mjs` 18/18
- `test:unit` 167/167

Note: `test:unit`'s glob only matches `.ts`, so the `.mjs` snapshot tests here are not covered by it — I ran them directly.

## Not verified

Not exercised in the running app. Worth a click-through on delete / toggle / save, and on opening the pane offline to see `Couldn't load automations` land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)