### PR TITLE
Fingerprint (anti-detect) browser — open-core Camoufox engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ apps/docs/build/
 
 # Brainstorming/spec scratch — not tracked
 docs/superpowers/
+
+# Enterprise (licensed) fingerprint-browser engine — lives in a separate private
+# repo, loaded by the OSS core at runtime via the FingerprintBrowserEngine seam.
+# Kept OUT of the public repo; enterprise devs clone it into this path.
+packages/fingerprint-ee/

--- a/apps/desktop/electron-builder.config.cjs
+++ b/apps/desktop/electron-builder.config.cjs
@@ -141,6 +141,12 @@ const extraResources = [
     to: "icon.png"
   },
   {
+    // Handed to the fingerprint engine to re-icon the Camoufox.app bundle so a
+    // launched profile shows the holaOS icon (see fingerprintBrandIconPath).
+    from: "resources/icon.icns",
+    to: "icon.icns"
+  },
+  {
     from: "electron/blank-templates",
     to: "blank-templates"
   },

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -49,6 +49,17 @@ export interface EngineBinaryStatus {
   error?: string;
 }
 
+/**
+ * Host-product branding for the shared browser bundle (dock name + app icon). The
+ * OSS core supplies the identity; the engine stamps it onto the Camoufox.app so a
+ * launched profile presents as the product, not "Camoufox". (Product owns the
+ * brand policy; the engine owns the mechanism.)
+ */
+export interface BundleBranding {
+  name?: string;
+  icnsPath?: string;
+}
+
 export interface LaunchProfileInput {
   id: string;
   name: string;
@@ -56,6 +67,7 @@ export interface LaunchProfileInput {
   proxy?: ProfileProxy | null;
   headless?: boolean;
   userDataDir?: string;
+  branding?: BundleBranding;
 }
 
 export interface LaunchedProfileBrowser {

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -154,7 +154,8 @@ export interface ServiceKeyboardOpts {
 }
 
 export interface FingerprintServiceClient {
-  launch(input: LaunchProfileInput): Promise<{ ok: boolean }>;
+  /** `restoredTabs` = how many previous-session tabs the service reopened. */
+  launch(input: LaunchProfileInput): Promise<{ ok: boolean; restoredTabs?: number }>;
   close(id: string): Promise<void>;
   running(): Promise<string[]>;
   isLive(id: string): Promise<boolean>;

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -105,3 +105,99 @@ export async function loadFingerprintEngine(): Promise<FingerprintBrowserEngine 
 export function isFingerprintEngineAvailable(): boolean {
   return Boolean(cached);
 }
+
+// --- Standalone fingerprint SERVICE client ----------------------------------
+//
+// The full "fingerprint browser is its own app" surface: the enterprise engine
+// runs in its OWN process (crash-isolated, off the Electron main thread) and the
+// core drives it entirely over IPC through this client. Mirrors the enterprise
+// `FingerprintServiceClient`; structural typing keeps the two sides compatible.
+
+export interface ServicePageInfo {
+  url: string;
+  title: string;
+  loading: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+}
+
+export interface ServiceCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  secure: boolean;
+  httpOnly: boolean;
+  session: boolean;
+  sameSite: string;
+  expirationDate: number | null;
+}
+
+export interface ServiceKeyboardOpts {
+  action: "press" | "insert_text";
+  text?: string;
+  key?: string;
+  clear?: boolean;
+  submit?: boolean;
+}
+
+export interface FingerprintServiceClient {
+  launch(input: LaunchProfileInput): Promise<{ ok: boolean }>;
+  close(id: string): Promise<void>;
+  running(): Promise<string[]>;
+  isLive(id: string): Promise<boolean>;
+  importProfiles(bytes: Uint8Array): Promise<ImportedProfile[]>;
+  navigate(id: string, url: string, sessionId?: string | null): Promise<void>;
+  evaluate(id: string, expression: string, sessionId?: string | null): Promise<unknown>;
+  pageInfo(id: string, sessionId?: string | null): Promise<ServicePageInfo>;
+  openTab(id: string, url: string, sessionId?: string | null): Promise<ServicePageInfo>;
+  screenshot(
+    id: string,
+    options?: { fullPage?: boolean; format?: "png" | "jpeg"; quality?: number },
+    sessionId?: string | null,
+  ): Promise<Buffer>;
+  mouse(
+    id: string,
+    x: number,
+    y: number,
+    action: "click" | "double_click" | "hover" | "context",
+    sessionId?: string | null,
+  ): Promise<void>;
+  keyboard(id: string, opts: ServiceKeyboardOpts, sessionId?: string | null): Promise<void>;
+  cookies(
+    id: string,
+    filter: { url?: string; name?: string; domain?: string },
+    sessionId?: string | null,
+  ): Promise<ServiceCookie[]>;
+  setCookie(id: string, cookie: Record<string, unknown>): Promise<void>;
+  addCookies(id: string, cookies: EngineCookie[]): Promise<{ added: number }>;
+  onRunningChanged(cb: (ids: string[]) => void): void;
+  dispose(): void;
+}
+
+interface EnterpriseServiceModule {
+  createFingerprintServiceClient(): FingerprintServiceClient;
+}
+
+let cachedService: FingerprintServiceClient | null | undefined;
+
+/**
+ * Spawn (once) and return the enterprise fingerprint service, or null when the
+ * licensed package is absent (OSS builds). Cached — the service process is a
+ * singleton for the app's lifetime.
+ */
+export async function loadFingerprintService(): Promise<FingerprintServiceClient | null> {
+  if (cachedService !== undefined) {
+    return cachedService;
+  }
+  try {
+    const mod = (await import(ENTERPRISE_MODULE_ID)) as EnterpriseServiceModule;
+    cachedService =
+      typeof mod.createFingerprintServiceClient === "function"
+        ? mod.createFingerprintServiceClient()
+        : null;
+  } catch {
+    cachedService = null;
+  }
+  return cachedService;
+}

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -191,6 +191,15 @@ interface EnterpriseServiceModule {
   createFingerprintServiceClient(): FingerprintServiceClient;
 }
 
+// A subpath into the enterprise package that pulls ONLY the lightweight service
+// CLIENT (a `fork()` wrapper — ~2ms to load). We deliberately DON'T import the
+// package barrel here: its `createCamoufoxEngine` re-export eagerly evaluates
+// camoufox-js + exceljs + playwright (~0.5s) on the MAIN thread, which the main
+// process never needs (all that runs in the forked service). Importing the barrel
+// on a Launch click is what stalls the UI. Held in a variable so bundlers treat
+// the optional package as an external runtime import.
+const ENTERPRISE_SERVICE_MODULE_ID = "@holaboss/fingerprint-ee/service-client";
+
 let cachedService: FingerprintServiceClient | null | undefined;
 
 /**
@@ -203,7 +212,7 @@ export async function loadFingerprintService(): Promise<FingerprintServiceClient
     return cachedService;
   }
   try {
-    const mod = (await import(ENTERPRISE_MODULE_ID)) as EnterpriseServiceModule;
+    const mod = (await import(ENTERPRISE_SERVICE_MODULE_ID)) as EnterpriseServiceModule;
     cachedService =
       typeof mod.createFingerprintServiceClient === "function"
         ? mod.createFingerprintServiceClient()

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -1,0 +1,107 @@
+/**
+ * Open-core SEAM for the enterprise fingerprint (anti-detect) browser engine.
+ *
+ * This file is OSS (MIT) and ships in the public core. It defines the interface
+ * an engine must satisfy and loads the LICENSED implementation
+ * (`@holaboss/fingerprint-ee`, a separate/gitignored package) at RUNTIME. When the
+ * package is absent — every plain OSS build — `loadFingerprintEngine()` returns
+ * null and callers fall back to the Contact-Sales flow. Nothing here depends on the
+ * enterprise package at build time.
+ *
+ * Build note: the import specifier is held in a variable so bundlers don't try to
+ * resolve it statically (which would break the OSS build where it's absent). The
+ * main-process bundler must treat `@holaboss/fingerprint-ee` as external/optional.
+ */
+import type { BrowserContext } from "playwright-core";
+
+import type {
+  ProfileFingerprint,
+  ProfileProxy,
+} from "../../shared/browser-pane-protocol.js";
+
+/** A cookie in the engine-neutral shape (1:1 with Playwright `addCookies`). */
+export interface EngineCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+  expires?: number;
+}
+
+/** One external identity resolved from an import source (e.g. an AdsPower export). */
+export interface ImportedProfile {
+  name: string;
+  group?: string;
+  fingerprint: ProfileFingerprint;
+  proxy?: ProfileProxy;
+  cookies: EngineCookie[];
+  startupUrls: string[];
+  warnings: string[];
+  source: "adspower";
+}
+
+export interface EngineBinaryStatus {
+  available: boolean;
+  version?: string;
+  error?: string;
+}
+
+export interface LaunchProfileInput {
+  id: string;
+  name: string;
+  fingerprint: ProfileFingerprint;
+  proxy?: ProfileProxy | null;
+  headless?: boolean;
+  userDataDir?: string;
+}
+
+export interface LaunchedProfileBrowser {
+  readonly browserType: "firefox" | "chromium";
+  /** The live, in-process persistent context to drive (same playwright-core). */
+  readonly context: BrowserContext;
+  close(): Promise<void>;
+}
+
+/** The contract the enterprise package's `createCamoufoxEngine()` satisfies. */
+export interface FingerprintBrowserEngine {
+  readonly id: string;
+  ensureBinary(): Promise<EngineBinaryStatus>;
+  launch(input: LaunchProfileInput): Promise<LaunchedProfileBrowser>;
+  importProfiles(fileBytes: Uint8Array): Promise<ImportedProfile[]>;
+}
+
+/** Shape of the enterprise package's default entry (a subset we call). */
+interface EnterpriseModule {
+  createCamoufoxEngine(): FingerprintBrowserEngine;
+}
+
+const ENTERPRISE_MODULE_ID = "@holaboss/fingerprint-ee";
+
+let cached: FingerprintBrowserEngine | null | undefined;
+
+/**
+ * Load the enterprise engine if the licensed package is present, else null.
+ * Cached after the first call (including the null result, so OSS builds don't
+ * retry the import on every profile action).
+ */
+export async function loadFingerprintEngine(): Promise<FingerprintBrowserEngine | null> {
+  if (cached !== undefined) {
+    return cached;
+  }
+  try {
+    const mod = (await import(ENTERPRISE_MODULE_ID)) as EnterpriseModule;
+    cached = typeof mod.createCamoufoxEngine === "function" ? mod.createCamoufoxEngine() : null;
+  } catch {
+    // Absent (OSS build) or failed to load → feature is off; caller shows Contact Sales.
+    cached = null;
+  }
+  return cached;
+}
+
+/** True when a licensed engine is loaded — gate main-process feature paths on this. */
+export function isFingerprintEngineAvailable(): boolean {
+  return Boolean(cached);
+}

--- a/apps/desktop/electron/browser-pane/fingerprint-presets.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-presets.ts
@@ -2,10 +2,10 @@
  * Built-in fingerprint preset library — the "pick a realistic device" gallery.
  *
  * Each preset is a COHERENT device profile (platform ↔ typical hardware/screen ↔
- * brand), deliberately WITHOUT a pinned GPU or seed: the CloakBrowser binary
- * derives a coherent GPU from platform + the profile's own seed, and each profile
- * keeps its own seed (its returning identity). `createdAt` is empty — these are
- * static, not user-created. See docs/cdp/fingerprint-profiles.md §2.3.
+ * brand), deliberately WITHOUT a pinned GPU or seed: the fingerprint engine derives
+ * a coherent GPU from platform + the profile's own seed, and each profile keeps its
+ * own seed (its returning identity). `createdAt` is empty — these are static, not
+ * user-created.
  */
 import type { FingerprintTemplate } from "../../shared/browser-pane-protocol.js";
 

