### PR TITLE
feat(desktop): create your own HolaApp (URL + MCP config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Install apps from the in-workspace marketplace and they open as **real, interact
 - **Real surfaces, not chat** — every app is a live UI (Notion, a browser, your own app), not a transcript.
 - **Side-by-side by design** — app and agent share the screen, so you always see what's happening and can take over.
 - **One click to install** — browse the in-workspace marketplace and open any app instantly.
+- **Bring your own** — point a HolaApp at any URL and MCP server; it lives on your machine, yours to open and drive.
 
 <p align="center">
   <img src="docs/images/hola-app-example.png" alt="The Notion HolaApp open side-by-side with the agent navigating it in holaOS" width="1280" />

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -1,0 +1,312 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { useSetAtom } from "jotai";
+import { useCallback, useEffect, useState } from "react";
+import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
+import { Button } from "@/components/ui/button";
+import { AppWindow, Globe, Loader2, Plus, X } from "@/components/ui/icons";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	type CustomHolaApp,
+	customHolaAppId,
+	deleteCustomHolaApp,
+	parseCustomMcpConfig,
+	readCustomHolaApps,
+	upsertCustomHolaApp,
+} from "@/lib/localCustomHolaApps";
+import { HolaAppIcon } from "./HolaAppIcon";
+
+const MCP_PLACEHOLDER = `{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}`;
+
+// Manage LOCAL, user-created HolaApps: an app is a URL the desktop opens as its
+// surface plus an OPTIONAL MCP server (pasted as an mcpServers-style JSON config)
+// whose tools the agent gains while the app is installed. Everything is stored on
+// this machine (localCustomHolaApps) — no backend. onChanged refreshes the shared
+// HolaApp catalog so the new/removed app (and its MCP) reflects in the grid + sidebar.
+//
+// Rendered as a Dialog above the native BrowserView layer, bumping the shell overlay
+// counter so the surface detaches — same pattern as McpInstallDialog.
+export function CustomHolaAppCreateDialog({
+	open,
+	onOpenChange,
+	onChanged,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Called after a custom app is created or removed — refresh the app catalog. */
+	onChanged: () => void;
+}) {
+	const setOverlayCount = useSetAtom(overlayOpenCountAtom);
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		setOverlayCount((c) => c + 1);
+		return () => {
+			setOverlayCount((c) => Math.max(0, c - 1));
+		};
+	}, [open, setOverlayCount]);
+
+	const [apps, setApps] = useState<CustomHolaApp[]>([]);
+	const [title, setTitle] = useState("");
+	const [url, setUrl] = useState("");
+	const [iconUrl, setIconUrl] = useState("");
+	const [mcpJson, setMcpJson] = useState("");
+	const [error, setError] = useState("");
+	const [saving, setSaving] = useState(false);
+
+	const reload = useCallback(() => setApps(readCustomHolaApps()), []);
+	useEffect(() => {
+		if (open) {
+			reload();
+		}
+	}, [open, reload]);
+
+	const resetForm = () => {
+		setTitle("");
+		setUrl("");
+		setIconUrl("");
+		setMcpJson("");
+		setError("");
+	};
+
+	const validUrl = (value: string): boolean => {
+		try {
+			const parsed = new URL(value);
+			return parsed.protocol === "http:" || parsed.protocol === "https:";
+		} catch {
+			return false;
+		}
+	};
+
+	const handleCreate = () => {
+		const trimmedTitle = title.trim();
+		const trimmedUrl = url.trim();
+		if (!trimmedTitle) {
+			setError("Give your app a name.");
+			return;
+		}
+		if (!validUrl(trimmedUrl)) {
+			setError("Enter a valid http(s) URL for the app to open.");
+			return;
+		}
+		setSaving(true);
+		setError("");
+		try {
+			const holaAppId = customHolaAppId(trimmedTitle);
+			let mcp: CustomHolaApp["mcp"];
+			const rawMcp = mcpJson.trim();
+			if (rawMcp) {
+				const parsed = parseCustomMcpConfig(rawMcp, holaAppId);
+				if ("error" in parsed) {
+					setError(parsed.error);
+					setSaving(false);
+					return;
+				}
+				mcp = parsed.attach;
+			}
+			const app: CustomHolaApp = {
+				holaAppId,
+				title: trimmedTitle,
+				url: trimmedUrl,
+				...(iconUrl.trim() ? { iconUrl: iconUrl.trim() } : {}),
+				...(mcp ? { mcp } : {}),
+				...(rawMcp ? { mcpConfigJson: rawMcp } : {}),
+			};
+			upsertCustomHolaApp(app);
+			resetForm();
+			reload();
+			onChanged();
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleRemove = (holaAppId: string) => {
+		deleteCustomHolaApp(holaAppId);
+		reload();
+		onChanged();
+	};
+
+	return (
+		<DialogPrimitive.Root onOpenChange={onOpenChange} open={open}>
+			<DialogPrimitive.Portal>
+				<DialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-foreground/20 backdrop-blur-sm ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0" />
+				<DialogPrimitive.Popup className="fixed top-[10%] left-1/2 z-[100] flex max-h-[80vh] w-[520px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-2xl outline-none ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+					<div className="flex items-center gap-3 border-border border-b px-4 py-3">
+						<div className="grid size-9 shrink-0 place-items-center rounded-lg border border-border bg-background">
+							<AppWindow className="size-5 text-muted-foreground" />
+						</div>
+						<div className="min-w-0 flex-1">
+							<DialogPrimitive.Title className="truncate font-medium text-foreground text-sm">
+								Create your own app
+							</DialogPrimitive.Title>
+							<DialogPrimitive.Description className="mt-0.5 text-muted-foreground text-xs">
+								A URL the app opens, plus an optional MCP server for its tools.
+								Stored only on this device.
+							</DialogPrimitive.Description>
+						</div>
+						<DialogPrimitive.Close
+							aria-label="Close"
+							className="grid size-7 shrink-0 place-items-center rounded-md text-foreground/60 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+						>
+							<X className="size-3.5" />
+						</DialogPrimitive.Close>
+					</div>
+
+					<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+						{apps.length > 0 ? (
+							<div className="flex flex-col gap-1.5">
+								<p className="font-medium text-foreground text-xs">Your apps</p>
+								{apps.map((app) => (
+									<div
+										className="flex items-center gap-2.5 rounded-lg border border-border bg-background px-3 py-2"
+										key={app.holaAppId}
+									>
+										<div className="grid size-7 shrink-0 place-items-center rounded-md border border-border">
+											{app.iconUrl ? (
+												<HolaAppIcon
+													iconUrl={app.iconUrl}
+													sizeClass="size-4"
+													title={app.title}
+												/>
+											) : (
+												<Globe className="size-3.5 text-muted-foreground" />
+											)}
+										</div>
+										<div className="min-w-0 flex-1">
+											<p className="truncate font-medium text-foreground text-sm leading-tight">
+												{app.title}
+											</p>
+											<p className="truncate text-muted-foreground text-xs">
+												{app.url}
+												{app.mcp ? " · MCP" : ""}
+											</p>
+										</div>
+										<button
+											aria-label={`Remove ${app.title}`}
+											className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+											onClick={() => handleRemove(app.holaAppId)}
+											type="button"
+										>
+											<X className="size-3.5" />
+										</button>
+									</div>
+								))}
+								<div className="my-1 h-px bg-border" />
+							</div>
+						) : null}
+
+						<div className="flex flex-col gap-1.5">
+							<Label
+								className="text-foreground text-xs"
+								htmlFor="custom-app-name"
+							>
+								Name
+							</Label>
+							<Input
+								autoComplete="off"
+								id="custom-app-name"
+								onChange={(event) => setTitle(event.target.value)}
+								placeholder="My App"
+								value={title}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label
+								className="text-foreground text-xs"
+								htmlFor="custom-app-url"
+							>
+								URL
+							</Label>
+							<Input
+								autoComplete="off"
+								id="custom-app-url"
+								onChange={(event) => setUrl(event.target.value)}
+								placeholder="https://example.com"
+								value={url}
+							/>
+							<p className="text-muted-foreground text-xs">
+								The page the app opens as its surface, next to your agent.
+							</p>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label
+								className="text-foreground text-xs"
+								htmlFor="custom-app-icon"
+							>
+								Icon URL{" "}
+								<span className="text-muted-foreground">(optional)</span>
+							</Label>
+							<Input
+								autoComplete="off"
+								id="custom-app-icon"
+								onChange={(event) => setIconUrl(event.target.value)}
+								placeholder="https://example.com/favicon.ico"
+								value={iconUrl}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label
+								className="text-foreground text-xs"
+								htmlFor="custom-app-mcp"
+							>
+								MCP server config{" "}
+								<span className="text-muted-foreground">(optional)</span>
+							</Label>
+							<Textarea
+								autoComplete="off"
+								className="min-h-[132px] font-mono text-xs"
+								id="custom-app-mcp"
+								onChange={(event) => setMcpJson(event.target.value)}
+								placeholder={MCP_PLACEHOLDER}
+								spellCheck={false}
+								value={mcpJson}
+							/>
+							<p className="text-muted-foreground text-xs">
+								Paste an MCP config to give the agent this app's tools. Remote
+								(URL) servers with optional headers; kept on this device.
+							</p>
+						</div>
+
+						{error ? <p className="text-destructive text-xs">{error}</p> : null}
+					</div>
+
+					<div className="flex items-center justify-end gap-2 border-border border-t px-4 py-3">
+						<DialogPrimitive.Close
+							render={
+								<Button size="sm" type="button" variant="ghost">
+									Done
+								</Button>
+							}
+						/>
+						<Button
+							disabled={saving || !title.trim() || !url.trim()}
+							onClick={handleCreate}
+							size="sm"
+							type="button"
+						>
+							{saving ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : (
+								<Plus className="size-3.5" />
+							)}
+							Add app
+						</Button>
+					</div>
+				</DialogPrimitive.Popup>
+			</DialogPrimitive.Portal>
+		</DialogPrimitive.Root>
+	);
+}

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -3,7 +3,14 @@ import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useState } from "react";
 import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
 import { Button } from "@/components/ui/button";
