### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/apps/desktop/src/components/settings/BYOKSettingsPanel.tsx
+++ b/apps/desktop/src/components/settings/BYOKSettingsPanel.tsx
@@ -29,6 +29,11 @@ import {
   saveOrgProviderModels,
 } from "@/lib/app-sdk-client";
 import { useOrganizations } from "@/lib/auth/useOrganizations";
+import {
+  CUSTOM_PROVIDER_PRESET_ID,
+  PROVIDER_FORM_PRESETS,
+  providerFormPreset,
+} from "@/lib/providerFormPresets";
 import { type ProviderBrand, ProviderBrandIcon } from "@/lib/providerBrandIcon";
 import { cn } from "@/lib/utils";
 import { SettingsCard } from "./SettingsCard";
@@ -447,6 +452,7 @@ function CreateProviderForm({
   onDone: () => void;
 }) {
   const queryClient = useQueryClient();
+  const [presetId, setPresetId] = useState(CUSTOM_PROVIDER_PRESET_ID);
   const [name, setName] = useState("");
   const [type, setType] = useState<string>(CUSTOM_TYPES[0].value);
   const [apiKey, setApiKey] = useState("");
@@ -455,7 +461,17 @@ function CreateProviderForm({
   const [error, setError] = useState<string | null>(null);
 
   const placeholder =
-    CUSTOM_TYPES.find((t) => t.value === type)?.placeholder ?? "sk-…";
+    presetId === CUSTOM_PROVIDER_PRESET_ID
+      ? (CUSTOM_TYPES.find((t) => t.value === type)?.placeholder ?? "sk-…")
+      : providerFormPreset(presetId).keyPlaceholder;
+
+  const applyPreset = (nextPresetId: string) => {
+    const preset = providerFormPreset(nextPresetId);
+    setPresetId(preset.id);
+    setName(preset.displayName);
+    setType(preset.providerType);
+    setApiHost(preset.apiHost);
+  };
 
   const create = useMutation({
     mutationFn: () => {
@@ -492,6 +508,29 @@ function CreateProviderForm({
         </Button>
       </div>
       <div className="grid gap-3">
+        <div>
+          <Label htmlFor="provider-preset">Provider Preset</Label>
+          <Select
+            onValueChange={(value) =>
+              applyPreset(value ?? CUSTOM_PROVIDER_PRESET_ID)
+            }
+            value={presetId}
+          >
+            <SelectTrigger
+              className="mt-1 w-full bg-background"
+              id="provider-preset"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" className="min-w-[220px]">
+              {PROVIDER_FORM_PRESETS.map((preset) => (
+                <SelectItem key={preset.id} value={preset.id}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div>
           <Label htmlFor="provider-name">Provider Name</Label>
           <Input

--- a/apps/desktop/src/lib/providerFormPresets.test.ts
+++ b/apps/desktop/src/lib/providerFormPresets.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CUSTOM_PROVIDER_PRESET_ID,
+  providerFormPreset,
+} from "./providerFormPresets.js";
+
+test("Atlas Cloud preset uses the OpenAI-compatible endpoint", () => {
+  assert.deepEqual(providerFormPreset("atlascloud"), {
+    id: "atlascloud",
+    label: "Atlas Cloud",
+    displayName: "Atlas Cloud",
+    providerType: "openai_compatible",
+    apiHost: "https://api.atlascloud.ai/v1",
+    keyPlaceholder: "sk-…",
+  });
+});
+
+test("unknown provider presets fall back to an empty custom form", () => {
+  const preset = providerFormPreset("unknown");
+
+  assert.equal(preset.id, CUSTOM_PROVIDER_PRESET_ID);
+  assert.equal(preset.displayName, "");
+  assert.equal(preset.apiHost, "");
+});

--- a/apps/desktop/src/lib/providerFormPresets.ts
+++ b/apps/desktop/src/lib/providerFormPresets.ts
@@ -1,0 +1,36 @@
+export const CUSTOM_PROVIDER_PRESET_ID = "custom";
+
+export interface ProviderFormPreset {
+  id: string;
+  label: string;
+  displayName: string;
+  providerType: "openai_compatible" | "anthropic_compatible";
+  apiHost: string;
+  keyPlaceholder: string;
+}
+
+export const PROVIDER_FORM_PRESETS = [
+  {
+    id: CUSTOM_PROVIDER_PRESET_ID,
+    label: "Custom",
+    displayName: "",
+    providerType: "openai_compatible",
+    apiHost: "",
+    keyPlaceholder: "sk-…",
+  },
+  {
+    id: "atlascloud",
+    label: "Atlas Cloud",
+    displayName: "Atlas Cloud",
+    providerType: "openai_compatible",
+    apiHost: "https://api.atlascloud.ai/v1",
+    keyPlaceholder: "sk-…",
+  },
+] as const satisfies readonly ProviderFormPreset[];
+
+export function providerFormPreset(presetId: string): ProviderFormPreset {
+  return (
+    PROVIDER_FORM_PRESETS.find((preset) => preset.id === presetId) ??
+    PROVIDER_FORM_PRESETS[0]
+  );
+}


### PR DESCRIPTION
## Summary

- add an Atlas Cloud option to the existing custom provider preset selector
- prefill the provider name, OpenAI-compatible type, and `https://api.atlascloud.ai/v1` endpoint while keeping the API key user-supplied
- reuse the existing BYOK validation, model discovery, and runtime path instead of adding a parallel provider implementation

## Validation

- [x] `node --import tsx --test src/lib/providerFormPresets.test.ts` (2 passed)
- [x] `bun run desktop:typecheck`
- [x] `bun run build:renderer`
- [x] real Atlas Cloud `/models` request returned HTTP 200 with 125 models and `deepseek-ai/deepseek-v4-pro`
- [x] real Atlas Cloud Chat Completions request returned HTTP 200 with a non-empty response
- [ ] `bun run lint` is blocked by existing, unrelated `apps/docs` Biome diagnostics (67 errors and 163 warnings in untouched files)

Renderer build excerpt:

```text
vite v7.3.1 building client environment for production...
✓ built in 4.37s
```

## Risks

- user-visible change is limited to the Create Provider form in desktop settings
- custom provider behavior is unchanged; selecting Atlas Cloud only pre-populates existing form fields
- no database migration, Supabase branch, backend API, dependency, or lockfile changes
- a full Electron launch was not completed because the fresh install's Electron binary download stalled; targeted tests, desktop typecheck, and the renderer production build passed

## Docs

- [x] no docs update is needed because the existing BYOK settings flow already explains compatible custom providers and the preset is self-contained