--- a/apps/desktop/electron/browser-pane/fingerprint.test.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint.test.ts
@@ -3,44 +3,12 @@ import { test } from "node:test";
 
 import type { ProfileFingerprint } from "../../shared/browser-pane-protocol.js";
 import {
-  buildFingerprintArgs,
   coerceFingerprint,
   defaultFingerprint,
   sanitizeFingerprint,
   sanitizeProxy,
   validateFingerprintCoherence,
 } from "./fingerprint.js";
-
-test("buildFingerprintArgs emits the baseline + explicit overrides, omits undefined", () => {
-  const args = buildFingerprintArgs({
-    seed: 12345,
-    platform: "windows",
-    gpuVendor: "Google Inc. (NVIDIA)",
-    hardwareConcurrency: 8,
-  });
-  // No --no-sandbox: it shows a desktop infobar + is a bot tell (dropped on purpose).
-  assert.ok(!args.includes("--no-sandbox"));
-  assert.ok(args.includes("--fingerprint=12345"));
-  assert.ok(args.includes("--fingerprint-platform=windows"));
-  assert.ok(args.includes("--fingerprint-gpu-vendor=Google Inc. (NVIDIA)"));
-  assert.ok(args.includes("--fingerprint-hardware-concurrency=8"));
-  // Unset fields produce no flag.
-  assert.ok(!args.some((a) => a.startsWith("--fingerprint-device-memory")));
-  assert.ok(!args.some((a) => a.startsWith("--fingerprint-locale")));
-});
-
-test("buildFingerprintArgs only adds the noise flag when noise === false", () => {
-  assert.ok(
-    buildFingerprintArgs({ seed: 1_0000, platform: "macos", noise: false }).includes(
-      "--fingerprint-noise=false",
-    ),
-  );
-  assert.ok(
-    !buildFingerprintArgs({ seed: 1_0000, platform: "macos", noise: true }).some(
-      (a) => a.startsWith("--fingerprint-noise"),
-    ),
-  );
-});
 
 test("sanitizeFingerprint keeps well-formed fields", () => {
   const { value, warnings } = sanitizeFingerprint({

--- a/apps/desktop/electron/browser-pane/fingerprint.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint.ts
@@ -1,15 +1,14 @@
 /**
- * Pure fingerprint logic for `cloak`-engine Browser Profiles.
+ * Pure fingerprint logic for `fingerprint`-engine Browser Profiles.
  *
- * Leaf-level (no electron, no fs, no clock) so it's unit-testable and shared by
- * the launcher (main.ts turns a fingerprint into `--fingerprint-*` flags) and,
- * later, the renderer's flag preview. See docs/cdp/fingerprint-profiles.md.
+ * Leaf-level (no electron, no fs, no clock) so it's unit-testable — the sanitize
+ * gate + the coherence check, shared by the import/edit paths and the editor.
  *
- * SECURITY: every fingerprint field is interpolated into a browser command-line
- * flag. `sanitizeFingerprint` is the mandatory gate on ALL set-paths (import,
- * paste, adapter, manual edit) — key-whitelist + enum + range-clamp + charset +
- * length caps — so an untrusted template can never inject a flag or a
- * pathological value. `buildFingerprintArgs` assumes it was given sanitized data.
+ * SECURITY: every fingerprint field eventually reaches the fingerprint engine
+ * (Camoufox config, applied out-of-process). `sanitizeFingerprint` is the
+ * mandatory gate on ALL set-paths (import, paste, adapter, manual edit) —
+ * key-whitelist + enum + range-clamp + charset + length caps — so an untrusted
+ * template can never inject a pathological value.
  */
 import type {
   FingerprintBrand,
@@ -29,48 +28,6 @@ const BRANDS: readonly FingerprintBrand[] = [
   "Opera",
   "Vivaldi",
 ];
-
-// --- Flag builder -----------------------------------------------------------
-
-/**
- * Materialise a (sanitized) fingerprint into CloakBrowser stealth flags. Omitted
- * fields fall through to seed-derived binary defaults. `--fingerprint` +
- * `--fingerprint-platform` are the baseline.
- *
- * We deliberately do NOT emit `--no-sandbox` (CloakBrowser's Docker/Linux-root
- * default): on a headed desktop it shows an "unsupported command-line flag"
- * infobar, disables the sandbox, and is itself a bot tell — the exact opposite of
- * what a stealth browser wants. The binary runs sandboxed fine on macOS/Windows.
- */
-export function buildFingerprintArgs(fp: ProfileFingerprint): string[] {
-  const args = [
-    `--fingerprint=${fp.seed}`,
-    `--fingerprint-platform=${fp.platform}`,
-  ];
-  const push = (flag: string, value: unknown) => {
-    if (value !== undefined && value !== "") {
-      args.push(`${flag}=${value}`);
-    }
-  };
-  push("--fingerprint-gpu-vendor", fp.gpuVendor);
-  push("--fingerprint-gpu-renderer", fp.gpuRenderer);
-  push("--fingerprint-hardware-concurrency", fp.hardwareConcurrency);
-  push("--fingerprint-device-memory", fp.deviceMemory);
-  push("--fingerprint-screen-width", fp.screenWidth);
-  push("--fingerprint-screen-height", fp.screenHeight);
-  push("--fingerprint-brand", fp.brand);
-  push("--fingerprint-brand-version", fp.brandVersion);
-  push("--fingerprint-platform-version", fp.platformVersion);
-  push("--fingerprint-timezone", fp.timezone);
-  push("--fingerprint-locale", fp.locale);
-  push("--fingerprint-storage-quota", fp.storageQuota);
-  push("--fingerprint-fonts-dir", fp.fontsDir);
-  push("--fingerprint-webrtc-ip", fp.webrtcIp);
-  if (fp.noise === false) {
-    args.push("--fingerprint-noise=false");
-  }
-  return args;
-}
 
 /** A minimal fingerprint: just an identity seed + a platform. */
 export function defaultFingerprint(

--- a/apps/desktop/electron/browser-pane/profile-store.test.ts
+++ b/apps/desktop/electron/browser-pane/profile-store.test.ts
@@ -258,7 +258,8 @@ test("normalizeBrowserProfileIndex preserves engine/fingerprint/proxy and saniti
     ],
   });
   const p = getBrowserProfile(normalized, idA);
-  assert.equal(p?.engine, "cloak");
+  // The legacy CloakBrowser-era "cloak" value migrates to "fingerprint" on load.
+  assert.equal(p?.engine, "fingerprint");
   assert.equal(p?.fingerprint?.seed, 42069);
   assert.equal(p?.fingerprint?.brand, "Chrome");
   assert.equal(p?.fingerprint?.gpuVendor, undefined); // sanitized out

--- a/apps/desktop/electron/browser-pane/profile-store.ts
+++ b/apps/desktop/electron/browser-pane/profile-store.ts
@@ -73,9 +73,12 @@ export function normalizeBrowserProfileIndex(raw: unknown): BrowserProfileIndex 
     const source: BrowserProfileSource =
       candidate.source === "imported" ? "imported" : "created";
     const engine =
-      candidate.engine === "cloak" || candidate.engine === "system"
-        ? candidate.engine
-        : undefined;
+      // Persisted data may carry the legacy CloakBrowser-era value — migrate it.
+      (candidate.engine as string) === "cloak"
+        ? "fingerprint"
+        : candidate.engine === "fingerprint" || candidate.engine === "system"
+          ? candidate.engine
+          : undefined;
     // Re-validate on load: a persisted fingerprint/proxy is untrusted input too.
     const fingerprint = candidate.fingerprint
       ? coerceFingerprint(candidate.fingerprint)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20148,7 +20148,7 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       if (engineRunningIds.has(profileId)) {
         return true;
       }
-      if (getBrowserProfile(browserProfileIndex, profileId)?.engine === "cloak") {
+      if (getBrowserProfile(browserProfileIndex, profileId)?.engine === "fingerprint") {
         const result = await launchProfileChromium(profileId, "about:blank");
         return result.ok && engineRunningIds.has(profileId);
       }
@@ -24741,7 +24741,7 @@ function profileChromeUserDataDir(
     // newer system Chrome stamped — Chromium SIGTRAPs on the version downgrade.
     // The two engines' cookies are encrypted differently anyway (§8: cloak = a
     // fresh identity), so separate dirs are correct, not just a crash workaround.
-    engine === "cloak" ? "cloak" : "chrome",
+    engine === "fingerprint" ? "fingerprint" : "chrome",
   );
 }
 
@@ -24869,7 +24869,7 @@ function resolveCloakBinary(): string | null {
 
 /** The browser binary for a profile: Cloak for `cloak`, else system Chrome. */
 function resolveProfileBrowserBinary(profile: BrowserProfile | null): string | null {
-  if (profile?.engine === "cloak") {
+  if (profile?.engine === "fingerprint") {
     return resolveCloakBinary();
   }
   return findChromiumBinary(profile ? profileLaunchFamily(profile.id) : null);
@@ -24920,7 +24920,7 @@ async function setBrowserProfileEngine(
       p.id === profileId ? { ...p, engine } : p,
     ),
   };
-  if (engine === "cloak") {
+  if (engine === "fingerprint") {
     browserProfileIndex = ensureProfileFingerprint(
       browserProfileIndex,
       profileId,
@@ -24955,7 +24955,7 @@ async function setBrowserProfileFingerprint(
     profile.fingerprint?.platform ??
     hostFingerprintPlatform();
   const fingerprint: ProfileFingerprint = { ...value, seed, platform };
-  const updated: BrowserProfile = { ...profile, engine: "cloak", fingerprint };
+  const updated: BrowserProfile = { ...profile, engine: "fingerprint", fingerprint };
   browserProfileIndex = {
     ...browserProfileIndex,
     profiles: browserProfileIndex.profiles.map((p) =>
@@ -25022,7 +25022,7 @@ async function importFingerprintBrowserProfiles(
       ...browserProfileIndex,
       profiles: browserProfileIndex.profiles.map((p) =>
         p.id === id
-          ? { ...p, engine: "cloak", fingerprint, ...(proxy ? { proxy } : {}) }
+          ? { ...p, engine: "fingerprint", fingerprint, ...(proxy ? { proxy } : {}) }
           : p,
       ),
     };
@@ -25031,7 +25031,7 @@ async function importFingerprintBrowserProfiles(
     // is structurally the pending `TransferableCookie` shape.
     if (entry.cookies.length > 0) {
       await writePendingImportedCookies(
-        profileChromeUserDataDir(id, "cloak"),
+        profileChromeUserDataDir(id, "fingerprint"),
         entry.cookies,
       );
     }
@@ -25103,7 +25103,7 @@ async function launchEngineProfile(
     return { ok: true };
   }
 
-  const userDataDir = profileChromeUserDataDir(profileId, "cloak");
+  const userDataDir = profileChromeUserDataDir(profileId, "fingerprint");
   await fs.mkdir(userDataDir, { recursive: true });
 
   try {
@@ -25153,10 +25153,10 @@ async function launchProfileChromium(
   const profile = getBrowserProfile(browserProfileIndex, profileId);
   // `cloak` profiles run through the enterprise fingerprint engine (Camoufox),
   // not the detached-Chrome path below.
-  if (profile && profile.engine === "cloak") {
+  if (profile && profile.engine === "fingerprint") {
     return launchEngineProfile(profileId, profile, url);
   }
-  const isCloak = profile?.engine === "cloak";
+  const isCloak = profile?.engine === "fingerprint";
   const binary = resolveProfileBrowserBinary(profile);
   if (!binary) {
     return {
@@ -26663,7 +26663,7 @@ app.whenReady().then(async () => {
     async (_event, profileId: string, engine: ProfileEngine) => {
       await setBrowserProfileEngine(
         profileId,
-        engine === "cloak" ? "cloak" : "system",
+        engine === "fingerprint" ? "fingerprint" : "system",
       );
       return listBrowserProfilePayloads();
     },

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -25027,18 +25027,16 @@ async function launchEngineProfile(
         "The fingerprint browser is an enterprise feature and isn't available in this build.",
     };
   }
-  // A named URL wins (agent drive / open-tab); a plain human Launch lands on the
-  // leak-check page so the identity is verifiable the moment the browser opens.
-  const landingUrl = safeChromiumPositionalUrl(
+  // A caller-named URL (agent drive / open-tab) always wins over restore/landing.
+  const namedUrl =
     typeof url === "string" && url.trim()
-      ? url.trim()
-      : FINGERPRINT_DEFAULT_LANDING_URL,
-  );
+      ? safeChromiumPositionalUrl(url.trim())
+      : null;
 
-  // Already running (per the service): open the URL as a new tab.
+  // Already running (per the service): open the named URL as a new tab.
   if (engineRunningIds.has(profileId)) {
-    if (typeof url === "string" && url.trim()) {
-      await service.openTab(profileId, landingUrl).catch(() => {});
+    if (namedUrl) {
+      await service.openTab(profileId, namedUrl).catch(() => {});
     }
     return { ok: true };
   }
@@ -25046,8 +25044,9 @@ async function launchEngineProfile(
   const userDataDir = profileChromeUserDataDir(profileId, "fingerprint");
   await fs.mkdir(userDataDir, { recursive: true });
 
+  let launchResult: { ok: boolean; restoredTabs?: number };
   try {
-    await service.launch({
+    launchResult = await service.launch({
       id: profileId,
       name: profile.name,
       fingerprint: profile.fingerprint ?? {
@@ -25084,7 +25083,16 @@ async function launchEngineProfile(
   } catch {
     // Best-effort; leave the pending file so a later launch can retry.
   }
-  await service.navigate(profileId, landingUrl).catch(() => {});
+  // Where to land: a named URL wins; otherwise the service has already reopened
+  // the previous session's tabs — only fall back to the leak-check page when there
+  // was nothing to restore (a brand-new profile).
+  if (namedUrl) {
+    await service.navigate(profileId, namedUrl).catch(() => {});
+  } else if (!launchResult.restoredTabs) {
+    await service
+      .navigate(profileId, safeChromiumPositionalUrl(FINGERPRINT_DEFAULT_LANDING_URL))
+      .catch(() => {});
+  }
 
   emitProfilesRunning();
   return { ok: true };

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -234,7 +234,6 @@ import {
   setDefaultBrowserProfile,
 } from "./browser-pane/profile-store.js";
 import {
-  buildFingerprintArgs,
   FINGERPRINT_SEED_MAX,
   FINGERPRINT_SEED_MIN,
   sanitizeFingerprint,
@@ -24802,14 +24801,13 @@ async function openUrlInProfileWindow(
   }
 }
 
-// --- Fingerprint (cloak) engine plumbing ------------------------------------
-// A `cloak` profile spawns the CloakBrowser stealth binary (instead of system
-// Chrome) with the profile's persisted fingerprint as `--fingerprint-*` flags,
-// then drives it over CDP exactly like a `system` profile. See
-// docs/cdp/fingerprint-profiles.md.
+// --- Fingerprint identity helpers -------------------------------------------
+// `fingerprint`-engine profiles run OUT-OF-PROCESS in the fingerprint service
+// (see launchEngineProfile). Only these small seed helpers, used when creating /
+// backfilling a profile's identity, live here.
 
-/** The fingerprint platform to seed a new cloak profile with — the host OS, so
- *  we never spoof Windows-on-Mac by default (a font/GPU mismatch tell). */
+/** The fingerprint platform to seed a new profile with — the host OS, so we never
+ *  spoof Windows-on-Mac by default (a font/GPU mismatch tell). */
 function hostFingerprintPlatform(): FingerprintPlatform {
   if (process.platform === "win32") {
     return "windows";
@@ -24825,81 +24823,9 @@ function randomFingerprintSeed(): number {
   return FINGERPRINT_SEED_MIN + Math.floor(Math.random() * span);
 }
 
-/** The stealth executable inside a `~/.cloakbrowser/chromium-<ver>` dir. */
-function cloakExecutableInDir(dir: string): string {
-  if (process.platform === "darwin") {
-    return path.join(dir, "Chromium.app", "Contents", "MacOS", "Chromium");
-  }
-  if (process.platform === "win32") {
-    return path.join(dir, "chrome.exe");
-  }
-  return path.join(dir, "chrome");
-}
-
-/**
- * Resolve the CloakBrowser stealth-Chromium binary: an explicit
- * `CLOAKBROWSER_BINARY_PATH` override, else the newest managed binary under
- * `~/.cloakbrowser/chromium-*` (downloaded by the cloakbrowser CLI). Null when
- * none is installed — the launcher surfaces an actionable error.
- */
-function resolveCloakBinary(): string | null {
-  const override = process.env.CLOAKBROWSER_BINARY_PATH;
-  if (override && existsSync(override)) {
-    return override;
-  }
-  const cacheDir = path.join(os.homedir(), ".cloakbrowser");
-  let entries: string[];
-  try {
-    entries = readdirSync(cacheDir);
-  } catch {
-    return null;
-  }
-  const dirs = entries
-    .filter((d) => d.startsWith("chromium-"))
-    .sort()
-    .reverse(); // newest version dir first
-  for (const d of dirs) {
-    const bin = cloakExecutableInDir(path.join(cacheDir, d));
-    if (existsSync(bin)) {
-      return bin;
-    }
-  }
-  return null;
-}
-
-/** The browser binary for a profile: Cloak for `cloak`, else system Chrome. */
+/** The browser binary for a (system) profile — the OS Chrome/Chromium/Edge/Brave. */
 function resolveProfileBrowserBinary(profile: BrowserProfile | null): string | null {
-  if (profile?.engine === "fingerprint") {
-    return resolveCloakBinary();
-  }
   return findChromiumBinary(profile ? profileLaunchFamily(profile.id) : null);
-}
-
-/**
- * Fingerprint (+ proxy) spawn args for a cloak profile. Seeds a stable
- * fingerprint on first launch (host platform; the user can re-spoof in the UI),
- * persisting it so the identity is a returning one.
- */
-async function ensureCloakFingerprintArgs(profileId: string): Promise<string[]> {
-  let profile = getBrowserProfile(browserProfileIndex, profileId);
-  if (profile && !profile.fingerprint) {
-    browserProfileIndex = ensureProfileFingerprint(
-      browserProfileIndex,
-      profileId,
-      randomFingerprintSeed(),
-      hostFingerprintPlatform(),
-    );
-    await saveBrowserProfiles();
-    profile = getBrowserProfile(browserProfileIndex, profileId);
-  }
-  if (!profile?.fingerprint) {
-    return [];
-  }
-  const args = buildFingerprintArgs(profile.fingerprint);
-  if (profile.proxy?.server) {
-    args.push(`--proxy-server=${profile.proxy.server}`);
-  }
-  return args;
 }
 
 /**
@@ -25156,18 +25082,14 @@ async function launchProfileChromium(
   if (profile && profile.engine === "fingerprint") {
     return launchEngineProfile(profileId, profile, url);
   }
-  const isCloak = profile?.engine === "fingerprint";
   const binary = resolveProfileBrowserBinary(profile);
   if (!binary) {
     return {
       ok: false,
-      error: isCloak
-        ? "CloakBrowser stealth binary not found. Set CLOAKBROWSER_BINARY_PATH, or install it (see docs/cdp/fingerprint-profiles.md)."
-        : "No Chrome / Chromium / Edge / Brave found. Install Google Chrome to use browser profiles.",
+      error:
+        "No Chrome / Chromium / Edge / Brave found. Install Google Chrome to use browser profiles.",
     };
   }
-  // A cloak profile spawns with its persisted fingerprint (seeded on first use).
-  const stealthArgs = isCloak ? await ensureCloakFingerprintArgs(profileId) : [];
   const userDataDir = profileChromeUserDataDir(profileId, profile?.engine);
   await fs.mkdir(userDataDir, { recursive: true });
   // Security: reject non-http(s)/about landing URLs and dash-prefixed argv
@@ -25235,7 +25157,6 @@ async function launchProfileChromium(
       `--remote-debugging-port=${port}`,
       "--no-first-run",
       "--no-default-browser-check",
-      ...stealthArgs,
       "--new-window",
       // `--` terminates flag parsing so the (validated) URL can never be read
       // as a Chromium flag.
@@ -26655,8 +26576,8 @@ app.whenReady().then(async () => {
       return importFingerprintBrowserProfiles(bytes);
     },
   );
-  // Opt a profile into the CloakBrowser fingerprint engine (or back to system
-  // Chrome). Switching to `cloak` seeds a fingerprint so the next launch spoofs.
+  // Opt a profile into the fingerprint (anti-detect) engine, or back to system
+  // Chrome. Switching seeds a fingerprint so the next launch spoofs.
   handleTrustedIpc(
     "profiles:setEngine",
     ["main"],
@@ -26676,8 +26597,8 @@ app.whenReady().then(async () => {
       return listBrowserProfilePayloads();
     },
   );
-  // Preview the flags + coherence warnings for an in-progress fingerprint edit
-  // (the editor's live preview) — pure, persists nothing.
+  // Coherence warnings for an in-progress fingerprint edit (the editor's live
+  // check) — pure, persists nothing.
   handleTrustedIpc(
     "profiles:previewFingerprint",
     ["main"],
@@ -26688,10 +26609,7 @@ app.whenReady().then(async () => {
         seed: typeof value.seed === "number" ? value.seed : FINGERPRINT_SEED_MIN,
         platform: value.platform ?? "windows",
       };
-      return {
-        args: buildFingerprintArgs(fingerprint),
-        warnings: validateFingerprintCoherence(fingerprint),
-      };
+      return { warnings: validateFingerprintCoherence(fingerprint) };
     },
   );
   // Fingerprint templates: built-in presets + user-saved/imported, reusable

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -346,6 +346,11 @@ const verboseTelemetryEnabled =
 const chromiumStderrLoggingEnabled =
   process.env.HOLABOSS_CHROMIUM_STDERR_LOGS?.trim() === "1";
 const HOME_URL = "https://www.google.com";
+// A fingerprint (anti-detect) profile lands here on a plain human Launch, so you
+// immediately see how the identity presents — IP/WebRTC/DNS leaks, timezone
+// coherence, canvas/WebGL, bot detection. Overridable per launch (a named URL) and
+// skipped for agent auto-launches (they land on about:blank to claim the tab).
+const FINGERPRINT_DEFAULT_LANDING_URL = "https://www.browserscan.net";
 const AUTH_POPUP_WIDTH = 380;
 const AUTH_POPUP_HEIGHT = 460;
 const AUTH_POPUP_CLOSE_DELAY_MS = 260;
@@ -25017,8 +25022,12 @@ async function launchEngineProfile(
         "The fingerprint browser is an enterprise feature and isn't available in this build.",
     };
   }
+  // A named URL wins (agent drive / open-tab); a plain human Launch lands on the
+  // leak-check page so the identity is verifiable the moment the browser opens.
   const landingUrl = safeChromiumPositionalUrl(
-    typeof url === "string" && url.trim() ? url.trim() : HOME_URL,
+    typeof url === "string" && url.trim()
+      ? url.trim()
+      : FINGERPRINT_DEFAULT_LANDING_URL,
   );
 
   // Already running (per the service): open the URL as a new tab.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -238,8 +238,13 @@ import {
   FINGERPRINT_SEED_MAX,
   FINGERPRINT_SEED_MIN,
   sanitizeFingerprint,
+  sanitizeProxy,
   validateFingerprintCoherence,
 } from "./browser-pane/fingerprint.js";
+import {
+  type LaunchedProfileBrowser,
+  loadFingerprintEngine,
+} from "./browser-pane/fingerprint-engine-seam.js";
 import {
   addFingerprintTemplate,
   emptyFingerprintTemplateIndex,
@@ -274,6 +279,7 @@ import {
   profileCdpScreenshot,
   profileCdpSetCookie,
   profileCdpTryAdopt,
+  registerProfileContext,
 } from "./profile-cdp.js";
 import type {
   BrowserProfile,
@@ -24370,6 +24376,23 @@ interface ProfileChromeInstance {
 
 const profileChromeInstances = new Map<string, ProfileChromeInstance>();
 
+// Engine-backed (`cloak`) profiles run a DIFFERENT lifecycle from the detached-
+// Chrome model above: the enterprise engine (Camoufox) owns a browser SERVER we
+// attach to over a ws endpoint (`LaunchedProfileBrowser`), so there's no spawned
+// proc and nothing to adopt by a fixed CDP port. Tracked separately; the browser
+// is registered under the profile's debug port so the SAME `profileCdp*` drive
+// path (agent + human) reaches it via `profileChromiumPort` → `connect`.
+interface EngineProfileInstance {
+  handle: LaunchedProfileBrowser;
+  port: number;
+}
+const engineProfileInstances = new Map<string, EngineProfileInstance>();
+
+/** A cloak/engine profile is running while its persistent context is open (tracked). */
+function engineProfileRunning(profileId: string): boolean {
+  return engineProfileInstances.has(profileId);
+}
+
 /**
  * Resolve the STABLE, collision-free remote-debugging port for a profile,
  * persisting it onto the catalogue the first time (see
@@ -24888,6 +24911,85 @@ async function setBrowserProfileFingerprint(
 }
 
 /**
+ * Import fingerprint profiles from an anti-detect export (AdsPower `.xlsx`) via
+ * the enterprise engine seam. Each row becomes a `cloak` profile carrying its
+ * fingerprint + proxy; its cookies are staged for injection on first launch
+ * (reusing the pending-cookies path). Requires the licensed engine
+ * (`loadFingerprintEngine`); OSS builds return an actionable error.
+ */
+async function importFingerprintBrowserProfiles(
+  fileBytes: Uint8Array,
+): Promise<{ ok: boolean; error?: string; imported: number; warnings: string[] }> {
+  const engine = await loadFingerprintEngine();
+  if (!engine) {
+    return {
+      ok: false,
+      error:
+        "The fingerprint browser is an enterprise feature and isn't available in this build.",
+      imported: 0,
+      warnings: [],
+    };
+  }
+  let parsed;
+  try {
+    parsed = await engine.importProfiles(fileBytes);
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Couldn't read that file: ${(error as Error).message}`,
+      imported: 0,
+      warnings: [],
+    };
+  }
+
+  const warnings: string[] = [];
+  let imported = 0;
+  for (const entry of parsed) {
+    const id = `${BROWSER_PROFILE_ID_PREFIX}${randomUUID()}`;
+    const { index } = addBrowserProfile(browserProfileIndex, {
+      id,
+      name: entry.name,
+      now: new Date().toISOString(),
+      source: "imported",
+      importedFrom: entry.group ? `AdsPower · ${entry.group}` : "AdsPower",
+    });
+    browserProfileIndex = index;
+
+    // Re-sanitize the (untrusted) imported fingerprint/proxy before persisting.
+    const { value } = sanitizeFingerprint(entry.fingerprint);
+    const fingerprint: ProfileFingerprint = {
+      ...value,
+      seed: typeof value.seed === "number" ? value.seed : randomFingerprintSeed(),
+      platform: value.platform ?? hostFingerprintPlatform(),
+    };
+    const proxy = entry.proxy ? sanitizeProxy(entry.proxy) : null;
+    browserProfileIndex = {
+      ...browserProfileIndex,
+      profiles: browserProfileIndex.profiles.map((p) =>
+        p.id === id
+          ? { ...p, engine: "cloak", fingerprint, ...(proxy ? { proxy } : {}) }
+          : p,
+      ),
+    };
+
+    // Stage the session cookies for injection on first launch. `EngineCookie`
+    // is structurally the pending `TransferableCookie` shape.
+    if (entry.cookies.length > 0) {
+      await writePendingImportedCookies(
+        profileChromeUserDataDir(id, "cloak"),
+        entry.cookies,
+      );
+    }
+    for (const w of entry.warnings) {
+      warnings.push(`${entry.name}: ${w}`);
+    }
+    imported += 1;
+  }
+  await saveBrowserProfiles();
+  return { ok: true, imported, warnings };
+}
+
+/**
  * One-time seed of an imported profile's login on Windows: inject the decrypted
  * cookies captured from the source at import time (see cdp-cookie-transfer.ts)
  * into the freshly-launched profile over CDP, then clear the pending file. The
@@ -24914,11 +25016,113 @@ async function seedPendingImportedCookies(
   }
 }
 
+/**
+ * Launch a `cloak` profile through the enterprise fingerprint engine (Camoufox):
+ * start its browser server, attach over the ws endpoint (registered under the
+ * profile's debug port so the shared `profileCdp*` drive path reaches it), inject
+ * any staged import cookies into the live context, and open the landing URL.
+ * Tracked in `engineProfileInstances`. Reuses the running browser (opens a tab)
+ * when already live; no detached proc, so no adopt-across-restart.
+ */
+async function launchEngineProfile(
+  profileId: string,
+  profile: BrowserProfile,
+  url?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const engine = await loadFingerprintEngine();
+  if (!engine) {
+    return {
+      ok: false,
+      error:
+        "The fingerprint browser is an enterprise feature and isn't available in this build.",
+    };
+  }
+  const landingUrl = safeChromiumPositionalUrl(
+    typeof url === "string" && url.trim() ? url.trim() : HOME_URL,
+  );
+
+  // Already running: open the URL as a new tab in the existing context.
+  const live = engineProfileInstances.get(profileId);
+  if (live) {
+    if (typeof url === "string" && url.trim()) {
+      await profileCdpOpenTab(profileId, live.port, landingUrl).catch(() => {});
+    }
+    return { ok: true };
+  }
+
+  const port = await resolveProfileDebugPort(profileId);
+  const userDataDir = profileChromeUserDataDir(profileId, "cloak");
+  await fs.mkdir(userDataDir, { recursive: true });
+
+  let handle: LaunchedProfileBrowser;
+  try {
+    handle = await engine.launch({
+      id: profileId,
+      name: profile.name,
+      fingerprint: profile.fingerprint ?? {
+        seed: randomFingerprintSeed(),
+        platform: hostFingerprintPlatform(),
+      },
+      proxy: profile.proxy ?? null,
+      headless: false,
+      userDataDir,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Couldn't start the fingerprint browser: ${(error as Error).message}`,
+    };
+  }
+
+  // The engine hands us the live persistent context; register it so the whole
+  // profileCdp* drive path (agent + human) reaches it via the profile's port.
+  registerProfileContext(profileId, handle.context, port);
+  engineProfileInstances.set(profileId, { handle, port });
+  handle.context.on("close", () => {
+    if (engineProfileInstances.get(profileId)?.handle === handle) {
+      engineProfileInstances.delete(profileId);
+      void handle.close().catch(() => {});
+    }
+    // Window closed (user quit / crash) → flip the row back to Launch.
+    emitProfilesRunning();
+  });
+
+  // First launch after an import: seed the staged cookies into the context (they
+  // then persist in the profile's user_data_dir). Open the landing page in the
+  // context's initial tab.
+  try {
+    const pending = await readPendingImportedCookies(userDataDir);
+    if (pending.length > 0) {
+      await handle.context.addCookies(pending);
+      await clearPendingImportedCookies(userDataDir);
+    }
+  } catch {
+    // Best-effort; leave the pending file so a later launch can retry.
+  }
+  try {
+    const page =
+      handle.context.pages()[0] ?? (await handle.context.newPage());
+    await page
+      .goto(landingUrl, { waitUntil: "domcontentloaded", timeout: 30000 })
+      .catch(() => {});
+  } catch {
+    // A window with no page is still usable; the agent opens tabs on demand.
+  }
+
+  emitProfilesRunning();
+  return { ok: true };
+}
+
 async function launchProfileChromium(
   profileId: string,
   url?: string,
 ): Promise<{ ok: boolean; error?: string }> {
   const profile = getBrowserProfile(browserProfileIndex, profileId);
+  // `cloak` profiles run through the enterprise fingerprint engine (Camoufox),
+  // not the detached-Chrome path below.
+  if (profile && profile.engine === "cloak") {
+    return launchEngineProfile(profileId, profile, url);
+  }
   const isCloak = profile?.engine === "cloak";
   const binary = resolveProfileBrowserBinary(profile);
   if (!binary) {
@@ -25042,11 +25246,20 @@ function runningProfileChromiumIds(): string[] {
       ids.push(id);
     }
   }
+  for (const id of engineProfileInstances.keys()) {
+    if (engineProfileRunning(id) && !ids.includes(id)) {
+      ids.push(id);
+    }
+  }
   return ids;
 }
 
 /** The remote-debugging port of a profile's LIVE Chromium, or null if not running. */
 function profileChromiumPort(profileId: string): number | null {
+  const engineInstance = engineProfileInstances.get(profileId);
+  if (engineInstance) {
+    return engineInstance.port;
+  }
   const instance = profileChromeInstances.get(profileId);
   return instance && profileChromeInstanceRunning(instance)
     ? instance.port
@@ -25188,6 +25401,17 @@ setInterval(() => {
  * during shutdown can't spawn a second instance on the same user-data-dir.
  */
 function closeProfileChromium(profileId: string): { ok: boolean } {
+  // Engine-backed (cloak) profile: drop the CDP link + close the browser server
+  // (which also tears down the proxy relay). The 'disconnected' handler clears the
+  // instance, but delete eagerly so a re-launch doesn't see a dead entry.
+  const engineInstance = engineProfileInstances.get(profileId);
+  if (engineInstance) {
+    engineProfileInstances.delete(profileId);
+    disconnectProfileCdp(profileId);
+    void engineInstance.handle.close().catch(() => {});
+    emitProfilesRunning();
+    return { ok: true };
+  }
   const existing = profileChromeInstances.get(profileId);
   if (!existing) {
     return { ok: true };
@@ -26391,6 +26615,18 @@ app.whenReady().then(async () => {
         name?: string | null;
       },
     ) => importBrowserProfileAsNewProfile(payload),
+  );
+  // Import fingerprint profiles from an anti-detect export (AdsPower .xlsx). The
+  // renderer reads the picked file to bytes and passes them here; the enterprise
+  // engine parses them into cloak profiles (fingerprint + proxy + staged cookies).
+  handleTrustedIpc(
+    "profiles:importSpreadsheet",
+    ["main"],
+    async (_event, fileBytes: ArrayBuffer | Uint8Array) => {
+      const bytes =
+        fileBytes instanceof Uint8Array ? fileBytes : new Uint8Array(fileBytes);
+      return importFingerprintBrowserProfiles(bytes);
+    },
   );
   // Opt a profile into the CloakBrowser fingerprint engine (or back to system
   // Chrome). Switching to `cloak` seeds a fingerprint so the next launch spoofs.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -351,6 +351,11 @@ const HOME_URL = "https://www.google.com";
 // coherence, canvas/WebGL, bot detection. Overridable per launch (a named URL) and
 // skipped for agent auto-launches (they land on about:blank to claim the tab).
 const FINGERPRINT_DEFAULT_LANDING_URL = "https://www.browserscan.net";
+// A launched fingerprint profile presents as the host product (not "Camoufox") in
+// the macOS dock / menu bar — the engine stamps this name + icon onto the shared
+// Camoufox.app bundle (see @holaboss/fingerprint-ee brand.ts). One constant to
+// change if we ever want a distinct browser sub-brand (e.g. "holaOS Browser").
+const FINGERPRINT_BROWSER_BRAND_NAME = "holaOS";
 const AUTH_POPUP_WIDTH = 380;
 const AUTH_POPUP_HEIGHT = 460;
 const AUTH_POPUP_CLOSE_DELAY_MS = 260;
@@ -25052,6 +25057,10 @@ async function launchEngineProfile(
       proxy: profile.proxy ?? null,
       headless: false,
       userDataDir,
+      branding: {
+        name: FINGERPRINT_BROWSER_BRAND_NAME,
+        icnsPath: fingerprintBrandIconPath(),
+      },
     });
   } catch (error) {
     return {
@@ -25868,6 +25877,15 @@ function desktopAppIconPath(): string {
   return app.isPackaged
     ? path.join(process.resourcesPath, "icon.png")
     : path.join(__dirname, "..", "..", "resources", "icon.png");
+}
+
+// The `.icns` handed to the fingerprint engine to re-icon the Camoufox.app bundle
+// (the dock icon of a launched profile). Bundled to `process.resourcesPath` via
+// electron-builder `extraResources`; the repo copy in dev.
+function fingerprintBrandIconPath(): string {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, "icon.icns")
+    : path.join(__dirname, "..", "..", "resources", "icon.icns");
 }
 
 function desktopStatusItemIconPath(): string {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -242,8 +242,8 @@ import {
   validateFingerprintCoherence,
 } from "./browser-pane/fingerprint.js";
 import {
-  type LaunchedProfileBrowser,
-  loadFingerprintEngine,
+  type FingerprintServiceClient,
+  loadFingerprintService,
 } from "./browser-pane/fingerprint-engine-seam.js";
 import {
   addFingerprintTemplate,
@@ -279,7 +279,6 @@ import {
   profileCdpScreenshot,
   profileCdpSetCookie,
   profileCdpTryAdopt,
-  registerProfileContext,
 } from "./profile-cdp.js";
 import type {
   BrowserProfile,
@@ -20133,28 +20132,31 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
   // control service routes its low-level ops to that real window over CDP
   // instead of the embedded Electron BrowserView.
   profileCdp: {
-    isLive: (profileId) => profileChromiumPort(profileId) !== null,
+    isLive: (profileId) =>
+      engineRunningIds.has(profileId) || profileChromiumPort(profileId) !== null,
     // Auto-launch on first drive: a browser tool targeting a not-yet-running
-    // profile spawns its real Chromium, so browsing always drives a profile
-    // window (the CDP connect retries until Chrome's debug port is listening).
-    // Land on about:blank (not HOME_URL) so the first drive CLAIMS that blank
-    // landing tab (see profile-cdp `activePage`) instead of opening a second tab
-    // and leaving a stray home page behind. Human-initiated launches (Browsers
-    // page / browser_launch_profile) still land on HOME_URL.
+    // profile spawns its real Chromium (or, for a cloak profile, starts it in the
+    // fingerprint service), so browsing always drives a profile window. Land on
+    // about:blank (not HOME_URL) so the first drive CLAIMS that blank landing tab
+    // (see profile-cdp / service `activePage`) instead of opening a second tab and
+    // leaving a stray home page behind.
     ensureLive: async (profileId) => {
       if (!isBrowserProfileId(profileId)) {
         return false;
       }
+      // Engine (cloak) profile → run through the fingerprint service.
+      if (engineRunningIds.has(profileId)) {
+        return true;
+      }
+      if (getBrowserProfile(browserProfileIndex, profileId)?.engine === "cloak") {
+        const result = await launchProfileChromium(profileId, "about:blank");
+        return result.ok && engineRunningIds.has(profileId);
+      }
       const trackedPort = profileChromiumPort(profileId);
       if (trackedPort !== null) {
-        // A SPAWNED instance we own is trustworthy — if its Chrome had died, the
-        // proc's exit would already have cleared the tracked port. But an ADOPTED
-        // instance (proc:null) counts as "running" forever, so a Chrome that has
-        // since been closed/crashed would be driven on a dead port: every call
-        // ECONNREFUSEs and the connect layer burns ~20s before failing, with no
-        // relaunch. For an adopted instance, relaunch when its port is
-        // DEFINITIVELY refused — never on a transient stall, so we don't tear
-        // down a live-but-busy browser mid-session.
+        // A SPAWNED instance we own is trustworthy. An ADOPTED instance
+        // (proc:null) counts as running forever, so relaunch only when its port is
+        // DEFINITIVELY refused — never on a transient stall.
         const instance = profileChromeInstances.get(profileId);
         const staleAdopted =
           instance?.proc === null &&
@@ -20173,6 +20175,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return result.ok && profileChromiumPort(profileId) !== null;
     },
     openTab: (profileId, url, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().openTab(profileId, url, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20180,6 +20185,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpOpenTab(profileId, port, url, sessionId);
     },
     evaluate: (profileId, expression, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().evaluate(profileId, expression, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20187,6 +20195,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpEvaluate(profileId, port, expression, sessionId);
     },
     pageInfo: (profileId, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().pageInfo(profileId, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20194,6 +20205,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpPageInfo(profileId, port, sessionId);
     },
     navigate: (profileId, url, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().navigate(profileId, url, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20201,6 +20215,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpNavigate(profileId, port, url, sessionId);
     },
     screenshot: (profileId, options, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().screenshot(profileId, options, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20208,6 +20225,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpScreenshot(profileId, port, options, sessionId);
     },
     mouse: (profileId, x, y, action, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().mouse(profileId, x, y, action, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20215,6 +20235,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpMouse(profileId, port, x, y, action, sessionId);
     },
     keyboard: (profileId, options, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().keyboard(profileId, options, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20222,6 +20245,9 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpKeyboard(profileId, port, options, sessionId);
     },
     cookies: (profileId, filter, sessionId) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().cookies(profileId, filter, sessionId);
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -20229,6 +20255,12 @@ const browserHttpService: BrowserHttpService = createBrowserHttpService({
       return profileCdpCookies(profileId, port, filter, sessionId);
     },
     setCookie: (profileId, cookie) => {
+      if (engineRunningIds.has(profileId)) {
+        return fingerprintServiceOrThrow().setCookie(
+          profileId,
+          cookie as Record<string, unknown>,
+        );
+      }
       const port = profileChromiumPort(profileId);
       if (port === null) {
         throw new Error("The profile browser is not running.");
@@ -24376,21 +24408,44 @@ interface ProfileChromeInstance {
 
 const profileChromeInstances = new Map<string, ProfileChromeInstance>();
 
-// Engine-backed (`cloak`) profiles run a DIFFERENT lifecycle from the detached-
-// Chrome model above: the enterprise engine (Camoufox) owns a browser SERVER we
-// attach to over a ws endpoint (`LaunchedProfileBrowser`), so there's no spawned
-// proc and nothing to adopt by a fixed CDP port. Tracked separately; the browser
-// is registered under the profile's debug port so the SAME `profileCdp*` drive
-// path (agent + human) reaches it via `profileChromiumPort` → `connect`.
-interface EngineProfileInstance {
-  handle: LaunchedProfileBrowser;
-  port: number;
-}
-const engineProfileInstances = new Map<string, EngineProfileInstance>();
+// The fingerprint browser runs as its OWN process (see fingerprint-engine-seam
+// `loadFingerprintService`): a cloak profile's Camoufox + relay + driving all live
+// there, and the core drives it over IPC. We track the loaded client + the set of
+// running engine profiles (kept in sync by the service's `onRunningChanged`).
+let fingerprintService: FingerprintServiceClient | null = null;
+const engineRunningIds = new Set<string>();
 
-/** A cloak/engine profile is running while its persistent context is open (tracked). */
+/** Load the fingerprint service once + subscribe to its running-set changes. */
+async function ensureFingerprintService(): Promise<FingerprintServiceClient | null> {
+  if (fingerprintService) {
+    return fingerprintService;
+  }
+  const client = await loadFingerprintService();
+  if (!client) {
+    return null;
+  }
+  fingerprintService = client;
+  client.onRunningChanged((ids) => {
+    engineRunningIds.clear();
+    for (const id of ids) {
+      engineRunningIds.add(id);
+    }
+    emitProfilesRunning();
+  });
+  return client;
+}
+
+/** The loaded fingerprint service, or throw — call sites gate on `engineRunningIds`. */
+function fingerprintServiceOrThrow(): FingerprintServiceClient {
+  if (!fingerprintService) {
+    throw new Error("The fingerprint browser is not running.");
+  }
+  return fingerprintService;
+}
+
+/** A cloak/engine profile is running while the service reports it running. */
 function engineProfileRunning(profileId: string): boolean {
-  return engineProfileInstances.has(profileId);
+  return engineRunningIds.has(profileId);
 }
 
 /**
@@ -24915,13 +24970,13 @@ async function setBrowserProfileFingerprint(
  * the enterprise engine seam. Each row becomes a `cloak` profile carrying its
  * fingerprint + proxy; its cookies are staged for injection on first launch
  * (reusing the pending-cookies path). Requires the licensed engine
- * (`loadFingerprintEngine`); OSS builds return an actionable error.
+ * (`loadFingerprintService`); OSS builds return an actionable error.
  */
 async function importFingerprintBrowserProfiles(
   fileBytes: Uint8Array,
 ): Promise<{ ok: boolean; error?: string; imported: number; warnings: string[] }> {
-  const engine = await loadFingerprintEngine();
-  if (!engine) {
+  const service = await ensureFingerprintService();
+  if (!service) {
     return {
       ok: false,
       error:
@@ -24932,7 +24987,7 @@ async function importFingerprintBrowserProfiles(
   }
   let parsed;
   try {
-    parsed = await engine.importProfiles(fileBytes);
+    parsed = await service.importProfiles(fileBytes);
   } catch (error) {
     return {
       ok: false,
@@ -25017,20 +25072,19 @@ async function seedPendingImportedCookies(
 }
 
 /**
- * Launch a `cloak` profile through the enterprise fingerprint engine (Camoufox):
- * start its browser server, attach over the ws endpoint (registered under the
- * profile's debug port so the shared `profileCdp*` drive path reaches it), inject
- * any staged import cookies into the live context, and open the landing URL.
- * Tracked in `engineProfileInstances`. Reuses the running browser (opens a tab)
- * when already live; no detached proc, so no adopt-across-restart.
+ * Launch a `cloak` profile through the fingerprint SERVICE (its own process):
+ * the service starts Camoufox (persistent context) + the relay + driving; the core
+ * then injects any staged import cookies and opens the landing URL over IPC.
+ * Tracked in `engineRunningIds` (kept in sync by the service). Reuses the running
+ * browser (opens a tab) when already live.
  */
 async function launchEngineProfile(
   profileId: string,
   profile: BrowserProfile,
   url?: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const engine = await loadFingerprintEngine();
-  if (!engine) {
+  const service = await ensureFingerprintService();
+  if (!service) {
     return {
       ok: false,
       error:
@@ -25041,22 +25095,19 @@ async function launchEngineProfile(
     typeof url === "string" && url.trim() ? url.trim() : HOME_URL,
   );
 
-  // Already running: open the URL as a new tab in the existing context.
-  const live = engineProfileInstances.get(profileId);
-  if (live) {
+  // Already running (per the service): open the URL as a new tab.
+  if (engineRunningIds.has(profileId)) {
     if (typeof url === "string" && url.trim()) {
-      await profileCdpOpenTab(profileId, live.port, landingUrl).catch(() => {});
+      await service.openTab(profileId, landingUrl).catch(() => {});
     }
     return { ok: true };
   }
 
-  const port = await resolveProfileDebugPort(profileId);
   const userDataDir = profileChromeUserDataDir(profileId, "cloak");
   await fs.mkdir(userDataDir, { recursive: true });
 
-  let handle: LaunchedProfileBrowser;
   try {
-    handle = await engine.launch({
+    await service.launch({
       id: profileId,
       name: profile.name,
       fingerprint: profile.fingerprint ?? {
@@ -25073,41 +25124,23 @@ async function launchEngineProfile(
       error: `Couldn't start the fingerprint browser: ${(error as Error).message}`,
     };
   }
+  // Mark running eagerly so a drive call right after launch routes to the service
+  // (the service's runningChanged notification confirms it a beat later).
+  engineRunningIds.add(profileId);
 
-  // The engine hands us the live persistent context; register it so the whole
-  // profileCdp* drive path (agent + human) reaches it via the profile's port.
-  registerProfileContext(profileId, handle.context, port);
-  engineProfileInstances.set(profileId, { handle, port });
-  handle.context.on("close", () => {
-    if (engineProfileInstances.get(profileId)?.handle === handle) {
-      engineProfileInstances.delete(profileId);
-      void handle.close().catch(() => {});
-    }
-    // Window closed (user quit / crash) → flip the row back to Launch.
-    emitProfilesRunning();
-  });
-
-  // First launch after an import: seed the staged cookies into the context (they
-  // then persist in the profile's user_data_dir). Open the landing page in the
-  // context's initial tab.
+  // First launch after an import: seed the staged cookies into the persistent
+  // context (they then persist in the profile's user_data_dir), then open the
+  // landing page — all inside the service process.
   try {
     const pending = await readPendingImportedCookies(userDataDir);
     if (pending.length > 0) {
-      await handle.context.addCookies(pending);
+      await service.addCookies(profileId, pending);
       await clearPendingImportedCookies(userDataDir);
     }
   } catch {
     // Best-effort; leave the pending file so a later launch can retry.
   }
-  try {
-    const page =
-      handle.context.pages()[0] ?? (await handle.context.newPage());
-    await page
-      .goto(landingUrl, { waitUntil: "domcontentloaded", timeout: 30000 })
-      .catch(() => {});
-  } catch {
-    // A window with no page is still usable; the agent opens tabs on demand.
-  }
+  await service.navigate(profileId, landingUrl).catch(() => {});
 
   emitProfilesRunning();
   return { ok: true };
@@ -25246,8 +25279,8 @@ function runningProfileChromiumIds(): string[] {
       ids.push(id);
     }
   }
-  for (const id of engineProfileInstances.keys()) {
-    if (engineProfileRunning(id) && !ids.includes(id)) {
+  for (const id of engineRunningIds) {
+    if (!ids.includes(id)) {
       ids.push(id);
     }
   }
@@ -25256,10 +25289,6 @@ function runningProfileChromiumIds(): string[] {
 
 /** The remote-debugging port of a profile's LIVE Chromium, or null if not running. */
 function profileChromiumPort(profileId: string): number | null {
-  const engineInstance = engineProfileInstances.get(profileId);
-  if (engineInstance) {
-    return engineInstance.port;
-  }
   const instance = profileChromeInstances.get(profileId);
   return instance && profileChromeInstanceRunning(instance)
     ? instance.port
@@ -25401,14 +25430,12 @@ setInterval(() => {
  * during shutdown can't spawn a second instance on the same user-data-dir.
  */
 function closeProfileChromium(profileId: string): { ok: boolean } {
-  // Engine-backed (cloak) profile: drop the CDP link + close the browser server
-  // (which also tears down the proxy relay). The 'disconnected' handler clears the
-  // instance, but delete eagerly so a re-launch doesn't see a dead entry.
-  const engineInstance = engineProfileInstances.get(profileId);
-  if (engineInstance) {
-    engineProfileInstances.delete(profileId);
-    disconnectProfileCdp(profileId);
-    void engineInstance.handle.close().catch(() => {});
+  // Engine-backed (cloak) profile: the service owns the browser + relay; tell it to
+  // close. Delete eagerly so a re-launch doesn't see a stale entry (the service's
+  // runningChanged confirms).
+  if (engineRunningIds.has(profileId)) {
+    engineRunningIds.delete(profileId);
+    void fingerprintService?.close(profileId).catch(() => {});
     emitProfilesRunning();
     return { ok: true };
   }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3080,6 +3080,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
 				"profiles:import",
 				payload,
 			) as Promise<ProfileImportResultPayload>,
+		importSpreadsheet: (fileBytes: ArrayBuffer) =>
+			ipcRenderer.invoke("profiles:importSpreadsheet", fileBytes) as Promise<{
+				ok: boolean;
+				error?: string;
+				imported: number;
+				warnings: string[];
+			}>,
 		close: (profileId: string) =>
 			ipcRenderer.invoke("profiles:close", profileId) as Promise<{
 				ok: boolean;

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -254,7 +254,7 @@ interface BrowserProfilePayload {
 	createdAt: string;
 	source: string;
 	importedFrom?: string;
-	engine?: "system" | "cloak";
+	engine?: "system" | "fingerprint";
 	fingerprint?: FingerprintPayload;
 	proxy?: ProfileProxyPayload;
 }
@@ -3093,7 +3093,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			}>,
 		runningIds: () =>
 			ipcRenderer.invoke("profiles:runningIds") as Promise<string[]>,
-		setEngine: (profileId: string, engine: "system" | "cloak") =>
+		setEngine: (profileId: string, engine: "system" | "fingerprint") =>
 			ipcRenderer.invoke("profiles:setEngine", profileId, engine) as Promise<
 				BrowserProfilePayload[]
 			>,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3107,7 +3107,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			ipcRenderer.invoke(
 				"profiles:previewFingerprint",
 				fingerprint,
-			) as Promise<{ args: string[]; warnings: string[] }>,
+			) as Promise<{ warnings: string[] }>,
 		onRunningChange: (listener: (runningIds: string[]) => void) => {
 			const wrapped = (
 				_event: Electron.IpcRendererEvent,

--- a/apps/desktop/electron/profile-cdp.ts
+++ b/apps/desktop/electron/profile-cdp.ts
@@ -20,13 +20,19 @@
  */
 import {
   type Browser,
+  type BrowserContext,
   chromium,
   type CDPSession,
   type Page,
 } from "playwright-core";
 
 interface ProfileConnection {
-  browser: Browser;
+  // A chromium profile connects to a `browser` (over CDP) and drives its default
+  // context. An engine (`cloak`) profile is driven through a PERSISTENT `context`
+  // launched in-process (Camoufox/Firefox) — a persistent context has no parent
+  // Browser (`context.browser()` is null), so exactly one of these is set.
+  browser: Browser | null;
+  context: BrowserContext | null;
   port: number;
   cdpByPage: WeakMap<Page, CDPSession>;
   // Per-agent tab isolation: each agent SESSION driving this profile gets its
@@ -59,7 +65,11 @@ function bindSessionPage(profileId: string, key: string, page: Page): void {
 /** Connect to (or reuse a connection to) a profile's Chromium debugging port. */
 async function connect(profileId: string, port: number): Promise<Browser> {
   const existing = connections.get(profileId);
-  if (existing && existing.port === port && existing.browser.isConnected()) {
+  if (
+    existing?.browser &&
+    existing.port === port &&
+    existing.browser.isConnected()
+  ) {
     return existing.browser;
   }
   if (existing) {
@@ -75,6 +85,7 @@ async function connect(profileId: string, port: number): Promise<Browser> {
       const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
       connections.set(profileId, {
         browser,
+        context: null,
         port,
         cdpByPage: new WeakMap(),
         pageBySession: new Map(),
@@ -98,6 +109,56 @@ async function connect(profileId: string, port: number): Promise<Browser> {
 }
 
 /**
+ * Register an engine-launched PERSISTENT context (a `cloak` profile's Camoufox
+ * Firefox context, launched in-process with a `user_data_dir` so cookies/logins
+ * persist) under a profile's connection slot, so the whole drive path (navigate /
+ * cookies / screenshot / input via the `profileCdp*` fns) works against it
+ * UNCHANGED — they resolve through `resolveContext(profileId, port)`, which
+ * returns this context once registered. A persistent context has no parent
+ * Browser, so it IS the drive unit. `port` is the profile's stable debug port,
+ * reused purely as the connection key so `profileChromiumPort` round-trips back.
+ */
+export function registerProfileContext(
+  profileId: string,
+  context: BrowserContext,
+  port: number,
+): void {
+  const existing = connections.get(profileId);
+  if (existing) {
+    connections.delete(profileId);
+  }
+  connections.set(profileId, {
+    browser: null,
+    context,
+    port,
+    cdpByPage: new WeakMap(),
+    pageBySession: new Map(),
+  });
+  context.on("close", () => {
+    if (connections.get(profileId)?.context === context) {
+      connections.delete(profileId);
+    }
+  });
+}
+
+/**
+ * The BrowserContext a caller drives: the engine's registered persistent context
+ * if present, else the default context of the profile's connected Chromium
+ * (connecting to the debug port on demand).
+ */
+async function resolveContext(
+  profileId: string,
+  port: number,
+): Promise<BrowserContext> {
+  const existing = connections.get(profileId);
+  if (existing?.context) {
+    return existing.context;
+  }
+  const browser = await connect(profileId, port);
+  return browser.contexts()[0] ?? (await browser.newContext());
+}
+
+/**
  * Try to adopt a Chrome ALREADY reachable on `port` for this profile — e.g. one
  * that survived an app restart (our spawns are detached). A single quick attempt
  * (no retry): the caller only wants to know "is one already listening?" so it can
@@ -109,7 +170,11 @@ export async function profileCdpTryAdopt(
   port: number,
 ): Promise<boolean> {
   const existing = connections.get(profileId);
-  if (existing && existing.port === port && existing.browser.isConnected()) {
+  if (
+    existing?.browser &&
+    existing.port === port &&
+    existing.browser.isConnected()
+  ) {
     return true;
   }
   try {
@@ -121,6 +186,7 @@ export async function profileCdpTryAdopt(
     }
     connections.set(profileId, {
       browser,
+      context: null,
       port,
       cdpByPage: new WeakMap(),
       pageBySession: new Map(),
@@ -167,8 +233,7 @@ async function activePage(
   port: number,
   sessionId?: string | null,
 ): Promise<Page> {
-  const browser = await connect(profileId, port);
-  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const context = await resolveContext(profileId, port);
   const connection = connections.get(profileId);
   const live = context.pages().filter((page) => !page.isClosed());
 
@@ -298,8 +363,7 @@ export async function profileCdpOpenTab(
   url: string,
   sessionId?: string | null,
 ): Promise<ProfileCdpPageInfo> {
-  const browser = await connect(profileId, port);
-  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const context = await resolveContext(profileId, port);
   const page = await context.newPage();
   // The agent moved to a new tab: make it this session's active page so
   // subsequent ops act on it (and it stays isolated from other agents).
@@ -429,11 +493,7 @@ export async function profileCdpCookies(
   filter: { url?: string; name?: string; domain?: string },
   sessionId?: string | null,
 ): Promise<ProfileCdpCookie[]> {
-  const browser = await connect(profileId, port);
-  const context = browser.contexts()[0];
-  if (!context) {
-    return [];
-  }
+  const context = await resolveContext(profileId, port);
   let url = filter.url?.trim() ?? "";
   if (!url) {
     try {
@@ -491,8 +551,7 @@ export async function profileCdpSetCookie(
     expires?: number;
   },
 ): Promise<void> {
-  const browser = await connect(profileId, port);
-  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const context = await resolveContext(profileId, port);
   await context.addCookies([
     {
       name: cookie.name,
@@ -534,8 +593,7 @@ export async function profileCdpAddCookies(
   if (cookies.length === 0) {
     return { added: 0, failed: 0 };
   }
-  const browser = await connect(profileId, port);
-  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const context = await resolveContext(profileId, port);
   let added = 0;
   let failed = 0;
   // addCookies is all-or-nothing per call, so add one at a time — a single
@@ -573,6 +631,11 @@ export function disconnectProfileCdp(profileId: string): void {
   const existing = connections.get(profileId);
   if (existing) {
     connections.delete(profileId);
-    void existing.browser.close().catch(() => undefined);
+    // Chromium: close the CDP connection. Engine (persistent context): the context
+    // is owned by the engine handle (closed via closeProfileChromium), so only drop
+    // the connection here — don't close the context out from under the handle.
+    if (existing.browser) {
+      void existing.browser.close().catch(() => undefined);
+    }
   }
 }

--- a/apps/desktop/shared/browser-pane-protocol.ts
+++ b/apps/desktop/shared/browser-pane-protocol.ts
@@ -143,12 +143,12 @@ export interface BrowserProfile {
    */
   debugPort?: number;
   /**
-   * Which browser binary drives this profile: `system` = the OS Chrome/Edge/…
-   * (default, keeps real logins), `cloak` = the CloakBrowser stealth binary that
-   * spoofs `fingerprint`. See docs/cdp/fingerprint-profiles.md.
+   * Which engine drives this profile: `system` = the OS Chrome/Edge/… (default,
+   * keeps real logins), `fingerprint` = the enterprise anti-detect engine
+   * (Camoufox, run out-of-process) that spoofs `fingerprint`.
    */
   engine?: ProfileEngine;
-  /** The spoofed fingerprint for a `cloak` profile (ignored when `system`). */
+  /** The spoofed fingerprint for a `fingerprint` profile (ignored when `system`). */
   fingerprint?: ProfileFingerprint;
   /** Per-profile network identity (proxy), independent of the fingerprint. */
   proxy?: ProfileProxy;
@@ -160,8 +160,8 @@ export interface BrowserProfile {
   isDefault?: boolean;
 }
 
-/** The browser binary that drives a profile. */
-export type ProfileEngine = "system" | "cloak";
+/** The engine that drives a profile. */
+export type ProfileEngine = "system" | "fingerprint";
 
 /** OS a fingerprint presents as (`--fingerprint-platform`). */
 export type FingerprintPlatform = "windows" | "macos" | "linux";

--- a/apps/desktop/shared/browser-pane-protocol.ts
+++ b/apps/desktop/shared/browser-pane-protocol.ts
@@ -170,12 +170,11 @@ export type FingerprintPlatform = "windows" | "macos" | "linux";
 export type FingerprintBrand = "Chrome" | "Edge" | "Opera" | "Vivaldi";
 
 /**
- * A spoofed browser fingerprint, materialised into CloakBrowser `--fingerprint-*`
- * flags by `browser-pane/fingerprint` `buildFingerprintArgs`. `seed` is the
- * master identity (canvas/WebGL/audio noise derive from it deterministically);
- * the optional fields explicitly override individual seed-derived values. Every
- * field is validated before it becomes a command-line flag (untrusted-import
- * safety) — see `sanitizeFingerprint`.
+ * A spoofed browser fingerprint, materialised into the fingerprint engine's config
+ * (Camoufox, applied out-of-process). `seed` is the master identity (canvas/WebGL/
+ * audio noise derive from it deterministically); the optional fields explicitly
+ * override individual seed-derived values. Every field is validated on all
+ * set-paths (untrusted-import safety) — see `sanitizeFingerprint`.
  */
 export interface ProfileFingerprint {
   /** Master seed → returning identity. Stable per profile (10000–99999). */

--- a/apps/desktop/src/components/panes/ContactSalesDialog.tsx
+++ b/apps/desktop/src/components/panes/ContactSalesDialog.tsx
@@ -1,10 +1,10 @@
 /**
- * Contact Sales gate for the fingerprint (cloak) Browser Profiles engine.
+ * Contact Sales gate for the fingerprint Browser Profiles engine.
  *
  * Shown instead of the fingerprint editor when `FEATURES.fingerprintBrowser` is
- * off (the default) — the anti-detect engine needs the OEM-licensed CloakBrowser
- * binary, so it's positioned as an Enterprise capability. The primary CTA opens
- * the sales URL in the user's default browser.
+ * off (the default) — the anti-detect engine is the licensed
+ * `@holaboss/fingerprint-ee` package, loaded at runtime, so it's positioned as an
+ * Enterprise capability. The primary CTA opens the sales URL in the default browser.
  */
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Button, buttonVariants } from "@/components/ui/button";

--- a/apps/desktop/src/components/panes/FingerprintDialog.tsx
+++ b/apps/desktop/src/components/panes/FingerprintDialog.tsx
@@ -8,7 +8,7 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { useCallback, useEffect, useState } from "react";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { RefreshCw, ShieldCheck, X } from "@/components/ui/icons";
+import { RefreshCw, X } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 
 type Engine = "system" | "fingerprint";
@@ -61,8 +61,7 @@ export function FingerprintDialog({
   const api = window.electronAPI?.profiles;
   const [engine, setEngine] = useState<Engine>("system");
   const [fp, setFp] = useState<Draft>({ seed: randomSeed(), platform: "windows" });
-  const [preview, setPreview] = useState<{ args: string[]; warnings: string[] }>({
-    args: [],
+  const [preview, setPreview] = useState<{ warnings: string[] }>({
     warnings: [],
   });
   const [saving, setSaving] = useState(false);
@@ -93,10 +92,10 @@ export function FingerprintDialog({
     }
   }, [open, tapi]);
 
-  // Live preview (flags + coherence) as the draft changes — computed by main.
+  // Live coherence check as the draft changes — computed by main.
   useEffect(() => {
     if (!open || engine !== "fingerprint" || !api) {
-      setPreview({ args: [], warnings: [] });
+      setPreview({ warnings: [] });
       return;
     }
     let cancelled = false;
@@ -541,17 +540,6 @@ export function FingerprintDialog({
                   />
                   Canvas / WebGL / audio noise (recommended)
                 </label>
-
-                {/* Preview */}
-                <div className="rounded-lg border border-border bg-fg-2 px-3 py-2">
-                  <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
-                    <ShieldCheck className="size-3.5" />
-                    {preview.args.length} launch flags
-                  </div>
-                  <code className="mt-1 block max-h-16 overflow-y-auto break-all font-mono text-[11px] text-muted-foreground leading-relaxed">
-                    {preview.args.join(" ")}
-                  </code>
-                </div>
               </div>
             )}
           </div>

--- a/apps/desktop/src/components/panes/FingerprintDialog.tsx
+++ b/apps/desktop/src/components/panes/FingerprintDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * Fingerprint editor — turns a Browser Profile into an AdsPower-style anti-detect
- * identity. Toggle the engine (system Chrome ⇄ CloakBrowser stealth), edit the
+ * identity. Toggle the engine (system Chrome ⇄ Fingerprint), edit the
  * spoofed fingerprint (platform / seed / GPU / hardware / screen / locale) and
  * per-profile proxy, with a live flag preview + coherence warnings from main.
  * See docs/cdp/fingerprint-profiles.md §5.
@@ -11,7 +11,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { RefreshCw, ShieldCheck, X } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 
-type Engine = "system" | "cloak";
+type Engine = "system" | "fingerprint";
 type Draft = FingerprintPayload;
 
 const PLATFORMS: FingerprintPayload["platform"][] = ["windows", "macos", "linux"];
@@ -77,7 +77,7 @@ export function FingerprintDialog({
   // Seed the form each time the dialog opens.
   useEffect(() => {
     if (open && profile) {
-      setEngine(profile.engine === "cloak" ? "cloak" : "system");
+      setEngine(profile.engine === "fingerprint" ? "fingerprint" : "system");
       setFp(profile.fingerprint ?? { seed: randomSeed(), platform: "windows" });
       setSaving(false);
     }
@@ -95,7 +95,7 @@ export function FingerprintDialog({
 
   // Live preview (flags + coherence) as the draft changes — computed by main.
   useEffect(() => {
-    if (!open || engine !== "cloak" || !api) {
+    if (!open || engine !== "fingerprint" || !api) {
       setPreview({ args: [], warnings: [] });
       return;
     }
@@ -130,7 +130,7 @@ export function FingerprintDialog({
     if (!api) {
       return null;
     }
-    return engine === "cloak"
+    return engine === "fingerprint"
       ? api.setFingerprint(profile.id, fp)
       : api.setEngine(profile.id, "system");
   };
@@ -249,13 +249,13 @@ export function FingerprintDialog({
             {/* Engine toggle */}
             <div className="mb-5 flex items-center gap-1 rounded-lg bg-fg-2 p-1">
               {engineButton("system", "System Chrome")}
-              {engineButton("cloak", "Cloak (fingerprinted)")}
+              {engineButton("fingerprint", "Fingerprint")}
             </div>
 
             {engine === "system" ? (
               <p className="rounded-lg border border-border bg-fg-2 px-3 py-2.5 text-muted-foreground text-sm">
                 This profile launches your installed Chrome with real logins and
-                no spoofing. Switch to <strong>Cloak</strong> to give it a
+                no spoofing. Switch to <strong>Fingerprint</strong> to give it a
                 distinct, detection-resistant fingerprint (a fresh identity —
                 sign in inside it).
               </p>
@@ -560,7 +560,7 @@ export function FingerprintDialog({
             <Button
               type="button"
               variant="ghost"
-              disabled={engine !== "cloak" || saving}
+              disabled={engine !== "fingerprint" || saving}
               onClick={() => void commit(true)}
               title="Save & open browserscan.net in this profile"
             >

--- a/apps/desktop/src/components/panes/ProfilesPane.tsx
+++ b/apps/desktop/src/components/panes/ProfilesPane.tsx
@@ -317,13 +317,13 @@ export function ProfilesPane() {
                             Default
                           </span>
                         ) : null}
-                        {profile.engine === "cloak" ? (
+                        {profile.engine === "fingerprint" ? (
                           <span
                             className="inline-flex shrink-0 items-center gap-0.5 rounded bg-violet-500/15 px-1.5 py-0.5 font-medium text-[10px] text-violet-600 dark:text-violet-400"
-                            title="Fingerprint-spoofed (CloakBrowser) identity"
+                            title="Anti-detect fingerprint identity"
                           >
                             <ShieldCheck className="size-2.5" />
-                            Cloak
+                            Fingerprint
                           </span>
                         ) : null}
                       </div>

--- a/apps/desktop/src/components/panes/ProfilesPane.tsx
+++ b/apps/desktop/src/components/panes/ProfilesPane.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   ChevronDown,
+  Loader2,
   Pencil,
   Plus,
   ShieldCheck,
@@ -73,6 +74,10 @@ export function ProfilesPane() {
   const [importOpen, setImportOpen] = useState(false);
   const [importNote, setImportNote] = useState<string | null>(null);
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set());
+  // Profiles whose browser is starting but not yet live — the window can take a
+  // couple seconds to appear (fingerprint engine cold-start), so the Launch button
+  // shows a spinner in the gap between click and the pushed `running` update.
+  const [launching, setLaunching] = useState<ReadonlySet<string>>(new Set());
   const [pendingDelete, setPendingDelete] = useState<Profile | null>(null);
   const [fingerprintProfile, setFingerprintProfile] = useState<Profile | null>(
     null,
@@ -139,6 +144,34 @@ export function ProfilesPane() {
     [api],
   );
 
+  // Launch a profile with a live "Launching…" state on its card, so there's clear
+  // feedback while the browser starts (the window can take a beat to appear). The
+  // pushed `running` update flips the button to Close once it's actually live.
+  const beginLaunch = useCallback(
+    async (id: string, url?: string) => {
+      if (!api) {
+        return;
+      }
+      setLaunchError(null);
+      setLaunching((prev) => new Set(prev).add(id));
+      try {
+        const result = await api.launch(id, url);
+        setLaunchError(
+          result && !result.ok ? (result.error ?? "Failed to launch.") : null,
+        );
+      } catch (error) {
+        setLaunchError((error as Error)?.message ?? "Failed to launch.");
+      } finally {
+        setLaunching((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    },
+    [api],
+  );
+
   const toggleLaunch = useCallback(
     async (id: string) => {
       if (!api) {
@@ -148,12 +181,9 @@ export function ProfilesPane() {
         await api.close(id);
         return;
       }
-      const result = await api.launch(id);
-      setLaunchError(
-        result && !result.ok ? (result.error ?? "Failed to launch.") : null,
-      );
+      await beginLaunch(id);
     },
-    [api, running],
+    [api, running, beginLaunch],
   );
 
   const onImported = useCallback(
@@ -297,6 +327,7 @@ export function ProfilesPane() {
               const isPermanent = profile.id === DEFAULT_PROFILE_ID;
               const isDefault = profile.isDefault ?? false;
               const isRunning = running.has(profile.id);
+              const isLaunching = launching.has(profile.id);
               return (
                 <div
                   key={profile.id}
@@ -344,10 +375,20 @@ export function ProfilesPane() {
                       type="button"
                       size="sm"
                       variant={isRunning ? "outline" : "default"}
-                      className="h-7 px-2.5 text-xs"
+                      className="h-7 gap-1.5 px-2.5 text-xs"
+                      disabled={isLaunching}
                       onClick={() => void toggleLaunch(profile.id)}
                     >
-                      {isRunning ? "Close" : "Launch"}
+                      {isLaunching ? (
+                        <>
+                          <Loader2 className="size-3.5 animate-spin" />
+                          Launching…
+                        </>
+                      ) : isRunning ? (
+                        "Close"
+                      ) : (
+                        "Launch"
+                      )}
                     </Button>
                     <div className="flex items-center gap-1.5">
                       {isRunning ? (
@@ -491,15 +532,7 @@ export function ProfilesPane() {
         profile={fingerprintProfile}
         onSaved={(next) => setProfiles(next)}
         onTest={(profileId) => {
-          void api
-            ?.launch(profileId, "https://browserscan.net")
-            .then((result) =>
-              setLaunchError(
-                result && !result.ok
-                  ? (result.error ?? "Failed to launch.")
-                  : null,
-              ),
-            );
+          void beginLaunch(profileId, "https://browserscan.net");
         }}
       />
       <ContactSalesDialog

--- a/apps/desktop/src/components/panes/ProfilesPane.tsx
+++ b/apps/desktop/src/components/panes/ProfilesPane.tsx
@@ -8,7 +8,7 @@
  * Profiles are independent of workspace, so this pane takes no workspaceId.
  * Layout mirrors the sibling panes (Projects / Automations / Channels).
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { BrowserNameDialog } from "@/components/panes/BrowserNameDialog";
 import { ContactSalesDialog } from "@/components/panes/ContactSalesDialog";
 import { FingerprintDialog } from "@/components/panes/FingerprintDialog";
@@ -173,6 +173,40 @@ export function ProfilesPane() {
     [refresh],
   );
 
+  // Import an AdsPower .xlsx export → fingerprint (cloak) profiles. The renderer
+  // reads the picked file to bytes; main hands them to the enterprise engine.
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const handleSpreadsheetSelected = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = ""; // allow re-picking the same file later
+      if (!file || !api?.importSpreadsheet) {
+        return;
+      }
+      const bytes = await file.arrayBuffer();
+      const result = await api.importSpreadsheet(bytes);
+      if (!result.ok) {
+        setImportNote(result.error ?? "Import failed.");
+        return;
+      }
+      await refresh();
+      const extra =
+        result.warnings.length > 0
+          ? ` ${result.warnings[0]}${
+              result.warnings.length > 1
+                ? ` (+${result.warnings.length - 1} more)`
+                : ""
+            }`
+          : "";
+      setImportNote(
+        `Imported ${result.imported} profile${
+          result.imported === 1 ? "" : "s"
+        } from AdsPower.${extra}`,
+      );
+    },
+    [api, refresh],
+  );
+
   const renderAddItems = () => (
     <>
       <DropdownMenuItem
@@ -192,6 +226,15 @@ export function ProfilesPane() {
         <UploadCloud className="size-4" />
         Import from browser…
       </DropdownMenuItem>
+      {FEATURES.fingerprintBrowser ? (
+        <DropdownMenuItem
+          className="gap-2 rounded-md px-2 py-1.5 text-[13px]"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <ShieldCheck className="size-4 text-violet-500" />
+          Import from AdsPower…
+        </DropdownMenuItem>
+      ) : null}
     </>
   );
 
@@ -462,6 +505,13 @@ export function ProfilesPane() {
       <ContactSalesDialog
         open={contactSalesOpen}
         onOpenChange={setContactSalesOpen}
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        className="hidden"
+        onChange={handleSpreadsheetSelected}
       />
     </div>
   );

--- a/apps/desktop/src/lib/featureFlags.ts
+++ b/apps/desktop/src/lib/featureFlags.ts
@@ -1,16 +1,16 @@
 /**
  * Build-time feature flags.
  *
- * `fingerprintBrowser` — the anti-detect / fingerprint ("cloak") Browser Profiles
- * engine. Gated OFF by default: the entry points (the 🛡 Fingerprint button)
- * show a Contact Sales popup instead of the editor, because the engine depends on
- * the proprietary CloakBrowser binary, which is OEM-licensed to bundle/ship (see
- * docs/cdp/fingerprint-profiles.md). The editor + template code stays intact
- * behind this flag — flip it to `true` for a customer/OEM build (where the
- * CloakBrowser binary is provisioned) and the full feature comes back.
+ * `fingerprintBrowser` — the anti-detect fingerprint Browser Profiles feature
+ * (the `fingerprint` engine). Gated OFF by default: the entry points (the 🛡
+ * Fingerprint button) show a Contact Sales popup instead of the editor, because
+ * the engine is an ENTERPRISE feature — the OSS core loads the licensed
+ * `@holaboss/fingerprint-ee` package (Camoufox, run out-of-process) at runtime
+ * through the FingerprintBrowserEngine seam; absent (plain OSS builds), the
+ * feature is off. Flip this to `true` for a licensed build to expose the UI.
  */
 export const FEATURES: { fingerprintBrowser: boolean } = {
-  // OFF by default. Enable for a customer/OEM build — or to test locally — with
+  // OFF by default. Enable for a licensed build — or to test locally — with
   // `VITE_FINGERPRINT_BROWSER=true` (e.g. `VITE_FINGERPRINT_BROWSER=true npm run dev`).
   fingerprintBrowser:
     (import.meta.env as unknown as Record<string, string | undefined>)

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -3171,6 +3171,12 @@ declare global {
 			import: (
 				payload: ProfileImportRequestPayload,
 			) => Promise<ProfileImportResultPayload>;
+			importSpreadsheet: (fileBytes: ArrayBuffer) => Promise<{
+				ok: boolean;
+				error?: string;
+				imported: number;
+				warnings: string[];
+			}>;
 			close: (profileId: string) => Promise<{ ok: boolean }>;
 			runningIds: () => Promise<string[]>;
 			setEngine: (

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -373,7 +373,7 @@ declare global {
 		createdAt: string;
 		source: string;
 		importedFrom?: string;
-		engine?: "system" | "cloak";
+		engine?: "system" | "fingerprint";
 		fingerprint?: FingerprintPayload;
 		proxy?: ProfileProxyPayload;
 		/** True for the pinned default browser the agent drives when none is named. */
@@ -3181,7 +3181,7 @@ declare global {
 			runningIds: () => Promise<string[]>;
 			setEngine: (
 				profileId: string,
-				engine: "system" | "cloak",
+				engine: "system" | "fingerprint",
 			) => Promise<BrowserProfilePayload[]>;
 			setFingerprint: (
 				profileId: string,

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -3189,7 +3189,7 @@ declare global {
 			) => Promise<BrowserProfilePayload[]>;
 			previewFingerprint: (
 				fingerprint: FingerprintPayload,
-			) => Promise<{ args: string[]; warnings: string[] }>;
+			) => Promise<{ warnings: string[] }>;
 			onRunningChange: (listener: (runningIds: string[]) => void) => () => void;
 		};
 		fingerprintTemplates: {


### PR DESCRIPTION
Adds a fingerprint / anti-detect browser to the desktop, built **open-core**: the OSS core defines a `FingerprintBrowserEngine` seam and loads the licensed `@holaboss/fingerprint-ee` (Camoufox) package at runtime via a variable-specifier dynamic import. Absent (every plain OSS build) → Contact Sales fallback, gated on `FEATURES.fingerprintBrowser`.

## OSS-side (this PR)
- **Seam** (`fingerprint-engine-seam.ts`): engine + service-client interfaces, runtime loader, Contact Sales fallback. No build-time dependency on the private package.
- **Standalone service drive**: the fingerprint browser runs in its own forked process; `main.ts`'s `profileCdp` bridge routes every drive op (navigate / click / type / screenshot / evaluate / cookies) to it for engine profiles — **full parity** with system Chrome profiles, incl. auto-launch on first agent drive and per-session tab isolation.
- **AdsPower `.xlsx` import** → coherent fingerprint profiles (ProfilesPane UI, flag-gated).
- Renamed the legacy `cloak` engine → `fingerprint`; removed dead CloakBrowser launch code.
- UX: "Launching…" state on the profile card; land on a leak-check page; no main-thread freeze on launch (loads the ~2ms service client, not the ~550ms engine barrel).

## Open-core boundary
- `@holaboss/fingerprint-ee` is a **separate private repo**, gitignored here and **not** in `package.json` / `bun.lock` — OSS `main` builds without it.
- The private engine (Camoufox launch, authed-proxy relay, holaOS branding, tab styling, AdsPower mappers, service) lives in that repo and is already on its `main`.

## Verification
- Desktop typecheck green.
- Agent-drive live check passed: navigate / evaluate / mouse / keyboard / screenshot through the real service, with the spoofed Firefox/macOS UA intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)