### PR TITLE
feat(desktop): one-click in-app installer for the fingerprint engine

### DIFF
--- a/apps/desktop/electron/browser-pane/fingerprint-engine-installer.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-installer.ts
@@ -1,0 +1,157 @@
+/**
+ * One-click installer for the enterprise fingerprint engine (the runtime plugin
+ * model — see `fingerprint-engine-seam.ts`). Downloads or takes a local
+ * `fingerprint-ee-*.zip` (self-contained: `dist/` + `node_modules/`), unpacks it
+ * into `<userData>/fingerprint-ee/`, strips the macOS quarantine so the native
+ * deps load, and resets the seam cache so the feature activates WITHOUT a restart.
+ *
+ * OSS + macOS-only (the engine is macOS today). The download SOURCE is deliberately
+ * a config point: `HOLABOSS_FINGERPRINT_ENGINE_URL` (a direct .zip URL) — wire it to
+ * a licensed/gated backend endpoint for real distribution. Install-from-file needs
+ * no source at all.
+ */
+import { app } from "electron";
+import { execFile } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { access, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { promisify } from "node:util";
+
+import { resetFingerprintEngineCache } from "./fingerprint-engine-seam.js";
+
+const execFileP = promisify(execFile);
+
+export interface InstallProgress {
+  phase: "downloading" | "extracting" | "installing" | "done" | "error";
+  /** 0–100 during download when the size is known. */
+  pct?: number;
+  message?: string;
+}
+
+export interface InstalledEngineInfo {
+  present: boolean;
+  version?: string;
+  dir: string;
+}
+
+/** The plugin dir the seam loads from — keep in sync with the seam's resolver. */
+function engineDir(): string {
+  const override = process.env.HOLABOSS_FINGERPRINT_ENGINE_PATH?.trim();
+  return override || path.join(app.getPath("userData"), "fingerprint-ee");
+}
+
+/** Which release asset matches this machine, or null off macOS. */
+export function engineArch(): "macos-arm64" | "macos-x64" | null {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  return process.arch === "arm64" ? "macos-arm64" : "macos-x64";
+}
+
+/** A configured direct-download URL for the engine bundle, if any. */
+export function resolveEngineDownloadUrl(): string | null {
+  return process.env.HOLABOSS_FINGERPRINT_ENGINE_URL?.trim() || null;
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function installedEngineInfo(): Promise<InstalledEngineInfo> {
+  const dir = engineDir();
+  try {
+    if (!(await exists(path.join(dir, "dist", "index.js")))) {
+      return { present: false, dir };
+    }
+    const pkg = JSON.parse(await readFile(path.join(dir, "package.json"), "utf8")) as {
+      version?: unknown;
+    };
+    return {
+      present: true,
+      version: typeof pkg.version === "string" ? pkg.version : undefined,
+      dir,
+    };
+  } catch {
+    return { present: false, dir };
+  }
+}
+
+/** Install from a local `fingerprint-ee-*.zip` on disk. */
+export async function installFromZip(
+  zipPath: string,
+  onProgress: (p: InstallProgress) => void,
+): Promise<InstalledEngineInfo> {
+  const dir = engineDir();
+  const parent = path.dirname(dir);
+  await mkdir(parent, { recursive: true });
+  // Work in the SAME filesystem as the target so the final swap is an atomic rename.
+  const work = await mkdtemp(path.join(parent, ".fpe-install-"));
+  try {
+    onProgress({ phase: "extracting", message: "Unpacking…" });
+    await execFileP("/usr/bin/unzip", ["-oq", zipPath, "-d", work]);
+
+    // The bundle root is the dir that contains dist/index.js (our zips wrap it in a
+    // `fingerprint-ee/` folder; tolerate a flat zip too).
+    let src = path.join(work, "fingerprint-ee");
+    if (!(await exists(path.join(src, "dist", "index.js")))) {
+      src = work;
+    }
+    if (!(await exists(path.join(src, "dist", "index.js")))) {
+      throw new Error("That zip isn't a fingerprint-ee bundle (no dist/index.js).");
+    }
+
+    onProgress({ phase: "installing", message: "Installing…" });
+    // Downloaded native files (better-sqlite3.node) are quarantined → the forked
+    // service refuses to load them. Clear it (best-effort).
+    await execFileP("/usr/bin/xattr", ["-dr", "com.apple.quarantine", src]).catch(() => {});
+
+    // Atomic-ish swap: drop any old copy, move the new one into place.
+    await rm(dir, { recursive: true, force: true });
+    await rename(src, dir);
+
+    // Re-resolve the engine on the next load — no app restart needed.
+    resetFingerprintEngineCache();
+    onProgress({ phase: "done", message: "Installed." });
+    return await installedEngineInfo();
+  } finally {
+    await rm(work, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/** Download a bundle zip from `url`, then install it. */
+export async function installFromUrl(
+  url: string,
+  onProgress: (p: InstallProgress) => void,
+): Promise<InstalledEngineInfo> {
+  const parent = path.dirname(engineDir());
+  await mkdir(parent, { recursive: true });
+  const work = await mkdtemp(path.join(parent, ".fpe-dl-"));
+  const zipPath = path.join(work, "engine.zip");
+  try {
+    onProgress({ phase: "downloading", pct: 0, message: "Downloading…" });
+    const res = await fetch(url);
+    if (!res.ok || !res.body) {
+      throw new Error(`Download failed (HTTP ${res.status}).`);
+    }
+    const total = Number(res.headers.get("content-length") ?? 0);
+    let got = 0;
+    const body = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
+    body.on("data", (chunk: Buffer) => {
+      got += chunk.length;
+      if (total > 0) {
+        onProgress({ phase: "downloading", pct: Math.min(100, Math.round((got / total) * 100)) });
+      }
+    });
+    await pipeline(body, createWriteStream(zipPath));
+    return await installFromZip(zipPath, onProgress);
+  } finally {
+    await rm(work, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
+++ b/apps/desktop/electron/browser-pane/fingerprint-engine-seam.ts
@@ -299,3 +299,18 @@ export async function loadFingerprintService(): Promise<FingerprintServiceClient
   }
   return cachedService;
 }
+
+/**
+ * Forget any loaded/absent engine so the next `load*` call re-resolves. Used after
+ * a runtime plugin install so the feature activates WITHOUT an app restart. Any
+ * forked service is disposed first.
+ */
+export function resetFingerprintEngineCache(): void {
+  try {
+    cachedService?.dispose();
+  } catch {
+    // best-effort
+  }
+  cached = undefined;
+  cachedService = undefined;
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -246,6 +246,13 @@ import {
   loadFingerprintService,
 } from "./browser-pane/fingerprint-engine-seam.js";
 import {
+  installedEngineInfo,
+  installFromUrl,
+  installFromZip,
+  type InstallProgress,
+  resolveEngineDownloadUrl,
+} from "./browser-pane/fingerprint-engine-installer.js";
+import {
   addFingerprintTemplate,
   emptyFingerprintTemplateIndex,
   type FingerprintTemplateIndex,
@@ -26619,6 +26626,49 @@ app.whenReady().then(async () => {
   handleTrustedIpc("profiles:fingerprintAvailable", ["main"], async () =>
     isFingerprintEnginePresent(),
   );
+  // --- One-click fingerprint engine installer (runtime plugin drop-in) ---
+  handleTrustedIpc("fingerprint:installedInfo", ["main"], async () =>
+    installedEngineInfo(),
+  );
+  handleTrustedIpc("fingerprint:downloadAvailable", ["main"], async () =>
+    resolveEngineDownloadUrl() !== null,
+  );
+  handleTrustedIpc("fingerprint:installFromFile", ["main"], async (event) => {
+    const pick = await dialog.showOpenDialog({
+      title: "Choose the fingerprint engine bundle",
+      properties: ["openFile"],
+      filters: [{ name: "Engine bundle", extensions: ["zip"] }],
+    });
+    if (pick.canceled || !pick.filePaths[0]) {
+      return { ok: false, canceled: true };
+    }
+    const onProgress = (p: InstallProgress) =>
+      event.sender.send("fingerprint:installProgress", p);
+    try {
+      const info = await installFromZip(pick.filePaths[0], onProgress);
+      return { ok: info.present, info };
+    } catch (error) {
+      const message = (error as Error).message;
+      onProgress({ phase: "error", message });
+      return { ok: false, error: message };
+    }
+  });
+  handleTrustedIpc("fingerprint:installFromUrl", ["main"], async (event) => {
+    const url = resolveEngineDownloadUrl();
+    if (!url) {
+      return { ok: false, error: "No engine download source is configured." };
+    }
+    const onProgress = (p: InstallProgress) =>
+      event.sender.send("fingerprint:installProgress", p);
+    try {
+      const info = await installFromUrl(url, onProgress);
+      return { ok: info.present, info };
+    } catch (error) {
+      const message = (error as Error).message;
+      onProgress({ phase: "error", message });
+      return { ok: false, error: message };
+    }
+  });
   // Opt a profile into the fingerprint (anti-detect) engine, or back to system
   // Chrome. Switching seeds a fingerprint so the next launch spoofs.
   handleTrustedIpc(

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3089,6 +3089,46 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			}>,
 		fingerprintAvailable: () =>
 			ipcRenderer.invoke("profiles:fingerprintAvailable") as Promise<boolean>,
+		installedEngineInfo: () =>
+			ipcRenderer.invoke("fingerprint:installedInfo") as Promise<{
+				present: boolean;
+				version?: string;
+				dir: string;
+			}>,
+		engineDownloadAvailable: () =>
+			ipcRenderer.invoke("fingerprint:downloadAvailable") as Promise<boolean>,
+		installEngineFromFile: () =>
+			ipcRenderer.invoke("fingerprint:installFromFile") as Promise<{
+				ok: boolean;
+				canceled?: boolean;
+				error?: string;
+				info?: { present: boolean; version?: string; dir: string };
+			}>,
+		installEngineFromUrl: () =>
+			ipcRenderer.invoke("fingerprint:installFromUrl") as Promise<{
+				ok: boolean;
+				error?: string;
+				info?: { present: boolean; version?: string; dir: string };
+			}>,
+		onEngineInstallProgress: (
+			listener: (progress: {
+				phase: "downloading" | "extracting" | "installing" | "done" | "error";
+				pct?: number;
+				message?: string;
+			}) => void,
+		) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, progress: unknown) =>
+				listener(
+					progress as {
+						phase: "downloading" | "extracting" | "installing" | "done" | "error";
+						pct?: number;
+						message?: string;
+					},
+				);
+			ipcRenderer.on("fingerprint:installProgress", wrapped);
+			return () =>
+				ipcRenderer.removeListener("fingerprint:installProgress", wrapped);
+		},
 		close: (profileId: string) =>
 			ipcRenderer.invoke("profiles:close", profileId) as Promise<{
 				ok: boolean;

--- a/apps/desktop/src/components/panes/ContactSalesDialog.tsx
+++ b/apps/desktop/src/components/panes/ContactSalesDialog.tsx
@@ -1,14 +1,18 @@
 /**
- * Contact Sales gate for the fingerprint Browser Profiles engine.
+ * Enable / install gate for the fingerprint Browser Profiles engine.
  *
- * Shown instead of the fingerprint editor when `FEATURES.fingerprintBrowser` is
- * off (the default) — the anti-detect engine is the licensed
- * `@holaboss/fingerprint-ee` package, loaded at runtime, so it's positioned as an
- * Enterprise capability. The primary CTA opens the sales URL in the default browser.
+ * Shown instead of the fingerprint editor when the engine isn't attached yet — the
+ * anti-detect engine is the licensed `@holaboss/fingerprint-ee` package, loaded at
+ * runtime (open-core). This dialog lets the user ATTACH it as a one-click plugin:
+ *   • "Install" — downloads the bundle from the configured source (if any),
+ *   • "Install from file…" — picks a downloaded `fingerprint-ee-*.zip`,
+ * both of which drop it into `<userData>/fingerprint-ee/` and activate it live (no
+ * restart). "Contact sales" remains for getting access/a license.
  */
+import { useCallback, useEffect, useState } from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { ShieldCheck, X } from "@/components/ui/icons";
+import { Loader2, ShieldCheck, X } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 
 // Where "Contact sales" sends the user. Update to the real enterprise/contact page.
@@ -23,16 +27,73 @@ const BULLETS = [
 interface ContactSalesDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Called after the engine is successfully installed, so the pane can re-gate. */
+  onInstalled?: () => void;
 }
+
+type Progress = {
+  phase: "downloading" | "extracting" | "installing" | "done" | "error";
+  pct?: number;
+  message?: string;
+};
 
 export function ContactSalesDialog({
   open,
   onOpenChange,
+  onInstalled,
 }: ContactSalesDialogProps) {
+  const api = window.electronAPI?.profiles;
+  const [downloadAvailable, setDownloadAvailable] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [progress, setProgress] = useState<Progress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !api?.engineDownloadAvailable) {
+      return;
+    }
+    setError(null);
+    void api.engineDownloadAvailable().then(setDownloadAvailable);
+  }, [open, api]);
+
   const contactSales = () => {
     void window.electronAPI?.ui.openExternalUrl(CONTACT_SALES_URL);
     onOpenChange(false);
   };
+
+  const runInstall = useCallback(
+    async (source: "file" | "url") => {
+      if (!api) {
+        return;
+      }
+      setError(null);
+      setInstalling(true);
+      setProgress({ phase: "installing", message: "Starting…" });
+      const unsubscribe = api.onEngineInstallProgress?.((p) => setProgress(p));
+      try {
+        const result =
+          source === "file"
+            ? await api.installEngineFromFile()
+            : await api.installEngineFromUrl();
+        if ("canceled" in result && result.canceled) {
+          return; // user dismissed the file picker
+        }
+        if (result.ok) {
+          onInstalled?.();
+          onOpenChange(false);
+          return;
+        }
+        setError(result.error ?? "Install failed.");
+      } catch (e) {
+        setError((e as Error)?.message ?? "Install failed.");
+      } finally {
+        unsubscribe?.();
+        setInstalling(false);
+        setProgress(null);
+      }
+    },
+    [api, onInstalled, onOpenChange],
+  );
 
   return (
     <DialogPrimitive.Root onOpenChange={onOpenChange} open={open}>
@@ -87,24 +148,61 @@ export function ContactSalesDialog({
               ))}
             </ul>
             <p className="mt-4 text-muted-foreground text-xs">
-              Available on holaOS Enterprise.
+              Install the licensed engine to enable it here — it drops in and
+              activates without a restart.
             </p>
+            {error ? (
+              <p className="mt-3 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-destructive text-xs">
+                {error}
+              </p>
+            ) : null}
           </div>
 
-          <div className="flex shrink-0 items-center justify-end gap-2 border-border border-t px-6 py-4">
-            <DialogPrimitive.Close
-              render={
+          <div className="flex min-h-[36px] shrink-0 items-center gap-2 border-border border-t px-6 py-4">
+            {installing ? (
+              <div className="flex w-full items-center gap-3">
+                <Loader2 className="size-4 shrink-0 animate-spin text-violet-500" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-foreground text-sm">
+                    {progress?.message ?? "Installing…"}
+                    {typeof progress?.pct === "number"
+                      ? ` ${progress.pct}%`
+                      : ""}
+                  </p>
+                  {typeof progress?.pct === "number" ? (
+                    <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-fg-2">
+                      <div
+                        className="h-full rounded-full bg-violet-500 transition-all"
+                        style={{ width: `${progress.pct}%` }}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              <>
                 <button
-                  className={buttonVariants({ variant: "outline" })}
+                  className={buttonVariants({ variant: "ghost" })}
+                  onClick={contactSales}
                   type="button"
                 >
-                  Maybe later
+                  Contact sales
                 </button>
-              }
-            />
-            <Button onClick={contactSales} type="button">
-              Contact sales
-            </Button>
+                <div className="flex-1" />
+                <button
+                  className={buttonVariants({ variant: "outline" })}
+                  onClick={() => void runInstall("file")}
+                  type="button"
+                >
+                  Install from file…
+                </button>
+                {downloadAvailable ? (
+                  <Button onClick={() => void runInstall("url")} type="button">
+                    Install
+                  </Button>
+                ) : null}
+              </>
+            )}
           </div>
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>

--- a/apps/desktop/src/components/panes/ProfilesPane.tsx
+++ b/apps/desktop/src/components/panes/ProfilesPane.tsx
@@ -557,6 +557,10 @@ export function ProfilesPane() {
       <ContactSalesDialog
         open={contactSalesOpen}
         onOpenChange={setContactSalesOpen}
+        onInstalled={() => {
+          setEngineAvailable(true);
+          void refresh();
+        }}
       />
       <input
         ref={fileInputRef}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -3178,6 +3178,30 @@ declare global {
 				warnings: string[];
 			}>;
 			fingerprintAvailable: () => Promise<boolean>;
+			installedEngineInfo: () => Promise<{
+				present: boolean;
+				version?: string;
+				dir: string;
+			}>;
+			engineDownloadAvailable: () => Promise<boolean>;
+			installEngineFromFile: () => Promise<{
+				ok: boolean;
+				canceled?: boolean;
+				error?: string;
+				info?: { present: boolean; version?: string; dir: string };
+			}>;
+			installEngineFromUrl: () => Promise<{
+				ok: boolean;
+				error?: string;
+				info?: { present: boolean; version?: string; dir: string };
+			}>;
+			onEngineInstallProgress: (
+				listener: (progress: {
+					phase: "downloading" | "extracting" | "installing" | "done" | "error";
+					pct?: number;
+					message?: string;
+				}) => void,
+			) => () => void;
 			close: (profileId: string) => Promise<{ ok: boolean }>;
 			runningIds: () => Promise<string[]>;
 			setEngine: (


### PR DESCRIPTION
Follow-up to #452/#453. Makes the runtime-plugin engine **installable in one click** instead of "find a hidden folder and unzip."

## What
The Contact-Sales gate becomes an **install flow**:
- **Install** — downloads the bundle from a configured source (`HOLABOSS_FINGERPRINT_ENGINE_URL`) — shown only when a source is set.
- **Install from file…** — pick a downloaded `fingerprint-ee-*.zip` (needs no source; great for testing).
- **Contact sales** — kept, for access/licensing.

New `fingerprint-engine-installer.ts` (main): unzip the bundle into `<userData>/fingerprint-ee/`, **strip the macOS quarantine** (`xattr -dr com.apple.quarantine`, so the native `better-sqlite3` loads), and **reset the seam cache** so the feature activates **live — no restart**. Atomic-ish swap (temp on the same FS → rename).

Wiring: IPC (`fingerprint:installFromFile` / `installFromUrl` / `installedInfo` / `downloadAvailable` + `installProgress` events) → preload → types → a live progress UI in the dialog; `ProfilesPane` re-gates on success.

## Notes / follow-ups
- **Download source is a config point** — `HOLABOSS_FINGERPRINT_ENGINE_URL`. Wire it to a licensed/gated backend endpoint (account/license → signed URL) for real distribution; the private release isn't publicly fetchable. Until then, **Install from file** works.
- macOS-only (the engine is macOS today).

Verified: desktop typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)