### PR TITLE
Custom HolaApp polish (URL/OAuth) + runtime: agents-optional & single-flight authorize

### DIFF
--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -14,14 +14,12 @@ import {
 	upsertCustomHolaApp,
 } from "@/lib/localCustomHolaApps";
 
-const MCP_PLACEHOLDER = `{
-  "mcpServers": {
-    "my-server": {
-      "url": "https://example.com/mcp",
-      "headers": { "Authorization": "Bearer <token>" }
-    }
-  }
-}`;
+// Lead with the simplest form — a bare URL — so the field doesn't look like it demands
+// a full JSON blob. The help text + parser also accept a { mcpServers } config and an
+// `npx mcp-remote <url>` config.
+const MCP_PLACEHOLDER = `https://mcp.example.com/mcp
+
+…or a full JSON / "npx mcp-remote <url>" config`;
 
 // Run the browser OAuth for a just-added custom app's MCP. The MCP attaches
 // asynchronously (onChanged → catalog refresh → syncAppOwned), so poll until the
@@ -251,7 +249,7 @@ export function CustomHolaAppCreateDialog({
 								className="text-foreground text-xs"
 								htmlFor="custom-app-mcp"
 							>
-								MCP server config{" "}
+								MCP server{" "}
 								<span className="text-muted-foreground">(optional)</span>
 							</Label>
 							<Textarea

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -147,15 +147,16 @@ export function CustomHolaAppCreateDialog({
 			...(mcp ? { mcp } : {}),
 			...(rawMcp ? { mcpConfigJson: rawMcp } : {}),
 		};
-		upsertCustomHolaApp(app);
+		// A header-less MCP is the OAuth case (a static-token server is already usable). The
+		// app is only KEPT if sign-in succeeds: save it as a DRAFT (`pending`) so the MCP
+		// attaches (auth needs it registered) yet a killed session's leftover can be purged on
+		// startup; a retry reuses it, it commits on success, and it's discarded if you close.
+		const needsOAuth =
+			Boolean(mcp) && Object.keys(mcp?.headerKeys ?? {}).length === 0;
+		upsertCustomHolaApp(needsOAuth ? { ...app, pending: true } : app);
 		// Fire the catalog refresh — attaches the app-owned MCP + shows the app.
 		onChanged();
 
-		// A header-less MCP is the OAuth case (a static-token server is already usable). The
-		// app is only KEPT if sign-in succeeds: it's saved above so the MCP attaches (auth
-		// needs it registered); a retry reuses it, and it's discarded if you close the dialog.
-		const needsOAuth =
-			Boolean(mcp) && Object.keys(mcp?.headerKeys ?? {}).length === 0;
 		if (needsOAuth && workspaceId && mcp) {
 			pendingAppIdRef.current = holaAppId;
 			authAbortRef.current = false;
@@ -183,6 +184,8 @@ export function CustomHolaAppCreateDialog({
 				);
 				return;
 			}
+			// Authorized — commit the app (drop its draft `pending` flag).
+			upsertCustomHolaApp(app);
 		}
 
 		// Committed — release the draft so a later add starts a fresh app.

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -31,14 +31,14 @@ const MCP_PLACEHOLDER = `https://mcp.example.com/mcp
 async function runCustomAppOAuth(
 	workspaceId: string,
 	serverId: string,
-): Promise<boolean> {
+): Promise<{ ok: boolean; reason: string }> {
 	for (let attempt = 0; attempt < 8; attempt += 1) {
 		const status = await window.electronAPI.workspace.mcpServerAuthorized(
 			workspaceId,
 			serverId,
 		);
 		if (status.authorized) {
-			return true;
+			return { ok: true, reason: "" };
 		}
 		if (status.registered !== false) {
 			const result = await window.electronAPI.workspace.authorizeMcpServer(
@@ -46,11 +46,11 @@ async function runCustomAppOAuth(
 				serverId,
 				false,
 			);
-			return result.ok === true;
+			return { ok: result.ok === true, reason: result.detail ?? "" };
 		}
 		await new Promise((resolve) => setTimeout(resolve, 1200));
 	}
-	return false;
+	return { ok: false, reason: "the MCP server didn't register in time" };
 }
 
 // A small "create your own app" form: a URL the desktop opens as the app's surface,
@@ -161,8 +161,11 @@ export function CustomHolaAppCreateDialog({
 			authAbortRef.current = false;
 			setPhase("authorizing");
 			let ok = false;
+			let reason = "";
 			try {
-				ok = await runCustomAppOAuth(workspaceId, mcp.id);
+				const result = await runCustomAppOAuth(workspaceId, mcp.id);
+				ok = result.ok;
+				reason = result.reason;
 			} catch {
 				// reactive fallback — ignore
 			}
@@ -174,7 +177,9 @@ export function CustomHolaAppCreateDialog({
 				// Keep the draft (same id) so a retry reuses the SAME server, no attach/detach
 				// churn or a conflicting sign-in; it's discarded when the dialog is closed.
 				setError(
-					"Sign-in was cancelled — try again to authorize, or close to discard.",
+					reason
+						? `Sign-in didn't complete: ${reason}. Try again, or close to discard.`
+						: "Sign-in didn't complete. Try again to authorize, or close to discard.",
 				);
 				return;
 			}

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -127,7 +127,7 @@ export function CustomHolaAppCreateDialog({
 		}
 		setError("");
 
-		const holaAppId = customHolaAppId(trimmedTitle);
+		const holaAppId = pendingAppIdRef.current ?? customHolaAppId(trimmedTitle);
 		let mcp: CustomHolaApp["mcp"];
 		const rawMcp = mcpJson.trim();
 		if (rawMcp) {
@@ -153,7 +153,7 @@ export function CustomHolaAppCreateDialog({
 
 		// A header-less MCP is the OAuth case (a static-token server is already usable). The
 		// app is only KEPT if sign-in succeeds: it's saved above so the MCP attaches (auth
-		// needs it registered), then rolled back below if the user cancels the sign-in.
+		// needs it registered); a retry reuses it, and it's discarded if you close the dialog.
 		const needsOAuth =
 			Boolean(mcp) && Object.keys(mcp?.headerKeys ?? {}).length === 0;
 		if (needsOAuth && workspaceId && mcp) {
@@ -170,39 +170,35 @@ export function CustomHolaAppCreateDialog({
 			if (authAbortRef.current) {
 				return;
 			}
-			pendingAppIdRef.current = null;
 			if (!ok) {
-				deleteCustomHolaApp(holaAppId);
-				onChanged();
+				// Keep the draft (same id) so a retry reuses the SAME server, no attach/detach
+				// churn or a conflicting sign-in; it's discarded when the dialog is closed.
 				setError(
-					"Sign-in was cancelled — the app wasn't added. Try again to authorize it.",
+					"Sign-in was cancelled — try again to authorize, or close to discard.",
 				);
 				return;
 			}
 		}
 
+		// Committed — release the draft so a later add starts a fresh app.
+		pendingAppIdRef.current = null;
 		resetForm();
 		onOpenChange(false);
 	};
 
 	const busy = phase === "authorizing";
 
-	// Cancelling during "Signing in…" (Cancel, X, Esc, backdrop) aborts the add: roll the
-	// pending app back and close, so a cancelled sign-in never leaves an app behind.
-	const cancelSignIn = () => {
-		authAbortRef.current = true;
-		if (pendingAppIdRef.current) {
-			deleteCustomHolaApp(pendingAppIdRef.current);
-			pendingAppIdRef.current = null;
-			onChanged();
-		}
-		setPhase("idle");
-		onOpenChange(false);
-	};
 	const handleRootOpenChange = (next: boolean) => {
-		if (!next && busy) {
-			cancelSignIn();
-			return;
+		// Closing the dialog (Cancel / X / Esc / backdrop) discards any un-committed draft
+		// app, so a cancelled or abandoned sign-in never leaves an app behind.
+		if (!next) {
+			authAbortRef.current = true;
+			if (pendingAppIdRef.current) {
+				deleteCustomHolaApp(pendingAppIdRef.current);
+				pendingAppIdRef.current = null;
+				onChanged();
+			}
+			setPhase("idle");
 		}
 		onOpenChange(next);
 	};

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { useSetAtom } from "jotai";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { overlayOpenCountAtom } from "@/components/layout/shell/overlay-presence";
 import { Button } from "@/components/ui/button";
 import { AppWindow, Loader2, Plus, X } from "@/components/ui/icons";
@@ -10,6 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	type CustomHolaApp,
 	customHolaAppId,
+	deleteCustomHolaApp,
 	parseCustomMcpConfig,
 	upsertCustomHolaApp,
 } from "@/lib/localCustomHolaApps";
@@ -29,25 +30,26 @@ const MCP_PLACEHOLDER = `https://mcp.example.com/mcp
 async function runCustomAppOAuth(
 	workspaceId: string,
 	serverId: string,
-): Promise<void> {
+): Promise<boolean> {
 	for (let attempt = 0; attempt < 8; attempt += 1) {
 		const status = await window.electronAPI.workspace.mcpServerAuthorized(
 			workspaceId,
 			serverId,
 		);
 		if (status.authorized) {
-			return;
+			return true;
 		}
 		if (status.registered !== false) {
-			await window.electronAPI.workspace.authorizeMcpServer(
+			const result = await window.electronAPI.workspace.authorizeMcpServer(
 				workspaceId,
 				serverId,
 				false,
 			);
-			return;
+			return result.ok === true;
 		}
 		await new Promise((resolve) => setTimeout(resolve, 1200));
 	}
+	return false;
 }
 
 // A small "create your own app" form: a URL the desktop opens as the app's surface,
@@ -89,6 +91,10 @@ export function CustomHolaAppCreateDialog({
 	const [mcpJson, setMcpJson] = useState("");
 	const [error, setError] = useState("");
 	const [phase, setPhase] = useState<"idle" | "authorizing">("idle");
+	// The just-saved app awaiting sign-in — kept so a cancel can roll it back. authAbort
+	// guards handleCreate's success path when the user cancels while OAuth is in flight.
+	const pendingAppIdRef = useRef<string | null>(null);
+	const authAbortRef = useRef(false);
 
 	const resetForm = () => {
 		setTitle("");
@@ -144,19 +150,34 @@ export function CustomHolaAppCreateDialog({
 		// Fire the catalog refresh — attaches the app-owned MCP + shows the app.
 		onChanged();
 
-		// A header-less MCP is the OAuth case (a static-token server is already usable):
-		// run the browser sign-in now so the app works immediately. Best-effort — on any
-		// failure the reactive chat Authorize card prompts instead. Never blocks the close.
+		// A header-less MCP is the OAuth case (a static-token server is already usable). The
+		// app is only KEPT if sign-in succeeds: it's saved above so the MCP attaches (auth
+		// needs it registered), then rolled back below if the user cancels the sign-in.
 		const needsOAuth =
 			Boolean(mcp) && Object.keys(mcp?.headerKeys ?? {}).length === 0;
 		if (needsOAuth && workspaceId && mcp) {
+			pendingAppIdRef.current = holaAppId;
+			authAbortRef.current = false;
 			setPhase("authorizing");
+			let ok = false;
 			try {
-				await runCustomAppOAuth(workspaceId, mcp.id);
+				ok = await runCustomAppOAuth(workspaceId, mcp.id);
 			} catch {
 				// reactive fallback — ignore
 			}
 			setPhase("idle");
+			if (authAbortRef.current) {
+				return;
+			}
+			pendingAppIdRef.current = null;
+			if (!ok) {
+				deleteCustomHolaApp(holaAppId);
+				onChanged();
+				setError(
+					"Sign-in was cancelled — the app wasn't added. Try again to authorize it.",
+				);
+				return;
+			}
 		}
 
 		resetForm();
@@ -165,8 +186,28 @@ export function CustomHolaAppCreateDialog({
 
 	const busy = phase === "authorizing";
 
+	// Cancelling during "Signing in…" (Cancel, X, Esc, backdrop) aborts the add: roll the
+	// pending app back and close, so a cancelled sign-in never leaves an app behind.
+	const cancelSignIn = () => {
+		authAbortRef.current = true;
+		if (pendingAppIdRef.current) {
+			deleteCustomHolaApp(pendingAppIdRef.current);
+			pendingAppIdRef.current = null;
+			onChanged();
+		}
+		setPhase("idle");
+		onOpenChange(false);
+	};
+	const handleRootOpenChange = (next: boolean) => {
+		if (!next && busy) {
+			cancelSignIn();
+			return;
+		}
+		onOpenChange(next);
+	};
+
 	return (
-		<DialogPrimitive.Root onOpenChange={onOpenChange} open={open}>
+		<DialogPrimitive.Root onOpenChange={handleRootOpenChange} open={open}>
 			<DialogPrimitive.Portal>
 				<DialogPrimitive.Backdrop className="fixed inset-0 z-[90] bg-foreground/20 backdrop-blur-sm ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0" />
 				<DialogPrimitive.Popup className="fixed top-[12%] left-1/2 z-[100] flex max-h-[80vh] w-[520px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-2xl outline-none ease-emphasized data-open:duration-snappy data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:duration-tap data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
@@ -276,8 +317,8 @@ export function CustomHolaAppCreateDialog({
 					<div className="flex items-center justify-end gap-2 border-border border-t px-4 py-3">
 						<DialogPrimitive.Close
 							render={
-								<Button disabled={busy} size="sm" type="button" variant="ghost">
-									Cancel
+								<Button size="sm" type="button" variant="ghost">
+									{busy ? "Cancel sign-in" : "Cancel"}
 								</Button>
 							}
 						/>

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -11,6 +11,7 @@ import {
 	type CustomHolaApp,
 	customHolaAppId,
 	deleteCustomHolaApp,
+	normalizeRemoteUrl,
 	parseCustomMcpConfig,
 	upsertCustomHolaApp,
 } from "@/lib/localCustomHolaApps";
@@ -115,13 +116,13 @@ export function CustomHolaAppCreateDialog({
 
 	const handleCreate = async () => {
 		const trimmedTitle = title.trim();
-		const trimmedUrl = url.trim();
+		const trimmedUrl = normalizeRemoteUrl(url);
 		if (!trimmedTitle) {
 			setError("Give your app a name.");
 			return;
 		}
 		if (!validUrl(trimmedUrl)) {
-			setError("Enter a valid http(s) URL for the app to open.");
+			setError("Enter a valid URL for the app to open.");
 			return;
 		}
 		setError("");

--- a/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
+++ b/apps/desktop/src/components/layout/shell/CustomHolaAppCreateDialog.tsx
@@ -264,10 +264,11 @@ export function CustomHolaAppCreateDialog({
 								value={mcpJson}
 							/>
 							<p className="text-muted-foreground text-xs">
-								Gives the agent this app's tools. Remote (URL) servers —
-								including <code>npx mcp-remote &lt;url&gt;</code> configs. Add
-								auth headers for a static token, or leave them out and we'll
-								open sign-in (OAuth) when you add it. Kept on this device.
+								Gives the agent this app's tools. Paste a JSON config, an{" "}
+								<code>npx mcp-remote &lt;url&gt;</code> config, or just the
+								remote server URL. Add auth headers for a static token, or leave
+								them out and we'll open sign-in (OAuth) when you add it. Kept on
+								this device.
 							</p>
 						</div>
 

--- a/apps/desktop/src/lib/holaAppMarketplace.ts
+++ b/apps/desktop/src/lib/holaAppMarketplace.ts
@@ -16,6 +16,7 @@ import {
 	customHolaAppMcpAttachInputs,
 	customHolaAppsAsWebApps,
 	deleteCustomHolaApp,
+	purgeOrphanedDraftApps,
 	readCustomHolaApps,
 } from "./localCustomHolaApps";
 import {
@@ -670,6 +671,9 @@ async function backendBaseUrl(): Promise<string | null> {
 export function createServerMarketplaceSource(): MarketplaceSource {
 	return {
 		async listCatalog() {
+			// Once per session: drop orphaned draft apps left by a session killed mid-sign-in
+			// (before the app-owned sync below re-attaches their MCPs).
+			purgeOrphanedDraftApps();
 			const serverApps = await listWebHolaApps();
 			// Fold in LOCAL user-created custom HolaApps (localCustomHolaApps) — they're
 			// absent from the backend catalog; each carries installed:true + a `url`

--- a/apps/desktop/src/lib/localCustomHolaApps.ts
+++ b/apps/desktop/src/lib/localCustomHolaApps.ts
@@ -226,6 +226,44 @@ function remoteUrlFromCommand(server: Record<string, unknown>): string | null {
 	return found ? found.trim() : null;
 }
 
+// Prepend https:// when a URL is entered without a scheme (mcp.example.com → https://…).
+export function normalizeRemoteUrl(raw: string): string {
+	const value = raw.trim();
+	if (!value) {
+		return value;
+	}
+	return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+// A single pasted token that is (or becomes, once https:// is prepended) a remote URL — so a
+// provider that hands you only a URL, with or without the scheme, can be pasted as-is. A
+// scheme-less token must have a dotted host so a stray word isn't misread as a URL.
+function bareUrlOrNull(raw: string): string | null {
+	const value = raw.trim();
+	if (
+		!value ||
+		/\s/.test(value) ||
+		value.startsWith("{") ||
+		value.startsWith("[")
+	) {
+		return null;
+	}
+	const hasScheme = /^https?:\/\//i.test(value);
+	const candidate = hasScheme ? value : `https://${value}`;
+	try {
+		const parsed = new URL(candidate);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return null;
+		}
+		if (hasScheme || parsed.hostname.includes(".")) {
+			return candidate;
+		}
+	} catch {
+		// not a URL — fall through to JSON parsing
+	}
+	return null;
+}
+
 /** Parse a pasted MCP config (mcpServers-style JSON, a `servers` map, or a bare
  * single-server object) into a resolved app-owned `McpAttachInput`. v1 supports
  * REMOTE (URL) servers with optional `headers`/`tools`; a command/stdio-only server
@@ -241,11 +279,12 @@ export function parseCustomMcpConfig(
 	// Many providers give ONLY a remote MCP URL (e.g. https://mcp.heygen.com/mcp/v1/) for an
 	// "add custom connector" flow — accept a bare URL as shorthand for { url }. No headers ⇒
 	// treated as OAuth, so sign-in opens on add (same as a headerless JSON config).
-	if (/^https?:\/\/\S+$/i.test(trimmed)) {
+	const bare = bareUrlOrNull(trimmed);
+	if (bare) {
 		return {
 			attach: {
 				id: ownerAppId,
-				mcpUrl: trimmed,
+				mcpUrl: bare,
 				holabossHosted: false,
 				headerKeys: {},
 				queryKeys: {},
@@ -267,7 +306,9 @@ export function parseCustomMcpConfig(
 		return { error: "No MCP server found in the config." };
 	}
 	const directUrl = typeof server.url === "string" ? server.url.trim() : "";
-	const url = directUrl || remoteUrlFromCommand(server) || "";
+	const url = normalizeRemoteUrl(
+		directUrl || remoteUrlFromCommand(server) || "",
+	);
 	if (!url) {
 		if (server.command !== undefined) {
 			return {

--- a/apps/desktop/src/lib/localCustomHolaApps.ts
+++ b/apps/desktop/src/lib/localCustomHolaApps.ts
@@ -24,6 +24,9 @@ export interface CustomHolaApp {
 	mcp?: McpAttachInput;
 	/** The raw JSON the user pasted, kept so the create form can pre-fill on edit. */
 	mcpConfigJson?: string;
+	/** True while a headerless-MCP app is mid-sign-in (a DRAFT): committed apps drop it, and
+	 *  a draft left by a session killed mid-add is purged on next startup. */
+	pending?: boolean;
 }
 
 const KEY = "holaboss.holaapps.custom.v1";
@@ -97,6 +100,7 @@ function normalizeStored(value: unknown): CustomHolaApp | null {
 		...(typeof value.mcpConfigJson === "string"
 			? { mcpConfigJson: value.mcpConfigJson }
 			: {}),
+		...(value.pending === true ? { pending: true } : {}),
 	};
 }
 
@@ -145,6 +149,22 @@ export function deleteCustomHolaApp(holaAppId: string): void {
 	writeCustomHolaApps(
 		readCustomHolaApps().filter((a) => a.holaAppId !== holaAppId),
 	);
+}
+
+// One-time (per app session) cleanup of orphaned DRAFT apps: a headerless-MCP app saved
+// mid-sign-in (`pending`) that a killed session never committed or discarded. Runs once, so
+// it only sweeps drafts from a PREVIOUS session — never the one being added right now.
+let orphanDraftsPurged = false;
+export function purgeOrphanedDraftApps(): void {
+	if (orphanDraftsPurged) {
+		return;
+	}
+	orphanDraftsPurged = true;
+	const all = readCustomHolaApps();
+	const kept = all.filter((app) => !app.pending);
+	if (kept.length !== all.length) {
+		writeCustomHolaApps(kept);
+	}
 }
 
 /** Custom apps as WebHolaApps (installed + ready) so they merge into the catalog and

--- a/apps/desktop/src/lib/localCustomHolaApps.ts
+++ b/apps/desktop/src/lib/localCustomHolaApps.ts
@@ -238,6 +238,23 @@ export function parseCustomMcpConfig(
 	if (!trimmed) {
 		return { error: "Paste an MCP server config." };
 	}
+	// Many providers give ONLY a remote MCP URL (e.g. https://mcp.heygen.com/mcp/v1/) for an
+	// "add custom connector" flow — accept a bare URL as shorthand for { url }. No headers ⇒
+	// treated as OAuth, so sign-in opens on add (same as a headerless JSON config).
+	if (/^https?:\/\/\S+$/i.test(trimmed)) {
+		return {
+			attach: {
+				id: ownerAppId,
+				mcpUrl: trimmed,
+				holabossHosted: false,
+				headerKeys: {},
+				queryKeys: {},
+				envKeys: {},
+				tools: [],
+				ownerAppId,
+			},
+		};
+	}
 	const parsed = safeJsonParse(trimmed);
 	if (parsed === undefined) {
 		return { error: "That isn't valid JSON." };

--- a/runtime/api-server/src/mcp-authorize-host.ts
+++ b/runtime/api-server/src/mcp-authorize-host.ts
@@ -76,18 +76,56 @@ export interface AuthorizeMcpServerViaHostOptions {
   reauthorize?: boolean;
 }
 
-export function authorizeMcpServerViaHost(
+// Only ONE authorize flow can run at a time: the OAuth callback binds a FIXED loopback
+// port (MCP_OAUTH_CALLBACK_PORT in mcp-authorize.ts), so a still-running prior attempt —
+// e.g. one the user abandoned in the browser, which keeps waiting out its full consent
+// timeout — holds that port and the next attempt dies with EADDRINUSE. Track the in-flight
+// child and kill it (freeing the port) before spawning a new one.
+let activeAuthorizeChild: ReturnType<typeof spawn> | null = null;
+
+async function terminateActiveAuthorize(): Promise<void> {
+  const prev = activeAuthorizeChild;
+  if (!prev) {
+    return;
+  }
+  activeAuthorizeChild = null;
+  await new Promise<void>((resolve) => {
+    let done = false;
+    const finish = (): void => {
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    };
+    // Wait for the child to actually exit so the OS releases the callback port before we
+    // spawn the next one; cap it so a wedged child can't block authorize forever.
+    prev.once("exit", finish);
+    setTimeout(finish, 1500);
+    try {
+      prev.kill("SIGKILL");
+    } catch {
+      finish();
+    }
+  });
+}
+
+export async function authorizeMcpServerViaHost(
   options: AuthorizeMcpServerViaHostOptions,
 ): Promise<AuthorizeMcpResult> {
   const innerTimeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : 180_000;
   const outerTimeoutMs = innerTimeoutMs + 15_000;
   const { entryPath, argsPrefix } = harnessHostEntryPath();
+  // Free the fixed OAuth callback port by killing any prior in-flight authorize first.
+  await terminateActiveAuthorize();
   return new Promise<AuthorizeMcpResult>((resolve) => {
     let settled = false;
     const finish = (result: AuthorizeMcpResult): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (activeAuthorizeChild === child) {
+        activeAuthorizeChild = null;
+      }
       resolve(result);
     };
 
@@ -111,7 +149,7 @@ export function authorizeMcpServerViaHost(
       spawnArgs.push("--reauthorize");
     }
 
-    let child;
+    let child: ReturnType<typeof spawn> | undefined;
     try {
       child = spawn(runtimeNodeBin(), spawnArgs, {
         cwd: runtimeRootDir(),
@@ -133,6 +171,7 @@ export function authorizeMcpServerViaHost(
       });
       return;
     }
+    activeAuthorizeChild = child;
 
     let stdout = "";
     let stderr = "";

--- a/runtime/api-server/src/mcp-authorize-host.ts
+++ b/runtime/api-server/src/mcp-authorize-host.ts
@@ -82,6 +82,9 @@ export interface AuthorizeMcpServerViaHostOptions {
 // timeout — holds that port and the next attempt dies with EADDRINUSE. Track the in-flight
 // child and kill it (freeing the port) before spawning a new one.
 let activeAuthorizeChild: ReturnType<typeof spawn> | null = null;
+// Children we killed to free the callback port for a newer attempt — so their close can
+// report a clear "superseded" reason instead of the generic "produced no result".
+const supersededAuthorizeChildren = new WeakSet<ReturnType<typeof spawn>>();
 
 async function terminateActiveAuthorize(): Promise<void> {
   const prev = activeAuthorizeChild;
@@ -89,6 +92,7 @@ async function terminateActiveAuthorize(): Promise<void> {
     return;
   }
   activeAuthorizeChild = null;
+  supersededAuthorizeChildren.add(prev);
   await new Promise<void>((resolve) => {
     let done = false;
     const finish = (): void => {
@@ -218,7 +222,10 @@ export async function authorizeMcpServerViaHost(
         parseAuthorizeResult(stdout) ?? {
           ok: false,
           tool_count: 0,
-          detail: withTrace("The authorize flow produced no result."),
+          detail:
+            child && supersededAuthorizeChildren.has(child)
+              ? "superseded by a newer sign-in attempt"
+              : withTrace("The authorize flow produced no result."),
         },
       ),
     );

--- a/runtime/api-server/src/workspace-runtime-plan.test.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.test.ts
@@ -519,6 +519,22 @@ mcp_registry:
   );
 });
 
+test("compileWorkspaceRuntimePlan defaults a missing agents block to the built-in single agent", () => {
+  const plan = compileWorkspaceRuntimePlan({
+    workspace_id: "workspace-1",
+    workspace_yaml: `
+mcp_registry:
+  allowlist:
+    tool_ids: []
+  servers: {}
+`,
+    references: {}
+  });
+  assert.equal(plan.general_config.type, "single");
+  assert.equal(plan.general_config.agent.id, "holaboss");
+  assert.equal(plan.general_config.agent.model, "gpt-5.4");
+});
+
 test("runWorkspaceRuntimePlanCli collects structured references", async () => {
   const stdout: string[] = [];
   const stderr: string[] = [];

--- a/runtime/api-server/src/workspace-runtime-plan.ts
+++ b/runtime/api-server/src/workspace-runtime-plan.ts
@@ -156,6 +156,10 @@ type WorkspaceRuntimePlanReferenceResponse =
     };
 
 const DEFAULT_PROMPT_FILE = "AGENTS.md";
+// Fallback single agent when a workspace.yaml has no `agents` block at all. The model is a
+// floor (the session picker overrides it) and matches the runner-prep scaffold default.
+const DEFAULT_AGENT_ID = "holaboss";
+const DEFAULT_AGENT_MODEL = "gpt-5.4";
 const DEFAULT_TIMEOUT_MS = 10_000;
 const TOOL_ID_PATTERN = /^(?<server>[A-Za-z0-9][A-Za-z0-9_-]*)\.(?<tool>[A-Za-z0-9][A-Za-z0-9_-]*)$/;
 const WORKSPACE_SERVER_ID = "workspace";
@@ -326,6 +330,20 @@ function parseMember(
 function loadGeneralConfig(config: JsonRecord, references: Record<string, string>): WorkspaceGeneralConfig {
   const agentsValue = config.agents;
   const prompt = references[DEFAULT_PROMPT_FILE] ?? "";
+
+  // `agents` is OPTIONAL: when the workspace.yaml has no `agents` key at all, fall back to
+  // the built-in default single agent (e.g. a General workspace, or a yaml only ever written
+  // by the MCP registry). A PRESENT-but-malformed `agents` is still a config error below.
+  if (agentsValue === undefined || agentsValue === null) {
+    return {
+      type: "single",
+      agent: parseMember(
+        { id: DEFAULT_AGENT_ID, model: DEFAULT_AGENT_MODEL },
+        "agents",
+        prompt
+      )
+    };
+  }
 
   if (isRecord(agentsValue)) {
     if (Object.hasOwn(agentsValue, "id") && Object.hasOwn(agentsValue, "model")) {


### PR DESCRIPTION
Follow-up polish on the "Create your own HolaApp" feature, plus two runtime fixes surfaced while testing it (an OAuth-MCP custom app against Heygen/Linear).

## Desktop — custom-app UX
- **Bare MCP URL** — paste just `https://mcp.heygen.com/mcp/v1/` (or any provider's "add custom connector" URL); no JSON blob required. The field placeholder/label now lead with the URL.
- **Auto-`https://`** — scheme-less URLs (`heygen.com`, `mcp.heygen.com/mcp/v1/`) are accepted and normalized (with a dotted-host guard so a stray word isn't mistaken for a URL). Applies to both the app URL and the MCP field.
- **Cancel = don't add** — for a headerless (OAuth) MCP app, the app is only kept if sign-in succeeds. It's saved as a `pending` draft so the MCP can attach + authorize, then rolled back if you cancel or close the dialog.
- **No-churn retries** — a cancelled sign-in keeps the same draft (same server id) so a retry reuses the SAME attached server instead of standing up a fresh one each click.
- **Real failure reasons** — the add dialog now shows the runtime's actual authorize `detail` (e.g. `EADDRINUSE`, `superseded by a newer sign-in attempt`) instead of a generic "cancelled".
- **Orphaned-draft purge** — a session killed mid-add no longer leaves stray entries: `pending` drafts are swept once at startup.

## Runtime
- **`agents` is optional** (`workspace-runtime-plan.ts`) — a `workspace.yaml` with no top-level `agents` block now defaults to the built-in single agent (`holaboss` / `gpt-5.4`, overridden per-session by the picker) instead of failing every run with `missing object field 'agents'`. A present-but-malformed `agents` is still rejected (existing tests stand; added a default-path test).
- **Single-flight authorize** (`mcp-authorize-host.ts`) — the OAuth callback binds a FIXED loopback port, so a cancelled/abandoned sign-in (which waits out its full consent timeout) held the port and the retry died with `EADDRINUSE 127.0.0.1:51703`. The api-server now SIGKILLs any in-flight authorize child (awaiting its exit so the OS frees the port) before spawning a new one, and reports "superseded" for the one it killed.

## Testing
- `turbo run typecheck` green for `holaboss-local` and `@holaboss/runtime-api-server`.
- `workspace-runtime-plan.test.ts`: 20/20 pass (added a test for the default-agent path).
- Biome clean on the touched desktop feature files (electron `main.ts` intentionally not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)