### PR TITLE
fix(desktop): let a deep link name the action, not just an app to open

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18,6 +18,7 @@ import { normalizeInlineImageMaterialization } from "./image-normalization";
 import { app as electronApp } from "electron";
 
 import {
+  type ChatStartAttachment,
   type ChatStartInput,
   type ChatStartResult,
   type EmployeesChangedInput,
@@ -468,9 +469,8 @@ function maybeAuthCallbackUrl(argument: string | undefined): string | null {
 // the scheme-prefix filter (picks our URL out of argv / commandLine); the host
 // then decides intent — `open-app` opens a HolaApp surface, anything else is
 // the OAuth callback. e.g. ai.holaboss.app://open-app?appId=gofunds[&path=/x]
-function maybeOpenAppUrl(
-  argument: string | undefined,
-): { appId: string; path?: string } | null {
+/** Our scheme, parsed — or null for anything that isn't one of our deep links. */
+function deepLinkUrl(argument: string | undefined): URL | null {
   if (!argument) {
     return null;
   }
@@ -478,13 +478,18 @@ function maybeOpenAppUrl(
   if (!normalized.startsWith(`${AUTH_CALLBACK_PROTOCOL}:`)) {
     return null;
   }
-  let parsed: URL;
   try {
-    parsed = new URL(normalized);
+    return new URL(normalized);
   } catch {
     return null;
   }
-  if (parsed.hostname !== "open-app") {
+}
+
+function maybeOpenAppUrl(
+  argument: string | undefined,
+): { appId: string; path?: string } | null {
+  const parsed = deepLinkUrl(argument);
+  if (!parsed || parsed.hostname !== "open-app") {
     return null;
   }
   const appId = parsed.searchParams.get("appId")?.trim();
@@ -518,12 +523,197 @@ function handleOpenAppDeepLink(target: {
   }
 }
 
-// Single entry for every ai.holaboss.app:// deep link: split open-app from the
-// OAuth callback so an app-open link is never misread as an auth token.
+// `open-app` is the wrong verb for most of what the web hands over. Pressing Try
+// this / Remix / Use as reference INSIDE the desktop installs what the post names
+// and opens a composer; pressing Open in desktop on a skill opens a General chat
+// carrying it. Expressed as "open a HolaApp surface", both arrive as a webview of
+// HolaHub with the click undone — which is not what either button does here.
+//
+// These two verbs name the action instead, and land on the same functions the
+// host bridge already calls for the in-desktop press.
+function maybeHubActionUrl(
+  argument: string | undefined,
+): { postId: string; action: string; mediaId?: string } | null {
+  const parsed = deepLinkUrl(argument);
+  if (!parsed || parsed.hostname !== "hub-action") {
+    return null;
+  }
+  const postId = parsed.searchParams.get("postId")?.trim();
+  const action = parsed.searchParams.get("action")?.trim();
+  if (!postId || !action) {
+    return null;
+  }
+  const mediaId = parsed.searchParams.get("mediaId")?.trim();
+  return { postId, action, ...(mediaId ? { mediaId } : {}) };
+}
+
+function maybeOpenItemUrl(
+  argument: string | undefined,
+): { type: string; ref: string; title?: string } | null {
+  const parsed = deepLinkUrl(argument);
+  if (!parsed || parsed.hostname !== "open-item") {
+    return null;
+  }
+  const type = parsed.searchParams.get("type")?.trim();
+  const ref = parsed.searchParams.get("ref")?.trim();
+  if (!type || !ref) {
+    return null;
+  }
+  const title = parsed.searchParams.get("title")?.trim();
+  return { type, ref, ...(title ? { title } : {}) };
+}
+
+interface HubHandoff {
+  action: string;
+  title: string;
+  prompt: string;
+  model?: string;
+  imageModel?: string;
+  videoModel?: string;
+  skillIds?: string[];
+  items?: { type: string; ref: string }[];
+  attachment?: {
+    mediaId: string;
+    kind: "image" | "video" | "file";
+    /** A document's real name — it does not survive the trip to the bytes. */
+    fileName?: string;
+    contentType?: string;
+  };
+}
+
+/** The shared artifact itself, for Use as reference. Best-effort: a reference
+ *  that will not load is worth less than the hand-off it would otherwise block. */
+async function hubReferenceAttachment(
+  attachment: NonNullable<HubHandoff["attachment"]>,
+): Promise<ChatStartAttachment | null> {
+  try {
+    const { mediaId, kind } = attachment;
+    const url =
+      kind === "file"
+        ? `${AUTH_BASE_URL}/gateway/hub/public/file/${mediaId}/download`
+        : `${AUTH_BASE_URL}/gateway/hub/public/media/${kind}/${mediaId}/bytes`;
+    const response = await fetch(url, {
+      headers: { Cookie: authCookieHeader() },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const contentType =
+      attachment.contentType ||
+      response.headers.get("content-type") ||
+      (kind === "video" ? "video/mp4" : "image/png");
+    const buffer = Buffer.from(await response.arrayBuffer());
+    // Name it after what it actually is — handing a composer an mp4 called
+    // reference.png makes every downstream sniff of the extension wrong.
+    const extension = contentType.split("/")[1]?.split(";")[0] || "bin";
+    return {
+      fileName: attachment.fileName || `reference.${extension}`,
+      contentType,
+      dataBase64: buffer.toString("base64"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Try this / Remix / Use as reference, arriving from the web. HolaHub can only
+// fire the link; the work is the same work the in-desktop press does, so it runs
+// here: install what the post names, then open the composer seeded with it.
+async function runHubActionDeepLink(target: {
+  postId: string;
+  action: string;
+  mediaId?: string;
+}): Promise<void> {
+  try {
+    const query = new URLSearchParams({ action: target.action });
+    if (target.mediaId) {
+      query.set("mediaId", target.mediaId);
+    }
+    const response = await fetch(
+      `${AUTH_BASE_URL}/gateway/hub/posts/${encodeURIComponent(target.postId)}/handoff?${query}`,
+      { headers: { Cookie: authCookieHeader() } },
+    );
+    if (!response.ok) {
+      console.warn(`[hub-action] handoff ${target.action}: ${response.status}`);
+      return;
+    }
+    const handoff = (await response.json()) as HubHandoff;
+
+    // Best-effort, exactly as the in-desktop press treats it: an item that needs
+    // connecting opens its own flow, and a failure there must not cost the
+    // reader the session they asked for.
+    await Promise.allSettled(
+      (handoff.items ?? []).map((item) =>
+        hostInstall(
+          { appId: HUB_APP_ID },
+          { type: item.type as InstallInput["type"], ref: item.ref },
+        ),
+      ),
+    );
+
+    const attachment = handoff.attachment
+      ? await hubReferenceAttachment(handoff.attachment)
+      : null;
+    if (handoff.attachment && !attachment) {
+      console.warn("[hub-action] reference bytes unavailable — not seeding");
+      return;
+    }
+
+    await hostChatStart(
+      { appId: HUB_APP_ID },
+      {
+        title: handoff.title,
+        prompt: handoff.prompt,
+        ...(handoff.model ? { model: handoff.model } : {}),
+        ...(handoff.imageModel ? { imageModel: handoff.imageModel } : {}),
+        ...(handoff.videoModel ? { videoModel: handoff.videoModel } : {}),
+        ...(handoff.skillIds?.length ? { skillIds: handoff.skillIds } : {}),
+        ...(attachment ? { attachments: [attachment] } : {}),
+        // HolaHub is a system surface with no app row of its own to live under.
+        general: true,
+        newSession: true,
+      },
+    );
+  } catch (error) {
+    console.warn("[hub-action] failed", error);
+  }
+}
+
+function focusMainWindow(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+  }
+}
+
+// Single entry for every ai.holaboss.app:// deep link. Every known verb is split
+// off before the fallthrough, so an action link is never misread as an auth
+// token — which is what an unrecognised hostname becomes.
 function dispatchDeepLink(targetUrl: string): void {
   const openApp = maybeOpenAppUrl(targetUrl);
   if (openApp) {
     handleOpenAppDeepLink(openApp);
+    return;
+  }
+  const hubAction = maybeHubActionUrl(targetUrl);
+  if (hubAction) {
+    focusMainWindow();
+    void runHubActionDeepLink(hubAction);
+    return;
+  }
+  const openItem = maybeOpenItemUrl(targetUrl);
+  if (openItem) {
+    focusMainWindow();
+    void hostItemOpen(
+      { appId: HUB_APP_ID },
+      {
+        type: openItem.type as OpenItemInput["type"],
+        ref: openItem.ref,
+        ...(openItem.title ? { title: openItem.title } : {}),
+      },
+    );
     return;
   }
   void handleAuthCallbackUrl(targetUrl);
@@ -1544,6 +1734,9 @@ const WEB_APP_BASE_URL = configuredRemoteBaseUrl(
 // staging hub.imerchstaging.com, local http://localhost:5174) — NOT a
 // `<WEB_APP_BASE_URL>/apps/<id>` HolaApp route. Derive its origin from
 // WEB_APP_BASE_URL (www.* → hub.*, local :5173 → the hub dev server :5174),
+/** HolaHub's app id — the identity a hand-off from it is attributed to. */
+const HUB_APP_ID = "holahub";
+
 // overridable with HOLABOSS_HUB_APP_BASE_URL. The "Home" nav loads its root.
 const HUB_APP_BASE_URL = ((): string => {
   const explicit = configuredRemoteBaseUrl(["HOLABOSS_HUB_APP_BASE_URL"]);
@@ -19089,7 +19282,7 @@ async function ensureWebHolaAppMcpAttached(workspaceId: string): Promise<void> {
 // first opening the HolaHub surface. Attached the same way as an installed app's MCP
 // (discover → app_servers entry → allowlist); auth rides the user's session bearer,
 // so no surface-open is required.
-const SYSTEM_MCP_APP_IDS = ["holahub"] as const;
+const SYSTEM_MCP_APP_IDS = [HUB_APP_ID] as const;
 
 async function ensureSystemMcpAttached(workspaceId: string): Promise<void> {
   for (const appId of SYSTEM_MCP_APP_IDS) {

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -285,6 +285,19 @@ export {
   ConversationTurns,
 };
 
+/** A model's identity without the provider that serves it. Only the leading
+ *  segment goes: `holaboss_model_proxy/qwen/qwen3.7-plus` is the qwen3.7-plus of
+ *  the qwen family, and dropping more than the provider would merge two models
+ *  that only share a suffix. */
+function modelIdentity(token: string): string {
+  const trimmed = token.trim().toLowerCase();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    return trimmed;
+  }
+  return trimmed.slice(slash + 1);
+}
+
 function sessionUserId(
   session: { user?: { id?: string | null } | null } | null | undefined,
 ): string {
@@ -9652,8 +9665,18 @@ export function ChatPane({
       onChatModelRequestConsumed?.(chatModelRequest.requestKey);
       return;
     }
-    if (availableChatModelOptions.some((o) => o.value === wanted)) {
-      applyComposerModelSelection(wanted);
+    const exact = availableChatModelOptions.find((o) => o.value === wanted);
+    // Same model, different route: a sharer on OpenAI natively writes
+    // `openai/gpt-5.4-mini` where a reader holding it through the proxy has
+    // `holaboss_model_proxy/gpt-5.4-mini`. Falling through to the default would
+    // reproduce the post on a different model entirely.
+    const sameModel =
+      exact ??
+      availableChatModelOptions.find(
+        (o) => modelIdentity(o.value) === modelIdentity(wanted),
+      );
+    if (sameModel) {
+      applyComposerModelSelection(sameModel.value);
     } else {
       // Falling back silently would let someone believe they reproduced
       // something on the model it was made with.


### PR DESCRIPTION
Pressing **Try this**, **Remix**, **Use as reference** or **Open in desktop** on
HolaHub's web build did not do what the same buttons do inside the desktop. This
is the desktop half of the fix.

## Why

`ai.holaboss.app://` had exactly one verb — `open-app?appId=&path=`. So every
hand-off the web could express was "open a HolaApp surface", regardless of what
the reader actually pressed:

| pressed on the web | link it could send | what the desktop does for the same press |
|---|---|---|
| Try this / Remix / Use as reference | `open-app?appId=holahub&path=/threads/…` | install what the post names, then open a seeded composer |
| Open in desktop, on a skill | `open-app?appId=<the skill's catalog ref>` | open a General chat carrying the skill |

The first landed the reader inside HolaHub in a webview with their click undone.
The second asked the desktop to open a HolaApp that does not exist — the blank
app surface people were reporting.

Both correct behaviours already existed here as `hostChatStart` and
`hostItemOpen` (which routes a skill/mcp/capability to a chat and a holaapp to a
surface). They were reachable from the host bridge and from nowhere else.

## What changed

Two verbs, landing on those same functions:

- **`hub-action?postId=&action=try|remix|reference[&mediaId=]`** — the resolution
  it needs is a whole opening ask, which will not fit in a URL, so it comes from
  the backend's new `GET /api/v1/holahub/posts/:id/handoff`. That response *is*
  the argument list for `chat.start`, which is what keeps the web press and the
  in-desktop press from drifting apart again. Items install best-effort first, as
  the in-desktop press treats them; a Use as reference fetches the artifact's
  bytes and stages it as an attachment.
- **`open-item?type=&ref=[&title=]`** — the item's own type is the fact that
  decides between a surface and a chat, so it travels.

The URL parse is now shared, so a third verb reads the scheme the same way, and
every known verb is split off before the fallthrough that still treats an
unrecognised hostname as an OAuth callback.

Also in this branch: a hand-off carrying `openai/gpt-5.4-mini` told the reader
they didn't have that model and opened on their default, while they had exactly
it through the proxy as `holaboss_model_proxy/gpt-5.4-mini`. The match now falls
back to model identity — the token minus its *leading* provider segment only, so
`holaboss_model_proxy/qwen/qwen3.7-plus` stays the qwen3.7-plus of the qwen
family rather than merging models that share a suffix.

## Ships with

- `holaboss-backend` `dev` — `feat(holahub): resolve a post's hand-off so the desktop can run it`
- `holaboss-frontend` `develop` — `fix(holahub): hand the desktop the action, not a page about it`

**The web half is already on `develop`.** Until a desktop build carrying this
ships, an older desktop answers the new verbs through the auth-callback
fallthrough and shows *"Invalid desktop authentication callback."* — no sign-out
or other side effect, but the exposure grows the longer the two halves are apart.

## Verification

`npm run typecheck` clean on this base. The link contract is checked both ways —
the links the web emits, parsed by the parser in this diff — over 11 cases:
each verb round-trips, url-hostile refs and titles survive, the three verbs do
not cross-match (so one action can never run as another), and `open-app` still
parses unchanged.

Not verified at runtime: the deep link has not been fired at a built desktop, so
`runHubActionDeepLink`'s fetch, install and chat.start path is reasoned and typed
but not exercised. Worth a manual pass before release.
