### PR TITLE
Let a PDF preview actually frame its PDF

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -599,8 +599,10 @@ const DEV_SHELL_CSP = [
   "connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss:",
   "worker-src 'self' blob:",
   // App surfaces are rendered in renderer iframes and resolve to local
-  // runtime ports such as http://localhost:38090 during development.
-  "frame-src 'self' http://localhost:* http://127.0.0.1:* https:",
+  // runtime ports such as http://localhost:38090 during development. `data:`
+  // is what a file preview frames a PDF from — the payload arrives as a data
+  // URL, the same way images and video already do under img-src/media-src.
+  "frame-src 'self' data: http://localhost:* http://127.0.0.1:* https:",
   "media-src 'self' data: blob: https:",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
The dev shell's CSP allows `data:` for images, video and fonts but not for
frames — and a PDF preview is `<iframe src="data:application/pdf;…">`
(`FilePreviewPane.tsx`, and the same shape in `FileQuickPreview`). Chrome
refused it on `frame-src`, so the pane rendered empty: no error, no fallback,
just nothing.

Verified in headless Chrome against the exact policy:

| CSP | result |
| --- | --- |
| as-is | `BLOCKED directive=frame-src` |
| `frame-src` + `data:` | `no-violation` |

Only dev is affected. The packaged shell is served over `file://`, which fires
no `onHeadersReceived` and carries no meta policy, so nothing was blocking it
there.

Split out of #450 so it isn't gated behind that branch — #450 contains the same
one-line change, which will merge as a no-op once this lands.

**Unrelated finding, not fixed here:** the comment above `DEV_SHELL_CSP` says
prod injects a strict policy at build time via `vite.config.ts`. There is no
such injection — `DEV_SHELL_CSP` is the only CSP in the repo, so packaged builds
currently run with no CSP at all. Worth its own issue.