### PR TITLE
refactor(remote-api): one test context factory instead of eight copies

### DIFF
--- a/packages/remote-api/src/__tests__/authz.test.ts
+++ b/packages/remote-api/src/__tests__/authz.test.ts
@@ -1,72 +1,14 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
-import type { RemoteApiContext, RemoteApiIdentity } from "../server";
-import { remoteApiRouter } from "../server/router";
-
-const notUsed = () => {
-  throw new Error("not used");
-};
+import type { RemoteApiIdentity } from "../server";
+import { makeTestClient } from "./testContext";
 
 function makeClient(identity?: RemoteApiIdentity) {
-  const context: RemoteApiContext = {
+  return makeTestClient({
     memory: {
       search: (input) => ({ ok: true, workspaceId: input.workspaceId }),
-      get: notUsed,
-      upsert: notUsed,
-      status: notUsed,
-      sync: notUsed,
-      browseTree: notUsed,
-      readFile: notUsed,
-      readNodeDetail: notUsed,
-      browseGraph: notUsed,
-    },
-    outputs: { list: notUsed },
-    notifications: { list: notUsed, update: notUsed },
-    cronjobs: {
-      list: notUsed,
-      runNow: notUsed,
-      create: notUsed,
-      update: notUsed,
-      delete: notUsed,
-    },
-    skills: {
-      catalog: () => ({ skills: [] }),
-      install: () => {
-        throw new Error("not used");
-      },
-      importUpload: () => {
-        throw new Error("not used");
-      },
-    },
-    channels: {
-      list: () => ({ channels: [], count: 0 }),
-      validate: () => ({ ok: false, bot_username: null, error: null }),
-      startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-      pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-      create: () => {
-        throw new Error("not used");
-      },
-      delete: () => ({ success: true }),
-      setModel: () => {
-        throw new Error("not used");
-      },
-      setHarness: () => {
-        throw new Error("not used");
-      },
-      listSessions: () => ({ sessions: [], count: 0 }),
-    },
-    capabilities: {
-      catalog: notUsed,
-      listInstalled: notUsed,
-      install: notUsed,
-      create: notUsed,
-      importPlugin: notUsed,
-      uninstall: notUsed,
-      toggle: notUsed,
     },
     identity,
-  };
-  return createRouterClient(remoteApiRouter, { context });
+  });
 }
 
 describe("remoteApiRouter authz seam", () => {

--- a/packages/remote-api/src/__tests__/capabilities.test.ts
+++ b/packages/remote-api/src/__tests__/capabilities.test.ts
@@ -1,24 +1,7 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
-import type { CapabilitiesService, RemoteApiContext } from "../server";
+import type { CapabilitiesService } from "../server";
+import { makeTestClient } from "./testContext";
 import { CapabilitiesServiceError } from "../server";
-import { remoteApiRouter } from "../server/router";
-
-const notUsed = () => {
-  throw new Error("not used");
-};
-
-const memoryStub: RemoteApiContext["memory"] = {
-  search: notUsed,
-  get: notUsed,
-  upsert: notUsed,
-  status: notUsed,
-  sync: notUsed,
-  browseTree: notUsed,
-  readFile: notUsed,
-  readNodeDetail: notUsed,
-  browseGraph: notUsed,
-};
 
 function makeWorkspaceCapability(workspaceId: string, capabilityId: string) {
   return {
@@ -66,43 +49,7 @@ function makeCapabilities(): CapabilitiesService {
 }
 
 function makeClient(capabilities: CapabilitiesService) {
-  return createRouterClient(remoteApiRouter, {
-    context: {
-      memory: memoryStub,
-      outputs: { list: () => ({ items: [] }) },
-      notifications: { list: () => ({ items: [], count: 0 }), update: notUsed },
-      cronjobs: {
-        list: () => ({ jobs: [], count: 0 }),
-        runNow: notUsed,
-        create: notUsed,
-        update: notUsed,
-        delete: () => ({ success: true }),
-      },
-      skills: {
-        catalog: () => ({ skills: [] }),
-        install: notUsed,
-        importUpload: notUsed,
-      },
-      channels: {
-        list: () => ({ channels: [], count: 0 }),
-        validate: () => ({ ok: false, bot_username: null, error: null }),
-        startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-        pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-        create: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-        setModel: () => {
-          throw new Error("not used");
-        },
-        setHarness: () => {
-          throw new Error("not used");
-        },
-        listSessions: () => ({ sessions: [], count: 0 }),
-      },
-      capabilities,
-    },
-  });
+  return makeTestClient({ capabilities });
 }
 
 describe("remoteApiRouter.capabilities", () => {

--- a/packages/remote-api/src/__tests__/cronjobs.test.ts
+++ b/packages/remote-api/src/__tests__/cronjobs.test.ts
@@ -1,4 +1,3 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
 import { remoteApiRouter } from "../server/router";
 import {
@@ -7,6 +6,7 @@ import {
   type CronjobsService,
   type RemoteApiContext,
 } from "../server";
+import { makeTestClient } from "./testContext";
 
 const memoryStub: RemoteApiContext["memory"] = {
   search: () => ({}),
@@ -86,56 +86,8 @@ function makeCronjobs(): CronjobsService {
 }
 
 function makeClient() {
-  return createRouterClient(remoteApiRouter, {
-    context: {
-      memory: memoryStub,
-      outputs: outputsStub,
-      notifications: notificationsStub,
-      cronjobs: makeCronjobs(),
-      skills: {
-        catalog: () => ({ skills: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        importUpload: () => {
-          throw new Error("not used");
-        },
-      },
-      channels: {
-        list: () => ({ channels: [], count: 0 }),
-        validate: () => ({ ok: false, bot_username: null, error: null }),
-        startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-        pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-        create: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-        setModel: () => {
-          throw new Error("not used");
-        },
-        setHarness: () => {
-          throw new Error("not used");
-        },
-        listSessions: () => ({ sessions: [], count: 0 }),
-      },
-      capabilities: {
-        catalog: () => ({ capabilities: [] }),
-        listInstalled: () => ({ capabilities: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        importPlugin: () => {
-          throw new Error("not used");
-        },
-        uninstall: () => ({ removed: false }),
-        toggle: () => {
-          throw new Error("not used");
-        },
-      },
-    },
+  return makeTestClient({
+    cronjobs: makeCronjobs(),
   });
 }
 

--- a/packages/remote-api/src/__tests__/mcp-http.test.ts
+++ b/packages/remote-api/src/__tests__/mcp-http.test.ts
@@ -7,26 +7,13 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRemoteApiMcpServer } from "../mcp";
 import type { RemoteApiContext, RemoteApiIdentity } from "../server";
-
-const notUsed = () => {
-  throw new Error("not used");
-};
+import { makeTestContext } from "./testContext";
 
 function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
-  return {
-    memory: {
-      search: notUsed,
-      get: notUsed,
-      upsert: notUsed,
-      status: notUsed,
-      sync: notUsed,
-      browseTree: notUsed,
-      readFile: notUsed,
-      readNodeDetail: notUsed,
-      browseGraph: notUsed,
-    },
+  return makeTestContext({
+    memory: { search: (input) => ({ ok: true, workspaceId: input.workspaceId }) },
     outputs: {
-      list: (input) => ({
+      list: () => ({
         items: [
           {
             id: "out_1",
@@ -51,51 +38,8 @@ function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
         ],
       }),
     },
-    notifications: { list: notUsed, update: notUsed },
-    cronjobs: {
-      list: notUsed,
-      runNow: notUsed,
-      create: notUsed,
-      update: notUsed,
-      delete: notUsed,
-    },
-    skills: {
-      catalog: () => ({ skills: [] }),
-      install: () => {
-        throw new Error("not used");
-      },
-      importUpload: () => {
-        throw new Error("not used");
-      },
-    },
-    channels: {
-      list: () => ({ channels: [], count: 0 }),
-      validate: () => ({ ok: false, bot_username: null, error: null }),
-      startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-      pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-      create: () => {
-        throw new Error("not used");
-      },
-      delete: () => ({ success: true }),
-      setModel: () => {
-        throw new Error("not used");
-      },
-      setHarness: () => {
-        throw new Error("not used");
-      },
-      listSessions: () => ({ sessions: [], count: 0 }),
-    },
-    capabilities: {
-      catalog: notUsed,
-      listInstalled: notUsed,
-      install: notUsed,
-      create: notUsed,
-      importPlugin: notUsed,
-      uninstall: notUsed,
-      toggle: notUsed,
-    },
     identity,
-  };
+  });
 }
 
 // A real Streamable-HTTP MCP endpoint over a localhost server, driven by a real

--- a/packages/remote-api/src/__tests__/mcp.test.ts
+++ b/packages/remote-api/src/__tests__/mcp.test.ts
@@ -3,26 +3,13 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
 import { createRemoteApiMcpServer } from "../mcp";
 import type { RemoteApiContext, RemoteApiIdentity } from "../server";
-
-const notUsed = () => {
-  throw new Error("not used");
-};
+import { makeTestContext } from "./testContext";
 
 function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
-  return {
-    memory: {
-      search: notUsed,
-      get: notUsed,
-      upsert: notUsed,
-      status: notUsed,
-      sync: notUsed,
-      browseTree: notUsed,
-      readFile: notUsed,
-      readNodeDetail: notUsed,
-      browseGraph: notUsed,
-    },
+  return makeTestContext({
+    memory: { search: (input) => ({ ok: true, workspaceId: input.workspaceId }) },
     outputs: {
-      list: (input) => ({
+      list: () => ({
         items: [
           {
             id: "out_1",
@@ -47,51 +34,8 @@ function makeContext(identity?: RemoteApiIdentity): RemoteApiContext {
         ],
       }),
     },
-    notifications: { list: notUsed, update: notUsed },
-    cronjobs: {
-      list: notUsed,
-      runNow: notUsed,
-      create: notUsed,
-      update: notUsed,
-      delete: notUsed,
-    },
-    skills: {
-      catalog: () => ({ skills: [] }),
-      install: () => {
-        throw new Error("not used");
-      },
-      importUpload: () => {
-        throw new Error("not used");
-      },
-    },
-    channels: {
-      list: () => ({ channels: [], count: 0 }),
-      validate: () => ({ ok: false, bot_username: null, error: null }),
-      startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-      pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-      create: () => {
-        throw new Error("not used");
-      },
-      delete: () => ({ success: true }),
-      setModel: () => {
-        throw new Error("not used");
-      },
-      setHarness: () => {
-        throw new Error("not used");
-      },
-      listSessions: () => ({ sessions: [], count: 0 }),
-    },
-    capabilities: {
-      catalog: notUsed,
-      listInstalled: notUsed,
-      install: notUsed,
-      create: notUsed,
-      importPlugin: notUsed,
-      uninstall: notUsed,
-      toggle: notUsed,
-    },
     identity,
-  };
+  });
 }
 
 async function connect(context: RemoteApiContext) {

--- a/packages/remote-api/src/__tests__/memory.test.ts
+++ b/packages/remote-api/src/__tests__/memory.test.ts
@@ -1,7 +1,7 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
 import { remoteApiRouter } from "../server/router";
 import type { MemoryService } from "../server";
+import { makeTestClient } from "./testContext";
 
 function makeMemory(): MemoryService {
   return {
@@ -22,73 +22,8 @@ function makeMemory(): MemoryService {
 }
 
 function makeClient() {
-  return createRouterClient(remoteApiRouter, {
-    context: {
-      memory: makeMemory(),
-      outputs: { list: () => ({ items: [] }) },
-      notifications: {
-        list: () => ({ items: [], count: 0 }),
-        update: () => {
-          throw new Error("not used");
-        },
-      },
-      cronjobs: {
-        list: () => ({ jobs: [], count: 0 }),
-        runNow: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        update: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-      },
-      skills: {
-        catalog: () => ({ skills: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        importUpload: () => {
-          throw new Error("not used");
-        },
-      },
-      channels: {
-        list: () => ({ channels: [], count: 0 }),
-        validate: () => ({ ok: false, bot_username: null, error: null }),
-        startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-        pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-        create: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-        setModel: () => {
-          throw new Error("not used");
-        },
-        setHarness: () => {
-          throw new Error("not used");
-        },
-        listSessions: () => ({ sessions: [], count: 0 }),
-      },
-      capabilities: {
-        catalog: () => ({ capabilities: [] }),
-        listInstalled: () => ({ capabilities: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        importPlugin: () => {
-          throw new Error("not used");
-        },
-        uninstall: () => ({ removed: false }),
-        toggle: () => {
-          throw new Error("not used");
-        },
-      },
-    },
+  return makeTestClient({
+    memory: makeMemory(),
   });
 }
 

--- a/packages/remote-api/src/__tests__/notifications.test.ts
+++ b/packages/remote-api/src/__tests__/notifications.test.ts
@@ -1,4 +1,3 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
 import { remoteApiRouter } from "../server/router";
 import {
@@ -7,6 +6,7 @@ import {
   type NotificationRecord,
   type RemoteApiContext,
 } from "../server";
+import { makeTestClient } from "./testContext";
 
 const memoryStub: RemoteApiContext["memory"] = {
   search: () => ({}),
@@ -65,68 +65,8 @@ function makeNotifications(): NotificationsService {
 }
 
 function makeClient() {
-  return createRouterClient(remoteApiRouter, {
-    context: {
-      memory: memoryStub,
-      outputs: outputsStub,
-      notifications: makeNotifications(),
-      cronjobs: {
-        list: () => ({ jobs: [], count: 0 }),
-        runNow: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        update: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-      },
-      skills: {
-        catalog: () => ({ skills: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        importUpload: () => {
-          throw new Error("not used");
-        },
-      },
-      channels: {
-        list: () => ({ channels: [], count: 0 }),
-        validate: () => ({ ok: false, bot_username: null, error: null }),
-        startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-        pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-        create: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-        setModel: () => {
-          throw new Error("not used");
-        },
-        setHarness: () => {
-          throw new Error("not used");
-        },
-        listSessions: () => ({ sessions: [], count: 0 }),
-      },
-      capabilities: {
-        catalog: () => ({ capabilities: [] }),
-        listInstalled: () => ({ capabilities: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        importPlugin: () => {
-          throw new Error("not used");
-        },
-        uninstall: () => ({ removed: false }),
-        toggle: () => {
-          throw new Error("not used");
-        },
-      },
-    },
+  return makeTestClient({
+    notifications: makeNotifications(),
   });
 }
 

--- a/packages/remote-api/src/__tests__/outputs.test.ts
+++ b/packages/remote-api/src/__tests__/outputs.test.ts
@@ -1,7 +1,7 @@
-import { createRouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
 import { remoteApiRouter } from "../server/router";
 import type { OutputsService, RemoteApiContext } from "../server";
+import { makeTestClient } from "./testContext";
 
 const memoryStub: RemoteApiContext["memory"] = {
   search: () => ({}),
@@ -45,73 +45,8 @@ function makeOutputs(): OutputsService {
 }
 
 function makeClient() {
-  return createRouterClient(remoteApiRouter, {
-    context: {
-      memory: memoryStub,
-      outputs: makeOutputs(),
-      notifications: {
-        list: () => ({ items: [], count: 0 }),
-        update: () => {
-          throw new Error("not used");
-        },
-      },
-      cronjobs: {
-        list: () => ({ jobs: [], count: 0 }),
-        runNow: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        update: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-      },
-      skills: {
-        catalog: () => ({ skills: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        importUpload: () => {
-          throw new Error("not used");
-        },
-      },
-      channels: {
-        list: () => ({ channels: [], count: 0 }),
-        validate: () => ({ ok: false, bot_username: null, error: null }),
-        startDeviceAuth: () => ({ device_code: "", qr_url: "", interval_sec: 5, expires_in_sec: 600 }),
-        pollDeviceAuth: () => ({ status: "pending" as const, connection: null }),
-        create: () => {
-          throw new Error("not used");
-        },
-        delete: () => ({ success: true }),
-        setModel: () => {
-          throw new Error("not used");
-        },
-        setHarness: () => {
-          throw new Error("not used");
-        },
-        listSessions: () => ({ sessions: [], count: 0 }),
-      },
-      capabilities: {
-        catalog: () => ({ capabilities: [] }),
-        listInstalled: () => ({ capabilities: [] }),
-        install: () => {
-          throw new Error("not used");
-        },
-        create: () => {
-          throw new Error("not used");
-        },
-        importPlugin: () => {
-          throw new Error("not used");
-        },
-        uninstall: () => ({ removed: false }),
-        toggle: () => {
-          throw new Error("not used");
-        },
-      },
-    },
+  return makeTestClient({
+    outputs: makeOutputs(),
   });
 }
 

--- a/packages/remote-api/src/__tests__/testContext.ts
+++ b/packages/remote-api/src/__tests__/testContext.ts
@@ -1,0 +1,94 @@
+import { createRouterClient } from "@orpc/server";
+import type { RemoteApiContext, RemoteApiIdentity } from "../server";
+import { remoteApiRouter } from "../server/router";
+
+/**
+ * A whole RemoteApiContext where every method throws, so a test only has to
+ * describe the handful of calls it actually exercises.
+ *
+ * Before this, each test file declared the full context inline. That is eight
+ * copies of a shape the router owns, which meant adding one method to a service
+ * interface failed eight files at tsc — none of which cared about the method.
+ *
+ * The throwing default is the point: a call the test did not plan for fails
+ * loudly at the call rather than quietly returning an empty list.
+ */
+export function notUsed(): never {
+  throw new Error("not used");
+}
+
+/** Per-service partial — override only the methods under test. */
+export type TestContextOverrides = {
+  [K in keyof Omit<RemoteApiContext, "identity">]?: Partial<RemoteApiContext[K]>;
+} & { identity?: RemoteApiIdentity };
+
+function baseContext(): Omit<RemoteApiContext, "identity"> {
+  return {
+    memory: {
+      search: notUsed,
+      get: notUsed,
+      upsert: notUsed,
+      status: notUsed,
+      sync: notUsed,
+      browseTree: notUsed,
+      readFile: notUsed,
+      readNodeDetail: notUsed,
+      browseGraph: notUsed,
+    },
+    outputs: { list: notUsed },
+    notifications: { list: notUsed, update: notUsed },
+    cronjobs: {
+      list: notUsed,
+      runNow: notUsed,
+      create: notUsed,
+      update: notUsed,
+      delete: notUsed,
+    },
+    skills: { catalog: notUsed, install: notUsed, importUpload: notUsed },
+    channels: {
+      list: notUsed,
+      validate: notUsed,
+      startDeviceAuth: notUsed,
+      pollDeviceAuth: notUsed,
+      create: notUsed,
+      delete: notUsed,
+      setModel: notUsed,
+      setHarness: notUsed,
+      listSessions: notUsed,
+    },
+    capabilities: {
+      catalog: notUsed,
+      listInstalled: notUsed,
+      install: notUsed,
+      create: notUsed,
+      importPlugin: notUsed,
+      uninstall: notUsed,
+      toggle: notUsed,
+    },
+  };
+}
+
+export function makeTestContext(
+  overrides: TestContextOverrides = {},
+): RemoteApiContext {
+  const base = baseContext();
+  // Merged one service at a time rather than in a loop: a keyed loop widens the
+  // value type past what tsc will spread, and being explicit costs one line each.
+  return {
+    memory: { ...base.memory, ...overrides.memory },
+    outputs: { ...base.outputs, ...overrides.outputs },
+    notifications: { ...base.notifications, ...overrides.notifications },
+    cronjobs: { ...base.cronjobs, ...overrides.cronjobs },
+    skills: { ...base.skills, ...overrides.skills },
+    channels: { ...base.channels, ...overrides.channels },
+    capabilities: { ...base.capabilities, ...overrides.capabilities },
+    identity: overrides.identity,
+  };
+}
+
+/** The common case: a router client over a context built from `overrides`. */
+export function makeTestClient(overrides: TestContextOverrides = {}) {
+  return createRouterClient(remoteApiRouter, {
+    context: makeTestContext(overrides),
+  });
+}


### PR DESCRIPTION
## Why

Every test file in the package declared the whole `RemoteApiContext` inline — seven services of mostly-throwing stubs — in order to exercise one of them. Eight copies of a shape the router already owns.

The cost showed up in #438: adding one method to `SkillsCatalogService` failed all eight files at `tsc`, none of which cared about the method. That repeats on the next service method.

## What

`makeTestContext(overrides)` builds the full context with every method throwing, and takes a per-service partial so a file describes only the calls it makes. `makeTestClient(overrides)` wraps it in a router client for the common case.

```ts
// capabilities.test.ts, before: ~40 lines of context
function makeClient(capabilities: CapabilitiesService) {
  return makeTestClient({ capabilities });
}
```

**−490 / +123** across nine files.

## The throwing default earns its keep

A call the test didn't plan for now fails at the call, instead of quietly returning an empty list from a stub nobody meant as fixture data.

That flushed out a real dependency during the migration: `mcp.test.ts` and `mcp-http.test.ts` were green because their inline context happened to declare an `outputs.list` returning one item — it read as boilerplate but was load-bearing. It's an explicit override now, so the next reader can see the test depends on it.

Method: migrate each file keeping only the service it is named after, run, add back whatever actually breaks. Only those two did.

## Tests

- `bunx turbo run typecheck test build --filter=@holaboss/remote-api …` — the exact `packages` CI job — 11/11
- 28/28, same count as before