### PR TITLE
fix(desktop): accept npx mcp-remote <url> MCP configs in custom HolaApps

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17857,6 +17857,37 @@ function appSurfaceBrowserSession(): Session {
   return surfaceSession;
 }
 
+// Google (Gaia), Microsoft and Apple refuse OAuth in an embedded main frame
+// ("disallowed_useragent" / a dead "Continue"), yet allow the same flow in a real
+// popup window — which is why a sign-in that opens via window.open (Typefully) works
+// while one that navigates the surface in place (Linear) stalls. These hosts serve
+// ONLY auth, so any in-surface navigation to them is an OAuth flow we re-run as a popup.
+const OAUTH_POPUP_ONLY_HOSTS = new Set([
+  "accounts.google.com",
+  "login.microsoftonline.com",
+  "login.live.com",
+  "appleid.apple.com",
+]);
+
+function isOAuthPopupOnlyUrl(rawUrl: string): boolean {
+  try {
+    return OAUTH_POPUP_ONLY_HOSTS.has(new URL(rawUrl).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function httpOrigin(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.origin
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function getOrCreateAppSurfaceView(
   appId: string,
   surfaceSession?: Electron.Session,
@@ -17897,6 +17928,10 @@ function getOrCreateAppSurfaceView(
     horizontal: false,
     vertical: false,
   });
+  // Armed when an in-surface navigation to a popup-only OAuth host is redirected to the
+  // window.open popup path (see will-navigate below); did-create-window consumes it to
+  // bridge that popup back to the surface once auth returns to the app's origin.
+  let pendingOAuthBridge: { appOrigin: string; returnUrl: string } | null = null;
   view.webContents.setWindowOpenHandler(({ url, disposition, features, frameName }) => {
     // Genuine popups (e.g. OAuth/login flows) call window.open with a named
     // target and/or window features and surface as disposition "new-window".
@@ -17946,6 +17981,32 @@ function getOrCreateAppSurfaceView(
     if (mainWindow && !mainWindow.isDestroyed()) {
       childWindow.setParentWindow(mainWindow);
     }
+    // If this popup was opened to satisfy an in-surface OAuth navigation we redirected
+    // to window.open (see will-navigate), bridge it back: when it returns to the app's
+    // own origin (auth done, cookie now in the shared jar), reload the surface at its
+    // pre-auth URL — now signed in — and close the popup. Reload the ORIGINAL url, never
+    // the popup's callback url (OAuth codes are single-use).
+    const oauthBridge = pendingOAuthBridge;
+    pendingOAuthBridge = null;
+    if (oauthBridge) {
+      let bridged = false;
+      const bridgeBack = (visitedUrl: string) => {
+        if (bridged || httpOrigin(visitedUrl) !== oauthBridge.appOrigin) {
+          return;
+        }
+        bridged = true;
+        if (!view.webContents.isDestroyed()) {
+          void view.webContents.loadURL(oauthBridge.returnUrl);
+        }
+        if (!childWindow.isDestroyed()) {
+          childWindow.close();
+        }
+      };
+      childWindow.webContents.on("did-navigate", (_e, u) => bridgeBack(u));
+      childWindow.webContents.on("did-redirect-navigation", (_e, u) =>
+        bridgeBack(u),
+      );
+    }
     try {
       const cw = childWindow.webContents;
       console.log(
@@ -17983,6 +18044,42 @@ function getOrCreateAppSurfaceView(
       openExternalUrlFromMain(url, "app surface auth popup");
       return { action: "deny" };
     });
+  });
+  // Some sites (Linear, …) sign in by navigating the SURFACE ITSELF to a provider OAuth
+  // page, which Google/Microsoft/Apple block in an embedded main frame (dead "Continue").
+  // Those providers allow the flow in a real popup — which is why a window.open-based
+  // sign-in (Typefully) works. So cancel the in-surface nav and re-issue it as a
+  // window.open FROM the surface, routing it through the proven setWindowOpenHandler →
+  // did-create-window popup path above (real popup, shared session). Do NOT hand-build a
+  // BrowserWindow here — creating one from the surface crashes (SIGSEGV).
+  view.webContents.on("will-navigate", (event, targetUrl) => {
+    if (!isOAuthPopupOnlyUrl(targetUrl)) {
+      return;
+    }
+    const returnUrl = view.webContents.getURL();
+    const appOrigin = httpOrigin(returnUrl);
+    if (!appOrigin) {
+      return; // no app origin to return to — let it navigate as before
+    }
+    event.preventDefault();
+    const armedBridge = { appOrigin, returnUrl };
+    pendingOAuthBridge = armedBridge;
+    // userGesture=true so the popup isn't blocked; the width/height features make
+    // setWindowOpenHandler treat it as a real popup (shared session). Only clear the
+    // bridge WE armed, so a later OAuth can't be cancelled by our stale timer.
+    const openPopupJs = `window.open(${JSON.stringify(
+      targetUrl,
+    )}, "_blank", "popup=yes,width=480,height=660")`;
+    view.webContents.executeJavaScript(openPopupJs, true).catch(() => {
+      if (pendingOAuthBridge === armedBridge) {
+        pendingOAuthBridge = null;
+      }
+    });
+    setTimeout(() => {
+      if (pendingOAuthBridge === armedBridge) {
+        pendingOAuthBridge = null;
+      }
+    }, 8000);
   });
   view.webContents.on(
     "did-fail-load",

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17990,22 +17990,25 @@ function getOrCreateAppSurfaceView(
     pendingOAuthBridge = null;
     if (oauthBridge) {
       let bridged = false;
-      const bridgeBack = (visitedUrl: string) => {
+      // Bridge only on a COMMITTED navigation (did-navigate) to the app origin — NOT on
+      // did-redirect-navigation, which fires on the callback url BEFORE its Set-Cookie
+      // lands (bridging there would reload the surface still-logged-out). And DEFER the
+      // close/reload with setImmediate: doing it synchronously inside the popup's own
+      // navigation event frees a WebContents Chromium still references → SIGSEGV.
+      childWindow.webContents.on("did-navigate", (_e, visitedUrl) => {
         if (bridged || httpOrigin(visitedUrl) !== oauthBridge.appOrigin) {
           return;
         }
         bridged = true;
-        if (!view.webContents.isDestroyed()) {
-          void view.webContents.loadURL(oauthBridge.returnUrl);
-        }
-        if (!childWindow.isDestroyed()) {
-          childWindow.close();
-        }
-      };
-      childWindow.webContents.on("did-navigate", (_e, u) => bridgeBack(u));
-      childWindow.webContents.on("did-redirect-navigation", (_e, u) =>
-        bridgeBack(u),
-      );
+        setImmediate(() => {
+          if (!view.webContents.isDestroyed()) {
+            void view.webContents.loadURL(oauthBridge.returnUrl);
+          }
+          if (!childWindow.isDestroyed()) {
+            childWindow.close();
+          }
+        });
+      });
     }
     try {
       const cw = childWindow.webContents;

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17990,24 +17990,42 @@ function getOrCreateAppSurfaceView(
     pendingOAuthBridge = null;
     if (oauthBridge) {
       let bridged = false;
-      // Bridge only on a COMMITTED navigation (did-navigate) to the app origin — NOT on
-      // did-redirect-navigation, which fires on the callback url BEFORE its Set-Cookie
-      // lands (bridging there would reload the surface still-logged-out). And DEFER the
-      // close/reload with setImmediate: doing it synchronously inside the popup's own
-      // navigation event frees a WebContents Chromium still references → SIGSEGV.
-      childWindow.webContents.on("did-navigate", (_e, visitedUrl) => {
+      let settleTimer: ReturnType<typeof setTimeout> | null = null;
+      // The popup reaching the app origin does NOT mean login is done: the provider
+      // callback (e.g. linear.app/auth/google/callback) exchanges the code CLIENT-SIDE
+      // and may SPA-route afterward, so closing the popup the instant it first hits the
+      // app origin ABORTS that exchange → the surface reloads still logged-out. Instead
+      // wait for the popup to SETTLE on the app origin (no further nav for a beat ⇒ the
+      // session cookie is now in the shared jar), THEN reload the surface at its pre-auth
+      // URL and close the popup. Timer fires outside the nav event ⇒ close is safe (no
+      // SIGSEGV). Reload the ORIGINAL url, never the popup's callback url (codes are
+      // single-use). Covers full-nav redirects (did-navigate) and SPA routes
+      // (did-navigate-in-page).
+      const onAppOrigin = (visitedUrl: string) => {
         if (bridged || httpOrigin(visitedUrl) !== oauthBridge.appOrigin) {
           return;
         }
-        bridged = true;
-        setImmediate(() => {
+        if (settleTimer) {
+          clearTimeout(settleTimer);
+        }
+        settleTimer = setTimeout(() => {
+          if (bridged) {
+            return;
+          }
+          bridged = true;
           if (!view.webContents.isDestroyed()) {
             void view.webContents.loadURL(oauthBridge.returnUrl);
           }
           if (!childWindow.isDestroyed()) {
             childWindow.close();
           }
-        });
+        }, 2500);
+      };
+      childWindow.webContents.on("did-navigate", (_e, u) => onAppOrigin(u));
+      childWindow.webContents.on("did-navigate-in-page", (_e, u, isMainFrame) => {
+        if (isMainFrame) {
+          onAppOrigin(u);
+        }
       });
     }
     try {

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -1,28 +1,18 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { useSetAtom } from "jotai";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
 import { Button } from "@/components/ui/button";
-import {
-	AppWindow,
-	Globe,
-	Loader2,
-	Plus,
-	ShieldCheck,
-	X,
-} from "@/components/ui/icons";
+import { AppWindow, Loader2, Plus, X } from "@/components/ui/icons";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
 	type CustomHolaApp,
 	customHolaAppId,
-	deleteCustomHolaApp,
 	parseCustomMcpConfig,
-	readCustomHolaApps,
 	upsertCustomHolaApp,
 } from "@/lib/localCustomHolaApps";
-import { HolaAppIcon } from "./HolaAppIcon";
 
 const MCP_PLACEHOLDER = `{
   "mcpServers": {
@@ -33,11 +23,41 @@ const MCP_PLACEHOLDER = `{
   }
 }`;
 
-// Manage LOCAL, user-created HolaApps: an app is a URL the desktop opens as its
-// surface plus an OPTIONAL MCP server (pasted as an mcpServers-style JSON config)
-// whose tools the agent gains while the app is installed. Everything is stored on
-// this machine (localCustomHolaApps) — no backend. onChanged refreshes the shared
-// HolaApp catalog so the new/removed app (and its MCP) reflects in the grid + sidebar.
+// Run the browser OAuth for a just-added custom app's MCP. The MCP attaches
+// asynchronously (onChanged → catalog refresh → syncAppOwned), so poll until the
+// server registers, then run the runtime's system-browser authorize (the same path
+// as the inline chat Authorize card). Best-effort: any failure/timeout is swallowed
+// — the agent's reactive Authorize card prompts when it first uses the tools.
+async function runCustomAppOAuth(
+	workspaceId: string,
+	serverId: string,
+): Promise<void> {
+	for (let attempt = 0; attempt < 8; attempt += 1) {
+		const status = await window.electronAPI.workspace.mcpServerAuthorized(
+			workspaceId,
+			serverId,
+		);
+		if (status.authorized) {
+			return;
+		}
+		if (status.registered !== false) {
+			await window.electronAPI.workspace.authorizeMcpServer(
+				workspaceId,
+				serverId,
+				false,
+			);
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 1200));
+	}
+}
+
+// A small "create your own app" form: a URL the desktop opens as the app's surface,
+// plus an OPTIONAL MCP server (pasted as an mcpServers-style JSON config) whose tools
+// the agent gains. Everything is stored on this machine (localCustomHolaApps) — no
+// backend. onChanged refreshes the shared HolaApp catalog so the new app (and its MCP)
+// shows in the grid + sidebar; the dialog then closes. Manage/remove custom apps from
+// their card in Customize → Apps.
 //
 // Rendered as a Dialog above the native BrowserView layer, bumping the shell overlay
 // counter so the surface detaches — same pattern as McpInstallDialog.
@@ -49,9 +69,9 @@ export function CustomHolaAppCreateDialog({
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	/** Called after a custom app is created or removed — refresh the app catalog. */
+	/** Called after a custom app is created — refresh the app catalog. */
 	onChanged: () => void;
-	/** Active workspace — needed to run/check a custom MCP's OAuth authorization. */
+	/** Active workspace — needed to run a header-less MCP's OAuth after adding. */
 	workspaceId: string | null;
 }) {
 	const setOverlayCount = useSetAtom(overlayOpenCountAtom);
@@ -65,20 +85,12 @@ export function CustomHolaAppCreateDialog({
 		};
 	}, [open, setOverlayCount]);
 
-	const [apps, setApps] = useState<CustomHolaApp[]>([]);
 	const [title, setTitle] = useState("");
 	const [url, setUrl] = useState("");
 	const [iconUrl, setIconUrl] = useState("");
 	const [mcpJson, setMcpJson] = useState("");
 	const [error, setError] = useState("");
-	const [saving, setSaving] = useState(false);
-
-	const reload = useCallback(() => setApps(readCustomHolaApps()), []);
-	useEffect(() => {
-		if (open) {
-			reload();
-		}
-	}, [open, reload]);
+	const [phase, setPhase] = useState<"idle" | "authorizing">("idle");
 
 	const resetForm = () => {
 		setTitle("");
@@ -97,7 +109,7 @@ export function CustomHolaAppCreateDialog({
 		}
 	};
 
-	const handleCreate = () => {
+	const handleCreate = async () => {
 		const trimmedTitle = title.trim();
 		const trimmedUrl = url.trim();
 		if (!trimmedTitle) {
@@ -108,49 +120,58 @@ export function CustomHolaAppCreateDialog({
 			setError("Enter a valid http(s) URL for the app to open.");
 			return;
 		}
-		setSaving(true);
 		setError("");
-		try {
-			const holaAppId = customHolaAppId(trimmedTitle);
-			let mcp: CustomHolaApp["mcp"];
-			const rawMcp = mcpJson.trim();
-			if (rawMcp) {
-				const parsed = parseCustomMcpConfig(rawMcp, holaAppId);
-				if ("error" in parsed) {
-					setError(parsed.error);
-					setSaving(false);
-					return;
-				}
-				mcp = parsed.attach;
+
+		const holaAppId = customHolaAppId(trimmedTitle);
+		let mcp: CustomHolaApp["mcp"];
+		const rawMcp = mcpJson.trim();
+		if (rawMcp) {
+			const parsed = parseCustomMcpConfig(rawMcp, holaAppId);
+			if ("error" in parsed) {
+				setError(parsed.error);
+				return;
 			}
-			const app: CustomHolaApp = {
-				holaAppId,
-				title: trimmedTitle,
-				url: trimmedUrl,
-				...(iconUrl.trim() ? { iconUrl: iconUrl.trim() } : {}),
-				...(mcp ? { mcp } : {}),
-				...(rawMcp ? { mcpConfigJson: rawMcp } : {}),
-			};
-			upsertCustomHolaApp(app);
-			resetForm();
-			reload();
-			onChanged();
-		} finally {
-			setSaving(false);
+			mcp = parsed.attach;
 		}
+
+		const app: CustomHolaApp = {
+			holaAppId,
+			title: trimmedTitle,
+			url: trimmedUrl,
+			...(iconUrl.trim() ? { iconUrl: iconUrl.trim() } : {}),
+			...(mcp ? { mcp } : {}),
+			...(rawMcp ? { mcpConfigJson: rawMcp } : {}),
+		};
+		upsertCustomHolaApp(app);
+		// Fire the catalog refresh — attaches the app-owned MCP + shows the app.
+		onChanged();
+
+		// A header-less MCP is the OAuth case (a static-token server is already usable):
+		// run the browser sign-in now so the app works immediately. Best-effort — on any
+		// failure the reactive chat Authorize card prompts instead. Never blocks the close.
+		const needsOAuth =
+			Boolean(mcp) && Object.keys(mcp?.headerKeys ?? {}).length === 0;
+		if (needsOAuth && workspaceId && mcp) {
+			setPhase("authorizing");
+			try {
+				await runCustomAppOAuth(workspaceId, mcp.id);
+			} catch {
+				// reactive fallback — ignore
+			}
+			setPhase("idle");
+		}
+
+		resetForm();
+		onOpenChange(false);
 	};
 
-	const handleRemove = (holaAppId: string) => {
-		deleteCustomHolaApp(holaAppId);
-		reload();
-		onChanged();
-	};
+	const busy = phase === "authorizing";
 
 	return (
 		<DialogPrimitive.Root onOpenChange={onOpenChange} open={open}>
 			<DialogPrimitive.Portal>
 				<DialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-foreground/20 backdrop-blur-sm ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0" />
-				<DialogPrimitive.Popup className="fixed top-[10%] left-1/2 z-[100] flex max-h-[80vh] w-[520px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-2xl outline-none ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+				<DialogPrimitive.Popup className="fixed top-[12%] left-1/2 z-[100] flex max-h-[80vh] w-[520px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-2xl outline-none ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
 					<div className="flex items-center gap-3 border-border border-b px-4 py-3">
 						<div className="grid size-9 shrink-0 place-items-center rounded-lg border border-border bg-background">
 							<AppWindow className="size-5 text-muted-foreground" />
@@ -173,54 +194,6 @@ export function CustomHolaAppCreateDialog({
 					</div>
 
 					<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
-						{apps.length > 0 ? (
-							<div className="flex flex-col gap-1.5">
-								<p className="font-medium text-foreground text-xs">Your apps</p>
-								{apps.map((app) => (
-									<div
-										className="flex items-center gap-2.5 rounded-lg border border-border bg-background px-3 py-2"
-										key={app.holaAppId}
-									>
-										<div className="grid size-7 shrink-0 place-items-center rounded-md border border-border">
-											{app.iconUrl ? (
-												<HolaAppIcon
-													iconUrl={app.iconUrl}
-													sizeClass="size-4"
-													title={app.title}
-												/>
-											) : (
-												<Globe className="size-3.5 text-muted-foreground" />
-											)}
-										</div>
-										<div className="min-w-0 flex-1">
-											<p className="truncate font-medium text-foreground text-sm leading-tight">
-												{app.title}
-											</p>
-											<p className="truncate text-muted-foreground text-xs">
-												{app.url}
-												{app.mcp ? " · MCP" : ""}
-											</p>
-										</div>
-										{app.mcp && Object.keys(app.mcp.headerKeys).length === 0 ? (
-											<CustomAppAuthorize
-												serverId={app.mcp.id}
-												workspaceId={workspaceId}
-											/>
-										) : null}
-										<button
-											aria-label={`Remove ${app.title}`}
-											className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
-											onClick={() => handleRemove(app.holaAppId)}
-											type="button"
-										>
-											<X className="size-3.5" />
-										</button>
-									</div>
-								))}
-								<div className="my-1 h-px bg-border" />
-							</div>
-						) : null}
-
 						<div className="flex flex-col gap-1.5">
 							<Label
 								className="text-foreground text-xs"
@@ -291,10 +264,10 @@ export function CustomHolaAppCreateDialog({
 								value={mcpJson}
 							/>
 							<p className="text-muted-foreground text-xs">
-								Paste an MCP config to give the agent this app's tools. Remote
-								(URL) servers; add auth headers for a static token, or leave
-								them out and Authorize (OAuth) after it's added. Kept on this
-								device.
+								Gives the agent this app's tools. Remote (URL) servers —
+								including <code>npx mcp-remote &lt;url&gt;</code> configs. Add
+								auth headers for a static token, or leave them out and we'll
+								open sign-in (OAuth) when you add it. Kept on this device.
 							</p>
 						</div>
 
@@ -304,160 +277,27 @@ export function CustomHolaAppCreateDialog({
 					<div className="flex items-center justify-end gap-2 border-border border-t px-4 py-3">
 						<DialogPrimitive.Close
 							render={
-								<Button size="sm" type="button" variant="ghost">
-									Done
+								<Button disabled={busy} size="sm" type="button" variant="ghost">
+									Cancel
 								</Button>
 							}
 						/>
 						<Button
-							disabled={saving || !title.trim() || !url.trim()}
-							onClick={handleCreate}
+							disabled={busy || !title.trim() || !url.trim()}
+							onClick={() => void handleCreate()}
 							size="sm"
 							type="button"
 						>
-							{saving ? (
+							{busy ? (
 								<Loader2 className="size-3.5 animate-spin" />
 							) : (
 								<Plus className="size-3.5" />
 							)}
-							Add app
+							{busy ? "Signing in…" : "Add app"}
 						</Button>
 					</div>
 				</DialogPrimitive.Popup>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>
-	);
-}
-
-type AuthorizeState =
-	| "checking"
-	| "hidden"
-	| "authorized"
-	| "needs"
-	| "authorizing"
-	| "error";
-
-// Proactive OAuth authorization for a custom app's MCP server. Rendered only for an
-// MCP with NO static auth header (a header-less server is the OAuth case — a static
-// token is already usable, so it never shows this). Checks the server's token on
-// mount; the button runs the runtime's system-browser OAuth flow (authorizeMcpServer)
-// — the same path as the inline chat Authorize card (McpAuthorizeCard).
-function CustomAppAuthorize({
-	serverId,
-	workspaceId,
-}: {
-	serverId: string;
-	workspaceId: string | null;
-}) {
-	const [state, setState] = useState<AuthorizeState>("checking");
-	const [detail, setDetail] = useState("");
-
-	useEffect(() => {
-		if (!workspaceId) {
-			setState("hidden");
-			return;
-		}
-		let cancelled = false;
-		let timer: ReturnType<typeof setTimeout> | undefined;
-		let attempts = 0;
-		const check = () => {
-			window.electronAPI.workspace
-				.mcpServerAuthorized(workspaceId, serverId)
-				.then((result) => {
-					if (cancelled) {
-						return;
-					}
-					if (result.authorized) {
-						setState("authorized");
-					} else if (result.registered === false) {
-						// The MCP attaches asynchronously after Add (catalog refresh →
-						// syncAppOwned), so a fresh row often isn't registered yet. Poll a
-						// few times before giving up so the button appears once it lands.
-						attempts += 1;
-						if (attempts < 6) {
-							timer = setTimeout(check, 1500);
-						} else {
-							setState("hidden");
-						}
-					} else {
-						setState("needs");
-					}
-				})
-				.catch(() => {
-					if (!cancelled) {
-						setState("hidden");
-					}
-				});
-		};
-		check();
-		return () => {
-			cancelled = true;
-			if (timer) {
-				clearTimeout(timer);
-			}
-		};
-	}, [workspaceId, serverId]);
-
-	const authorize = async () => {
-		if (!workspaceId) {
-			return;
-		}
-		setState("authorizing");
-		setDetail("");
-		try {
-			const result = await window.electronAPI.workspace.authorizeMcpServer(
-				workspaceId,
-				serverId,
-				false,
-			);
-			if (result.ok) {
-				setState("authorized");
-			} else {
-				setState("error");
-				setDetail(result.detail || "Authorization failed.");
-			}
-		} catch (err) {
-			setState("error");
-			setDetail(err instanceof Error ? err.message : "Request failed.");
-		}
-	};
-
-	if (state === "checking" || state === "hidden") {
-		return null;
-	}
-	if (state === "authorized") {
-		return (
-			<span className="shrink-0 text-emerald-600 text-xs">Authorized</span>
-		);
-	}
-	return (
-		<div className="flex shrink-0 flex-col items-end gap-1">
-			<Button
-				disabled={state === "authorizing"}
-				onClick={() => void authorize()}
-				size="sm"
-				type="button"
-				variant="outline"
-			>
-				{state === "authorizing" ? (
-					<Loader2 className="size-3.5 animate-spin" />
-				) : (
-					<ShieldCheck className="size-3.5" />
-				)}
-				{state === "authorizing"
-					? "Signing in…"
-					: state === "error"
-						? "Try again"
-						: "Authorize"}
-			</Button>
-			{state === "error" && detail ? (
-				<span
-					className="max-w-[180px] truncate text-[11px] text-destructive"
-					title={detail}
-				>
-					{detail}
-				</span>
-			) : null}
-		</div>
 	);
 }

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -358,28 +358,43 @@ function CustomAppAuthorize({
 			return;
 		}
 		let cancelled = false;
-		window.electronAPI.workspace
-			.mcpServerAuthorized(workspaceId, serverId)
-			.then((result) => {
-				if (cancelled) {
-					return;
-				}
-				if (result.authorized) {
-					setState("authorized");
-				} else if (result.registered === false) {
-					// Not attached yet (its catalog sync is still in flight) — nothing to do.
-					setState("hidden");
-				} else {
-					setState("needs");
-				}
-			})
-			.catch(() => {
-				if (!cancelled) {
-					setState("hidden");
-				}
-			});
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let attempts = 0;
+		const check = () => {
+			window.electronAPI.workspace
+				.mcpServerAuthorized(workspaceId, serverId)
+				.then((result) => {
+					if (cancelled) {
+						return;
+					}
+					if (result.authorized) {
+						setState("authorized");
+					} else if (result.registered === false) {
+						// The MCP attaches asynchronously after Add (catalog refresh →
+						// syncAppOwned), so a fresh row often isn't registered yet. Poll a
+						// few times before giving up so the button appears once it lands.
+						attempts += 1;
+						if (attempts < 6) {
+							timer = setTimeout(check, 1500);
+						} else {
+							setState("hidden");
+						}
+					} else {
+						setState("needs");
+					}
+				})
+				.catch(() => {
+					if (!cancelled) {
+						setState("hidden");
+					}
+				});
+		};
+		check();
 		return () => {
 			cancelled = true;
+			if (timer) {
+				clearTimeout(timer);
+			}
 		};
 	}, [workspaceId, serverId]);
 

--- a/apps/desktop/src/components/panes/CustomizePane.tsx
+++ b/apps/desktop/src/components/panes/CustomizePane.tsx
@@ -154,15 +154,18 @@ export function CustomizePane({ workspaceId }: { workspaceId: string | null }) {
 								</button>
 							))}
 						</div>
-						<div className="flex shrink-0 items-center gap-3">
+						<div className="flex shrink-0 items-center gap-6">
 							{tab === "apps" ? (
 								<button
-									className="inline-flex items-center gap-1 font-medium text-foreground text-sm transition-colors hover:text-foreground/70"
+									className="inline-flex items-center gap-1.5 font-medium text-foreground text-sm transition-colors hover:text-foreground/70"
 									onClick={() => setCustomAppsOpen(true)}
 									type="button"
 								>
 									<Plus className="size-4" />
 									Create your own app
+									<span className="rounded-full bg-muted px-1.5 py-px font-semibold text-[10px] text-muted-foreground uppercase tracking-wide">
+										Beta
+									</span>
 								</button>
 							) : null}
 							<button

--- a/apps/desktop/src/lib/holaAppMarketplace.ts
+++ b/apps/desktop/src/lib/holaAppMarketplace.ts
@@ -15,6 +15,8 @@ import { getIntegrationLogo } from "./integrationLogo";
 import {
 	customHolaAppMcpAttachInputs,
 	customHolaAppsAsWebApps,
+	deleteCustomHolaApp,
+	readCustomHolaApps,
 } from "./localCustomHolaApps";
 import {
 	type McpRequiredKey,
@@ -757,6 +759,14 @@ export function createServerMarketplaceSource(): MarketplaceSource {
 			return { mcp: [], skills: [] };
 		},
 		async uninstall(holaAppId) {
+			// A locally-created custom HolaApp isn't a backend app — remove it from
+			// local storage; the catalog refresh that follows re-runs the app-owned MCP
+			// sync, which reconciles (detaches) its now-absent server. Skip the gateway
+			// (a POST there just 404s for a local-only app).
+			if (readCustomHolaApps().some((app) => app.holaAppId === holaAppId)) {
+				deleteCustomHolaApp(holaAppId);
+				return;
+			}
 			const base = await backendBaseUrl();
 			if (!base) {
 				throw new Error(

--- a/apps/desktop/src/lib/localCustomHolaApps.ts
+++ b/apps/desktop/src/lib/localCustomHolaApps.ts
@@ -206,6 +206,26 @@ function pickServerObject(
 	return null;
 }
 
+// A remote MCP exposed via a stdio bridge — `npx -y mcp-remote <url>`,
+// `mcp-proxy <url>`, `supergateway --sse <url>`, etc. The desktop speaks remote
+// MCP (and handles its OAuth) directly, so pull the http(s) URL out of the
+// command + args and use it as the server url.
+function remoteUrlFromCommand(server: Record<string, unknown>): string | null {
+	const tokens: string[] = [];
+	if (typeof server.command === "string") {
+		tokens.push(server.command);
+	}
+	if (Array.isArray(server.args)) {
+		for (const arg of server.args) {
+			if (typeof arg === "string") {
+				tokens.push(arg);
+			}
+		}
+	}
+	const found = tokens.find((token) => /^https?:\/\//i.test(token.trim()));
+	return found ? found.trim() : null;
+}
+
 /** Parse a pasted MCP config (mcpServers-style JSON, a `servers` map, or a bare
  * single-server object) into a resolved app-owned `McpAttachInput`. v1 supports
  * REMOTE (URL) servers with optional `headers`/`tools`; a command/stdio-only server
@@ -229,12 +249,13 @@ export function parseCustomMcpConfig(
 	if (!server) {
 		return { error: "No MCP server found in the config." };
 	}
-	const url = typeof server.url === "string" ? server.url.trim() : "";
+	const directUrl = typeof server.url === "string" ? server.url.trim() : "";
+	const url = directUrl || remoteUrlFromCommand(server) || "";
 	if (!url) {
 		if (server.command !== undefined) {
 			return {
 				error:
-					'Only remote (URL) MCP servers are supported here for now — provide a server with a "url".',
+					"This looks like a local (stdio) MCP server — use its remote URL, or an 'npx mcp-remote <url>' bridge config.",
 			};
 		}
 		return { error: 'The MCP server needs a "url".' };


### PR DESCRIPTION
Follow-up to #436. Custom-app MCP configs published as a stdio→remote bridge (`npx -y mcp-remote <url>`, `mcp-proxy`, `supergateway`) were rejected because the parser only accepted a top-level `url`. Since the desktop speaks remote MCP + handles its OAuth natively, extract the http(s) URL from `command`/`args` and use it directly — so Linear-style OAuth MCPs resolve and get the Authorize control. Genuinely local stdio servers still get a clear message. Typecheck ✅, biome ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)