### PR TITLE
feat(desktop): attach the fingerprint engine as a runtime plugin (no rebuild)

### DIFF
--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -8,10 +8,22 @@
  * null and callers fall back to the Contact-Sales flow. Nothing here depends on the
  * enterprise package at build time.
  *
- * Build note: the import specifier is held in a variable so bundlers don't try to
- * resolve it statically (which would break the OSS build where it's absent). The
- * main-process bundler must treat `@holaboss/fingerprint-ee` as external/optional.
+ * Two ways the engine attaches (both optional; absent → Contact Sales):
+ *   1. BUILD-TIME — the package present in `node_modules` (bare specifier below).
+ *   2. RUNTIME PLUGIN — a self-contained prebuilt engine bundle (its `dist/` plus
+ *      its `node_modules/`) dropped into `<userData>/fingerprint-ee/` (or the dir
+ *      named by `$HOLABOSS_FINGERPRINT_ENGINE_PATH`), loaded by ABSOLUTE PATH. This
+ *      lets an already-released OSS app gain the feature with NO rebuild.
+ *
+ * Build note: the bare specifier is held in a variable so bundlers don't resolve it
+ * statically (it's absent in OSS builds); treat `@holaboss/fingerprint-ee` as
+ * external/optional.
  */
+import { app } from "electron";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
 import type { BrowserContext } from "playwright-core";
 
 import type {
@@ -92,23 +104,66 @@ interface EnterpriseModule {
 
 const ENTERPRISE_MODULE_ID = "@holaboss/fingerprint-ee";
 
+// --- Runtime plugin path -----------------------------------------------------
+//
+// A drop-in engine bundle for an already-released app lives at:
+//     <dir>/dist/index.js  +  <dir>/dist/service-client.js
+// with the engine's own `node_modules/` beside `dist/` (self-contained, so the
+// forked service child — a plain node process — resolves camoufox-js/etc. there).
+// `dir` = $HOLABOSS_FINGERPRINT_ENGINE_PATH or `<userData>/fingerprint-ee`.
+
+function pluginEngineDir(): string | null {
+  const override = process.env.HOLABOSS_FINGERPRINT_ENGINE_PATH?.trim();
+  if (override) {
+    return override;
+  }
+  try {
+    return path.join(app.getPath("userData"), "fingerprint-ee");
+  } catch {
+    return null; // Electron app not ready yet — no userData path
+  }
+}
+
+/** Absolute path to a built entry in the plugin bundle, if the file exists. */
+function pluginEntry(name: "index" | "service-client"): string | null {
+  const dir = pluginEngineDir();
+  if (!dir) {
+    return null;
+  }
+  const abs = path.join(dir, "dist", `${name}.js`);
+  return existsSync(abs) ? abs : null;
+}
+
 let cached: FingerprintBrowserEngine | null | undefined;
 
 /**
- * Load the enterprise engine if the licensed package is present, else null.
- * Cached after the first call (including the null result, so OSS builds don't
- * retry the import on every profile action).
+ * Load the enterprise engine — from `node_modules` (build-time attach) OR a runtime
+ * plugin drop-in — else null. Cached (incl. the null, so OSS builds don't retry).
  */
 export async function loadFingerprintEngine(): Promise<FingerprintBrowserEngine | null> {
   if (cached !== undefined) {
     return cached;
   }
+  cached = null;
   try {
-    const mod = (await import(ENTERPRISE_MODULE_ID)) as EnterpriseModule;
-    cached = typeof mod.createCamoufoxEngine === "function" ? mod.createCamoufoxEngine() : null;
+    const mod = (await import(ENTERPRISE_MODULE_ID)) as EnterpriseModule; // build-time attach
+    if (typeof mod.createCamoufoxEngine === "function") {
+      cached = mod.createCamoufoxEngine();
+      return cached;
+    }
   } catch {
-    // Absent (OSS build) or failed to load → feature is off; caller shows Contact Sales.
-    cached = null;
+    // not in node_modules — fall through to the runtime plugin path
+  }
+  const entry = pluginEntry("index");
+  if (entry) {
+    try {
+      const mod = (await import(pathToFileURL(entry).href)) as EnterpriseModule;
+      if (typeof mod.createCamoufoxEngine === "function") {
+        cached = mod.createCamoufoxEngine();
+      }
+    } catch {
+      // a bundle is present but failed to load → leave the feature off
+    }
   }
   return cached;
 }
@@ -116,6 +171,15 @@ export async function loadFingerprintEngine(): Promise<FingerprintBrowserEngine 
 /** True when a licensed engine is loaded — gate main-process feature paths on this. */
 export function isFingerprintEngineAvailable(): boolean {
   return Boolean(cached);
+}
+
+/**
+ * Cheap synchronous check for the renderer's UI gate: is an engine ATTACHED —
+ * already loaded, or a plugin drop-in present on disk? No heavy import. (A build-
+ * time attach is surfaced instead by the build-time `FEATURES.fingerprintBrowser`.)
+ */
+export function isFingerprintEnginePresent(): boolean {
+  return Boolean(cached) || pluginEntry("index") !== null;
 }
 
 // --- Standalone fingerprint SERVICE client ----------------------------------
@@ -212,14 +276,26 @@ export async function loadFingerprintService(): Promise<FingerprintServiceClient
   if (cachedService !== undefined) {
     return cachedService;
   }
+  cachedService = null;
   try {
-    const mod = (await import(ENTERPRISE_SERVICE_MODULE_ID)) as EnterpriseServiceModule;
-    cachedService =
-      typeof mod.createFingerprintServiceClient === "function"
-        ? mod.createFingerprintServiceClient()
-        : null;
+    const mod = (await import(ENTERPRISE_SERVICE_MODULE_ID)) as EnterpriseServiceModule; // build-time
+    if (typeof mod.createFingerprintServiceClient === "function") {
+      cachedService = mod.createFingerprintServiceClient();
+      return cachedService;
+    }
   } catch {
-    cachedService = null;
+    // not in node_modules — fall through to the runtime plugin path
+  }
+  const entry = pluginEntry("service-client");
+  if (entry) {
+    try {
+      const mod = (await import(pathToFileURL(entry).href)) as EnterpriseServiceModule;
+      if (typeof mod.createFingerprintServiceClient === "function") {
+        cachedService = mod.createFingerprintServiceClient();
+      }
+    } catch {
+      // a bundle is present but failed to load
+    }
   }
   return cachedService;
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -242,6 +242,7 @@ import {
 } from "./browser-pane/fingerprint.js";
 import {
   type FingerprintServiceClient,
+  isFingerprintEnginePresent,
   loadFingerprintService,
 } from "./browser-pane/fingerprint-engine-seam.js";
 import {
@@ -26610,6 +26611,13 @@ app.whenReady().then(async () => {
         fileBytes instanceof Uint8Array ? fileBytes : new Uint8Array(fileBytes);
       return importFingerprintBrowserProfiles(bytes);
     },
+  );
+  // Runtime engine presence for the renderer's feature gate: true when an engine is
+  // attached — build-time in node_modules, or a runtime plugin drop-in under
+  // <userData>/fingerprint-ee. Lets a released OSS app light up the fingerprint UI
+  // when the engine is dropped in, without needing the build-time flag.
+  handleTrustedIpc("profiles:fingerprintAvailable", ["main"], async () =>
+    isFingerprintEnginePresent(),
   );
   // Opt a profile into the fingerprint (anti-detect) engine, or back to system
   // Chrome. Switching seeds a fingerprint so the next launch spoofs.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3087,6 +3087,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
 				imported: number;
 				warnings: string[];
 			}>,
+		fingerprintAvailable: () =>
+			ipcRenderer.invoke("profiles:fingerprintAvailable") as Promise<boolean>,
 		close: (profileId: string) =>
 			ipcRenderer.invoke("profiles:close", profileId) as Promise<{
 				ok: boolean;

--- a/apps/desktop/src/components/panes/ProfilesPane.tsx
+++ b/apps/desktop/src/components/panes/ProfilesPane.tsx
@@ -83,6 +83,13 @@ export function ProfilesPane() {
     null,
   );
   const [contactSalesOpen, setContactSalesOpen] = useState(false);
+  // The fingerprint feature shows when the engine is ATTACHED: the build-time flag,
+  // OR a runtime plugin drop-in (main reports the latter via fingerprintAvailable).
+  // This is what lets a released OSS app light up the feature when the engine is
+  // dropped into <userData>/fingerprint-ee — no rebuild.
+  const [engineAvailable, setEngineAvailable] = useState(
+    FEATURES.fingerprintBrowser,
+  );
 
   const refresh = useCallback(async () => {
     if (!api) {
@@ -105,6 +112,18 @@ export function ProfilesPane() {
     }
     void api.runningIds().then((ids) => setRunning(new Set(ids)));
     return api.onRunningChange((ids) => setRunning(new Set(ids)));
+  }, [api]);
+
+  // Detect a runtime engine plugin drop-in (skip if the build flag already enables it).
+  useEffect(() => {
+    if (FEATURES.fingerprintBrowser || !api?.fingerprintAvailable) {
+      return;
+    }
+    void api.fingerprintAvailable().then((ok) => {
+      if (ok) {
+        setEngineAvailable(true);
+      }
+    });
   }, [api]);
 
   const handleCreate = useCallback(
@@ -256,7 +275,7 @@ export function ProfilesPane() {
         <UploadCloud className="size-4" />
         Import from browser…
       </DropdownMenuItem>
-      {FEATURES.fingerprintBrowser ? (
+      {engineAvailable ? (
         <DropdownMenuItem
           className="gap-2 rounded-md px-2 py-1.5 text-[13px]"
           onClick={() => fileInputRef.current?.click()}
@@ -274,7 +293,7 @@ export function ProfilesPane() {
         title="Browsers"
         actions={
           <>
-            {FEATURES.fingerprintBrowser ? null : (
+            {engineAvailable ? null : (
               <Button
                 type="button"
                 size="sm"
@@ -412,7 +431,7 @@ export function ProfilesPane() {
                           <Star className="size-3.5" />
                         </Button>
                       )}
-                      {FEATURES.fingerprintBrowser ? (
+                      {engineAvailable ? (
                         <Button
                           type="button"
                           size="sm"

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -3177,6 +3177,7 @@ declare global {
 				imported: number;
 				warnings: string[];
 			}>;
+			fingerprintAvailable: () => Promise<boolean>;
 			close: (profileId: string) => Promise<{ ok: boolean }>;
 			runningIds: () => Promise<string[]>;
 			setEngine: (


### PR DESCRIPTION
Follow-up to #452. Lets an **already-released OSS holaOS app** gain the fingerprint browser by **dropping in the engine** — no rebuild.

## How
- The seam (`loadFingerprintEngine` / `loadFingerprintService`) now attaches the engine **two ways**:
  1. **Build-time** — the package in `node_modules` (bare specifier, unchanged).
  2. **Runtime plugin** — a self-contained prebuilt engine bundle (`dist/` + its own `node_modules/`) dropped into `<userData>/fingerprint-ee/` (or `$HOLABOSS_FINGERPRINT_ENGINE_PATH`), loaded **by absolute path** (`pathToFileURL`).
- The forked service child is a plain Node process, so the drop-in must be self-contained (deps beside `dist/`) — documented in the engine README.
- **Renderer gate is now runtime-aware**: `ProfilesPane` shows the fingerprint UI when the engine is *attached* — the build flag `FEATURES.fingerprintBrowser` **or** a plugin drop-in (new `profiles:fingerprintAvailable` IPC → `isFingerprintEnginePresent()`), else Contact Sales. So a dropped-in engine lights up the UI without the build flag.

## Verified
- Desktop typecheck green.
- Absolute-path plugin resolution confirmed: `dist/index.js` → `createCamoufoxEngine`, `dist/service-client.js` → `createFingerprintServiceClient`.

Nothing changes for OSS builds with no engine (still Contact Sales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)