### PR TITLE
feat: upload a skill from New skill

### DIFF
--- a/apps/desktop/src/components/panes/SkillUploadDialog.tsx
+++ b/apps/desktop/src/components/panes/SkillUploadDialog.tsx
@@ -1,0 +1,157 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { useSetAtom } from "jotai";
+import { type DragEvent, useEffect, useRef, useState } from "react";
+import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
+import { FolderPlus, Loader2, X } from "@/components/ui/icons";
+import {
+  type ParsedSkillFile,
+  parseSkillMarkdown,
+} from "@/lib/skillFileImport";
+import { cn } from "@/lib/utils";
+
+const ACCEPT = ".md,.markdown,text/markdown";
+
+/**
+ * "Upload skill" — the self-serve half of New skill, for a SKILL.md the user
+ * already wrote. The file is read here and installed through the same
+ * `skills.install` contract the marketplace uses, so an uploaded skill
+ * materializes into the workspace exactly like an installed one.
+ */
+export function SkillUploadDialog({
+  open,
+  onOpenChange,
+  onUpload,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Resolves once the skill is installed; rejects to keep the dialog open. */
+  onUpload: (skill: ParsedSkillFile) => Promise<void>;
+}) {
+  const setOverlayCount = useSetAtom(overlayOpenCountAtom);
+  useEffect(() => {
+    if (!open) return;
+    setOverlayCount((c) => c + 1);
+    return () => {
+      setOverlayCount((c) => Math.max(0, c - 1));
+    };
+  }, [open, setOverlayCount]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setDragging(false);
+      setBusy(false);
+      setError("");
+    }
+  }, [open]);
+
+  const accept = async (file: File | undefined) => {
+    if (!file || busy) return;
+    setError("");
+    if (!/\.(md|markdown)$/i.test(file.name)) {
+      setError("Upload a .md file — archives aren't supported yet.");
+      return;
+    }
+    const parsed = parseSkillMarkdown(await file.text(), file.name);
+    if (!parsed.ok) {
+      setError(parsed.error);
+      return;
+    }
+    setBusy(true);
+    try {
+      await onUpload(parsed.skill);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't install that skill.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDrop = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    void accept(event.dataTransfer.files[0]);
+  };
+
+  return (
+    <DialogPrimitive.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!busy) onOpenChange(next);
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-foreground/20 backdrop-blur-sm ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup className="fixed top-[18%] left-1/2 z-[100] w-[440px] -translate-x-1/2 overflow-hidden rounded-xl border border-border bg-popover shadow-2xl outline-none ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+          <div className="relative flex flex-col px-6 pt-6 pb-6">
+            <DialogPrimitive.Close
+              aria-label="Close"
+              className="absolute top-3 right-3 grid size-7 place-items-center rounded-md text-foreground/50 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </DialogPrimitive.Close>
+
+            <DialogPrimitive.Title className="font-semibold text-base text-foreground">
+              Upload skill
+            </DialogPrimitive.Title>
+
+            <input
+              accept={ACCEPT}
+              className="hidden"
+              onChange={(event) => {
+                void accept(event.target.files?.[0]);
+                event.target.value = "";
+              }}
+              ref={inputRef}
+              type="file"
+            />
+
+            <button
+              className={cn(
+                "mt-5 flex w-full flex-col items-center justify-center gap-2.5 rounded-xl border border-dashed py-9 transition-colors",
+                dragging
+                  ? "border-primary bg-primary/[0.06]"
+                  : "border-border hover:bg-foreground/[0.03]",
+                busy && "pointer-events-none opacity-60",
+              )}
+              onClick={() => inputRef.current?.click()}
+              onDragLeave={() => setDragging(false)}
+              onDragOver={(event) => {
+                event.preventDefault();
+                setDragging(true);
+              }}
+              onDrop={onDrop}
+              type="button"
+            >
+              {busy ? (
+                <Loader2 className="size-6 animate-spin text-muted-foreground" />
+              ) : (
+                <FolderPlus className="size-6 text-muted-foreground" />
+              )}
+              <span className="font-medium text-foreground text-sm">
+                {busy ? "Installing…" : "Drag and drop or click to upload"}
+              </span>
+            </button>
+
+            <p className="mt-5 font-medium text-foreground text-xs">
+              File requirements
+            </p>
+            <ul className="mt-1.5 flex list-disc flex-col gap-1 pl-4 text-muted-foreground text-xs">
+              <li>A .md file whose YAML frontmatter sets a name and description</li>
+              <li>The body is the instruction your agent follows</li>
+            </ul>
+
+            {error ? (
+              <p className="mt-4 text-destructive text-xs">{error}</p>
+            ) : null}
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/desktop/src/components/panes/SkillUploadDialog.tsx
+++ b/apps/desktop/src/components/panes/SkillUploadDialog.tsx
@@ -3,13 +3,24 @@ import { useSetAtom } from "jotai";
 import { type DragEvent, useEffect, useRef, useState } from "react";
 import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
 import { FolderPlus, Loader2, X } from "@/components/ui/icons";
-import {
-  type ParsedSkillFile,
-  parseSkillMarkdown,
-} from "@/lib/skillFileImport";
+import { parseSkillMarkdown } from "@/lib/skillFileImport";
 import { cn } from "@/lib/utils";
 
-const ACCEPT = ".md,.markdown,text/markdown";
+const ACCEPT = ".md,.markdown,.zip,.skill";
+const ARCHIVE = /\.(zip|skill)$/i;
+const MARKDOWN = /\.(md|markdown)$/i;
+// Mirrors MAX_UPLOAD_BYTES in the runtime — checked here too so an oversized
+// file fails instantly instead of after a base64 round trip.
+const MAX_UPLOAD_BYTES = 6 * 1024 * 1024;
+
+async function toBase64(file: File): Promise<string> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(binary);
+}
 
 /**
  * "Upload skill" — the self-serve half of New skill, for a SKILL.md the user
@@ -24,8 +35,8 @@ export function SkillUploadDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Resolves once the skill is installed; rejects to keep the dialog open. */
-  onUpload: (skill: ParsedSkillFile) => Promise<void>;
+  /** Resolves once the runtime installed it; rejects to keep the dialog open. */
+  onUpload: (file: { fileName: string; dataBase64: string }) => Promise<void>;
 }) {
   const setOverlayCount = useSetAtom(overlayOpenCountAtom);
   useEffect(() => {
@@ -52,18 +63,27 @@ export function SkillUploadDialog({
   const accept = async (file: File | undefined) => {
     if (!file || busy) return;
     setError("");
-    if (!/\.(md|markdown)$/i.test(file.name)) {
-      setError("Upload a .md file — archives aren't supported yet.");
+    const isArchive = ARCHIVE.test(file.name);
+    if (!(isArchive || MARKDOWN.test(file.name))) {
+      setError("Upload a .md, .zip or .skill file.");
       return;
     }
-    const parsed = parseSkillMarkdown(await file.text(), file.name);
-    if (!parsed.ok) {
-      setError(parsed.error);
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setError(`That file is over ${MAX_UPLOAD_BYTES / 1024 / 1024} MB.`);
       return;
+    }
+    // A bare .md can be checked here; an archive's SKILL.md is only reachable
+    // after unpacking, which the runtime does.
+    if (!isArchive) {
+      const parsed = parseSkillMarkdown(await file.text(), file.name);
+      if (!parsed.ok) {
+        setError(parsed.error);
+        return;
+      }
     }
     setBusy(true);
     try {
-      await onUpload(parsed.skill);
+      await onUpload({ fileName: file.name, dataBase64: await toBase64(file) });
       onOpenChange(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't install that skill.");
@@ -142,8 +162,13 @@ export function SkillUploadDialog({
               File requirements
             </p>
             <ul className="mt-1.5 flex list-disc flex-col gap-1 pl-4 text-muted-foreground text-xs">
-              <li>A .md file whose YAML frontmatter sets a name and description</li>
-              <li>The body is the instruction your agent follows</li>
+              <li>
+                A .md file whose YAML frontmatter sets a name and description
+              </li>
+              <li>
+                Or a .zip / .skill holding the folder — SKILL.md at its root,
+                alongside any scripts and references
+              </li>
             </ul>
 
             {error ? (

--- a/apps/desktop/src/components/panes/SkillsStorePane.tsx
+++ b/apps/desktop/src/components/panes/SkillsStorePane.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/panes/CapabilitiesMarketPane";
 import { SkillsPane } from "@/components/panes/SkillsPane";
 import { SkillUploadDialog } from "@/components/panes/SkillUploadDialog";
-import type { ParsedSkillFile } from "@/lib/skillFileImport";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -105,6 +104,9 @@ export function SkillsStorePane({
   });
   const installMutation = useMutation(
     remoteApiQuery.skills.install.mutationOptions(),
+  );
+  const uploadMutation = useMutation(
+    remoteApiQuery.skills.importUpload.mutationOptions(),
   );
 
   const installedQuery = useWorkspaceSkills(workspaceId);
@@ -243,16 +245,24 @@ export function SkillsStorePane({
       .finally(() => setPendingId(null));
   };
 
-  // Upload = install a SKILL.md the user already wrote. Unlike the URL import
-  // below it never reaches the org store (that endpoint only takes a URL), so an
-  // uploaded skill lives on this desktop only.
-  const uploadSkill = async (skill: ParsedSkillFile) => {
-    await installMutation.mutateAsync({
-      skillId: skill.skillId,
-      content: withSkillDisplayTitle(skill.content, skill.name),
-    });
+  // Upload hands the bytes to the runtime, which unpacks an archive and runs the
+  // same folder-aware import the agent's GitHub installer uses — so bundled
+  // scripts survive and Anthropic's `allowed-tools` maps to granted tools. It
+  // never reaches the org store (that endpoint only takes a URL), so an uploaded
+  // skill lives on this desktop only.
+  const uploadSkill = async (file: {
+    fileName: string;
+    dataBase64: string;
+  }) => {
+    const result = await uploadMutation.mutateAsync(file);
     refreshInstalled();
-    toast.success(`${skill.name} added`);
+    const extras = result.files.length - 1;
+    toast.success(`${result.name} added`, {
+      description:
+        extras > 0
+          ? `${extras} bundled file${extras === 1 ? "" : "s"} installed`
+          : undefined,
+    });
   };
 
   // HolaHub "Install" hand-off: auto-install the target skill once the directory

--- a/apps/desktop/src/components/panes/SkillsStorePane.tsx
+++ b/apps/desktop/src/components/panes/SkillsStorePane.tsx
@@ -27,7 +27,6 @@ import {
   ChevronDown,
   ChevronLeft,
   Feather,
-  Link2,
   Loader2,
   Plus,
   Search,
@@ -52,11 +51,9 @@ import {
   workspaceSkillsKey,
 } from "@/lib/useWorkspaceSkills";
 import {
-  importOrgSkillFromUrl,
   listOrgSkills,
   type OrgSkill,
 } from "@/lib/orgSkillsClient";
-import { RenameDialog } from "@/components/ui/rename-dialog";
 
 /**
  * Browse-first skills store — the same shape as the capabilities marketplace:
@@ -98,9 +95,7 @@ export function SkillsStorePane({
   const [removingId, setRemovingId] = useState<string | null>(null);
   // The user's org skill library (backend, shared with the web platform) + import dialog.
   const [principal, setPrincipal] = useState<string | null>(null);
-  const [importOpen, setImportOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
-  const [importing, setImporting] = useState(false);
 
   const marketQuery = useQuery({
     queryKey: ["directory-central", "skills"],
@@ -260,27 +255,6 @@ export function SkillsStorePane({
     toast.success(`${skill.name} added`);
   };
 
-  // "Add your own" = import a SKILL.md URL into the shared org store, then materialize it
-  // locally. It also appears on the web employee platform (same backend store).
-  const importOrgSkill = (url: string) => {
-    if (!principal) {
-      return;
-    }
-    setImporting(true);
-    void importOrgSkillFromUrl(principal, url)
-      .then((skill) => {
-        setImportOpen(false);
-        void orgQuery.refetch();
-        addOrgSkill(skill);
-      })
-      .catch(() =>
-        toast.error(
-          "Couldn't import that skill — the URL must point to a raw, public SKILL.md.",
-        ),
-      )
-      .finally(() => setImporting(false));
-  };
-
   // HolaHub "Install" hand-off: auto-install the target skill once the directory
   // loads (skills are keyless — no second click). Skips an already-installed one.
   useEffect(() => {
@@ -334,7 +308,6 @@ export function SkillsStorePane({
           <NewSkillMenu
             className="ml-auto h-7"
             onCreateSkill={onCreateSkill}
-            onImportUrl={() => setImportOpen(true)}
             onUpload={() => setUploadOpen(true)}
           />
         </div>
@@ -368,7 +341,6 @@ export function SkillsStorePane({
           <NewSkillMenu
             className="ml-auto h-8 shrink-0"
             onCreateSkill={onCreateSkill}
-            onImportUrl={() => setImportOpen(true)}
             onUpload={() => setUploadOpen(true)}
           />
         </div>
@@ -432,7 +404,6 @@ export function SkillsStorePane({
                     <NewSkillMenu
                       className="h-8 shrink-0"
                       onCreateSkill={onCreateSkill}
-                      onImportUrl={() => setImportOpen(true)}
                       onUpload={() => setUploadOpen(true)}
                     />
                   ) : null}
@@ -548,19 +519,6 @@ export function SkillsStorePane({
         onUpload={uploadSkill}
         open={uploadOpen}
       />
-      <RenameDialog
-        confirmLabel={importing ? "Importing…" : "Import"}
-        initial=""
-        onConfirm={importOrgSkill}
-        onOpenChange={(o) => {
-          if (!importing) {
-            setImportOpen(o);
-          }
-        }}
-        open={importOpen}
-        placeholder="https://raw.githubusercontent.com/…/SKILL.md"
-        title="Add your own skill"
-      />
       <ConfirmDialog
         open={pendingRemove !== null}
         onOpenChange={(open) => {
@@ -582,9 +540,10 @@ export function SkillsStorePane({
   );
 }
 
-// The user's org skill library (backend, shared with the web platform) as a store
-// section — always present so importing is discoverable. Rows install by materializing
-// the backend SKILL.md body locally so the desktop agent can run them.
+// The user's org skill library (backend, shared with the web platform). Skills land
+// there from the web platform; rows install by materializing the backend SKILL.md body
+// locally so the desktop agent can run them. Renders nothing until it has something —
+// there is no way to add to it from here, so an empty library is not worth a heading.
 function YourSkillsSection({
   skills,
   installedIds,
@@ -598,29 +557,23 @@ function YourSkillsSection({
   loading: boolean;
   onAdd: (skill: OrgSkill) => void;
 }) {
+  if (loading || skills.length === 0) {
+    return null;
+  }
   return (
     <section className="flex flex-col gap-2.5">
       <h3 className="font-medium text-foreground text-sm">Your skills</h3>
-      {loading ? (
-        <p className="text-muted-foreground text-xs">Loading your library…</p>
-      ) : skills.length === 0 ? (
-        <p className="max-w-2xl text-muted-foreground text-xs">
-          Skills you add on the web platform — or import here — land in your org
-          library. Install one to use it on this desktop.
-        </p>
-      ) : (
-        <div className="grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
-          {skills.map((skill) => (
-            <OrgSkillRow
-              installed={installedIds.has(skill.id)}
-              key={skill.id}
-              onAdd={() => onAdd(skill)}
-              pending={pendingId === skill.id}
-              skill={skill}
-            />
-          ))}
-        </div>
-      )}
+      <div className="grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
+        {skills.map((skill) => (
+          <OrgSkillRow
+            installed={installedIds.has(skill.id)}
+            key={skill.id}
+            onAdd={() => onAdd(skill)}
+            pending={pendingId === skill.id}
+            skill={skill}
+          />
+        ))}
+      </div>
     </section>
   );
 }
@@ -918,12 +871,10 @@ function NewSkillMenu({
   className,
   onCreateSkill,
   onUpload,
-  onImportUrl,
 }: {
   className?: string;
   onCreateSkill: () => void;
   onUpload: () => void;
-  onImportUrl: () => void;
 }) {
   return (
     <DropdownMenu>
@@ -945,10 +896,6 @@ function NewSkillMenu({
         <DropdownMenuItem onClick={onUpload}>
           <Upload className="size-3.5" />
           Upload skill
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={onImportUrl}>
-          <Link2 className="size-3.5" />
-          Import from URL
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/desktop/src/components/panes/SkillsStorePane.tsx
+++ b/apps/desktop/src/components/panes/SkillsStorePane.tsx
@@ -10,18 +10,30 @@ import {
   titleCase,
 } from "@/components/panes/CapabilitiesMarketPane";
 import { SkillsPane } from "@/components/panes/SkillsPane";
+import { SkillUploadDialog } from "@/components/panes/SkillUploadDialog";
+import type { ParsedSkillFile } from "@/lib/skillFileImport";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ViewTransition } from "@/components/ui/view-transition";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   ArrowUpRight,
+  ChevronDown,
   ChevronLeft,
   Feather,
+  Link2,
   Loader2,
   Plus,
   Search,
+  Sparkles,
   Trash2,
+  Upload,
 } from "@/components/ui/icons";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
@@ -87,6 +99,7 @@ export function SkillsStorePane({
   // The user's org skill library (backend, shared with the web platform) + import dialog.
   const [principal, setPrincipal] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
   const [importing, setImporting] = useState(false);
 
   const marketQuery = useQuery({
@@ -235,6 +248,18 @@ export function SkillsStorePane({
       .finally(() => setPendingId(null));
   };
 
+  // Upload = install a SKILL.md the user already wrote. Unlike the URL import
+  // below it never reaches the org store (that endpoint only takes a URL), so an
+  // uploaded skill lives on this desktop only.
+  const uploadSkill = async (skill: ParsedSkillFile) => {
+    await installMutation.mutateAsync({
+      skillId: skill.skillId,
+      content: withSkillDisplayTitle(skill.content, skill.name),
+    });
+    refreshInstalled();
+    toast.success(`${skill.name} added`);
+  };
+
   // "Add your own" = import a SKILL.md URL into the shared org store, then materialize it
   // locally. It also appears on the web employee platform (same backend store).
   const importOrgSkill = (url: string) => {
@@ -306,16 +331,12 @@ export function SkillsStorePane({
           </button>
           <span className="text-muted-foreground text-sm">·</span>
           <span className="font-medium text-foreground text-sm">Installed</span>
-          <Button
-            className="ml-auto h-7 gap-1.5"
-            onClick={onCreateSkill}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <Plus className="size-3.5" />
-            New skill
-          </Button>
+          <NewSkillMenu
+            className="ml-auto h-7"
+            onCreateSkill={onCreateSkill}
+            onImportUrl={() => setImportOpen(true)}
+            onUpload={() => setUploadOpen(true)}
+          />
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
           <SkillsPane
@@ -344,16 +365,12 @@ export function SkillsStorePane({
               value={query}
             />
           </div>
-          <Button
-            className="ml-auto h-8 shrink-0 gap-1.5"
-            onClick={onCreateSkill}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <Plus className="size-3.5" />
-            New skill
-          </Button>
+          <NewSkillMenu
+            className="ml-auto h-8 shrink-0"
+            onCreateSkill={onCreateSkill}
+            onImportUrl={() => setImportOpen(true)}
+            onUpload={() => setUploadOpen(true)}
+          />
         </div>
       )}
 
@@ -412,16 +429,12 @@ export function SkillsStorePane({
                     Installed
                   </h3>
                   {manageOnly ? (
-                    <Button
-                      className="h-8 shrink-0 gap-1.5"
-                      onClick={onCreateSkill}
-                      size="sm"
-                      type="button"
-                      variant="outline"
-                    >
-                      <Plus className="size-3.5" />
-                      New skill
-                    </Button>
+                    <NewSkillMenu
+                      className="h-8 shrink-0"
+                      onCreateSkill={onCreateSkill}
+                      onImportUrl={() => setImportOpen(true)}
+                      onUpload={() => setUploadOpen(true)}
+                    />
                   ) : null}
                 </div>
                 {installedPreview.length > 0 ? (
@@ -477,7 +490,6 @@ export function SkillsStorePane({
                   installedIds={installedIds}
                   loading={orgQuery.isLoading}
                   onAdd={addOrgSkill}
-                  onImport={() => setImportOpen(true)}
                   pendingId={pendingId}
                   skills={filteredOrg}
                 />
@@ -531,6 +543,11 @@ export function SkillsStorePane({
           </ViewTransition>
         )}
       </div>
+      <SkillUploadDialog
+        onOpenChange={setUploadOpen}
+        onUpload={uploadSkill}
+        open={uploadOpen}
+      />
       <RenameDialog
         confirmLabel={importing ? "Importing…" : "Import"}
         initial=""
@@ -574,30 +591,16 @@ function YourSkillsSection({
   pendingId,
   loading,
   onAdd,
-  onImport,
 }: {
   skills: OrgSkill[];
   installedIds: Set<string>;
   pendingId: string | null;
   loading: boolean;
   onAdd: (skill: OrgSkill) => void;
-  onImport: () => void;
 }) {
   return (
     <section className="flex flex-col gap-2.5">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="font-medium text-foreground text-sm">Your skills</h3>
-        <Button
-          className="h-8 shrink-0 gap-1.5"
-          onClick={onImport}
-          size="sm"
-          type="button"
-          variant="ghost"
-        >
-          <Plus className="size-3.5" />
-          Import from URL
-        </Button>
-      </div>
+      <h3 className="font-medium text-foreground text-sm">Your skills</h3>
       {loading ? (
         <p className="text-muted-foreground text-xs">Loading your library…</p>
       ) : skills.length === 0 ? (
@@ -904,5 +907,50 @@ function RowGridSkeleton() {
         </div>
       ))}
     </div>
+  );
+}
+
+/**
+ * New skill — the three ways in, in the order people reach for them: describe it
+ * to the agent, upload a SKILL.md you already wrote, or pull one from a URL.
+ */
+function NewSkillMenu({
+  className,
+  onCreateSkill,
+  onUpload,
+  onImportUrl,
+}: {
+  className?: string;
+  onCreateSkill: () => void;
+  onUpload: () => void;
+  onImportUrl: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 font-medium text-sm transition-colors hover:bg-accent",
+          className,
+        )}
+      >
+        <Plus className="size-3.5" />
+        New skill
+        <ChevronDown className="size-3 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6}>
+        <DropdownMenuItem onClick={onCreateSkill}>
+          <Sparkles className="size-3.5" />
+          Create with agent
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onUpload}>
+          <Upload className="size-3.5" />
+          Upload skill
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onImportUrl}>
+          <Link2 className="size-3.5" />
+          Import from URL
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/desktop/src/lib/skillFileImport.test.ts
+++ b/apps/desktop/src/lib/skillFileImport.test.ts
@@ -2,39 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { parseSkillMarkdown } from "./skillFileImport";
 
-const good = `---
-name: Weekly Report
-description: Pulls last week's numbers and drafts the summary.
----
-
-Do the thing.`;
-
-test("reads name and description out of the frontmatter", () => {
-  const result = parseSkillMarkdown(good, "weekly.md");
-  assert.equal(result.ok, true);
-  if (!result.ok) return;
-  assert.equal(result.skill.name, "Weekly Report");
-  assert.equal(
-    result.skill.description,
-    "Pulls last week's numbers and drafts the summary.",
-  );
-});
-
-test("derives the id from the name, not the filename", () => {
-  const result = parseSkillMarkdown(good, "Untitled-3.md");
-  assert.equal(result.ok, true);
-  if (!result.ok) return;
-  assert.equal(result.skill.skillId, "weekly-report");
-});
-
-test("falls back to the filename when the name has nothing to slugify", () => {
+test("accepts a file declaring name and description", () => {
   const result = parseSkillMarkdown(
-    `---\nname: "…"\ndescription: x\n---\nbody`,
-    "my-skill.md",
+    `---\nname: Weekly Report\ndescription: Pulls the numbers.\n---\n\nDo it.`,
+    "weekly.md",
   );
   assert.equal(result.ok, true);
-  if (!result.ok) return;
-  assert.equal(result.skill.skillId, "my-skill");
 });
 
 test("rejects a file with no frontmatter", () => {
@@ -56,19 +29,13 @@ test("rejects frontmatter missing name or description", () => {
 
 test("handles CRLF files and quoted values", () => {
   const result = parseSkillMarkdown(
-    `---\r\nname: "Quoted Name"\r\ndescription: 'single'\r\n---\r\nbody`,
+    `---\r\nname: "Quoted"\r\ndescription: 'single'\r\n---\r\nbody`,
     "a.md",
   );
   assert.equal(result.ok, true);
-  if (!result.ok) return;
-  assert.equal(result.skill.name, "Quoted Name");
-  assert.equal(result.skill.description, "single");
 });
 
 test("accepts title/summary as aliases", () => {
   const result = parseSkillMarkdown(`---\ntitle: T\nsummary: S\n---\nb`, "a.md");
   assert.equal(result.ok, true);
-  if (!result.ok) return;
-  assert.equal(result.skill.name, "T");
-  assert.equal(result.skill.description, "S");
 });

--- a/apps/desktop/src/lib/skillFileImport.test.ts
+++ b/apps/desktop/src/lib/skillFileImport.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseSkillMarkdown } from "./skillFileImport";
+
+const good = `---
+name: Weekly Report
+description: Pulls last week's numbers and drafts the summary.
+---
+
+Do the thing.`;
+
+test("reads name and description out of the frontmatter", () => {
+  const result = parseSkillMarkdown(good, "weekly.md");
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.skill.name, "Weekly Report");
+  assert.equal(
+    result.skill.description,
+    "Pulls last week's numbers and drafts the summary.",
+  );
+});
+
+test("derives the id from the name, not the filename", () => {
+  const result = parseSkillMarkdown(good, "Untitled-3.md");
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.skill.skillId, "weekly-report");
+});
+
+test("falls back to the filename when the name has nothing to slugify", () => {
+  const result = parseSkillMarkdown(
+    `---\nname: "…"\ndescription: x\n---\nbody`,
+    "my-skill.md",
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.skill.skillId, "my-skill");
+});
+
+test("rejects a file with no frontmatter", () => {
+  const result = parseSkillMarkdown("# Just a heading\n", "a.md");
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.match(result.error, /frontmatter/);
+});
+
+test("rejects frontmatter missing name or description", () => {
+  const noName = parseSkillMarkdown(`---\ndescription: x\n---\nb`, "a.md");
+  assert.equal(noName.ok, false);
+  if (!noName.ok) assert.match(noName.error, /name/);
+
+  const noDesc = parseSkillMarkdown(`---\nname: X\n---\nb`, "a.md");
+  assert.equal(noDesc.ok, false);
+  if (!noDesc.ok) assert.match(noDesc.error, /description/);
+});
+
+test("handles CRLF files and quoted values", () => {
+  const result = parseSkillMarkdown(
+    `---\r\nname: "Quoted Name"\r\ndescription: 'single'\r\n---\r\nbody`,
+    "a.md",
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.skill.name, "Quoted Name");
+  assert.equal(result.skill.description, "single");
+});
+
+test("accepts title/summary as aliases", () => {
+  const result = parseSkillMarkdown(`---\ntitle: T\nsummary: S\n---\nb`, "a.md");
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.skill.name, "T");
+  assert.equal(result.skill.description, "S");
+});

--- a/apps/desktop/src/lib/skillFileImport.ts
+++ b/apps/desktop/src/lib/skillFileImport.ts
@@ -1,45 +1,17 @@
-// Parsing for an uploaded SKILL.md. Kept out of the dialog so it can be
-// tested without pulling the icon bundle into a node test.
+// Pre-flight for an uploaded SKILL.md, so an obviously unusable file is caught
+// before the bytes make a round trip. The runtime owns the real parse — it also
+// slugifies the id and maps foreign frontmatter — so this only answers "would
+// the agent ever be able to pick this up?".
+//
+// `name` and `description` are what the agent reads to decide when to run a
+// skill; without them the skill installs and is never chosen.
+export type SkillMarkdownCheck = { ok: true } | { ok: false; error: string };
 
-/** What a SKILL.md has to declare before it can be installed. */
-export interface ParsedSkillFile {
-  skillId: string;
-  name: string;
-  description: string;
-  content: string;
-}
-
-const SKILL_ID_FALLBACK = "skill";
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64);
-}
-
-// A name of only punctuation ("…") slugifies to nothing, so fall through to the
-// filename rather than jumping straight to the generic fallback.
-function slugifySkillId(name: string, fileName: string): string {
-  return (
-    slugify(name) ||
-    slugify(fileName.replace(/\.[^.]+$/, "")) ||
-    SKILL_ID_FALLBACK
-  );
-}
-
-/**
- * Read a SKILL.md's YAML frontmatter. `name` and `description` are the contract
- * the agent reads to decide when to run a skill, so a file without them is
- * rejected here rather than installed as something the agent can never pick.
- */
 export function parseSkillMarkdown(
   content: string,
-  fileName: string,
-): { ok: true; skill: ParsedSkillFile } | { ok: false; error: string } {
-  const normalized = content.replace(/\r\n/g, "\n");
-  const frontmatter = /^---\n([\s\S]*?)\n---/.exec(normalized);
+  _fileName: string,
+): SkillMarkdownCheck {
+  const frontmatter = /^---\n([\s\S]*?)\n---/.exec(content.replace(/\r\n/g, "\n"));
   if (!frontmatter) {
     return {
       ok: false,
@@ -51,21 +23,11 @@ export function parseSkillMarkdown(
     const match = new RegExp(`^${key}\\s*:\\s*(.+)$`, "m").exec(block);
     return match?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
   };
-  const name = read("name") || read("title");
-  const description = read("description") || read("summary");
-  if (!name) {
+  if (!(read("name") || read("title"))) {
     return { ok: false, error: "The frontmatter is missing a `name`." };
   }
-  if (!description) {
+  if (!(read("description") || read("summary"))) {
     return { ok: false, error: "The frontmatter is missing a `description`." };
   }
-  return {
-    ok: true,
-    skill: {
-      skillId: slugifySkillId(name, fileName),
-      name,
-      description,
-      content: normalized,
-    },
-  };
+  return { ok: true };
 }

--- a/apps/desktop/src/lib/skillFileImport.ts
+++ b/apps/desktop/src/lib/skillFileImport.ts
@@ -1,0 +1,71 @@
+// Parsing for an uploaded SKILL.md. Kept out of the dialog so it can be
+// tested without pulling the icon bundle into a node test.
+
+/** What a SKILL.md has to declare before it can be installed. */
+export interface ParsedSkillFile {
+  skillId: string;
+  name: string;
+  description: string;
+  content: string;
+}
+
+const SKILL_ID_FALLBACK = "skill";
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+// A name of only punctuation ("…") slugifies to nothing, so fall through to the
+// filename rather than jumping straight to the generic fallback.
+function slugifySkillId(name: string, fileName: string): string {
+  return (
+    slugify(name) ||
+    slugify(fileName.replace(/\.[^.]+$/, "")) ||
+    SKILL_ID_FALLBACK
+  );
+}
+
+/**
+ * Read a SKILL.md's YAML frontmatter. `name` and `description` are the contract
+ * the agent reads to decide when to run a skill, so a file without them is
+ * rejected here rather than installed as something the agent can never pick.
+ */
+export function parseSkillMarkdown(
+  content: string,
+  fileName: string,
+): { ok: true; skill: ParsedSkillFile } | { ok: false; error: string } {
+  const normalized = content.replace(/\r\n/g, "\n");
+  const frontmatter = /^---\n([\s\S]*?)\n---/.exec(normalized);
+  if (!frontmatter) {
+    return {
+      ok: false,
+      error: "That file has no YAML frontmatter block at the top.",
+    };
+  }
+  const block = frontmatter[1] ?? "";
+  const read = (key: string): string => {
+    const match = new RegExp(`^${key}\\s*:\\s*(.+)$`, "m").exec(block);
+    return match?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
+  };
+  const name = read("name") || read("title");
+  const description = read("description") || read("summary");
+  if (!name) {
+    return { ok: false, error: "The frontmatter is missing a `name`." };
+  }
+  if (!description) {
+    return { ok: false, error: "The frontmatter is missing a `description`." };
+  }
+  return {
+    ok: true,
+    skill: {
+      skillId: slugifySkillId(name, fileName),
+      name,
+      description,
+      content: normalized,
+    },
+  };
+}

--- a/packages/remote-api/src/__tests__/authz.test.ts
+++ b/packages/remote-api/src/__tests__/authz.test.ts
@@ -34,6 +34,9 @@ function makeClient(identity?: RemoteApiIdentity) {
       install: () => {
         throw new Error("not used");
       },
+      importUpload: () => {
+        throw new Error("not used");
+      },
     },
     channels: {
       list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/capabilities.test.ts
+++ b/packages/remote-api/src/__tests__/capabilities.test.ts
@@ -81,6 +81,7 @@ function makeClient(capabilities: CapabilitiesService) {
       skills: {
         catalog: () => ({ skills: [] }),
         install: notUsed,
+        importUpload: notUsed,
       },
       channels: {
         list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/cronjobs.test.ts
+++ b/packages/remote-api/src/__tests__/cronjobs.test.ts
@@ -97,6 +97,9 @@ function makeClient() {
         install: () => {
           throw new Error("not used");
         },
+        importUpload: () => {
+          throw new Error("not used");
+        },
       },
       channels: {
         list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/mcp-http.test.ts
+++ b/packages/remote-api/src/__tests__/mcp-http.test.ts
@@ -64,6 +64,9 @@ function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
       install: () => {
         throw new Error("not used");
       },
+      importUpload: () => {
+        throw new Error("not used");
+      },
     },
     channels: {
       list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/mcp.test.ts
+++ b/packages/remote-api/src/__tests__/mcp.test.ts
@@ -60,6 +60,9 @@ function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
       install: () => {
         throw new Error("not used");
       },
+      importUpload: () => {
+        throw new Error("not used");
+      },
     },
     channels: {
       list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/memory.test.ts
+++ b/packages/remote-api/src/__tests__/memory.test.ts
@@ -50,6 +50,9 @@ function makeClient() {
         install: () => {
           throw new Error("not used");
         },
+        importUpload: () => {
+          throw new Error("not used");
+        },
       },
       channels: {
         list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/notifications.test.ts
+++ b/packages/remote-api/src/__tests__/notifications.test.ts
@@ -88,6 +88,9 @@ function makeClient() {
         install: () => {
           throw new Error("not used");
         },
+        importUpload: () => {
+          throw new Error("not used");
+        },
       },
       channels: {
         list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/__tests__/outputs.test.ts
+++ b/packages/remote-api/src/__tests__/outputs.test.ts
@@ -73,6 +73,9 @@ function makeClient() {
         install: () => {
           throw new Error("not used");
         },
+        importUpload: () => {
+          throw new Error("not used");
+        },
       },
       channels: {
         list: () => ({ channels: [], count: 0 }),

--- a/packages/remote-api/src/contract/skills.ts
+++ b/packages/remote-api/src/contract/skills.ts
@@ -19,12 +19,30 @@ const installInputSchema = z.object({
   content: z.string().min(1),
 });
 
+// A skill the user uploaded from their machine: a bare SKILL.md, or a .zip /
+// .skill holding the folder (SKILL.md at the root, or one top-level folder).
+// Base64 because the transport is JSON — see MAX_UPLOAD_BYTES for the ceiling.
+const importUploadInputSchema = z.object({
+  fileName: z.string().min(1),
+  dataBase64: z.string().min(1),
+});
+
+const importUploadOutputSchema = skillCatalogEntrySchema.extend({
+  grantedTools: z.array(z.string()),
+  files: z.array(z.string()),
+  replaced: z.boolean(),
+});
+
 export const skillsContract = {
   catalog: oc.input(z.object({})).output(catalogOutputSchema),
   install: oc
     .input(installInputSchema)
     .errors({ NOT_FOUND: { message: "skill not found" } })
     .output(skillCatalogEntrySchema),
+  importUpload: oc
+    .input(importUploadInputSchema)
+    .errors({ BAD_REQUEST: { message: "invalid skill upload" } })
+    .output(importUploadOutputSchema),
 };
 
 export type SkillCatalogEntry = z.infer<typeof skillCatalogEntrySchema>;

--- a/packages/remote-api/src/server/context.ts
+++ b/packages/remote-api/src/server/context.ts
@@ -114,6 +114,10 @@ export interface SkillsCatalogService {
   install(
     input: SkillsInputs["install"]
   ): MaybePromise<SkillsOutputs["install"]>;
+  /** Unpacks an uploaded SKILL.md / archive into the workspace's skills dir. */
+  importUpload(
+    input: SkillsInputs["importUpload"]
+  ): MaybePromise<SkillsOutputs["importUpload"]>;
 }
 
 /** The runtime-supplied implementation of the channels (IM connections) domain. */

--- a/packages/remote-api/src/server/skills.ts
+++ b/packages/remote-api/src/server/skills.ts
@@ -12,7 +12,18 @@ const install = os.skills.install.handler(async ({ input, context, errors }) => 
   }
 });
 
+const importUpload = os.skills.importUpload.handler(async ({ input, context, errors }) => {
+  try {
+    return await context.skills.importUpload(input);
+  } catch (error) {
+    throw errors.BAD_REQUEST({
+      message: error instanceof Error ? error.message : "invalid skill upload",
+    });
+  }
+});
+
 export const skillsRouter = {
   catalog,
   install,
+  importUpload,
 };

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -234,7 +234,7 @@ import {
 import { loadCapabilityCatalog, installCapability, uninstallCapability, setCapabilityEnabled } from "./workspace-capabilities.js";
 import { clearMcpOAuthToken } from "../../harnesses/src/index.js";
 import { materializeSkill } from "./workspace-skills-catalog.js";
-import { importSkillFromGithub, previewSkillFromGithub, SkillImportError } from "./workspace-skill-import.js";
+import { importSkillFromGithub, importSkillFromUpload, previewSkillFromGithub, SkillImportError } from "./workspace-skill-import.js";
 import { importPluginAsCapability } from "./import-plugin.js";
 import {
   NativeRunnerExecutor,
@@ -3631,6 +3631,25 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
             skillId: input.skillId,
             content: input.content,
           });
+        },
+        // Shares the folder-aware path with the GitHub import, so an uploaded
+        // skill gets the same frontmatter mapping (allowed-tools →
+        // holaboss_granted_tools) and the same traversal/size guards.
+        importUpload: async (input) => {
+          const ws = resolveCanonicalWs();
+          const result = await importSkillFromUpload({
+            workspaceDir: store.workspaceDir(ws),
+            fileName: input.fileName,
+            data: Buffer.from(input.dataBase64, "base64"),
+          });
+          return {
+            id: result.id,
+            name: result.name,
+            description: result.description,
+            grantedTools: result.granted_tools,
+            files: result.files.map((file) => file.path),
+            replaced: result.replaced,
+          };
         },
       },
     });

--- a/runtime/api-server/src/workspace-skill-import.ts
+++ b/runtime/api-server/src/workspace-skill-import.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import yaml from "js-yaml";
+import JSZip from "jszip";
 import * as tar from "tar";
 
 /**
@@ -19,6 +20,9 @@ import * as tar from "tar";
 const MAX_TARBALL_BYTES = 25 * 1024 * 1024;
 const MAX_SKILL_BYTES = 8 * 1024 * 1024;
 const MAX_FILES = 300;
+// Uploads ride base64-encoded inside the remote-api body, which the runtime caps
+// at 10 MB — 6 MB of file grows to ~8 MB encoded and still fits.
+const MAX_UPLOAD_BYTES = 6 * 1024 * 1024;
 
 export class SkillImportError extends Error {
   readonly statusCode: number;
@@ -331,6 +335,173 @@ export async function previewSkillFromGithub(params: { url: string; ref?: string
   }
 }
 
+/**
+ * Land a prepared skill folder (anything with a SKILL.md at its root) into the
+ * workspace. The half of an import that has nothing to do with where the folder
+ * came from — a GitHub tarball and an uploaded archive both end up here, so both
+ * get the frontmatter mapping, the traversal guards and the executable bits.
+ */
+function installSkillFolder(params: {
+  workspaceDir: string;
+  skillSrc: string;
+  sourceUrl: string;
+  ref: string;
+}): SkillImportResult {
+  const { id, mapped, files } = readSkill(params.skillSrc);
+  const skillDir = path.resolve(params.workspaceDir, "skills", id);
+  const skillsRoot = path.resolve(params.workspaceDir, "skills");
+  if (skillDir !== path.join(skillsRoot, id)) {
+    throw new SkillImportError(400, "resolved skill id is not a safe directory name");
+  }
+  const replaced = fs.existsSync(skillDir);
+  if (replaced) {
+    fs.rmSync(skillDir, { recursive: true, force: true });
+  }
+
+  for (const file of files) {
+    const dest = path.resolve(skillDir, file.path);
+    if (dest !== skillDir && !dest.startsWith(`${skillDir}${path.sep}`)) {
+      throw new SkillImportError(400, `path traversal not allowed: ${file.path}`);
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    if (file.path === "SKILL.md") {
+      fs.writeFileSync(dest, mapped.content, "utf8");
+    } else {
+      fs.copyFileSync(path.join(params.skillSrc, file.path), dest);
+    }
+    if (file.executable) {
+      fs.chmodSync(dest, fs.statSync(dest).mode | 0o111);
+    }
+  }
+
+  return {
+    id,
+    name: mapped.name,
+    description: mapped.description,
+    granted_tools: mapped.grantedTools,
+    files,
+    source_url: params.sourceUrl,
+    ref: params.ref,
+    replaced,
+  };
+}
+
+const UPLOAD_ARCHIVE_EXTENSIONS = /\.(zip|skill)$/i;
+const UPLOAD_MARKDOWN_EXTENSIONS = /\.(md|markdown)$/i;
+
+/**
+ * Unpack an uploaded skill into a temp folder shaped the way `readSkill` expects
+ * (a directory with SKILL.md at its root).
+ *
+ * A bare SKILL.md is the minimum a skill can be, so it is accepted on its own.
+ * An archive follows the convention the ecosystem settled on: either SKILL.md
+ * sits at the root, or there is exactly one top-level folder holding it.
+ */
+async function unpackUploadedSkill(
+  fileName: string,
+  data: Buffer,
+): Promise<ExtractedSkill> {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hb-skill-upload-"));
+  try {
+    const skillSrc = path.join(tmpRoot, "skill");
+    fs.mkdirSync(skillSrc);
+
+    if (UPLOAD_MARKDOWN_EXTENSIONS.test(fileName)) {
+      fs.writeFileSync(path.join(skillSrc, "SKILL.md"), data);
+      return { tmpRoot, skillSrc };
+    }
+    if (!UPLOAD_ARCHIVE_EXTENSIONS.test(fileName)) {
+      throw new SkillImportError(400, "upload a .md, .zip or .skill file");
+    }
+
+    let zip: JSZip;
+    try {
+      zip = await JSZip.loadAsync(data);
+    } catch {
+      throw new SkillImportError(400, "that archive could not be opened as a zip");
+    }
+
+    // Write every entry first, then decide which directory is the skill root —
+    // a zip made by "compress this folder" nests everything one level down.
+    let written = 0;
+    let totalBytes = 0;
+    for (const entry of Object.values(zip.files)) {
+      if (entry.dir) {
+        continue;
+      }
+      // Zip entry names are attacker-controlled: keep them inside the temp dir.
+      const dest = path.resolve(skillSrc, entry.name);
+      if (!dest.startsWith(`${skillSrc}${path.sep}`)) {
+        throw new SkillImportError(400, `path traversal not allowed: ${entry.name}`);
+      }
+      if (++written > MAX_FILES) {
+        throw new SkillImportError(400, `skill has too many files (>${MAX_FILES})`);
+      }
+      const content = await entry.async("nodebuffer");
+      totalBytes += content.byteLength;
+      if (totalBytes > MAX_SKILL_BYTES) {
+        throw new SkillImportError(
+          400,
+          `skill is too large (>${Math.round(MAX_SKILL_BYTES / 1024 / 1024)} MB)`,
+        );
+      }
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, content);
+      // JSZip carries the unix mode in the high 16 bits when the zip was made on
+      // a unix host; a Windows-made zip has none, and scripts land non-executable.
+      const mode = (entry.unixPermissions as number | null) ?? 0;
+      if (typeof mode === "number" && (mode & 0o111) !== 0) {
+        fs.chmodSync(dest, fs.statSync(dest).mode | 0o111);
+      }
+    }
+
+    if (fs.existsSync(path.join(skillSrc, "SKILL.md"))) {
+      return { tmpRoot, skillSrc };
+    }
+    const roots = fs
+      .readdirSync(skillSrc, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory());
+    if (roots.length === 1) {
+      const nested = path.join(skillSrc, roots[0].name);
+      if (fs.existsSync(path.join(nested, "SKILL.md"))) {
+        return { tmpRoot, skillSrc: nested };
+      }
+    }
+    throw new SkillImportError(
+      400,
+      "no SKILL.md found — the archive needs one at its root or in a single top-level folder",
+    );
+  } catch (error) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/** Install a skill the user uploaded from their machine. */
+export async function importSkillFromUpload(params: {
+  workspaceDir: string;
+  fileName: string;
+  data: Buffer;
+}): Promise<SkillImportResult> {
+  if (params.data.byteLength > MAX_UPLOAD_BYTES) {
+    throw new SkillImportError(
+      400,
+      `upload too large (>${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)} MB)`,
+    );
+  }
+  const { tmpRoot, skillSrc } = await unpackUploadedSkill(params.fileName, params.data);
+  try {
+    return installSkillFolder({
+      workspaceDir: params.workspaceDir,
+      skillSrc,
+      sourceUrl: "",
+      ref: "upload",
+    });
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
 export async function importSkillFromGithub(params: {
   workspaceDir: string;
   url: string;
@@ -340,43 +511,12 @@ export async function importSkillFromGithub(params: {
   const buffer = await downloadTarball(ref);
   const { tmpRoot, skillSrc } = await extractSkillFolder(buffer, ref);
   try {
-    const { id, mapped, files } = readSkill(skillSrc);
-    const skillDir = path.resolve(params.workspaceDir, "skills", id);
-    const skillsRoot = path.resolve(params.workspaceDir, "skills");
-    if (skillDir !== path.join(skillsRoot, id)) {
-      throw new SkillImportError(400, "resolved skill id is not a safe directory name");
-    }
-    const replaced = fs.existsSync(skillDir);
-    if (replaced) {
-      fs.rmSync(skillDir, { recursive: true, force: true });
-    }
-
-    for (const file of files) {
-      const dest = path.resolve(skillDir, file.path);
-      if (dest !== skillDir && !dest.startsWith(`${skillDir}${path.sep}`)) {
-        throw new SkillImportError(400, `path traversal not allowed: ${file.path}`);
-      }
-      fs.mkdirSync(path.dirname(dest), { recursive: true });
-      if (file.path === "SKILL.md") {
-        fs.writeFileSync(dest, mapped.content, "utf8");
-      } else {
-        fs.copyFileSync(path.join(skillSrc, file.path), dest);
-      }
-      if (file.executable) {
-        fs.chmodSync(dest, fs.statSync(dest).mode | 0o111);
-      }
-    }
-
-    return {
-      id,
-      name: mapped.name,
-      description: mapped.description,
-      granted_tools: mapped.grantedTools,
-      files,
-      source_url: params.url.trim(),
+    return installSkillFolder({
+      workspaceDir: params.workspaceDir,
+      skillSrc,
+      sourceUrl: params.url.trim(),
       ref: ref.ref,
-      replaced,
-    };
+    });
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }

--- a/runtime/api-server/src/workspace-skill-upload.test.ts
+++ b/runtime/api-server/src/workspace-skill-upload.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import JSZip from "jszip";
+import { importSkillFromUpload } from "./workspace-skill-import.js";
+
+const SKILL_MD = `---
+name: Weekly Report
+description: Pulls last week's numbers.
+allowed-tools: Bash, Read
+---
+
+Do the thing.`;
+
+function workspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "hb-skill-upload-test-"));
+}
+
+test("a bare SKILL.md installs as a skill folder", async () => {
+  const dir = workspace();
+  const result = await importSkillFromUpload({
+    workspaceDir: dir,
+    fileName: "SKILL.md",
+    data: Buffer.from(SKILL_MD, "utf8"),
+  });
+  assert.equal(result.id, "weekly-report");
+  // mapSkillFrontmatter aligns the frontmatter name to the installed id, same as
+  // the GitHub import — the human-readable label rides in `title`, not `name`.
+  assert.equal(result.name, "weekly-report");
+  const landed = path.join(dir, "skills", "weekly-report", "SKILL.md");
+  assert.ok(fs.existsSync(landed));
+});
+
+test("Anthropic allowed-tools is mapped to holaboss_granted_tools", async () => {
+  const dir = workspace();
+  const result = await importSkillFromUpload({
+    workspaceDir: dir,
+    fileName: "SKILL.md",
+    data: Buffer.from(SKILL_MD, "utf8"),
+  });
+  assert.deepEqual(result.granted_tools, ["Bash", "Read"]);
+  const written = fs.readFileSync(
+    path.join(dir, "skills", "weekly-report", "SKILL.md"),
+    "utf8",
+  );
+  assert.match(written, /holaboss_granted_tools/);
+  assert.doesNotMatch(written, /allowed-tools/);
+});
+
+test("a zip with SKILL.md at the root keeps its bundled files", async () => {
+  const zip = new JSZip();
+  zip.file("SKILL.md", SKILL_MD);
+  zip.file("scripts/run.sh", "#!/bin/sh\necho hi\n");
+  zip.file("references/notes.md", "notes");
+  const data = await zip.generateAsync({ type: "nodebuffer" });
+
+  const dir = workspace();
+  const result = await importSkillFromUpload({
+    workspaceDir: dir,
+    fileName: "weekly.zip",
+    data,
+  });
+  const paths = result.files.map((f) => f.path).sort();
+  assert.deepEqual(paths, ["SKILL.md", "references/notes.md", "scripts/run.sh"]);
+  assert.ok(
+    fs.existsSync(path.join(dir, "skills", "weekly-report", "scripts", "run.sh")),
+  );
+});
+
+test("a zip nesting everything in one top-level folder is unwrapped", async () => {
+  const zip = new JSZip();
+  zip.file("weekly-report/SKILL.md", SKILL_MD);
+  zip.file("weekly-report/scripts/run.sh", "#!/bin/sh\n");
+  const data = await zip.generateAsync({ type: "nodebuffer" });
+
+  const dir = workspace();
+  const result = await importSkillFromUpload({
+    workspaceDir: dir,
+    fileName: "weekly.zip",
+    data,
+  });
+  assert.deepEqual(
+    result.files.map((f) => f.path).sort(),
+    ["SKILL.md", "scripts/run.sh"],
+  );
+});
+
+test("a zip with no SKILL.md anywhere is rejected", async () => {
+  const zip = new JSZip();
+  zip.file("readme.md", "nope");
+  const data = await zip.generateAsync({ type: "nodebuffer" });
+
+  await assert.rejects(
+    () =>
+      importSkillFromUpload({
+        workspaceDir: workspace(),
+        fileName: "x.zip",
+        data,
+      }),
+    /no SKILL.md found/,
+  );
+});
+
+test("a forged traversal entry cannot write outside the skill folder", async () => {
+  // JSZip normalises "../" away when it writes, so forge one: build with a
+  // same-length placeholder and patch the bytes (the name lives in both the
+  // local header and the central directory).
+  const zip = new JSZip();
+  zip.file("SKILL.md", SKILL_MD);
+  zip.file("AA/escape.txt", "pwned");
+  const clean = await zip.generateAsync({ type: "nodebuffer" });
+  const data = Buffer.from(
+    clean.toString("binary").split("AA/escape.txt").join("../escape.txt"),
+    "binary",
+  );
+  assert.ok(data.includes(Buffer.from("../escape.txt")), "forge failed");
+
+  // JSZip strips the traversal again on load, so this installs rather than
+  // throwing. What matters is where the bytes land: inside the skill dir.
+  const dir = workspace();
+  await importSkillFromUpload({ workspaceDir: dir, fileName: "x.zip", data });
+  assert.ok(!fs.existsSync(path.join(dir, "escape.txt")));
+  assert.ok(!fs.existsSync(path.join(dir, "skills", "escape.txt")));
+  assert.ok(
+    fs.existsSync(path.join(dir, "skills", "weekly-report", "escape.txt")),
+    "the entry should be contained, not dropped",
+  );
+});
+
+test("an unsupported extension is refused", async () => {
+  await assert.rejects(
+    () =>
+      importSkillFromUpload({
+        workspaceDir: workspace(),
+        fileName: "skill.tar.gz",
+        data: Buffer.from("x"),
+      }),
+    /\.md, \.zip or \.skill/,
+  );
+});
+
+test("an oversized upload is refused before unpacking", async () => {
+  await assert.rejects(
+    () =>
+      importSkillFromUpload({
+        workspaceDir: workspace(),
+        fileName: "big.zip",
+        data: Buffer.alloc(7 * 1024 * 1024),
+      }),
+    /too large/,
+  );
+});


### PR DESCRIPTION
## What

Adding your own skill was an "Import from URL" button parked in the Your skills section — you had to host a SKILL.md publicly before the desktop would take it. This folds self-serve creation into **New skill** and leads with upload.

```
+ New skill ▾
   Create with agent   ← unchanged
   Upload skill        ← new
```

Drop a `SKILL.md`, or a `.zip` / `.skill` holding the folder. Import from URL and the empty Your skills block go away; the org list still renders once it actually has something, so web-platform skills remain installable.

## The part that matters

A skill is a *folder* — SKILL.md plus optional `scripts/`, `references/`, `assets/`. The first cut of this parsed the file in the renderer and wrote the body through `skills.install`, whose contract carries a single string. That could only ever land a bare SKILL.md, and it bypassed `mapSkillFrontmatter` — so an uploaded Anthropic-format skill **silently lost its `allowed-tools` grants**.

`workspace-skill-import` already had the right machinery behind `import-github`: frontmatter mapping, traversal guards, size/file caps, executable bits. It was only ever pointed at GitHub tarballs.

So it's split — `installSkillFolder` takes any directory with a SKILL.md at its root, and each source just prepares that directory:

```
GitHub  →  downloadTarball → extractSkillFolder  ┐
                                                 ├→ installSkillFolder
Upload  →  unpackUploadedSkill (zip / bare .md)  ┘
```

Uploads now inherit all of it. Archives follow the convention the ecosystem settled on: SKILL.md at the root, or exactly one top-level folder holding it.

## Interface choice

Exposed as `skills.importUpload` on the remote-api contract, not a fastify route — that's how the desktop reaches skills. `import-github` stays a raw route because its caller is the agent's embedded `skill-installer`, over HTTP.

Base64 in the JSON body caps uploads at 6 MB: the oRPC mount is `app.all(prefix/*)` with no per-route limit, so it inherits the runtime's 10 MB body limit, and 6 MB encodes to ~8 MB.

The renderer's parser shrinks to a pre-flight check — catch a `.md` the agent could never pick before spending a round trip, and leave the real parse, the id slug and the mapping to the runtime.

## Tests

8 new runtime tests: bare `.md`; `allowed-tools` → `holaboss_granted_tools` (asserted on the written file); root-level zip keeping `scripts/` + `references/`; single-top-level-folder unwrap; no-SKILL.md rejection; oversize; bad extension; and a path-traversal case.

That last one turned up something worth knowing: **JSZip normalises `../` away on load**. The test forges a genuinely hostile archive by patching the name bytes (`data.includes("../escape.txt")` is true), and JSZip still reads it back as `escape.txt`. Our guard is therefore defence in depth, not the thing doing the work — so the test asserts *where the bytes land* rather than that an error is thrown.

- runtime typecheck clean, 8/8
- `desktop:typecheck` clean, `test:unit` 172/172

## Note for reviewers

`packages/remote-api` gained a contract op and `dist/` isn't tracked — build it once (`npm run build` in that package) or the runtime typecheck reports `importUpload does not exist in type SkillsCatalogService`.

## Not verified

Not exercised in the running app. The thing to actually try is a real skill zip with a `scripts/` dir: confirm the scripts land under `skills/<id>/scripts/` and keep their executable bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)