-import { AppWindow, Globe, Loader2, Plus, X } from "@/components/ui/icons";
+import {
+	AppWindow,
+	Globe,
+	Loader2,
+	Plus,
+	ShieldCheck,
+	X,
+} from "@/components/ui/icons";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -38,11 +45,14 @@ export function CustomHolaAppCreateDialog({
 	open,
 	onOpenChange,
 	onChanged,
+	workspaceId,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	/** Called after a custom app is created or removed — refresh the app catalog. */
 	onChanged: () => void;
+	/** Active workspace — needed to run/check a custom MCP's OAuth authorization. */
+	workspaceId: string | null;
 }) {
 	const setOverlayCount = useSetAtom(overlayOpenCountAtom);
 	useEffect(() => {
@@ -191,6 +201,12 @@ export function CustomHolaAppCreateDialog({
 												{app.mcp ? " · MCP" : ""}
 											</p>
 										</div>
+										{app.mcp && Object.keys(app.mcp.headerKeys).length === 0 ? (
+											<CustomAppAuthorize
+												serverId={app.mcp.id}
+												workspaceId={workspaceId}
+											/>
+										) : null}
 										<button
 											aria-label={`Remove ${app.title}`}
 											className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
@@ -276,7 +292,9 @@ export function CustomHolaAppCreateDialog({
 							/>
 							<p className="text-muted-foreground text-xs">
 								Paste an MCP config to give the agent this app's tools. Remote
-								(URL) servers with optional headers; kept on this device.
+								(URL) servers; add auth headers for a static token, or leave
+								them out and Authorize (OAuth) after it's added. Kept on this
+								device.
 							</p>
 						</div>
 
@@ -308,5 +326,123 @@ export function CustomHolaAppCreateDialog({
 				</DialogPrimitive.Popup>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>
+	);
+}
+
+type AuthorizeState =
+	| "checking"
+	| "hidden"
+	| "authorized"
+	| "needs"
+	| "authorizing"
+	| "error";
+
+// Proactive OAuth authorization for a custom app's MCP server. Rendered only for an
+// MCP with NO static auth header (a header-less server is the OAuth case — a static
+// token is already usable, so it never shows this). Checks the server's token on
+// mount; the button runs the runtime's system-browser OAuth flow (authorizeMcpServer)
+// — the same path as the inline chat Authorize card (McpAuthorizeCard).
+function CustomAppAuthorize({
+	serverId,
+	workspaceId,
+}: {
+	serverId: string;
+	workspaceId: string | null;
+}) {
+	const [state, setState] = useState<AuthorizeState>("checking");
+	const [detail, setDetail] = useState("");
+
+	useEffect(() => {
+		if (!workspaceId) {
+			setState("hidden");
+			return;
+		}
+		let cancelled = false;
+		window.electronAPI.workspace
+			.mcpServerAuthorized(workspaceId, serverId)
+			.then((result) => {
+				if (cancelled) {
+					return;
+				}
+				if (result.authorized) {
+					setState("authorized");
+				} else if (result.registered === false) {
+					// Not attached yet (its catalog sync is still in flight) — nothing to do.
+					setState("hidden");
+				} else {
+					setState("needs");
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setState("hidden");
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceId, serverId]);
+
+	const authorize = async () => {
+		if (!workspaceId) {
+			return;
+		}
+		setState("authorizing");
+		setDetail("");
+		try {
+			const result = await window.electronAPI.workspace.authorizeMcpServer(
+				workspaceId,
+				serverId,
+				false,
+			);
+			if (result.ok) {
+				setState("authorized");
+			} else {
+				setState("error");
+				setDetail(result.detail || "Authorization failed.");
+			}
+		} catch (err) {
+			setState("error");
+			setDetail(err instanceof Error ? err.message : "Request failed.");
+		}
+	};
+
+	if (state === "checking" || state === "hidden") {
+		return null;
+	}
+	if (state === "authorized") {
+		return (
+			<span className="shrink-0 text-emerald-600 text-xs">Authorized</span>
+		);
+	}
+	return (
+		<div className="flex shrink-0 flex-col items-end gap-1">
+			<Button
+				disabled={state === "authorizing"}
+				onClick={() => void authorize()}
+				size="sm"
+				type="button"
+				variant="outline"
+			>
+				{state === "authorizing" ? (
+					<Loader2 className="size-3.5 animate-spin" />
+				) : (
+					<ShieldCheck className="size-3.5" />
+				)}
+				{state === "authorizing"
+					? "Signing in…"
+					: state === "error"
+						? "Try again"
+						: "Authorize"}
+			</Button>
+			{state === "error" && detail ? (
+				<span
+					className="max-w-[180px] truncate text-[11px] text-destructive"
+					title={detail}
+				>
+					{detail}
+				</span>
+			) : null}
+		</div>
 	);
 }

--- a/apps/desktop/src/components/panes/CustomizePane.tsx
+++ b/apps/desktop/src/components/panes/CustomizePane.tsx
@@ -1,387 +1,412 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useEffect, useMemo, useState } from "react";
+import { CustomHolaAppCreateDialog } from "@/components/layout/shell/CustomHolaAppCreateDialog";
 import { HolaAppMarketplacePane } from "@/components/layout/shell/HolaAppMarketplacePane";
 import {
-  type CustomizeTab,
-  customizeTabAtom,
-  pendingHubInstallAtom,
+	type CustomizeTab,
+	customizeTabAtom,
+	pendingHubInstallAtom,
 } from "@/components/layout/shell/state/ui";
+import { useHolaAppCatalog } from "@/components/layout/shell/useHolaAppCatalog";
 import { useOpenDiscover } from "@/components/layout/shell/useOpenDiscover";
 import { useStartCapabilityCreation } from "@/components/layout/shell/useStartCapabilityCreation";
 import { useStartChatDraft } from "@/components/layout/shell/useStartChatDraft";
 import { useStartSkillCreation } from "@/components/layout/shell/useStartSkillCreation";
-import { CapabilityCreatePane } from "@/components/panes/CapabilityCreatePane";
 import { CapabilityGlyph } from "@/components/marketplace/CapabilityGlyph";
-import { CapabilityDetailView } from "@/components/panes/CapabilityDetailView";
 import { CapabilitiesMarketPane } from "@/components/panes/CapabilitiesMarketPane";
+import { CapabilityCreatePane } from "@/components/panes/CapabilityCreatePane";
+import { CapabilityDetailView } from "@/components/panes/CapabilityDetailView";
 import { CapabilityImportPane } from "@/components/panes/CapabilityImportPane";
 import { McpsPane } from "@/components/panes/McpsPane";
 import { SkillsStorePane } from "@/components/panes/SkillsStorePane";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  ArrowUpRight,
-  Boxes,
-  ChevronLeft,
-  ChevronRight,
-  Plus,
-  Search,
-  Sparkles,
-  Wrench,
-} from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-shell";
-import { Input } from "@/components/ui/input";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+	ArrowUpRight,
+	Boxes,
+	ChevronLeft,
+	ChevronRight,
+	Plus,
+	Search,
+	Sparkles,
+	Wrench,
+} from "@/components/ui/icons";
+import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/ui/page-shell";
 import { remoteApiQuery } from "@/lib/remoteApiQuery";
 import { cn } from "@/lib/utils";
 
 const SEGMENTS: { id: CustomizeTab; label: string }[] = [
-  { id: "apps", label: "Apps" },
-  { id: "capabilities", label: "Combos" },
-  { id: "skills", label: "Skills" },
-  { id: "mcps", label: "MCPs" },
+	{ id: "apps", label: "Apps" },
+	{ id: "capabilities", label: "Combos" },
+	{ id: "skills", label: "Skills" },
+	{ id: "mcps", label: "MCPs" },
 ];
 
 // Full browsing lives in the HolaHub Marketplace; each tab links out to its
 // matching marketplace type. (Customize itself is for managing what's installed.)
 const MARKETPLACE_TYPE_BY_TAB: Record<CustomizeTab, string> = {
-  apps: "holaapp",
-  capabilities: "capability",
-  skills: "skill",
-  mcps: "mcp",
+	apps: "holaapp",
+	capabilities: "capability",
+	skills: "skill",
+	mcps: "mcp",
 };
 
 export function CustomizePane({ workspaceId }: { workspaceId: string | null }) {
-  const openDiscover = useOpenDiscover();
-  const [tab, setTab] = useAtom(customizeTabAtom);
-  const browseMarketplace = () =>
-    openDiscover(`/marketplace?type=${MARKETPLACE_TYPE_BY_TAB[tab]}`);
-  const [selectedCapabilityId, setSelectedCapabilityId] = useState<
-    string | null
-  >(null);
-  const [capabilityView, setCapabilityView] = useState<"market" | "installed">(
-    "market",
-  );
-  const [creating, setCreating] = useState(false);
-  const [importing, setImporting] = useState(false);
-  const [mcpsView, setMcpsView] = useState<"store" | "connected">("connected");
-  const [mcpsQuery, setMcpsQuery] = useState("");
-  // A catalog id to auto-open/install when HolaHub's "Install" op routes a
-  // KEYED/gated item here (HeadlessInstaller → pendingHubInstallAtom) so the user
-  // can complete its connect step — one per tab's native surface.
-  const [openCapabilityRef, setOpenCapabilityRef] = useState<string | null>(
-    null,
-  );
-  const [openMcpRef, setOpenMcpRef] = useState<string | null>(null);
-  const [openSkillRef, setOpenSkillRef] = useState<string | null>(null);
-  const [pendingInstall, setPendingInstall] = useAtom(pendingHubInstallAtom);
-  const startSkillCreation = useStartSkillCreation();
-  const startCapabilityCreation = useStartCapabilityCreation();
-  const startChatDraft = useStartChatDraft();
+	const openDiscover = useOpenDiscover();
+	const [tab, setTab] = useAtom(customizeTabAtom);
+	const browseMarketplace = () =>
+		openDiscover(`/marketplace?type=${MARKETPLACE_TYPE_BY_TAB[tab]}`);
+	const { refresh: refreshHolaApps } = useHolaAppCatalog();
+	const [customAppsOpen, setCustomAppsOpen] = useState(false);
+	const [selectedCapabilityId, setSelectedCapabilityId] = useState<
+		string | null
+	>(null);
+	const [capabilityView, setCapabilityView] = useState<"market" | "installed">(
+		"market",
+	);
+	const [creating, setCreating] = useState(false);
+	const [importing, setImporting] = useState(false);
+	const [mcpsView, setMcpsView] = useState<"store" | "connected">("connected");
+	const [mcpsQuery, setMcpsQuery] = useState("");
+	// A catalog id to auto-open/install when HolaHub's "Install" op routes a
+	// KEYED/gated item here (HeadlessInstaller → pendingHubInstallAtom) so the user
+	// can complete its connect step — one per tab's native surface.
+	const [openCapabilityRef, setOpenCapabilityRef] = useState<string | null>(
+		null,
+	);
+	const [openMcpRef, setOpenMcpRef] = useState<string | null>(null);
+	const [openSkillRef, setOpenSkillRef] = useState<string | null>(null);
+	const [pendingInstall, setPendingInstall] = useAtom(pendingHubInstallAtom);
+	const startSkillCreation = useStartSkillCreation();
+	const startCapabilityCreation = useStartCapabilityCreation();
+	const startChatDraft = useStartChatDraft();
 
-  const installedQuery = useQuery(
-    remoteApiQuery.capabilities.listInstalled.queryOptions({
-      input: {},
-      enabled: Boolean(workspaceId),
-    }),
-  );
-  const installed = installedQuery.data?.capabilities ?? [];
-  const installedIds = useMemo(
-    () => new Set(installed.map((c) => c.capabilityId)),
-    [installed],
-  );
-  const selectedCapability =
-    installed.find((c) => c.capabilityId === selectedCapabilityId) ?? null;
+	const installedQuery = useQuery(
+		remoteApiQuery.capabilities.listInstalled.queryOptions({
+			input: {},
+			enabled: Boolean(workspaceId),
+		}),
+	);
+	const installed = installedQuery.data?.capabilities ?? [];
+	const installedIds = useMemo(
+		() => new Set(installed.map((c) => c.capabilityId)),
+		[installed],
+	);
+	const selectedCapability =
+		installed.find((c) => c.capabilityId === selectedCapabilityId) ?? null;
 
-  // Consume a HolaHub "install" intent (routed here by HeadlessInstaller for
-  // keyed/gated items): open the item's tab and focus it in its native install
-  // surface so the user can connect, then clear the intent.
-  useEffect(() => {
-    if (!pendingInstall) {
-      return;
-    }
-    if (pendingInstall.type === "capability") {
-      setTab("capabilities");
-      setCapabilityView("market");
-      setOpenCapabilityRef(pendingInstall.ref);
-    } else if (pendingInstall.type === "mcp") {
-      setTab("mcps");
-      setMcpsView("store");
-      setOpenMcpRef(pendingInstall.ref);
-    } else if (pendingInstall.type === "skill") {
-      setTab("skills");
-      setOpenSkillRef(pendingInstall.ref);
-    }
-    setPendingInstall(null);
-  }, [pendingInstall, setPendingInstall]);
+	// Consume a HolaHub "install" intent (routed here by HeadlessInstaller for
+	// keyed/gated items): open the item's tab and focus it in its native install
+	// surface so the user can connect, then clear the intent.
+	useEffect(() => {
+		if (!pendingInstall) {
+			return;
+		}
+		if (pendingInstall.type === "capability") {
+			setTab("capabilities");
+			setCapabilityView("market");
+			setOpenCapabilityRef(pendingInstall.ref);
+		} else if (pendingInstall.type === "mcp") {
+			setTab("mcps");
+			setMcpsView("store");
+			setOpenMcpRef(pendingInstall.ref);
+		} else if (pendingInstall.type === "skill") {
+			setTab("skills");
+			setOpenSkillRef(pendingInstall.ref);
+		}
+		setPendingInstall(null);
+	}, [pendingInstall, setPendingInstall]);
 
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <PageHeader
-        maxWidth="5xl"
-        title="Customize"
-        toolbar={
-          <div className="flex items-center justify-between gap-3">
-            <div className="inline-flex items-center gap-0.5 rounded-lg bg-fg-4 p-0.5">
-            {SEGMENTS.map(({ id, label }) => (
-              <button
-                className={cn(
-                  "rounded-md px-3 py-1 font-medium text-sm transition-colors",
-                  tab === id
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-                key={id}
-                onClick={() => {
-                  setTab(id);
-                  setSelectedCapabilityId(null);
-                  setCreating(false);
-                  setImporting(false);
-                }}
-                type="button"
-              >
-                {label}
-              </button>
-            ))}
-            </div>
-            <button
-              className="inline-flex shrink-0 items-center gap-1 font-medium text-primary text-sm transition-colors hover:text-primary/80"
-              onClick={browseMarketplace}
-              type="button"
-            >
-              Browse in Marketplace
-              <ArrowUpRight className="size-4" />
-            </button>
-          </div>
-        }
-      />
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			<PageHeader
+				maxWidth="5xl"
+				title="Customize"
+				toolbar={
+					<div className="flex items-center justify-between gap-3">
+						<div className="inline-flex items-center gap-0.5 rounded-lg bg-fg-4 p-0.5">
+							{SEGMENTS.map(({ id, label }) => (
+								<button
+									className={cn(
+										"rounded-md px-3 py-1 font-medium text-sm transition-colors",
+										tab === id
+											? "bg-background text-foreground shadow-sm"
+											: "text-muted-foreground hover:text-foreground",
+									)}
+									key={id}
+									onClick={() => {
+										setTab(id);
+										setSelectedCapabilityId(null);
+										setCreating(false);
+										setImporting(false);
+									}}
+									type="button"
+								>
+									{label}
+								</button>
+							))}
+						</div>
+						<div className="flex shrink-0 items-center gap-3">
+							{tab === "apps" ? (
+								<button
+									className="inline-flex items-center gap-1 font-medium text-foreground text-sm transition-colors hover:text-foreground/70"
+									onClick={() => setCustomAppsOpen(true)}
+									type="button"
+								>
+									<Plus className="size-4" />
+									Create your own app
+								</button>
+							) : null}
+							<button
+								className="inline-flex items-center gap-1 font-medium text-primary text-sm transition-colors hover:text-primary/80"
+								onClick={browseMarketplace}
+								type="button"
+							>
+								Browse in Marketplace
+								<ArrowUpRight className="size-4" />
+							</button>
+						</div>
+					</div>
+				}
+			/>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
-        {tab === "apps" ? (
-          <HolaAppMarketplacePane embedded onBrowseMarketplace={browseMarketplace} />
-        ) : tab === "skills" ? (
-          <SkillsStorePane
-            installRef={openSkillRef}
-            manageOnly
-            onBrowseMarketplace={browseMarketplace}
-            onCreateSkill={startSkillCreation}
-            onInstallHandled={() => setOpenSkillRef(null)}
-            onTryWithAgent={(skillId) =>
-              startChatDraft(`/${skillId}\n`, { returnTo: "customize" })
-            }
-            workspaceId={workspaceId}
-          />
-        ) : tab === "mcps" ? (
-          mcpsView === "store" ? (
-            <div className="flex h-full min-h-0 flex-col">
-              <div className="mx-auto flex w-full max-w-5xl shrink-0 items-center gap-3 px-6 py-2.5">
-                <div className="relative w-full max-w-xs">
-                  <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    aria-label="Search MCP servers"
-                    className="h-8 w-full rounded-md pl-8 text-sm"
-                    onChange={(event) => setMcpsQuery(event.target.value)}
-                    placeholder="Search MCP servers"
-                    value={mcpsQuery}
-                  />
-                </div>
-              </div>
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <McpsPane
-                  browseQuery={mcpsQuery}
-                  installRef={openMcpRef}
-                  mode="browse"
-                  onInstallHandled={() => {
-                    setOpenMcpRef(null);
-                    setMcpsView("connected");
-                  }}
-                  onSeeInstalled={() => setMcpsView("connected")}
-                  workspaceId={workspaceId}
-                />
-              </div>
-            </div>
-          ) : (
-            <div className="flex h-full min-h-0 flex-col">
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <McpsPane
-                  onAddMcpServer={() =>
-                    startChatDraft("Add an MCP server: ", {
-                      returnTo: "customize",
-                    })
-                  }
-                  onBrowseMarketplace={browseMarketplace}
-                  workspaceId={workspaceId}
-                />
-              </div>
-            </div>
-          )
-        ) : (
-          <div className="flex h-full min-h-0 flex-col">
-            {capabilityView === "market" ? (
-              <div className="min-h-0 flex-1">
-                <CapabilitiesMarketPane
-                  installedCount={installed.length}
-                  installedIds={installedIds}
-                  manageOnly
-                  onBrowseMarketplace={browseMarketplace}
-                  onChanged={() => void installedQuery.refetch()}
-                  onDetailOpened={() => setOpenCapabilityRef(null)}
-                  onManage={() => setCapabilityView("installed")}
-                  onNew={startCapabilityCreation}
-                  openDetailRef={openCapabilityRef}
-                  workspaceId={workspaceId}
-                />
-              </div>
-            ) : (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <div className="mx-auto flex w-full max-w-5xl shrink-0 items-center gap-2 px-6 py-2">
-                  <button
-                    className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-muted-foreground text-sm transition-colors hover:bg-accent hover:text-foreground"
-                    onClick={() => {
-                      setSelectedCapabilityId(null);
-                      setCreating(false);
-                      setImporting(false);
-                      setCapabilityView("market");
-                    }}
-                    type="button"
-                  >
-                    <ChevronLeft className="size-3.5" />
-                    Marketplace
-                  </button>
-                  <span className="text-muted-foreground text-sm">·</span>
-                  <span className="font-medium text-foreground text-sm">
-                    Installed
-                  </span>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      render={
-                        <Button
-                          className="ml-auto h-7 gap-1.5"
-                          size="sm"
-                          type="button"
-                          variant="outline"
-                        />
-                      }
-                    >
-                      <Plus className="size-3.5" />
-                      New
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={startCapabilityCreation}>
-                        <Sparkles className="text-muted-foreground" />
-                        Create with agent
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => {
-                          setSelectedCapabilityId(null);
-                          setCreating(true);
-                        }}
-                      >
-                        <Wrench className="text-muted-foreground" />
-                        Build manually
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+			<div className="min-h-0 flex-1 overflow-hidden">
+				{tab === "apps" ? (
+					<HolaAppMarketplacePane
+						embedded
+						onBrowseMarketplace={browseMarketplace}
+					/>
+				) : tab === "skills" ? (
+					<SkillsStorePane
+						installRef={openSkillRef}
+						manageOnly
+						onBrowseMarketplace={browseMarketplace}
+						onCreateSkill={startSkillCreation}
+						onInstallHandled={() => setOpenSkillRef(null)}
+						onTryWithAgent={(skillId) =>
+							startChatDraft(`/${skillId}\n`, { returnTo: "customize" })
+						}
+						workspaceId={workspaceId}
+					/>
+				) : tab === "mcps" ? (
+					mcpsView === "store" ? (
+						<div className="flex h-full min-h-0 flex-col">
+							<div className="mx-auto flex w-full max-w-5xl shrink-0 items-center gap-3 px-6 py-2.5">
+								<div className="relative w-full max-w-xs">
+									<Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+									<Input
+										aria-label="Search MCP servers"
+										className="h-8 w-full rounded-md pl-8 text-sm"
+										onChange={(event) => setMcpsQuery(event.target.value)}
+										placeholder="Search MCP servers"
+										value={mcpsQuery}
+									/>
+								</div>
+							</div>
+							<div className="min-h-0 flex-1 overflow-hidden">
+								<McpsPane
+									browseQuery={mcpsQuery}
+									installRef={openMcpRef}
+									mode="browse"
+									onInstallHandled={() => {
+										setOpenMcpRef(null);
+										setMcpsView("connected");
+									}}
+									onSeeInstalled={() => setMcpsView("connected")}
+									workspaceId={workspaceId}
+								/>
+							</div>
+						</div>
+					) : (
+						<div className="flex h-full min-h-0 flex-col">
+							<div className="min-h-0 flex-1 overflow-hidden">
+								<McpsPane
+									onAddMcpServer={() =>
+										startChatDraft("Add an MCP server: ", {
+											returnTo: "customize",
+										})
+									}
+									onBrowseMarketplace={browseMarketplace}
+									workspaceId={workspaceId}
+								/>
+							</div>
+						</div>
+					)
+				) : (
+					<div className="flex h-full min-h-0 flex-col">
+						{capabilityView === "market" ? (
+							<div className="min-h-0 flex-1">
+								<CapabilitiesMarketPane
+									installedCount={installed.length}
+									installedIds={installedIds}
+									manageOnly
+									onBrowseMarketplace={browseMarketplace}
+									onChanged={() => void installedQuery.refetch()}
+									onDetailOpened={() => setOpenCapabilityRef(null)}
+									onManage={() => setCapabilityView("installed")}
+									onNew={startCapabilityCreation}
+									openDetailRef={openCapabilityRef}
+									workspaceId={workspaceId}
+								/>
+							</div>
+						) : (
+							<div className="flex min-h-0 flex-1 flex-col">
+								<div className="mx-auto flex w-full max-w-5xl shrink-0 items-center gap-2 px-6 py-2">
+									<button
+										className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-muted-foreground text-sm transition-colors hover:bg-accent hover:text-foreground"
+										onClick={() => {
+											setSelectedCapabilityId(null);
+											setCreating(false);
+											setImporting(false);
+											setCapabilityView("market");
+										}}
+										type="button"
+									>
+										<ChevronLeft className="size-3.5" />
+										Marketplace
+									</button>
+									<span className="text-muted-foreground text-sm">·</span>
+									<span className="font-medium text-foreground text-sm">
+										Installed
+									</span>
+									<DropdownMenu>
+										<DropdownMenuTrigger
+											render={
+												<Button
+													className="ml-auto h-7 gap-1.5"
+													size="sm"
+													type="button"
+													variant="outline"
+												/>
+											}
+										>
+											<Plus className="size-3.5" />
+											New
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end">
+											<DropdownMenuItem onClick={startCapabilityCreation}>
+												<Sparkles className="text-muted-foreground" />
+												Create with agent
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												onClick={() => {
+													setSelectedCapabilityId(null);
+													setCreating(true);
+												}}
+											>
+												<Wrench className="text-muted-foreground" />
+												Build manually
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</div>
 
-                <div className="min-h-0 flex-1 overflow-hidden">
-                  {importing ? (
-                    <CapabilityImportPane
-                      onClose={() => setImporting(false)}
-                      onImported={(capabilityId) => {
-                        setImporting(false);
-                        setSelectedCapabilityId(capabilityId);
-                      }}
-                    />
-                  ) : creating ? (
-                    <CapabilityCreatePane
-                      onClose={() => setCreating(false)}
-                      onCreated={(capabilityId) => {
-                        setCreating(false);
-                        setSelectedCapabilityId(capabilityId);
-                      }}
-                      workspaceId={workspaceId ?? ""}
-                    />
-                  ) : selectedCapability ? (
-                    <CapabilityDetailView
-                      backLabel="All installed"
-                      capabilityId={selectedCapability.capabilityId}
-                      connectorProviders={Object.keys(
-                        selectedCapability.integrationStatus ?? {},
-                      )}
-                      description={selectedCapability.description}
-                      icon={selectedCapability.icon}
-                      installed
-                      name={selectedCapability.name}
-                      onBack={() => setSelectedCapabilityId(null)}
-                      onUninstalled={() => setSelectedCapabilityId(null)}
-                      skillIds={selectedCapability.installedSkillIds}
-                      status={selectedCapability.status}
-                      workspaceId={workspaceId ?? ""}
-                    />
-                  ) : installed.length === 0 ? (
-                    <div className="flex h-full items-center justify-center p-6">
-                      <EmptyState
-                        action={
-                          <Button
-                            onClick={() => setCapabilityView("market")}
-                            size="sm"
-                            variant="outline"
-                          >
-                            Browse marketplace
-                          </Button>
-                        }
-                        description="Combos bundle related skills and integrations. Add some from the marketplace."
-                        icon={Boxes}
-                        size="md"
-                        title="No combos installed"
-                      />
-                    </div>
-                  ) : (
-                    <div className="h-full overflow-y-auto py-5">
-                      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-x-8 gap-y-1 px-6 sm:grid-cols-2">
-                        {installed.map((capability) => (
-                          <button
-                            className="flex items-center gap-3 rounded-xl px-2 py-2 text-left transition-colors hover:bg-fg-2"
-                            key={capability.capabilityId}
-                            onClick={() =>
-                              setSelectedCapabilityId(capability.capabilityId)
-                            }
-                            type="button"
-                          >
-                            <CapabilityGlyph
-                              className="size-12"
-                              icon={capability.icon ?? undefined}
-                              id={capability.capabilityId}
-                            />
-                            <div className="min-w-0 flex-1">
-                              <p className="truncate font-semibold text-[15px] text-foreground leading-tight">
-                                {capability.name}
-                              </p>
-                              {capability.description ? (
-                                <p className="mt-0.5 truncate text-[13px] text-muted-foreground leading-5">
-                                  {capability.description}
-                                </p>
-                              ) : null}
-                            </div>
-                            <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+								<div className="min-h-0 flex-1 overflow-hidden">
+									{importing ? (
+										<CapabilityImportPane
+											onClose={() => setImporting(false)}
+											onImported={(capabilityId) => {
+												setImporting(false);
+												setSelectedCapabilityId(capabilityId);
+											}}
+										/>
+									) : creating ? (
+										<CapabilityCreatePane
+											onClose={() => setCreating(false)}
+											onCreated={(capabilityId) => {
+												setCreating(false);
+												setSelectedCapabilityId(capabilityId);
+											}}
+											workspaceId={workspaceId ?? ""}
+										/>
+									) : selectedCapability ? (
+										<CapabilityDetailView
+											backLabel="All installed"
+											capabilityId={selectedCapability.capabilityId}
+											connectorProviders={Object.keys(
+												selectedCapability.integrationStatus ?? {},
+											)}
+											description={selectedCapability.description}
+											icon={selectedCapability.icon}
+											installed
+											name={selectedCapability.name}
+											onBack={() => setSelectedCapabilityId(null)}
+											onUninstalled={() => setSelectedCapabilityId(null)}
+											skillIds={selectedCapability.installedSkillIds}
+											status={selectedCapability.status}
+											workspaceId={workspaceId ?? ""}
+										/>
+									) : installed.length === 0 ? (
+										<div className="flex h-full items-center justify-center p-6">
+											<EmptyState
+												action={
+													<Button
+														onClick={() => setCapabilityView("market")}
+														size="sm"
+														variant="outline"
+													>
+														Browse marketplace
+													</Button>
+												}
+												description="Combos bundle related skills and integrations. Add some from the marketplace."
+												icon={Boxes}
+												size="md"
+												title="No combos installed"
+											/>
+										</div>
+									) : (
+										<div className="h-full overflow-y-auto py-5">
+											<div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-x-8 gap-y-1 px-6 sm:grid-cols-2">
+												{installed.map((capability) => (
+													<button
+														className="flex items-center gap-3 rounded-xl px-2 py-2 text-left transition-colors hover:bg-fg-2"
+														key={capability.capabilityId}
+														onClick={() =>
+															setSelectedCapabilityId(capability.capabilityId)
+														}
+														type="button"
+													>
+														<CapabilityGlyph
+															className="size-12"
+															icon={capability.icon ?? undefined}
+															id={capability.capabilityId}
+														/>
+														<div className="min-w-0 flex-1">
+															<p className="truncate font-semibold text-[15px] text-foreground leading-tight">
+																{capability.name}
+															</p>
+															{capability.description ? (
+																<p className="mt-0.5 truncate text-[13px] text-muted-foreground leading-5">
+																	{capability.description}
+																</p>
+															) : null}
+														</div>
+														<ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+													</button>
+												))}
+											</div>
+										</div>
+									)}
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			<CustomHolaAppCreateDialog
+				onChanged={() => void refreshHolaApps()}
+				onOpenChange={setCustomAppsOpen}
+				open={customAppsOpen}
+			/>
+		</div>
+	);
 }

--- a/apps/desktop/src/components/panes/CustomizePane.tsx
+++ b/apps/desktop/src/components/panes/CustomizePane.tsx
@@ -406,6 +406,7 @@ export function CustomizePane({ workspaceId }: { workspaceId: string | null }) {
 				onChanged={() => void refreshHolaApps()}
 				onOpenChange={setCustomAppsOpen}
 				open={customAppsOpen}
+				workspaceId={workspaceId}
 			/>
 		</div>
 	);

--- a/apps/desktop/src/lib/holaAppMarketplace.ts
+++ b/apps/desktop/src/lib/holaAppMarketplace.ts
@@ -13,15 +13,19 @@
 import { bffFetch } from "./bff-fetch-bridge";
 import { getIntegrationLogo } from "./integrationLogo";
 import {
-  type McpRequiredKey,
-  type McpTool,
-  syncInstalledAppHostedMcps,
+	customHolaAppMcpAttachInputs,
+	customHolaAppsAsWebApps,
+} from "./localCustomHolaApps";
+import {
+	type McpRequiredKey,
+	type McpTool,
+	syncInstalledAppHostedMcps,
 } from "./mcpMarketplace";
 import { toolkitDisplayName } from "./toolkitDisplay";
 import {
-  type HolaAppIntegrationRequirement,
-  listWebHolaApps,
-  type WebHolaApp,
+	type HolaAppIntegrationRequirement,
+	listWebHolaApps,
+	type WebHolaApp,
 } from "./webHolaApps";
 
 export type { HolaAppIntegrationRequirement } from "./webHolaApps";
@@ -29,103 +33,103 @@ export type { HolaAppIntegrationRequirement } from "./webHolaApps";
 // ── contract types (v1 subset) ───────────────────────────────────────────────
 
 export type AppSurface =
-  | { type: "hosted"; path?: string; url?: string }
-  | { type: "local"; port: number }
-  | { type: "none" };
+	| { type: "hosted"; path?: string; url?: string }
+	| { type: "local"; port: number }
+	| { type: "none" };
 
 /** A marketplace card. Thin — no tools/skills (those are never surfaced). */
 export interface AppCatalogEntry {
-  holaAppId: string;
-  title: string;
-  description?: string;
-  iconUrl?: string;
-  category?: string;
-  /** Highlighted in the marketplace "Featured" shelf. */
-  featured?: boolean;
-  /** Banner image for the Featured shelf's large card. */
-  heroImageUrl?: string;
-  /** Small badge label (e.g. "beta", "new"), rendered uppercased. Absent ⇒ none. */
-  badge?: string;
-  /** Capability chips shown on the card (backend-authored). Absent ⇒ no chips. */
-  tags?: string[];
-  /** ISO timestamp the app was added — drives the "Latest" sort. */
-  createdAt?: string;
-  /** Unique users who currently have the app installed — drives "Popular". */
-  installCount?: number;
-  version: string;
-  installed: boolean;
-  surface: AppSurface;
-  /** Which tier of App this is — the merge's single discriminator:
-   *  - `connection`: a Composio toolkit with no interaction surface, driven
-   *    headless by the agent through the shared Composio MCP passthrough
-   *    (the former "integration").
-   *  - `module`: a materialized app-builder module with its own process + MCP.
-   *  - `hosted`: an App with a hosted web surface.
-   * Not intrinsic to a provider — a slug moves between tiers as a real module
-   * is authored for it. Absent ⇒ derive from `surface` via {@link appKind}. */
-  kind?: "connection" | "module" | "hosted";
-  /** Connections the app requires. When any is `required`, install gates on
-   * connecting (or selecting an existing) account before the app is added. */
-  integrations?: HolaAppIntegrationRequirement[];
-  /** Runtime-derived: the app is NOT added to the sidebar, but all of its
-   * required connections are already bound — so the agent can already use it in
-   * chat. Drives the card's "Connected" state + a secondary "Add to sidebar". */
-  connectionBound?: boolean;
-  /** Tool names from the app's own MCP server, for apps whose capabilities come
-   * from a bundled MCP server rather than a Composio integration. Used as a soft
-   * tool hint to the copilot. */
-  mcpTools?: string[];
-  /** API-key install flow (OmniSocials, Publora) — see ApiKeyInstall. Present ⇒
-   * install routes through the blocked-until-keyed gate: entering the key
-   * attaches the app's own external MCP server so the agent gains its tools. */
-  apiKeyInstall?: ApiKeyInstall;
-  /** Command/stdio MCP install (drawio) — see CommandMcpInstall. Present ⇒ install
-   * is one-click and attaches a LOCAL MCP server the runtime spawns; the app's
-   * `url` surface is loaded live (the agent drives it via the MCP). */
-  commandMcpInstall?: CommandMcpInstall;
-  /** Hosted-MCP install (jianguoyun) — see HostedMcpInstall. Present ⇒ install
-   * gates for the app's BYO credentials (requiredKeys), then attaches its
-   * Holaboss-hosted MCP (session bearer + those creds) grouped under the app. */
-  hostedMcpInstall?: HostedMcpInstall;
-  /** Rich detail-page content (overview / features / screenshots), served on the
-   * catalog entry so the app detail view is backend-managed. Absent fields fall
-   * back to synthetic copy in HolaAppDetailView. */
-  detail?: AppDetail;
-  /** App-tailored chat empty-state (greeting / subtitle / starter prompts) for
-   * sessions opened under this app. Absent ⇒ ChatPane shows a tailored greeting
-   * derived from the app title. */
-  landing?: AppLanding;
-  /** Lifecycle status. `coming_soon` → the card/detail render a disabled Install
-   * + "Coming soon" badge (install is also rejected server-side). Absent → ready. */
-  status?: "ready" | "coming_soon";
-  /** Team-native: an org-owned app (Need Review, HolaEmployee) shown in the ORG left
-   * column (org-mode only), never the app store. Backend-served from the
-   * `HolaAppDefinition.teamNative` flag. Absent/false ⇒ a store app. */
-  teamNative?: boolean;
+	holaAppId: string;
+	title: string;
+	description?: string;
+	iconUrl?: string;
+	category?: string;
+	/** Highlighted in the marketplace "Featured" shelf. */
+	featured?: boolean;
+	/** Banner image for the Featured shelf's large card. */
+	heroImageUrl?: string;
+	/** Small badge label (e.g. "beta", "new"), rendered uppercased. Absent ⇒ none. */
+	badge?: string;
+	/** Capability chips shown on the card (backend-authored). Absent ⇒ no chips. */
+	tags?: string[];
+	/** ISO timestamp the app was added — drives the "Latest" sort. */
+	createdAt?: string;
+	/** Unique users who currently have the app installed — drives "Popular". */
+	installCount?: number;
+	version: string;
+	installed: boolean;
+	surface: AppSurface;
+	/** Which tier of App this is — the merge's single discriminator:
+	 *  - `connection`: a Composio toolkit with no interaction surface, driven
+	 *    headless by the agent through the shared Composio MCP passthrough
+	 *    (the former "integration").
+	 *  - `module`: a materialized app-builder module with its own process + MCP.
+	 *  - `hosted`: an App with a hosted web surface.
+	 * Not intrinsic to a provider — a slug moves between tiers as a real module
+	 * is authored for it. Absent ⇒ derive from `surface` via {@link appKind}. */
+	kind?: "connection" | "module" | "hosted";
+	/** Connections the app requires. When any is `required`, install gates on
+	 * connecting (or selecting an existing) account before the app is added. */
+	integrations?: HolaAppIntegrationRequirement[];
+	/** Runtime-derived: the app is NOT added to the sidebar, but all of its
+	 * required connections are already bound — so the agent can already use it in
+	 * chat. Drives the card's "Connected" state + a secondary "Add to sidebar". */
+	connectionBound?: boolean;
+	/** Tool names from the app's own MCP server, for apps whose capabilities come
+	 * from a bundled MCP server rather than a Composio integration. Used as a soft
+	 * tool hint to the copilot. */
+	mcpTools?: string[];
+	/** API-key install flow (OmniSocials, Publora) — see ApiKeyInstall. Present ⇒
+	 * install routes through the blocked-until-keyed gate: entering the key
+	 * attaches the app's own external MCP server so the agent gains its tools. */
+	apiKeyInstall?: ApiKeyInstall;
+	/** Command/stdio MCP install (drawio) — see CommandMcpInstall. Present ⇒ install
+	 * is one-click and attaches a LOCAL MCP server the runtime spawns; the app's
+	 * `url` surface is loaded live (the agent drives it via the MCP). */
+	commandMcpInstall?: CommandMcpInstall;
+	/** Hosted-MCP install (jianguoyun) — see HostedMcpInstall. Present ⇒ install
+	 * gates for the app's BYO credentials (requiredKeys), then attaches its
+	 * Holaboss-hosted MCP (session bearer + those creds) grouped under the app. */
+	hostedMcpInstall?: HostedMcpInstall;
+	/** Rich detail-page content (overview / features / screenshots), served on the
+	 * catalog entry so the app detail view is backend-managed. Absent fields fall
+	 * back to synthetic copy in HolaAppDetailView. */
+	detail?: AppDetail;
+	/** App-tailored chat empty-state (greeting / subtitle / starter prompts) for
+	 * sessions opened under this app. Absent ⇒ ChatPane shows a tailored greeting
+	 * derived from the app title. */
+	landing?: AppLanding;
+	/** Lifecycle status. `coming_soon` → the card/detail render a disabled Install
+	 * + "Coming soon" badge (install is also rejected server-side). Absent → ready. */
+	status?: "ready" | "coming_soon";
+	/** Team-native: an org-owned app (Need Review, HolaEmployee) shown in the ORG left
+	 * column (org-mode only), never the app store. Backend-served from the
+	 * `HolaAppDefinition.teamNative` flag. Absent/false ⇒ a store app. */
+	teamNative?: boolean;
 }
 
 /** One "what you can do" card on the app detail page. */
 export interface AppDetailFeature {
-  title: string;
-  body: string;
-  /** Semantic icon key (e.g. "search", "pencil", "clock", "send", "plug"),
-   * mapped to a glyph in HolaAppDetailView; unknown/omitted → a generic glyph. */
-  icon?: string;
+	title: string;
+	body: string;
+	/** Semantic icon key (e.g. "search", "pencil", "clock", "send", "plug"),
+	 * mapped to a glyph in HolaAppDetailView; unknown/omitted → a generic glyph. */
+	icon?: string;
 }
 
 /** One preview image on the app detail page. */
 export interface AppDetailScreenshot {
-  url: string;
-  alt?: string;
+	url: string;
+	alt?: string;
 }
 
 /** Rich detail-page content served on the catalog entry (backend-managed). Every
  * field is optional; HolaAppDetailView renders synthetic, platform-level copy for
  * anything omitted, so an app supplies only what it wants to override. */
 export interface AppDetail {
-  overview?: string;
-  features?: AppDetailFeature[];
-  screenshots?: AppDetailScreenshot[];
+	overview?: string;
+	features?: AppDetailFeature[];
+	screenshots?: AppDetailScreenshot[];
 }
 
 /** App-tailored chat empty-state, served on the catalog entry (backend-managed).
@@ -133,22 +137,22 @@ export interface AppDetail {
  * app's terms instead of the generic workspace copy. Every field optional; the
  * ChatPane falls back to a tailored greeting derived from the app title. */
 export interface AppLanding {
-  greeting?: string;
-  subtitle?: string;
-  /** Starter prompts sent verbatim as the first message when picked. */
-  prompts?: string[];
+	greeting?: string;
+	subtitle?: string;
+	/** Starter prompts sent verbatim as the first message when picked. */
+	prompts?: string[];
 }
 
 /** API-key install config for an app that ships its OWN external MCP server,
  * authenticated by a key the user pastes on the desktop (OmniSocials, Publora).
  * Served on the catalog entry (backend) so no desktop code is per-app. */
 export interface ApiKeyInstall {
-  mcpUrl: string;
-  instructionsUrl?: string;
-  auth: ApiKeyMcpAuth;
-  /** Custom "get your key" step shown in the gate (title + one detail line).
-   * When set it replaces the default sign-in / create-a-key copy. */
-  keyInstructions?: { title: string; detail: string };
+	mcpUrl: string;
+	instructionsUrl?: string;
+	auth: ApiKeyMcpAuth;
+	/** Custom "get your key" step shown in the gate (title + one detail line).
+	 * When set it replaces the default sign-in / create-a-key copy. */
+	keyInstructions?: { title: string; detail: string };
 }
 
 /** Command/stdio MCP install for an app whose tools come from a LOCAL MCP server
@@ -158,8 +162,8 @@ export interface ApiKeyInstall {
  * desktop code is per-app. Distinct from ApiKeyInstall (a remote HTTP server +
  * a user-supplied key) — here there is no key and the server runs locally. */
 export interface CommandMcpInstall {
-  command: string[];
-  env?: Record<string, string>;
+	command: string[];
+	env?: Record<string, string>;
 }
 
 /** Hosted-MCP install for a HolaApp whose tools come from a Holaboss-HOSTED MCP
@@ -170,17 +174,17 @@ export interface CommandMcpInstall {
  * `requiredKeys` then attaches the MCP via the marketplace machinery tagged
  * app-owned (owner_app_id) so it groups under the app. */
 export interface HostedMcpInstall {
-  mcpUrl: string;
-  holabossHosted?: boolean;
-  requiredKeys: McpRequiredKey[];
-  tools?: McpTool[];
+	mcpUrl: string;
+	holabossHosted?: boolean;
+	requiredKeys: McpRequiredKey[];
+	tools?: McpTool[];
 }
 
 /** What the API-key install gate renders — the app id/title + its install config
  * (built from the active surface, not a per-app desktop table). */
 export type ApiKeyGateConfig = {
-  holaAppId: string;
-  title: string;
+	holaAppId: string;
+	title: string;
 } & ApiKeyInstall;
 
 /** How a user-supplied API key authenticates an app's MCP server:
@@ -188,32 +192,32 @@ export type ApiKeyGateConfig = {
  *  - `header`: sent as the `<name>` request header `<prefix><key>`
  *    (Publora `Authorization: Bearer <key>`). */
 export type ApiKeyMcpAuth =
-  | { kind: "query"; param: string }
-  | { kind: "header"; name: string; prefix?: string };
+	| { kind: "query"; param: string }
+	| { kind: "header"; name: string; prefix?: string };
 
 export type McpAuth = { mode: "session" } | { mode: "token"; token: string };
 
 export interface McpServerSpec {
-  id: string;
-  transport: "http";
-  url: string;
-  auth: McpAuth;
-  tools: string[];
-  timeoutMs?: number;
+	id: string;
+	transport: "http";
+	url: string;
+	auth: McpAuth;
+	tools: string[];
+	timeoutMs?: number;
 }
 
 export interface SkillDelivery {
-  id: string;
-  version: string;
-  source:
-    | { type: "inline"; files: { path: string; content: string }[] }
-    | { type: "url"; url: string };
+	id: string;
+	version: string;
+	source:
+		| { type: "inline"; files: { path: string; content: string }[] }
+		| { type: "url"; url: string };
 }
 
 /** What the desktop applies to the local runtime on install. */
 export interface AppProvisioning {
-  mcp: McpServerSpec[];
-  skills: SkillDelivery[];
+	mcp: McpServerSpec[];
+	skills: SkillDelivery[];
 }
 
 /** The catalog entry as the server returns it, before install state is merged in. */
@@ -222,20 +226,20 @@ export type CatalogEntryBase = Omit<AppCatalogEntry, "installed">;
 // ── the adapter the rest of the desktop depends on ───────────────────────────
 
 export interface MarketplaceSource {
-  /** Available apps + this user's install state. */
-  listCatalog(): Promise<AppCatalogEntry[]>;
-  /** Install; returns the provisioning the desktop applies locally. */
-  install(holaAppId: string): Promise<AppProvisioning>;
-  /** Uninstall. */
-  uninstall(holaAppId: string): Promise<void>;
+	/** Available apps + this user's install state. */
+	listCatalog(): Promise<AppCatalogEntry[]>;
+	/** Install; returns the provisioning the desktop applies locally. */
+	install(holaAppId: string): Promise<AppProvisioning>;
+	/** Uninstall. */
+	uninstall(holaAppId: string): Promise<void>;
 }
 
 // ── local stub (until the backend ships the endpoints) ───────────────────────
 
 /** Persistence for install state — abstracted so the stub is unit-testable. */
 export interface InstalledStore {
-  read(): string[] | null;
-  write(ids: string[]): void;
+	read(): string[] | null;
+	write(ids: string[]): void;
 }
 
 /**
@@ -246,71 +250,73 @@ export interface InstalledStore {
  * in-memory store.
  */
 export function createStubMarketplaceSource(deps: {
-  fetchCatalog: () => Promise<CatalogEntryBase[]>;
-  store: InstalledStore;
+	fetchCatalog: () => Promise<CatalogEntryBase[]>;
+	store: InstalledStore;
 }): MarketplaceSource {
-  const { fetchCatalog, store } = deps;
+	const { fetchCatalog, store } = deps;
 
-  function installedIds(catalogIds: string[]): Set<string> {
-    const stored = store.read();
-    if (stored === null) {
-      // Migration: when install state is first introduced, treat every app the catalog
-      // currently surfaces as already installed — so the launcher doesn't go empty.
-      store.write(catalogIds);
-      return new Set(catalogIds);
-    }
-    return new Set(stored);
-  }
+	function installedIds(catalogIds: string[]): Set<string> {
+		const stored = store.read();
+		if (stored === null) {
+			// Migration: when install state is first introduced, treat every app the catalog
+			// currently surfaces as already installed — so the launcher doesn't go empty.
+			store.write(catalogIds);
+			return new Set(catalogIds);
+		}
+		return new Set(stored);
+	}
 
-  return {
-    async listCatalog() {
-      const base = await fetchCatalog();
-      const installed = installedIds(base.map((entry) => entry.holaAppId));
-      return base.map((entry) => ({
-        ...entry,
-        installed: installed.has(entry.holaAppId),
-      }));
-    },
-    async install(holaAppId) {
-      const stored = store.read() ?? [];
-      store.write([...stored, holaAppId]);
-      // Stub: real MCP/skill provisioning will come from the server's install response.
-      return { mcp: [], skills: [] };
-    },
-    async uninstall(holaAppId) {
-      const stored = store.read() ?? [];
-      store.write(stored.filter((id) => id !== holaAppId));
-    },
-  };
+	return {
+		async listCatalog() {
+			const base = await fetchCatalog();
+			const installed = installedIds(base.map((entry) => entry.holaAppId));
+			return base.map((entry) => ({
+				...entry,
+				installed: installed.has(entry.holaAppId),
+			}));
+		},
+		async install(holaAppId) {
+			const stored = store.read() ?? [];
+			store.write([...stored, holaAppId]);
+			// Stub: real MCP/skill provisioning will come from the server's install response.
+			return { mcp: [], skills: [] };
+		},
+		async uninstall(holaAppId) {
+			const stored = store.read() ?? [];
+			store.write(stored.filter((id) => id !== holaAppId));
+		},
+	};
 }
 
 const STORAGE_KEY = "holaboss.holaapps.installed.v1";
 
 const localStorageStore: InstalledStore = {
-  read() {
-    try {
-      const raw =
-        typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
-      if (!raw) {
-        return null;
-      }
-      const parsed: unknown = JSON.parse(raw);
-      return Array.isArray(parsed)
-        ? parsed.filter((id): id is string => typeof id === "string")
-        : null;
-    } catch {
-      return null;
-    }
-  },
-  write(ids) {
-    try {
-      if (typeof localStorage !== "undefined") {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify([...new Set(ids)]));
-      }
-    } catch {
-      // ignore — install state is best-effort in the stub
-    }
-  },
+	read() {
+		try {
+			const raw =
+				typeof localStorage !== "undefined"
+					? localStorage.getItem(STORAGE_KEY)
+					: null;
+			if (!raw) {
+				return null;
+			}
+			const parsed: unknown = JSON.parse(raw);
+			return Array.isArray(parsed)
+				? parsed.filter((id): id is string => typeof id === "string")
+				: null;
+		} catch {
+			return null;
+		}
+	},
+	write(ids) {
+		try {
+			if (typeof localStorage !== "undefined") {
+				localStorage.setItem(STORAGE_KEY, JSON.stringify([...new Set(ids)]));
+			}
+		} catch {
+			// ignore — install state is best-effort in the stub
+		}
+	},
 };
 
 // A few Holaboss-hosted apps have been promoted OUT of the generic `/apps/<id>`
@@ -319,48 +325,48 @@ const localStorageStore: InstalledStore = {
 // frontend's back-compat redirect. (HolaEmployee → /employees; the old
 // /apps/holaemployee still redirects, so this is an optimization, not a hard dep.)
 const WEB_APP_PATH_OVERRIDES: Record<string, string> = {
-  holaemployee: "/employees",
+	holaemployee: "/employees",
 };
 
 function webHolaAppPath(holaAppId: string): string {
-  return WEB_APP_PATH_OVERRIDES[holaAppId] ?? `/apps/${holaAppId}`;
+	return WEB_APP_PATH_OVERRIDES[holaAppId] ?? `/apps/${holaAppId}`;
 }
 
 /** Map the existing `GET /api/v1/apps` shape to a catalog entry (v1: hosted surface). */
 export function webHolaAppToCatalogEntry(app: WebHolaApp): CatalogEntryBase {
-  return {
-    holaAppId: app.holaAppId,
-    title: app.title,
-    ...(app.description ? { description: app.description } : {}),
-    ...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
-    version: "0.0.0",
-    // A third-party `url` (e.g. Notion) loads directly; otherwise the surface derives
-    // `<WEB_APP_BASE_URL>/<path>` — usually `/apps/<id>`, or a promoted route (see
-    // WEB_APP_PATH_OVERRIDES) — mirroring how WebAppSurfacePane opens it.
-    surface: app.url
-      ? { type: "hosted", url: app.url }
-      : { type: "hosted", path: webHolaAppPath(app.holaAppId) },
-    ...(app.integrations ? { integrations: app.integrations } : {}),
-    ...(app.mcpTools ? { mcpTools: app.mcpTools } : {}),
-    ...(app.apiKeyInstall ? { apiKeyInstall: app.apiKeyInstall } : {}),
-    ...(app.commandMcpInstall
-      ? { commandMcpInstall: app.commandMcpInstall }
-      : {}),
-    ...(app.hostedMcpInstall
-      ? { hostedMcpInstall: app.hostedMcpInstall }
-      : {}),
-    ...(app.detail ? { detail: app.detail } : {}),
-    ...(app.landing ? { landing: app.landing } : {}),
-    ...(app.status ? { status: app.status } : {}),
-    ...(app.category ? { category: app.category } : {}),
-    ...(app.featured ? { featured: true } : {}),
-    ...(app.heroImageUrl ? { heroImageUrl: app.heroImageUrl } : {}),
-    ...(app.badge ? { badge: app.badge } : {}),
-    ...(app.tags && app.tags.length > 0 ? { tags: app.tags } : {}),
-    ...(app.createdAt ? { createdAt: app.createdAt } : {}),
-    ...(app.installCount !== undefined ? { installCount: app.installCount } : {}),
-    ...(app.teamNative ? { teamNative: true } : {}),
-  };
+	return {
+		holaAppId: app.holaAppId,
+		title: app.title,
+		...(app.description ? { description: app.description } : {}),
+		...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
+		version: "0.0.0",
+		// A third-party `url` (e.g. Notion) loads directly; otherwise the surface derives
+		// `<WEB_APP_BASE_URL>/<path>` — usually `/apps/<id>`, or a promoted route (see
+		// WEB_APP_PATH_OVERRIDES) — mirroring how WebAppSurfacePane opens it.
+		surface: app.url
+			? { type: "hosted", url: app.url }
+			: { type: "hosted", path: webHolaAppPath(app.holaAppId) },
+		...(app.integrations ? { integrations: app.integrations } : {}),
+		...(app.mcpTools ? { mcpTools: app.mcpTools } : {}),
+		...(app.apiKeyInstall ? { apiKeyInstall: app.apiKeyInstall } : {}),
+		...(app.commandMcpInstall
+			? { commandMcpInstall: app.commandMcpInstall }
+			: {}),
+		...(app.hostedMcpInstall ? { hostedMcpInstall: app.hostedMcpInstall } : {}),
+		...(app.detail ? { detail: app.detail } : {}),
+		...(app.landing ? { landing: app.landing } : {}),
+		...(app.status ? { status: app.status } : {}),
+		...(app.category ? { category: app.category } : {}),
+		...(app.featured ? { featured: true } : {}),
+		...(app.heroImageUrl ? { heroImageUrl: app.heroImageUrl } : {}),
+		...(app.badge ? { badge: app.badge } : {}),
+		...(app.tags && app.tags.length > 0 ? { tags: app.tags } : {}),
+		...(app.createdAt ? { createdAt: app.createdAt } : {}),
+		...(app.installCount !== undefined
+			? { installCount: app.installCount }
+			: {}),
+		...(app.teamNative ? { teamNative: true } : {}),
+	};
 }
 
 // ── connection-tier Apps (former "integrations") ─────────────────────────────
@@ -369,73 +375,73 @@ export function webHolaAppToCatalogEntry(app: WebHolaApp): CatalogEntryBase {
  * (`workspace:listIntegrationStoreCatalog` → `IntegrationStoreCatalogEntry`).
  * Mirrored here so the synthesizer below is a pure, testable function of it. */
 export interface StoreCatalogConnection {
-  slug: string;
-  tier: "hero" | "supported";
-  category: string;
-  beta?: boolean;
+	slug: string;
+	tier: "hero" | "supported";
+	category: string;
+	beta?: boolean;
 }
 
 /** Derive an App's tier when the catalog entry doesn't state it explicitly.
  * `surface` alone determines it: no surface ⇒ headless connection, a local
  * port ⇒ an app-builder module, anything hosted ⇒ a hosted App. */
 export function appKind(
-  entry: Pick<AppCatalogEntry, "kind" | "surface">,
+	entry: Pick<AppCatalogEntry, "kind" | "surface">,
 ): "connection" | "module" | "hosted" {
-  if (entry.kind) {
-    return entry.kind;
-  }
-  switch (entry.surface.type) {
-    case "none":
-      return "connection";
-    case "local":
-      return "module";
-    default:
-      return "hosted";
-  }
+	if (entry.kind) {
+		return entry.kind;
+	}
+	switch (entry.surface.type) {
+		case "none":
+			return "connection";
+		case "local":
+			return "module";
+		default:
+			return "hosted";
+	}
 }
 
 // Store-catalog categories arrive as terse slugs (crm, ci_cloud, ai_data). Map
 // them to human labels for display; authored app categories are already
 // Title-Case ("Social Media Ops") and pass through unchanged.
 const CATEGORY_LABELS: Record<string, string> = {
-  dev: "Developer",
-  comm: "Communication",
-  ci_cloud: "Cloud",
-  db: "Database",
-  observability: "Observability",
-  ai_data: "AI & Data",
-  social: "Social",
-  email: "Email",
-  analytics: "Analytics",
-  crm: "CRM",
-  ads: "Ads",
-  seo: "SEO",
-  cms: "CMS",
-  design: "Design",
-  forms: "Forms",
-  calendar: "Calendar",
-  commerce: "Commerce",
-  video: "Video",
-  productivity: "Productivity",
+	dev: "Developer",
+	comm: "Communication",
+	ci_cloud: "Cloud",
+	db: "Database",
+	observability: "Observability",
+	ai_data: "AI & Data",
+	social: "Social",
+	email: "Email",
+	analytics: "Analytics",
+	crm: "CRM",
+	ads: "Ads",
+	seo: "SEO",
+	cms: "CMS",
+	design: "Design",
+	forms: "Forms",
+	calendar: "Calendar",
+	commerce: "Commerce",
+	video: "Video",
+	productivity: "Productivity",
 };
 
 /** Human label for a catalog category — maps known store slugs, passes authored
  * categories through untouched. Display-only: filtering/grouping still key on the
  * raw category value. */
 export function categoryLabel(raw?: string): string {
-  const key = (raw ?? "").trim();
-  if (!key) {
-    return "";
-  }
-  return CATEGORY_LABELS[key.toLowerCase()] ?? key;
+	const key = (raw ?? "").trim();
+	if (!key) {
+		return "";
+	}
+	return CATEGORY_LABELS[key.toLowerCase()] ?? key;
 }
 
 /** The one-word tier a card wears so its kind is legible without hovering:
  * "Connection" (headless, agent-driven) vs "App" (something you open). */
 export function appTierLabel(
-  entry: Pick<AppCatalogEntry, "kind" | "surface">,
+	entry: Pick<AppCatalogEntry, "kind" | "surface">,
 ): string {
-  return appKind(entry) === "connection" ? "Connection" : "App";
+	return appKind(entry) === "connection" ? "Connection" : "App";
 }
 
 /** Map one Composio store-catalog toolkit into a connection-tier catalog entry:
@@ -444,23 +450,23 @@ export function appTierLabel(
  * — the same slug a future app-builder module for this provider would key on, so
  * upgrading a connection to a module reuses the connection unchanged. */
 export function storeConnectionToCatalogEntry(
-  entry: StoreCatalogConnection,
+	entry: StoreCatalogConnection,
 ): CatalogEntryBase {
-  const logo = getIntegrationLogo(entry.slug);
-  return {
-    holaAppId: entry.slug,
-    title: toolkitDisplayName(entry.slug),
-    kind: "connection",
-    version: "0.0.0",
-    surface: { type: "none" },
-    integrations: [{ provider: entry.slug, required: true }],
-    ...(logo.url ? { iconUrl: logo.url } : {}),
-    ...(entry.category ? { category: entry.category } : {}),
-    ...(entry.beta ? { badge: "beta" } : {}),
-    // Connections are NOT featured: the Featured shelf is a small curated
-    // highlight, and flooding it with every hero toolkit buries the real picks.
-    // Hero-ness still surfaces them via category + sort order.
-  };
+	const logo = getIntegrationLogo(entry.slug);
+	return {
+		holaAppId: entry.slug,
+		title: toolkitDisplayName(entry.slug),
+		kind: "connection",
+		version: "0.0.0",
+		surface: { type: "none" },
+		integrations: [{ provider: entry.slug, required: true }],
+		...(logo.url ? { iconUrl: logo.url } : {}),
+		...(entry.category ? { category: entry.category } : {}),
+		...(entry.beta ? { badge: "beta" } : {}),
+		// Connections are NOT featured: the Featured shelf is a small curated
+		// highlight, and flooding it with every hero toolkit buries the real picks.
+		// Hero-ness still surfaces them via category + sort order.
+	};
 }
 
 /** Every provider slug already "covered" by an authored app — its own
@@ -469,16 +475,16 @@ export function storeConnectionToCatalogEntry(
  * entry for that provider (e.g. the Notion App owns the `notion` connection, so
  * `notion` never gets its own bare Connection card). */
 function coveredProviderSlugs(
-  apps: Pick<AppCatalogEntry, "holaAppId" | "integrations">[],
+	apps: Pick<AppCatalogEntry, "holaAppId" | "integrations">[],
 ): Set<string> {
-  const covered = new Set<string>();
-  for (const app of apps) {
-    covered.add(app.holaAppId.trim().toLowerCase());
-    for (const integration of app.integrations ?? []) {
-      covered.add(integration.provider.trim().toLowerCase());
-    }
-  }
-  return covered;
+	const covered = new Set<string>();
+	for (const app of apps) {
+		covered.add(app.holaAppId.trim().toLowerCase());
+		for (const integration of app.integrations ?? []) {
+			covered.add(integration.provider.trim().toLowerCase());
+		}
+	}
+	return covered;
 }
 
 /** Fold synthesized connection cards into the authored app catalog. Authored
@@ -486,43 +492,46 @@ function coveredProviderSlugs(
  * OR as a required integration — is not re-added as a bare connection, so a
  * provider that has an App never shows two cards. */
 export function mergeConnectionCatalog(
-  apps: CatalogEntryBase[],
-  storeEntries: StoreCatalogConnection[],
+	apps: CatalogEntryBase[],
+	storeEntries: StoreCatalogConnection[],
 ): CatalogEntryBase[] {
-  const covered = coveredProviderSlugs(apps);
-  const connections = storeEntries
-    .filter((entry) => !covered.has(entry.slug.trim().toLowerCase()))
-    .map(storeConnectionToCatalogEntry);
-  return [...apps, ...connections];
+	const covered = coveredProviderSlugs(apps);
+	const connections = storeEntries
+		.filter((entry) => !covered.has(entry.slug.trim().toLowerCase()))
+		.map(storeConnectionToCatalogEntry);
+	return [...apps, ...connections];
 }
 
 /** Read the runtime's Composio store catalog through the desktop bridge.
  * Tolerant: a missing bridge or a failed call yields an empty list so the app
  * catalog still renders its authored entries. */
-export async function fetchStoreConnections(): Promise<StoreCatalogConnection[]> {
-  try {
-    const payload = await window.electronAPI.workspace?.listIntegrationStoreCatalog();
-    const entries = payload?.entries;
-    if (!Array.isArray(entries)) {
-      return [];
-    }
-    return entries.flatMap((entry): StoreCatalogConnection[] => {
-      const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
-      if (!slug) {
-        return [];
-      }
-      return [
-        {
-          slug,
-          tier: entry.tier === "hero" ? "hero" : "supported",
-          category: typeof entry.category === "string" ? entry.category : "",
-          ...(entry.beta ? { beta: true } : {}),
-        },
-      ];
-    });
-  } catch {
-    return [];
-  }
+export async function fetchStoreConnections(): Promise<
+	StoreCatalogConnection[]
+> {
+	try {
+		const payload =
+			await window.electronAPI.workspace?.listIntegrationStoreCatalog();
+		const entries = payload?.entries;
+		if (!Array.isArray(entries)) {
+			return [];
+		}
+		return entries.flatMap((entry): StoreCatalogConnection[] => {
+			const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
+			if (!slug) {
+				return [];
+			}
+			return [
+				{
+					slug,
+					tier: entry.tier === "hero" ? "hero" : "supported",
+					category: typeof entry.category === "string" ? entry.category : "",
+					...(entry.beta ? { beta: true } : {}),
+				},
+			];
+		});
+	} catch {
+		return [];
+	}
 }
 
 /** Build the connection-tier cards for the live catalog: synthesize a card per
@@ -538,42 +547,44 @@ export async function fetchStoreConnections(): Promise<StoreCatalogConnection[]>
  * an authored app's `connectionBound` state. Tolerant: any failure ⇒ empty set
  * (callers fall back to "not connected"). */
 export async function fetchConnectedSlugs(): Promise<Set<string>> {
-  const connectedSlugs = new Set<string>();
-  try {
-    const [{ listAllIntegrationConnections }, { composioToolkitSlugForProvider }] =
-      await Promise.all([
-        import("./listAllIntegrationConnections"),
-        import("./workspaceDesktop"),
-      ]);
-    const { connections } = await listAllIntegrationConnections();
-    for (const connection of connections) {
-      const slug = composioToolkitSlugForProvider(
-        (connection.provider_id ?? "").trim().toLowerCase(),
-      );
-      if (slug) {
-        connectedSlugs.add(slug);
-      }
-    }
-  } catch {
-    // empty set — the store still lists every toolkit as not-connected.
-  }
-  return connectedSlugs;
+	const connectedSlugs = new Set<string>();
+	try {
+		const [
+			{ listAllIntegrationConnections },
+			{ composioToolkitSlugForProvider },
+		] = await Promise.all([
+			import("./listAllIntegrationConnections"),
+			import("./workspaceDesktop"),
+		]);
+		const { connections } = await listAllIntegrationConnections();
+		for (const connection of connections) {
+			const slug = composioToolkitSlugForProvider(
+				(connection.provider_id ?? "").trim().toLowerCase(),
+			);
+			if (slug) {
+				connectedSlugs.add(slug);
+			}
+		}
+	} catch {
+		// empty set — the store still lists every toolkit as not-connected.
+	}
+	return connectedSlugs;
 }
 
 async function buildConnectionCards(
-  existingIds: Set<string>,
-  connectedSlugs: Set<string>,
+	existingIds: Set<string>,
+	connectedSlugs: Set<string>,
 ): Promise<AppCatalogEntry[]> {
-  const storeConnections = await fetchStoreConnections();
-  if (storeConnections.length === 0) {
-    return [];
-  }
-  return storeConnections
-    .filter((entry) => !existingIds.has(entry.slug.trim().toLowerCase()))
-    .map((entry) => ({
-      ...storeConnectionToCatalogEntry(entry),
-      installed: connectedSlugs.has(entry.slug.trim().toLowerCase()),
-    }));
+	const storeConnections = await fetchStoreConnections();
+	if (storeConnections.length === 0) {
+		return [];
+	}
+	return storeConnections
+		.filter((entry) => !existingIds.has(entry.slug.trim().toLowerCase()))
+		.map((entry) => ({
+			...storeConnectionToCatalogEntry(entry),
+			installed: connectedSlugs.has(entry.slug.trim().toLowerCase()),
+		}));
 }
 
 /** True when an app's tools come from a Holaboss-HOSTED `/mcp/<id>` server (so
@@ -582,24 +593,24 @@ async function buildConnectionCards(
  * skip them (or attaches them by a dedicated path), so we keep them out of the
  * per-turn hosted sync entirely. */
 function usesHostedMcp(entry: AppCatalogEntry): boolean {
-  return (
-    !entry.apiKeyInstall &&
-    !entry.commandMcpInstall &&
-    // hostedMcpInstall apps carry BYO creds — they attach through the install
-    // gate (marketplace machinery), NOT the credential-less per-turn hosted sync.
-    !entry.hostedMcpInstall &&
-    !(entry.surface.type === "hosted" && Boolean(entry.surface.url))
-  );
+	return (
+		!entry.apiKeyInstall &&
+		!entry.commandMcpInstall &&
+		// hostedMcpInstall apps carry BYO creds — they attach through the install
+		// gate (marketplace machinery), NOT the credential-less per-turn hosted sync.
+		!entry.hostedMcpInstall &&
+		!(entry.surface.type === "hosted" && Boolean(entry.surface.url))
+	);
 }
 
 async function defaultFetchCatalog(): Promise<CatalogEntryBase[]> {
-  const apps = await listWebHolaApps();
-  return apps.map(webHolaAppToCatalogEntry);
+	const apps = await listWebHolaApps();
+	return apps.map(webHolaAppToCatalogEntry);
 }
 
 const stubSource = createStubMarketplaceSource({
-  fetchCatalog: defaultFetchCatalog,
-  store: localStorageStore,
+	fetchCatalog: defaultFetchCatalog,
+	store: localStorageStore,
 });
 
 // Stub-backed source: catalogue from the server, install STATE in localStorage, tools
@@ -609,24 +620,26 @@ const stubSource = createStubMarketplaceSource({
 // Kept as the fallback. Swap `marketplace` (bottom of file) back to this to disable the
 // server-managed path.
 export const stubMarketplace: MarketplaceSource = {
-  async listCatalog() {
-    const catalog = await stubSource.listCatalog();
-    // Keep the main process in sync with what's installed (covers app restart), so its
-    // per-turn MCP attach covers every installed app.
-    void window.electronAPI.holaApps?.sync(
-      catalog.filter((entry) => entry.installed).map((entry) => entry.holaAppId),
-    );
-    return catalog;
-  },
-  async install(holaAppId) {
-    const provisioning = await stubSource.install(holaAppId);
-    void window.electronAPI.holaApps?.install(holaAppId);
-    return provisioning;
-  },
-  async uninstall(holaAppId) {
-    await stubSource.uninstall(holaAppId);
-    void window.electronAPI.holaApps?.uninstall(holaAppId);
-  },
+	async listCatalog() {
+		const catalog = await stubSource.listCatalog();
+		// Keep the main process in sync with what's installed (covers app restart), so its
+		// per-turn MCP attach covers every installed app.
+		void window.electronAPI.holaApps?.sync(
+			catalog
+				.filter((entry) => entry.installed)
+				.map((entry) => entry.holaAppId),
+		);
+		return catalog;
+	},
+	async install(holaAppId) {
+		const provisioning = await stubSource.install(holaAppId);
+		void window.electronAPI.holaApps?.install(holaAppId);
+		return provisioning;
+	},
+	async uninstall(holaAppId) {
+		await stubSource.uninstall(holaAppId);
+		void window.electronAPI.holaApps?.uninstall(holaAppId);
+	},
 };
 
 // The gateway calls go to the backend/api host, NOT the www SPA host
@@ -634,11 +647,11 @@ export const stubMarketplace: MarketplaceSource = {
 // /gateway/* before the Worker runs, so install/uninstall (POST) silently failed
 // there. The api host accepts POST and the session cookie is valid on it.
 async function backendBaseUrl(): Promise<string | null> {
-  const base = (await window.electronAPI.auth.getBackendBaseUrl())?.replace(
-    /\/+$/,
-    "",
-  );
-  return base || null;
+	const base = (await window.electronAPI.auth.getBackendBaseUrl())?.replace(
+		/\/+$/,
+		"",
+	);
+	return base || null;
 }
 
 /**
@@ -653,101 +666,117 @@ async function backendBaseUrl(): Promise<string | null> {
  * (branch feat/holaapp-server-managed-install). See the marketplace API contract.
  */
 export function createServerMarketplaceSource(): MarketplaceSource {
-  return {
-    async listCatalog() {
-      const apps = await listWebHolaApps();
-      const catalog: AppCatalogEntry[] = apps.map((app) => ({
-        ...webHolaAppToCatalogEntry(app),
-        installed: app.installed ?? false,
-      }));
-      // Sync only apps that use a Holaboss-hosted `/mcp/<id>` server to main —
-      // external / API-key apps (Notion, OmniSocials, Publora) have none, and
-      // main skips them anyway; keep them out of the per-turn re-attach.
-      void window.electronAPI.holaApps?.sync(
-        catalog
-          .filter((entry) => entry.installed && usesHostedMcp(entry))
-          .map((entry) => entry.holaAppId),
-      );
-      // App-owned hosted MCPs (hostedMcpInstall apps like jianguoyun) ride their
-      // OWN per-turn re-attach track — kept separate so the standalone marketplace
-      // sync can't detach them. Rebuilds each config from the locally-stored creds.
-      void syncInstalledAppHostedMcps(
-        catalog.map((entry) => ({
-          holaAppId: entry.holaAppId,
-          title: entry.title,
-          ...(entry.iconUrl ? { iconUrl: entry.iconUrl } : {}),
-          installed: entry.installed,
-          ...(entry.hostedMcpInstall
-            ? { hostedMcpInstall: entry.hostedMcpInstall }
-            : {}),
-        })),
-      );
-      // Fold in the connection-tier Apps (former "integrations"): every Composio
-      // toolkit becomes a headless, surface-less App card. An authored App wins on
-      // any provider it OWNS or REQUIRES, so e.g. the Notion App is the sole Notion
-      // card (no duplicate bare Connection).
-      const covered = coveredProviderSlugs(catalog);
-      const connectedSlugs = await fetchConnectedSlugs();
-      // Mark an authored app whose required connection(s) are bound but which
-      // isn't in the sidebar yet — the card then reads "Connected" + offers a
-      // secondary "Add to sidebar".
-      const withConnectionState = catalog.map((entry) => {
-        if (entry.installed) {
-          return entry;
-        }
-        const required = (entry.integrations ?? []).filter((i) => i.required);
-        const bound =
-          required.length > 0 &&
-          required.every((i) =>
-            connectedSlugs.has(i.provider.trim().toLowerCase()),
-          );
-        return bound ? { ...entry, connectionBound: true } : entry;
-      });
-      const connectionCards = await buildConnectionCards(covered, connectedSlugs);
-      return [...withConnectionState, ...connectionCards];
-    },
-    async install(holaAppId) {
-      const base = await backendBaseUrl();
-      if (!base) {
-        throw new Error("HolaApp install failed: backend base URL is not configured.");
-      }
-      const resp = await bffFetch(
-        `${base}/gateway/wapp/${encodeURIComponent(holaAppId)}/install`,
-        { method: "POST" },
-      );
-      if (!resp.ok) {
-        // Don't swallow the failure: a silent non-2xx here is what made the
-        // install button spin and then quietly do nothing.
-        throw new Error(
-          `HolaApp install failed: POST /gateway/wapp/${holaAppId}/install → ${resp.status}`,
-        );
-      }
-      // Apply the local MCP attach — a no-op for apps with no hosted `/mcp/<id>`
-      // (attachWebHolaAppMcp skips when it discovers zero tools).
-      void window.electronAPI.holaApps?.install(holaAppId);
-      return { mcp: [], skills: [] };
-    },
-    async uninstall(holaAppId) {
-      const base = await backendBaseUrl();
-      if (!base) {
-        throw new Error(
-          "HolaApp uninstall failed: backend base URL is not configured.",
-        );
-      }
-      const resp = await bffFetch(
-        `${base}/gateway/wapp/${encodeURIComponent(holaAppId)}/uninstall`,
-        { method: "POST" },
-      );
-      if (!resp.ok) {
-        throw new Error(
-          `HolaApp uninstall failed: POST /gateway/wapp/${holaAppId}/uninstall → ${resp.status}`,
-        );
-      }
-      // Removes the MCP server entry from workspace.yaml — works for both hosted
-      // and API-key/custom servers (both keyed by holaAppId).
-      void window.electronAPI.holaApps?.uninstall(holaAppId);
-    },
-  };
+	return {
+		async listCatalog() {
+			const serverApps = await listWebHolaApps();
+			// Fold in LOCAL user-created custom HolaApps (localCustomHolaApps) — they're
+			// absent from the backend catalog; each carries installed:true + a `url`
+			// surface, and its MCP is re-attached via the app-owned sync below.
+			const serverIds = new Set(serverApps.map((app) => app.holaAppId));
+			const apps = [
+				...serverApps,
+				...customHolaAppsAsWebApps().filter(
+					(app) => !serverIds.has(app.holaAppId),
+				),
+			];
+			const catalog: AppCatalogEntry[] = apps.map((app) => ({
+				...webHolaAppToCatalogEntry(app),
+				installed: app.installed ?? false,
+			}));
+			// Sync only apps that use a Holaboss-hosted `/mcp/<id>` server to main —
+			// external / API-key apps (Notion, OmniSocials, Publora) have none, and
+			// main skips them anyway; keep them out of the per-turn re-attach.
+			void window.electronAPI.holaApps?.sync(
+				catalog
+					.filter((entry) => entry.installed && usesHostedMcp(entry))
+					.map((entry) => entry.holaAppId),
+			);
+			// App-owned hosted MCPs (hostedMcpInstall apps like jianguoyun) ride their
+			// OWN per-turn re-attach track — kept separate so the standalone marketplace
+			// sync can't detach them. Rebuilds each config from the locally-stored creds.
+			void syncInstalledAppHostedMcps(
+				catalog.map((entry) => ({
+					holaAppId: entry.holaAppId,
+					title: entry.title,
+					...(entry.iconUrl ? { iconUrl: entry.iconUrl } : {}),
+					installed: entry.installed,
+					...(entry.hostedMcpInstall
+						? { hostedMcpInstall: entry.hostedMcpInstall }
+						: {}),
+				})),
+				customHolaAppMcpAttachInputs(),
+			);
+			// Fold in the connection-tier Apps (former "integrations"): every Composio
+			// toolkit becomes a headless, surface-less App card. An authored App wins on
+			// any provider it OWNS or REQUIRES, so e.g. the Notion App is the sole Notion
+			// card (no duplicate bare Connection).
+			const covered = coveredProviderSlugs(catalog);
+			const connectedSlugs = await fetchConnectedSlugs();
+			// Mark an authored app whose required connection(s) are bound but which
+			// isn't in the sidebar yet — the card then reads "Connected" + offers a
+			// secondary "Add to sidebar".
+			const withConnectionState = catalog.map((entry) => {
+				if (entry.installed) {
+					return entry;
+				}
+				const required = (entry.integrations ?? []).filter((i) => i.required);
+				const bound =
+					required.length > 0 &&
+					required.every((i) =>
+						connectedSlugs.has(i.provider.trim().toLowerCase()),
+					);
+				return bound ? { ...entry, connectionBound: true } : entry;
+			});
+			const connectionCards = await buildConnectionCards(
+				covered,
+				connectedSlugs,
+			);
+			return [...withConnectionState, ...connectionCards];
+		},
+		async install(holaAppId) {
+			const base = await backendBaseUrl();
+			if (!base) {
+				throw new Error(
+					"HolaApp install failed: backend base URL is not configured.",
+				);
+			}
+			const resp = await bffFetch(
+				`${base}/gateway/wapp/${encodeURIComponent(holaAppId)}/install`,
+				{ method: "POST" },
+			);
+			if (!resp.ok) {
+				// Don't swallow the failure: a silent non-2xx here is what made the
+				// install button spin and then quietly do nothing.
+				throw new Error(
+					`HolaApp install failed: POST /gateway/wapp/${holaAppId}/install → ${resp.status}`,
+				);
+			}
+			// Apply the local MCP attach — a no-op for apps with no hosted `/mcp/<id>`
+			// (attachWebHolaAppMcp skips when it discovers zero tools).
+			void window.electronAPI.holaApps?.install(holaAppId);
+			return { mcp: [], skills: [] };
+		},
+		async uninstall(holaAppId) {
+			const base = await backendBaseUrl();
+			if (!base) {
+				throw new Error(
+					"HolaApp uninstall failed: backend base URL is not configured.",
+				);
+			}
+			const resp = await bffFetch(
+				`${base}/gateway/wapp/${encodeURIComponent(holaAppId)}/uninstall`,
+				{ method: "POST" },
+			);
+			if (!resp.ok) {
+				throw new Error(
+					`HolaApp uninstall failed: POST /gateway/wapp/${holaAppId}/uninstall → ${resp.status}`,
+				);
+			}
+			// Removes the MCP server entry from workspace.yaml — works for both hosted
+			// and API-key/custom servers (both keyed by holaAppId).
+			void window.electronAPI.holaApps?.uninstall(holaAppId);
+		},
+	};
 }
 
 /** The marketplace source the desktop uses. Server-managed install is LIVE — the backend's
@@ -757,38 +786,38 @@ export const marketplace: MarketplaceSource = createServerMarketplaceSource();
 
 /** Params to open an installed app's surface (mirrors `useOpenHolaApp`). */
 export function catalogEntryToOpenParams(entry: AppCatalogEntry): {
-  holaAppId: string;
-  title: string;
-  url?: string;
-  integrations?: { provider: string; required: boolean }[];
-  mcpTools?: string[];
-  apiKeyInstall?: ApiKeyInstall;
-  commandMcpInstall?: CommandMcpInstall;
+	holaAppId: string;
+	title: string;
+	url?: string;
+	integrations?: { provider: string; required: boolean }[];
+	mcpTools?: string[];
+	apiKeyInstall?: ApiKeyInstall;
+	commandMcpInstall?: CommandMcpInstall;
 } {
-  return {
-    holaAppId: entry.holaAppId,
-    title: entry.title,
-    ...(entry.surface.type === "hosted" && entry.surface.url
-      ? { url: entry.surface.url }
-      : {}),
-    // Carry the declared integrations + MCP tool names so the copilot can be
-    // nudged toward this app's relevant connections/tools (soft guide; see
-    // activeSurfaceContextText). An app uses one or the other: a Composio
-    // integration (e.g. Notion) or its own bundled MCP server (e.g. need-review).
-    ...(entry.integrations && entry.integrations.length > 0
-      ? {
-          integrations: entry.integrations.map((integration) => ({
-            provider: integration.provider,
-            required: integration.required,
-          })),
-        }
-      : {}),
-    ...(entry.mcpTools && entry.mcpTools.length > 0
-      ? { mcpTools: entry.mcpTools }
-      : {}),
-    ...(entry.apiKeyInstall ? { apiKeyInstall: entry.apiKeyInstall } : {}),
-    ...(entry.commandMcpInstall
-      ? { commandMcpInstall: entry.commandMcpInstall }
-      : {}),
-  };
+	return {
+		holaAppId: entry.holaAppId,
+		title: entry.title,
+		...(entry.surface.type === "hosted" && entry.surface.url
+			? { url: entry.surface.url }
+			: {}),
+		// Carry the declared integrations + MCP tool names so the copilot can be
+		// nudged toward this app's relevant connections/tools (soft guide; see
+		// activeSurfaceContextText). An app uses one or the other: a Composio
+		// integration (e.g. Notion) or its own bundled MCP server (e.g. need-review).
+		...(entry.integrations && entry.integrations.length > 0
+			? {
+					integrations: entry.integrations.map((integration) => ({
+						provider: integration.provider,
+						required: integration.required,
+					})),
+				}
+			: {}),
+		...(entry.mcpTools && entry.mcpTools.length > 0
+			? { mcpTools: entry.mcpTools }
+			: {}),
+		...(entry.apiKeyInstall ? { apiKeyInstall: entry.apiKeyInstall } : {}),
+		...(entry.commandMcpInstall
+			? { commandMcpInstall: entry.commandMcpInstall }
+			: {}),
+	};
 }

--- a/apps/desktop/src/lib/localCustomHolaApps.ts
+++ b/apps/desktop/src/lib/localCustomHolaApps.ts
@@ -1,0 +1,261 @@
+// Local-only persistence for user-created ("custom") HolaApps.
+//
+// A custom HolaApp is defined entirely on THIS machine: a URL the desktop opens as
+// the app's surface, plus an optional remote MCP server (a URL + headers, pasted as
+// an mcpServers-style JSON config) whose tools the agent gets while the app is around.
+// Everything lives in localStorage — mirroring the custom-MCP creds store
+// (localMcpKeys.ts); no `/gateway/*` call ever carries it. The MCP is attached
+// APP-OWNED (owner_app_id === holaAppId) and folded into the SAME per-turn re-attach
+// set as a HolaApp's hostedMcpInstall (syncInstalledAppHostedMcps) — the app-owned
+// sync reconciles that whole set, so custom apps must ride it rather than a separate
+// call. It survives a restart and is torn down when the app is deleted.
+
+import type { McpAttachInput } from "./mcpMarketplace";
+import type { WebHolaApp } from "./webHolaApps";
+
+export interface CustomHolaApp {
+	/** Stable local id, always prefixed `custom-`. */
+	holaAppId: string;
+	title: string;
+	/** The surface URL the app opens (e.g. https://notion.so). */
+	url: string;
+	iconUrl?: string;
+	/** Resolved app-owned MCP attach input (ownerAppId === holaAppId). Absent ⇒ no MCP. */
+	mcp?: McpAttachInput;
+	/** The raw JSON the user pasted, kept so the create form can pre-fill on edit. */
+	mcpConfigJson?: string;
+}
+
+const KEY = "holaboss.holaapps.custom.v1";
+
+function hasLocalStorage(): boolean {
+	return typeof localStorage !== "undefined";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStringMap(value: unknown): Record<string, string> {
+	if (!isRecord(value)) {
+		return {};
+	}
+	const out: Record<string, string> = {};
+	for (const [name, entry] of Object.entries(value)) {
+		if (typeof entry === "string") {
+			out[name] = entry;
+		}
+	}
+	return out;
+}
+
+function normalizeAttach(value: unknown): McpAttachInput | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+	const id = typeof value.id === "string" ? value.id : "";
+	const mcpUrl = typeof value.mcpUrl === "string" ? value.mcpUrl : "";
+	const ownerAppId =
+		typeof value.ownerAppId === "string" ? value.ownerAppId : "";
+	if (!(id && mcpUrl && ownerAppId)) {
+		return undefined;
+	}
+	const tools = Array.isArray(value.tools)
+		? value.tools.filter((tool): tool is string => typeof tool === "string")
+		: [];
+	return {
+		id,
+		mcpUrl,
+		holabossHosted: value.holabossHosted === true,
+		headerKeys: normalizeStringMap(value.headerKeys),
+		queryKeys: normalizeStringMap(value.queryKeys),
+		envKeys: normalizeStringMap(value.envKeys),
+		tools,
+		ownerAppId,
+	};
+}
+
+function normalizeStored(value: unknown): CustomHolaApp | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const holaAppId = typeof value.holaAppId === "string" ? value.holaAppId : "";
+	const title = typeof value.title === "string" ? value.title : "";
+	const url = typeof value.url === "string" ? value.url : "";
+	if (!(holaAppId && title && url)) {
+		return null;
+	}
+	const mcp = normalizeAttach(value.mcp);
+	return {
+		holaAppId,
+		title,
+		url,
+		...(typeof value.iconUrl === "string" && value.iconUrl
+			? { iconUrl: value.iconUrl }
+			: {}),
+		...(mcp ? { mcp } : {}),
+		...(typeof value.mcpConfigJson === "string"
+			? { mcpConfigJson: value.mcpConfigJson }
+			: {}),
+	};
+}
+
+/** Every custom HolaApp this machine has defined. Tolerant of a corrupt store. */
+export function readCustomHolaApps(): CustomHolaApp[] {
+	if (!hasLocalStorage()) {
+		return [];
+	}
+	try {
+		const raw = localStorage.getItem(KEY);
+		if (!raw) {
+			return [];
+		}
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) {
+			return [];
+		}
+		return parsed
+			.map(normalizeStored)
+			.filter((app): app is CustomHolaApp => app !== null);
+	} catch {
+		return [];
+	}
+}
+
+function writeCustomHolaApps(apps: CustomHolaApp[]): void {
+	if (!hasLocalStorage()) {
+		return;
+	}
+	try {
+		localStorage.setItem(KEY, JSON.stringify(apps));
+	} catch {
+		// best-effort — custom apps are local UI state
+	}
+}
+
+/** Create or replace a custom app (keyed by holaAppId). */
+export function upsertCustomHolaApp(app: CustomHolaApp): void {
+	const rest = readCustomHolaApps().filter(
+		(a) => a.holaAppId !== app.holaAppId,
+	);
+	writeCustomHolaApps([...rest, app]);
+}
+
+export function deleteCustomHolaApp(holaAppId: string): void {
+	writeCustomHolaApps(
+		readCustomHolaApps().filter((a) => a.holaAppId !== holaAppId),
+	);
+}
+
+/** Custom apps as WebHolaApps (installed + ready) so they merge into the catalog and
+ * open their `url` surface like any other hosted HolaApp. */
+export function customHolaAppsAsWebApps(): WebHolaApp[] {
+	return readCustomHolaApps().map((app) => ({
+		holaAppId: app.holaAppId,
+		title: app.title,
+		url: app.url,
+		installed: true,
+		category: "Custom",
+		...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
+	}));
+}
+
+/** The resolved app-owned MCP attach inputs for every custom app that has one —
+ * folded into the app-owned sync (syncInstalledAppHostedMcps) so main re-attaches
+ * them per turn alongside the hosted-app MCPs, without either clobbering the other. */
+export function customHolaAppMcpAttachInputs(): McpAttachInput[] {
+	return readCustomHolaApps().flatMap((app) => (app.mcp ? [app.mcp] : []));
+}
+
+/** A stable, unique-enough id for a new custom app, derived from its title. */
+export function customHolaAppId(title: string): string {
+	const slug = title
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 40);
+	return `custom-${slug || "app"}-${Date.now().toString(36)}`;
+}
+
+function safeJsonParse(text: string): unknown {
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		// Undefined is never a valid JSON.parse result, so callers read it as "failed".
+		return undefined;
+	}
+}
+
+// Accept { mcpServers: { "<name>": {...} } }, { servers: { … } }, or a bare
+// single-server object ({ url, headers, … } / { command, … }).
+function pickServerObject(
+	obj: Record<string, unknown>,
+): Record<string, unknown> | null {
+	for (const container of [obj.mcpServers, obj.servers]) {
+		if (isRecord(container)) {
+			const first = Object.values(container).find(isRecord);
+			if (first) {
+				return first;
+			}
+		}
+	}
+	if (typeof obj.url === "string" || obj.command !== undefined) {
+		return obj;
+	}
+	return null;
+}
+
+/** Parse a pasted MCP config (mcpServers-style JSON, a `servers` map, or a bare
+ * single-server object) into a resolved app-owned `McpAttachInput`. v1 supports
+ * REMOTE (URL) servers with optional `headers`/`tools`; a command/stdio-only server
+ * is rejected with a clear message. Returns `{ error }` on any problem. */
+export function parseCustomMcpConfig(
+	json: string,
+	ownerAppId: string,
+): { attach: McpAttachInput } | { error: string } {
+	const trimmed = json.trim();
+	if (!trimmed) {
+		return { error: "Paste an MCP server config." };
+	}
+	const parsed = safeJsonParse(trimmed);
+	if (parsed === undefined) {
+		return { error: "That isn't valid JSON." };
+	}
+	if (!isRecord(parsed)) {
+		return { error: "Expected a JSON object." };
+	}
+	const server = pickServerObject(parsed);
+	if (!server) {
+		return { error: "No MCP server found in the config." };
+	}
+	const url = typeof server.url === "string" ? server.url.trim() : "";
+	if (!url) {
+		if (server.command !== undefined) {
+			return {
+				error:
+					'Only remote (URL) MCP servers are supported here for now — provide a server with a "url".',
+			};
+		}
+		return { error: 'The MCP server needs a "url".' };
+	}
+	const headerKeys = normalizeStringMap(server.headers);
+	const tools = Array.isArray(server.tools)
+		? server.tools.filter(
+				(tool): tool is string =>
+					typeof tool === "string" && tool.trim().length > 0,
+			)
+		: [];
+	return {
+		attach: {
+			id: ownerAppId,
+			mcpUrl: url,
+			holabossHosted: false,
+			headerKeys,
+			queryKeys: {},
+			envKeys: {},
+			tools,
+			ownerAppId,
+		},
+	};
+}

--- a/apps/desktop/src/lib/mcpMarketplace.ts
+++ b/apps/desktop/src/lib/mcpMarketplace.ts
@@ -15,12 +15,12 @@
 
 import { bffFetch } from "./bff-fetch-bridge";
 import {
-  clearMcpKeys,
-  markMcpInstalled,
-  markMcpUninstalled,
-  readInstalledMcpIds,
-  readMcpKeys,
-  writeMcpKeys,
+	clearMcpKeys,
+	markMcpInstalled,
+	markMcpUninstalled,
+	readInstalledMcpIds,
+	readMcpKeys,
+	writeMcpKeys,
 } from "./localMcpKeys";
 
 // ── catalog types (mirror the backend McpCatalogEntry contract) ──────────────
@@ -31,207 +31,217 @@ export type McpKeyTarget = "header" | "query" | "env";
 /** One credential the user must supply to install an MCP server. Every declared key is
  * required — install is blocked until all are non-empty. */
 export interface McpRequiredKey {
-  target: McpKeyTarget;
-  /** The header name / query param / env var the value is applied as. */
-  name: string;
-  /** Human label shown above the input. */
-  label: string;
-  /** Optional helper text under the input. */
-  help?: string;
-  /** Masked (password) input + never rendered back once stored. */
-  secret?: boolean;
+	target: McpKeyTarget;
+	/** The header name / query param / env var the value is applied as. */
+	name: string;
+	/** Human label shown above the input. */
+	label: string;
+	/** Optional helper text under the input. */
+	help?: string;
+	/** Masked (password) input + never rendered back once stored. */
+	secret?: boolean;
 }
 
 export interface McpTool {
-  name: string;
-  description: string;
+	name: string;
+	description: string;
 }
 
 /** A marketplace card for an installable MCP server, plus the local `installed` flag. */
 export interface McpCatalogEntry {
-  id: string;
-  name: string;
-  description?: string;
-  /** Favicon/logo image URL. */
-  iconUrl?: string;
-  category?: string;
-  badge?: string;
-  tags?: string[];
-  /** Holaboss-hosted → a PATH like "/mcp/<id>/mcp" (prepend the API base in main);
-   * external → an absolute URL. */
-  mcpUrl: string;
-  /** true → main ALSO attaches the Holaboss session bearer (Authorization header). */
-  holabossHosted: boolean;
-  requiredKeys: McpRequiredKey[];
-  /** Optional web surface to open (e.g. the provider's site) for the user to get a key. */
-  surfaceUrl?: string;
-  /** Tool names/descriptions from the server — enumerated into the agent's allowlist. */
-  tools?: McpTool[];
-  /** Shown in the marketplace but greyed / not-installable (backend availability=coming_soon). */
-  comingSoon: boolean;
-  /** false = a community (user-uploaded) server, not Holaboss-vetted — install is
-   * gated behind an "unverified — its tools run in your agent" consent prompt. */
-  verified: boolean;
-  /** Local install state (from localMcpKeys), merged in by listMcpCatalog. */
-  installed: boolean;
+	id: string;
+	name: string;
+	description?: string;
+	/** Favicon/logo image URL. */
+	iconUrl?: string;
+	category?: string;
+	badge?: string;
+	tags?: string[];
+	/** Holaboss-hosted → a PATH like "/mcp/<id>/mcp" (prepend the API base in main);
+	 * external → an absolute URL. */
+	mcpUrl: string;
+	/** true → main ALSO attaches the Holaboss session bearer (Authorization header). */
+	holabossHosted: boolean;
+	requiredKeys: McpRequiredKey[];
+	/** Optional web surface to open (e.g. the provider's site) for the user to get a key. */
+	surfaceUrl?: string;
+	/** Tool names/descriptions from the server — enumerated into the agent's allowlist. */
+	tools?: McpTool[];
+	/** Shown in the marketplace but greyed / not-installable (backend availability=coming_soon). */
+	comingSoon: boolean;
+	/** false = a community (user-uploaded) server, not Holaboss-vetted — install is
+	 * gated behind an "unverified — its tools run in your agent" consent prompt. */
+	verified: boolean;
+	/** Local install state (from localMcpKeys), merged in by listMcpCatalog. */
+	installed: boolean;
 }
 
 /** The resolved config handed to the Electron main process to attach the server. Carries
  * the user's credentials split by their `target`, so main can apply them to the local
  * workspace.yaml server entry (header → headers, query → url query, env → server env). */
 export interface McpAttachInput {
-  id: string;
-  mcpUrl: string;
-  holabossHosted: boolean;
-  headerKeys: Record<string, string>;
-  queryKeys: Record<string, string>;
-  envKeys: Record<string, string>;
-  tools: string[];
-  /** When set, this MCP is OWNED by the app container with this id — main writes
-   * it to workspace.yaml's `app_servers` (grouped under the app), not the
-   * standalone `servers` pool. Set for a HolaApp's `hostedMcpInstall`. */
-  ownerAppId?: string;
+	id: string;
+	mcpUrl: string;
+	holabossHosted: boolean;
+	headerKeys: Record<string, string>;
+	queryKeys: Record<string, string>;
+	envKeys: Record<string, string>;
+	tools: string[];
+	/** When set, this MCP is OWNED by the app container with this id — main writes
+	 * it to workspace.yaml's `app_servers` (grouped under the app), not the
+	 * standalone `servers` pool. Set for a HolaApp's `hostedMcpInstall`. */
+	ownerAppId?: string;
 }
 
 // ── normalization ────────────────────────────────────────────────────────────
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function normalizeRequiredKey(value: unknown): McpRequiredKey | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const target =
-    value.target === "header" || value.target === "query" || value.target === "env"
-      ? value.target
-      : null;
-  const name = typeof value.name === "string" ? value.name.trim() : "";
-  const label = typeof value.label === "string" ? value.label.trim() : "";
-  if (!(target && name && label)) {
-    return null;
-  }
-  return {
-    target,
-    name,
-    label,
-    ...(typeof value.help === "string" && value.help.trim()
-      ? { help: value.help }
-      : {}),
-    ...(value.secret === true ? { secret: true } : {}),
-  };
+	if (!isRecord(value)) {
+		return null;
+	}
+	const target =
+		value.target === "header" ||
+		value.target === "query" ||
+		value.target === "env"
+			? value.target
+			: null;
+	const name = typeof value.name === "string" ? value.name.trim() : "";
+	const label = typeof value.label === "string" ? value.label.trim() : "";
+	if (!(target && name && label)) {
+		return null;
+	}
+	return {
+		target,
+		name,
+		label,
+		...(typeof value.help === "string" && value.help.trim()
+			? { help: value.help }
+			: {}),
+		...(value.secret === true ? { secret: true } : {}),
+	};
 }
 
 function normalizeTools(value: unknown): McpTool[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const tools = value.flatMap((entry): McpTool[] => {
-    if (!isRecord(entry) || typeof entry.name !== "string" || !entry.name.trim()) {
-      return [];
-    }
-    return [
-      {
-        name: entry.name.trim(),
-        description:
-          typeof entry.description === "string" ? entry.description : "",
-      },
-    ];
-  });
-  return tools.length > 0 ? tools : undefined;
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const tools = value.flatMap((entry): McpTool[] => {
+		if (
+			!isRecord(entry) ||
+			typeof entry.name !== "string" ||
+			!entry.name.trim()
+		) {
+			return [];
+		}
+		return [
+			{
+				name: entry.name.trim(),
+				description:
+					typeof entry.description === "string" ? entry.description : "",
+			},
+		];
+	});
+	return tools.length > 0 ? tools : undefined;
 }
 
 function normalizeMcpEntry(value: unknown): McpCatalogEntry | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const id = typeof value.id === "string" ? value.id.trim() : "";
-  const name = typeof value.name === "string" ? value.name.trim() : "";
-  const mcpUrl = typeof value.mcpUrl === "string" ? value.mcpUrl.trim() : "";
-  if (!(id && name && mcpUrl)) {
-    return null;
-  }
-  const requiredKeys = Array.isArray(value.requiredKeys)
-    ? value.requiredKeys
-        .map(normalizeRequiredKey)
-        .filter((key): key is McpRequiredKey => key !== null)
-    : [];
-  const tags = Array.isArray(value.tags)
-    ? value.tags.filter(
-        (tag): tag is string => typeof tag === "string" && tag.trim().length > 0,
-      )
-    : undefined;
-  const tools = normalizeTools(value.tools);
-  return {
-    id,
-    name,
-    mcpUrl,
-    holabossHosted: value.holabossHosted === true,
-    requiredKeys,
-    comingSoon: value.comingSoon === true,
-    // Default true unless the backend explicitly marks it unverified (community).
-    verified: value.verified !== false,
-    installed: false,
-    ...(typeof value.description === "string" && value.description.trim()
-      ? { description: value.description }
-      : {}),
-    ...(typeof value.iconUrl === "string" && value.iconUrl.trim()
-      ? { iconUrl: value.iconUrl }
-      : {}),
-    ...(typeof value.category === "string" && value.category.trim()
-      ? { category: value.category }
-      : {}),
-    ...(typeof value.badge === "string" && value.badge.trim()
-      ? { badge: value.badge }
-      : {}),
-    ...(tags && tags.length > 0 ? { tags } : {}),
-    ...(typeof value.surfaceUrl === "string" && value.surfaceUrl.trim()
-      ? { surfaceUrl: value.surfaceUrl }
-      : {}),
-    ...(tools ? { tools } : {}),
-  };
+	if (!isRecord(value)) {
+		return null;
+	}
+	const id = typeof value.id === "string" ? value.id.trim() : "";
+	const name = typeof value.name === "string" ? value.name.trim() : "";
+	const mcpUrl = typeof value.mcpUrl === "string" ? value.mcpUrl.trim() : "";
+	if (!(id && name && mcpUrl)) {
+		return null;
+	}
+	const requiredKeys = Array.isArray(value.requiredKeys)
+		? value.requiredKeys
+				.map(normalizeRequiredKey)
+				.filter((key): key is McpRequiredKey => key !== null)
+		: [];
+	const tags = Array.isArray(value.tags)
+		? value.tags.filter(
+				(tag): tag is string =>
+					typeof tag === "string" && tag.trim().length > 0,
+			)
+		: undefined;
+	const tools = normalizeTools(value.tools);
+	return {
+		id,
+		name,
+		mcpUrl,
+		holabossHosted: value.holabossHosted === true,
+		requiredKeys,
+		comingSoon: value.comingSoon === true,
+		// Default true unless the backend explicitly marks it unverified (community).
+		verified: value.verified !== false,
+		installed: false,
+		...(typeof value.description === "string" && value.description.trim()
+			? { description: value.description }
+			: {}),
+		...(typeof value.iconUrl === "string" && value.iconUrl.trim()
+			? { iconUrl: value.iconUrl }
+			: {}),
+		...(typeof value.category === "string" && value.category.trim()
+			? { category: value.category }
+			: {}),
+		...(typeof value.badge === "string" && value.badge.trim()
+			? { badge: value.badge }
+			: {}),
+		...(tags && tags.length > 0 ? { tags } : {}),
+		...(typeof value.surfaceUrl === "string" && value.surfaceUrl.trim()
+			? { surfaceUrl: value.surfaceUrl }
+			: {}),
+		...(tools ? { tools } : {}),
+	};
 }
 
 // ── catalog fetch ─────────────────────────────────────────────────────────────
 
 async function backendBaseUrl(): Promise<string | null> {
-  const base = (await window.electronAPI.auth.getBackendBaseUrl())?.replace(
-    /\/+$/,
-    "",
-  );
-  return base || null;
+	const base = (await window.electronAPI.auth.getBackendBaseUrl())?.replace(
+		/\/+$/,
+		"",
+	);
+	return base || null;
 }
 
 /** Fetch the MCP catalog and merge in this machine's local install state. Returns an
  * empty catalog (and logs why) when it can't be fetched — same posture as the HolaApp
  * catalog. */
 export async function listMcpCatalog(): Promise<McpCatalogEntry[]> {
-  const installed = new Set(readInstalledMcpIds());
-  try {
-    const base = await backendBaseUrl();
-    if (!base) {
-      console.warn("[mcp-marketplace] no backend base URL — empty catalog");
-      return [];
-    }
-    const resp = await bffFetch(`${base}/gateway/wapp/mcp-catalog`);
-    if (!resp.ok) {
-      console.warn(
-        `[mcp-marketplace] GET /gateway/wapp/mcp-catalog → ${resp.status}; empty catalog`,
-      );
-      return [];
-    }
-    const data = (await resp.json()) as { mcps?: unknown };
-    const mcps = Array.isArray(data.mcps)
-      ? data.mcps
-          .map(normalizeMcpEntry)
-          .filter((entry): entry is McpCatalogEntry => entry !== null)
-      : [];
-    return mcps.map((entry) => ({ ...entry, installed: installed.has(entry.id) }));
-  } catch (err) {
-    console.warn("[mcp-marketplace] catalog fetch failed; empty catalog", err);
-    return [];
-  }
+	const installed = new Set(readInstalledMcpIds());
+	try {
+		const base = await backendBaseUrl();
+		if (!base) {
+			console.warn("[mcp-marketplace] no backend base URL — empty catalog");
+			return [];
+		}
+		const resp = await bffFetch(`${base}/gateway/wapp/mcp-catalog`);
+		if (!resp.ok) {
+			console.warn(
+				`[mcp-marketplace] GET /gateway/wapp/mcp-catalog → ${resp.status}; empty catalog`,
+			);
+			return [];
+		}
+		const data = (await resp.json()) as { mcps?: unknown };
+		const mcps = Array.isArray(data.mcps)
+			? data.mcps
+					.map(normalizeMcpEntry)
+					.filter((entry): entry is McpCatalogEntry => entry !== null)
+			: [];
+		return mcps.map((entry) => ({
+			...entry,
+			installed: installed.has(entry.id),
+		}));
+	} catch (err) {
+		console.warn("[mcp-marketplace] catalog fetch failed; empty catalog", err);
+		return [];
+	}
 }
 
 // ── install / uninstall / sync (LOCAL — never hits the gateway) ───────────────
@@ -239,36 +249,36 @@ export async function listMcpCatalog(): Promise<McpCatalogEntry[]> {
 /** Split a server's stored key values by their declared `target` so main can apply each
  * to the right place on the workspace.yaml server entry. */
 export function buildAttachInput(
-  entry: McpCatalogEntry,
-  values: Record<string, string>,
-  ownerAppId?: string,
+	entry: McpCatalogEntry,
+	values: Record<string, string>,
+	ownerAppId?: string,
 ): McpAttachInput {
-  const headerKeys: Record<string, string> = {};
-  const queryKeys: Record<string, string> = {};
-  const envKeys: Record<string, string> = {};
-  for (const key of entry.requiredKeys) {
-    const value = values[key.name];
-    if (typeof value !== "string" || value.length === 0) {
-      continue;
-    }
-    if (key.target === "header") {
-      headerKeys[key.name] = value;
-    } else if (key.target === "query") {
-      queryKeys[key.name] = value;
-    } else {
-      envKeys[key.name] = value;
-    }
-  }
-  return {
-    id: entry.id,
-    mcpUrl: entry.mcpUrl,
-    holabossHosted: entry.holabossHosted,
-    headerKeys,
-    queryKeys,
-    envKeys,
-    tools: (entry.tools ?? []).map((tool) => tool.name),
-    ...(ownerAppId ? { ownerAppId } : {}),
-  };
+	const headerKeys: Record<string, string> = {};
+	const queryKeys: Record<string, string> = {};
+	const envKeys: Record<string, string> = {};
+	for (const key of entry.requiredKeys) {
+		const value = values[key.name];
+		if (typeof value !== "string" || value.length === 0) {
+			continue;
+		}
+		if (key.target === "header") {
+			headerKeys[key.name] = value;
+		} else if (key.target === "query") {
+			queryKeys[key.name] = value;
+		} else {
+			envKeys[key.name] = value;
+		}
+	}
+	return {
+		id: entry.id,
+		mcpUrl: entry.mcpUrl,
+		holabossHosted: entry.holabossHosted,
+		headerKeys,
+		queryKeys,
+		envKeys,
+		tools: (entry.tools ?? []).map((tool) => tool.name),
+		...(ownerAppId ? { ownerAppId } : {}),
+	};
 }
 
 /** Build a synthetic `McpCatalogEntry` from a HolaApp's `hostedMcpInstall` block
@@ -277,43 +287,45 @@ export function buildAttachInput(
  * id; `installMcp(entry, values, app.holaAppId)` then tags it app-owned so it
  * lands in `app_servers` (grouped under its app), not the standalone pool. */
 export function hostedMcpInstallToEntry(app: {
-  holaAppId: string;
-  title: string;
-  iconUrl?: string;
-  hostedMcpInstall: {
-    mcpUrl: string;
-    holabossHosted?: boolean;
-    requiredKeys: McpRequiredKey[];
-    tools?: McpTool[];
-  };
+	holaAppId: string;
+	title: string;
+	iconUrl?: string;
+	hostedMcpInstall: {
+		mcpUrl: string;
+		holabossHosted?: boolean;
+		requiredKeys: McpRequiredKey[];
+		tools?: McpTool[];
+	};
 }): McpCatalogEntry {
-  return {
-    id: app.holaAppId,
-    name: app.title,
-    mcpUrl: app.hostedMcpInstall.mcpUrl,
-    holabossHosted: app.hostedMcpInstall.holabossHosted !== false,
-    requiredKeys: app.hostedMcpInstall.requiredKeys,
-    comingSoon: false,
-    // A HolaApp's own hosted MCP is Holaboss-official — no consent prompt.
-    verified: true,
-    installed: false,
-    ...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
-    ...(app.hostedMcpInstall.tools ? { tools: app.hostedMcpInstall.tools } : {}),
-  };
+	return {
+		id: app.holaAppId,
+		name: app.title,
+		mcpUrl: app.hostedMcpInstall.mcpUrl,
+		holabossHosted: app.hostedMcpInstall.holabossHosted !== false,
+		requiredKeys: app.hostedMcpInstall.requiredKeys,
+		comingSoon: false,
+		// A HolaApp's own hosted MCP is Holaboss-official — no consent prompt.
+		verified: true,
+		installed: false,
+		...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
+		...(app.hostedMcpInstall.tools
+			? { tools: app.hostedMcpInstall.tools }
+			: {}),
+	};
 }
 
 /** Install an MCP server: persist its credentials LOCALLY, then hand the resolved config
  * to main to attach it to the agent's workspace.yaml. Keys never leave the machine. */
 export async function installMcp(
-  entry: McpCatalogEntry,
-  values: Record<string, string>,
-  ownerAppId?: string,
+	entry: McpCatalogEntry,
+	values: Record<string, string>,
+	ownerAppId?: string,
 ): Promise<void> {
-  writeMcpKeys(entry.id, values);
-  markMcpInstalled(entry.id);
-  await window.electronAPI.mcpMarketplace?.install(
-    buildAttachInput(entry, values, ownerAppId),
-  );
+	writeMcpKeys(entry.id, values);
+	markMcpInstalled(entry.id);
+	await window.electronAPI.mcpMarketplace?.install(
+		buildAttachInput(entry, values, ownerAppId),
+	);
 }
 
 /** Attach a HolaApp's hosted MCP (`hostedMcpInstall`) as APP-OWNED: persist its
@@ -323,32 +335,34 @@ export async function installMcp(
  * which an app MCP is never in, so `installMcp` would attach then instantly
  * detach it. Torn down with the app on uninstall (detach clears app_servers). */
 export async function attachAppOwnedMcp(
-  entry: McpCatalogEntry,
-  values: Record<string, string>,
-  ownerAppId: string,
+	entry: McpCatalogEntry,
+	values: Record<string, string>,
+	ownerAppId: string,
 ): Promise<void> {
-  writeMcpKeys(entry.id, values);
-  await window.electronAPI.mcpMarketplace?.attachAppOwned({
-    ...buildAttachInput(entry, values, ownerAppId),
-    ownerAppId,
-  });
+	writeMcpKeys(entry.id, values);
+	await window.electronAPI.mcpMarketplace?.attachAppOwned({
+		...buildAttachInput(entry, values, ownerAppId),
+		ownerAppId,
+	});
 }
 
 /** Uninstall an MCP server: detach it from workspace.yaml and forget its local keys. */
 export async function uninstallMcp(id: string): Promise<void> {
-  markMcpUninstalled(id);
-  clearMcpKeys(id);
-  await window.electronAPI.mcpMarketplace?.uninstall(id);
+	markMcpUninstalled(id);
+	clearMcpKeys(id);
+	await window.electronAPI.mcpMarketplace?.uninstall(id);
 }
 
 /** Re-apply every installed MCP server to main from local state (on catalog load / app
  * restart), so main can hold the resolved configs and refresh the Holaboss session bearer
  * per turn — mirroring holaApps:sync. */
-export async function syncInstalledMcps(catalog: McpCatalogEntry[]): Promise<void> {
-  const configs = catalog
-    .filter((entry) => entry.installed)
-    .map((entry) => buildAttachInput(entry, readMcpKeys(entry.id)));
-  await window.electronAPI.mcpMarketplace?.sync(configs);
+export async function syncInstalledMcps(
+	catalog: McpCatalogEntry[],
+): Promise<void> {
+	const configs = catalog
+		.filter((entry) => entry.installed)
+		.map((entry) => buildAttachInput(entry, readMcpKeys(entry.id)));
+	await window.electronAPI.mcpMarketplace?.sync(configs);
 }
 
 /** Re-apply every installed APP-OWNED hosted MCP (a HolaApp's `hostedMcpInstall`,
@@ -357,40 +371,55 @@ export async function syncInstalledMcps(catalog: McpCatalogEntry[]): Promise<voi
  * `syncInstalledMcps`, kept on its OWN track (never catalog-reconciled, so it can't
  * be detached by the standalone marketplace sync). Torn down with the app on uninstall. */
 export async function syncInstalledAppHostedMcps(
-  apps: {
-    holaAppId: string;
-    title: string;
-    iconUrl?: string;
-    installed: boolean;
-    hostedMcpInstall?: {
-      mcpUrl: string;
-      holabossHosted?: boolean;
-      requiredKeys: McpRequiredKey[];
-      tools?: McpTool[];
-    };
-  }[],
+	apps: {
+		holaAppId: string;
+		title: string;
+		iconUrl?: string;
+		installed: boolean;
+		hostedMcpInstall?: {
+			mcpUrl: string;
+			holabossHosted?: boolean;
+			requiredKeys: McpRequiredKey[];
+			tools?: McpTool[];
+		};
+	}[],
+	// App-owned MCPs from LOCAL custom HolaApps (localCustomHolaApps) — already
+	// resolved. Folded into the SAME syncAppOwned set because that set is reconciled
+	// (entries not in it are detached), so hosted + custom must sync together.
+	extraAppOwned: McpAttachInput[] = [],
 ): Promise<void> {
-  const configs = apps.flatMap((app) => {
-    if (!(app.installed && app.hostedMcpInstall)) {
-      return [];
-    }
-    const values = readMcpKeys(app.holaAppId);
-    // Skip a gate that never completed: attaching a required-key server without
-    // its creds would just fail (and churn the attach). Bearer-only servers
-    // (no required keys) always qualify.
-    const missingKey = app.hostedMcpInstall.requiredKeys.some(
-      (key) => !values[key.name],
-    );
-    if (missingKey) {
-      return [];
-    }
-    const entry = hostedMcpInstallToEntry({
-      holaAppId: app.holaAppId,
-      title: app.title,
-      ...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
-      hostedMcpInstall: app.hostedMcpInstall,
-    });
-    return [{ ...buildAttachInput(entry, values, app.holaAppId), ownerAppId: app.holaAppId }];
-  });
-  await window.electronAPI.mcpMarketplace?.syncAppOwned(configs);
+	const configs = apps.flatMap((app) => {
+		if (!(app.installed && app.hostedMcpInstall)) {
+			return [];
+		}
+		const values = readMcpKeys(app.holaAppId);
+		// Skip a gate that never completed: attaching a required-key server without
+		// its creds would just fail (and churn the attach). Bearer-only servers
+		// (no required keys) always qualify.
+		const missingKey = app.hostedMcpInstall.requiredKeys.some(
+			(key) => !values[key.name],
+		);
+		if (missingKey) {
+			return [];
+		}
+		const entry = hostedMcpInstallToEntry({
+			holaAppId: app.holaAppId,
+			title: app.title,
+			...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
+			hostedMcpInstall: app.hostedMcpInstall,
+		});
+		return [
+			{
+				...buildAttachInput(entry, values, app.holaAppId),
+				ownerAppId: app.holaAppId,
+			},
+		];
+	});
+	await window.electronAPI.mcpMarketplace?.syncAppOwned([
+		...configs,
+		...extraAppOwned.map((input) => ({
+			...input,
+			ownerAppId: input.ownerAppId ?? input.id,
+		})),
+	]);
 }


### PR DESCRIPTION
## What

Adds a **"Create your own app"** flow to **Customize → Apps** so a user can define a personal HolaApp from:
- a **name**,
- a **URL** the app opens as its surface (side-by-side with the agent), and
- an optional **MCP server config**, pasted as an `mcpServers`-style JSON, whose tools the agent gains while the app is around.

<img width="480" alt="Create your own app dialog" src="—add screenshot—" />

## How it works

- **Local-only (v1)** — custom apps live in `localStorage` (`holaboss.holaapps.custom.v1`), mirroring the existing custom-MCP creds store. No backend changes.
- They're **merged into the app catalog** (`createServerMarketplaceSource.listCatalog`) as `installed`, so they render in the Apps grid **and** the sidebar and open their `url` surface like any hosted HolaApp.
- The MCP is attached **app-owned** (`owner_app_id`). Because the app-owned sync (`syncHostedAppMcps`) *reconciles* the whole set (detaching entries not in it), custom-app MCPs are folded into the **same** `syncInstalledAppHostedMcps` → `syncAppOwned` call as the hosted-app MCPs — so neither clobbers the other. Attach/detach is driven purely by persist + catalog refresh; delete tears the MCP down on the next sync.
- MCP JSON parsing accepts `{ mcpServers: {…} }`, `{ servers: {…} }`, or a bare single-server object; **remote (URL) servers** with optional `headers`/`tools`. Command/stdio-only servers are rejected with a clear message (v1).

## Files

| File | Change |
|---|---|
| `lib/localCustomHolaApps.ts` (new) | Local CRUD, WebHolaApp/MCP-attach adapters, `parseCustomMcpConfig` |
| `lib/mcpMarketplace.ts` | `syncInstalledAppHostedMcps` takes extra app-owned attach inputs |
| `lib/holaAppMarketplace.ts` | Fold custom apps into the catalog + pass their MCPs to the sync |
| `components/layout/shell/CustomHolaAppCreateDialog.tsx` (new) | Create/manage dialog |
| `components/panes/CustomizePane.tsx` | Header button (Apps tab) + wire dialog to refresh the catalog |

## Status / follow-ups

- ✅ `desktop:typecheck` passes; biome-formatted.
- ⚠️ **Not yet verified in-app** (Electron) — needs a manual smoke test: create an app with a URL + an MCP config, confirm it appears in Apps + sidebar, opens the surface, and the agent sees the MCP tools; then remove it and confirm the MCP detaches.
- **v1 scope:** local/per-device only (not synced or publishable to the marketplace); URL-based MCP only; create + remove (no edit-in-place yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)