### PR TITLE
feat(desktop): per-cronjob thinking level + model-catalogue resync in every picker

### DIFF
--- a/apps/desktop/src/components/harness/ChannelModelPicker.tsx
+++ b/apps/desktop/src/components/harness/ChannelModelPicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { ModelCatalogRefreshButton } from "@/components/model/ModelCatalogRefreshButton";
 import { ChevronDown } from "@/components/ui/icons";
 import {
   Popover,
@@ -78,6 +79,12 @@ export function ChannelModelPicker({
         sideOffset={8}
         className="w-[260px] gap-0 overflow-hidden rounded-xl border border-border/70 bg-popover/95 p-0 shadow-2xl ring-1 ring-foreground/[0.04] backdrop-blur-xl"
       >
+        <div className="flex items-center justify-between border-b border-border/60 py-1 pr-1 pl-2.5">
+          <span className="text-[10px] font-medium uppercase text-foreground/40">
+            Model
+          </span>
+          <ModelCatalogRefreshButton />
+        </div>
         <div className="chat-scrollbar-thin max-h-[280px] overflow-y-auto p-1">
           <button
             type="button"

--- a/apps/desktop/src/components/model/ModelCatalogRefreshButton.test.mjs
+++ b/apps/desktop/src/components/model/ModelCatalogRefreshButton.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel) => readFile(path.join(__dirname, rel), "utf8");
+
+test("the shared button drives the resync through the shared hook", async () => {
+  const button = await read("ModelCatalogRefreshButton.tsx");
+  // Delegates to the shared hook and shows a spinner while refreshing.
+  assert.match(button, /useRefreshModelCatalog\(\)/);
+  assert.match(button, /animate-spin/);
+  // Stops the click from selecting/dismissing a host popover or select.
+  assert.match(button, /stopPropagation\(\)/);
+});
+
+test("the hook re-pulls the catalogue and guards re-entrancy", async () => {
+  const hook = await read("../../lib/useRefreshModelCatalog.ts");
+  // Re-pulls via the main-process IPC (which broadcasts a fresh config).
+  assert.match(hook, /window\.electronAPI\.runtime\.refreshModelCatalog\(\)/);
+  // A single-flight guard so overlapping clicks coalesce.
+  assert.match(hook, /inFlight/);
+});
+
+test("every named model selector wires in the shared resync button", async () => {
+  const selectors = [
+    "../panes/ChatPane/Composer/ModelCombobox.tsx", // composer
+    "../harness/ChannelModelPicker.tsx", // channels
+  ];
+  for (const rel of selectors) {
+    const source = await read(rel);
+    assert.match(
+      source,
+      /ModelCatalogRefreshButton/,
+      `${rel} should render the shared resync button`,
+    );
+  }
+});

--- a/apps/desktop/src/components/model/ModelCatalogRefreshButton.tsx
+++ b/apps/desktop/src/components/model/ModelCatalogRefreshButton.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button";
+import { Loader2, RefreshCw } from "@/components/ui/icons";
+import { useRefreshModelCatalog } from "@/lib/useRefreshModelCatalog";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared "resync the model catalogue" affordance rendered inside every model
+ * selector (composer, automations, channels). Clicking it re-pulls the runtime
+ * catalogue; the fresh config broadcasts to the whole app, so every open picker
+ * updates at once. Icon-only by default — pass `className` to fit the host.
+ */
+export function ModelCatalogRefreshButton({
+  className,
+}: {
+  className?: string;
+}) {
+  const { refreshing, refresh } = useRefreshModelCatalog();
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label="Resync models"
+      title="Resync models"
+      disabled={refreshing}
+      // Stop the click from bubbling into a parent popover/select surface so a
+      // resync never doubles as a selection or dismissal.
+      onClick={(event) => {
+        event.stopPropagation();
+        void refresh();
+      }}
+      className={cn(
+        "size-6 shrink-0 justify-center !p-0 text-muted-foreground hover:text-foreground",
+        className,
+      )}
+    >
+      {refreshing ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <RefreshCw className="size-3.5" />
+      )}
+    </Button>
+  );
+}

--- a/apps/desktop/src/components/panes/AutomationsPane.test.mjs
+++ b/apps/desktop/src/components/panes/AutomationsPane.test.mjs
@@ -185,6 +185,30 @@ test("automations expose their model: shown in detail, editable in the dialog, p
   assert.match(source, /selected_model: draft\.model/);
 });
 
+test("automations expose a reasoning-effort pin: editable in the dialog, persisted to metadata", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  // Reads the pinned effort (metadata.thinking_value), null => model default.
+  assert.match(
+    source,
+    /function jobThinkingValue\(job: CronjobRecordPayload\): string \| null/,
+  );
+  // Edit dialog offers a Thinking picker, gated on the model exposing any.
+  assert.match(source, /automationThinkingChoiceForModel\(/);
+  assert.match(source, /thinkingChoice\.thinkingValues\.length > 0/);
+  assert.match(source, /<EditField label="Thinking">/);
+  // Saving pins (or clears) metadata.thinking_value while preserving the rest.
+  assert.match(source, /metadata\.thinking_value = draft\.thinkingValue;/);
+  assert.match(source, /delete metadata\.thinking_value;/);
+  // Manual create persists the same pinned-effort key.
+  assert.match(source, /thinking_value: draft\.thinkingValue/);
+});
+
+test("edit dialog offers a catalogue resync next to the model picker", async () => {
+  const source = await readFile(sourcePath, "utf8");
+  assert.match(source, /ModelCatalogRefreshButton/);
+});
+
 test("edit dialog exposes an agent picker that re-scopes the model list and persists the harness", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/apps/desktop/src/components/panes/AutomationsPane.tsx
+++ b/apps/desktop/src/components/panes/AutomationsPane.tsx
@@ -54,13 +54,18 @@ import { useStartAutomationCreation } from "@/components/layout/shell/useStartAu
 import { cn } from "@/lib/utils";
 import { cronToHumanReadable } from "@/lib/cron";
 import { remoteApi } from "@/lib/remoteApiClient";
+import { ModelCatalogRefreshButton } from "@/components/model/ModelCatalogRefreshButton";
 import { displayModelLabel } from "@/components/panes/ChatPane/helpers";
+import { displayThinkingValueLabel } from "@/components/panes/ChatPane/Composer/ThinkingValueSelect";
 import { useChatComposerModelSelection } from "@/lib/chat/useChatComposerModelSelection";
+import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import { HarnessPicker } from "@/components/harness/HarnessPicker";
 import { useAvailableHarnesses } from "@/components/harness/useAvailableHarnesses";
 import {
   automationModelChoiceForHarness,
+  automationThinkingChoiceForModel,
   reconcileAutomationModel,
+  reconcileAutomationThinkingValue,
 } from "@/components/panes/automationModelOptions";
 import { SchedulePicker } from "@/components/panes/AutomationsPaneInlineEditors";
 import {
@@ -171,6 +176,13 @@ function jobModel(job: CronjobRecordPayload): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+// The reasoning effort pinned to this automation (metadata.thinking_value), or
+// null to follow the model's own default at run time. Read back in fireCronjob.
+function jobThinkingValue(job: CronjobRecordPayload): string | null {
+  const value = job.metadata?.thinking_value;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 // The agent (harness) an automation's runs execute under (metadata.harness),
 // defaulting to pi/Hola.
 function jobHarness(job: CronjobRecordPayload): string {
@@ -228,6 +240,9 @@ function automationSearchScore(
 // Sentinel <Select> value for "no pinned model → workspace default" (Select
 // can't hold null/empty).
 const MODEL_WORKSPACE_DEFAULT = "__workspace_default__";
+
+// Sentinel <Select> value for "no pinned reasoning effort → model default".
+const THINKING_MODEL_DEFAULT = "__model_default__";
 
 function jobLastSessionId(job: CronjobRecordPayload): string | null {
   const value = job.metadata?.last_session_id;
@@ -604,6 +619,9 @@ export function AutomationsPane({
           harness: draft.harness,
           ...(draft.projectId ? { project_id: draft.projectId } : {}),
           ...(draft.model ? { selected_model: draft.model } : {}),
+          ...(draft.thinkingValue
+            ? { thinking_value: draft.thinkingValue }
+            : {}),
         },
       });
       toast.success(`Created "${draft.name || "automation"}"`);
@@ -625,6 +643,11 @@ export function AutomationsPane({
         metadata.selected_model = draft.model;
       } else {
         delete metadata.selected_model;
+      }
+      if (draft.thinkingValue) {
+        metadata.thinking_value = draft.thinkingValue;
+      } else {
+        delete metadata.thinking_value;
       }
       await handleUpdateCronjobField(
         job,
@@ -1326,6 +1349,7 @@ interface EditAutomationDraft {
   cron: string;
   projectId: string | null;
   model: string | null;
+  thinkingValue: string | null;
   harness: string;
 }
 
@@ -1382,12 +1406,16 @@ function EditAutomationForm({
   const [cronValid, setCronValid] = useState(true);
   const [projectId, setProjectId] = useState<string | null>(jobProjectId(job));
   const [model, setModel] = useState<string | null>(jobModel(job));
+  const [thinkingValue, setThinkingValue] = useState<string | null>(
+    jobThinkingValue(job),
+  );
   const [harness, setHarness] = useState(jobHarness(job));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { harnesses, isLoading: harnessesLoading } =
     useAvailableHarnesses(workspaceId);
+  const { runtimeConfig } = useWorkspaceDesktop();
   const { availableChatModelOptions, runtimeDefaultModelLabel } =
     useChatComposerModelSelection();
   // Models are scoped to the selected agent: pi/Hola uses the runtime catalogue
@@ -1408,8 +1436,24 @@ function EditAutomationForm({
   const modelNotInCatalog =
     model !== null && !modelChoice.options.some((option) => option.value === model);
 
+  // Reasoning-effort levels for the pinned (or default) model — same source as
+  // the composer. A CLI-namespace harness doesn't declare per-model effort, so
+  // no default fallback there and the field stays hidden.
+  const providerModelGroups = runtimeConfig?.providerModelGroups ?? [];
+  const thinkingChoiceFor = (nextModel: string | null, namespace: boolean) =>
+    automationThinkingChoiceForModel({
+      model: nextModel,
+      providerModelGroups,
+      defaultModel: namespace ? null : (runtimeConfig?.defaultModel ?? null),
+    });
+  const thinkingChoice = thinkingChoiceFor(
+    model,
+    modelChoice.usesHarnessNamespace,
+  );
+
   // Switching the agent re-scopes the model list; drop a now-invalid pin to the
-  // new agent's default (or workspace default for pi).
+  // new agent's default (or workspace default for pi), then reconcile the
+  // reasoning-effort pin against the resulting model.
   const handleHarnessChange = (nextHarness: string) => {
     setHarness(nextHarness);
     const nextChoice = automationModelChoiceForHarness({
@@ -1417,8 +1461,25 @@ function EditAutomationForm({
       harnesses,
       chatModelOptions: availableChatModelOptions,
     });
-    setModel((prev) =>
-      reconcileAutomationModel({ model: prev, choice: nextChoice }),
+    const nextModel = reconcileAutomationModel({ model, choice: nextChoice });
+    setModel(nextModel);
+    setThinkingValue((prev) =>
+      reconcileAutomationThinkingValue({
+        thinkingValue: prev,
+        choice: thinkingChoiceFor(nextModel, nextChoice.usesHarnessNamespace),
+      }),
+    );
+  };
+
+  // Re-scope the reasoning-effort pin when the model changes under the same
+  // agent (a new model may not offer the previously-pinned effort).
+  const handleModelChange = (nextModel: string | null) => {
+    setModel(nextModel);
+    setThinkingValue((prev) =>
+      reconcileAutomationThinkingValue({
+        thinkingValue: prev,
+        choice: thinkingChoiceFor(nextModel, modelChoice.usesHarnessNamespace),
+      }),
     );
   };
 
@@ -1442,6 +1503,7 @@ function EditAutomationForm({
         cron: cron.trim(),
         projectId,
         model,
+        thinkingValue,
         harness,
       });
       onCancel();
@@ -1501,41 +1563,79 @@ function EditAutomationForm({
       </EditField>
 
       <EditField label="Model">
-        <Select
-          items={[
-            { value: MODEL_WORKSPACE_DEFAULT, label: defaultOptionLabel },
-            ...(modelNotInCatalog && model
-              ? [{ value: model, label: displayModelLabel(model) }]
-              : []),
-            ...modelChoice.options,
-          ]}
-          value={model ?? MODEL_WORKSPACE_DEFAULT}
-          onValueChange={(value) =>
-            setModel(value === MODEL_WORKSPACE_DEFAULT ? null : value)
-          }
-        >
-          <SelectTrigger className="h-8 w-full bg-transparent text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent align="start" className="min-w-[240px]">
-            <SelectItem value={MODEL_WORKSPACE_DEFAULT}>
-              {defaultOptionLabel}
-            </SelectItem>
-            {modelNotInCatalog && model ? (
-              <SelectItem value={model}>{displayModelLabel(model)}</SelectItem>
-            ) : null}
-            {modelChoice.options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
+        <div className="flex items-center gap-1.5">
+          <Select
+            items={[
+              { value: MODEL_WORKSPACE_DEFAULT, label: defaultOptionLabel },
+              ...(modelNotInCatalog && model
+                ? [{ value: model, label: displayModelLabel(model) }]
+                : []),
+              ...modelChoice.options,
+            ]}
+            value={model ?? MODEL_WORKSPACE_DEFAULT}
+            onValueChange={(value) =>
+              handleModelChange(value === MODEL_WORKSPACE_DEFAULT ? null : value)
+            }
+          >
+            <SelectTrigger className="h-8 min-w-0 flex-1 bg-transparent text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" className="min-w-[240px]">
+              <SelectItem value={MODEL_WORKSPACE_DEFAULT}>
+                {defaultOptionLabel}
               </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+              {modelNotInCatalog && model ? (
+                <SelectItem value={model}>{displayModelLabel(model)}</SelectItem>
+              ) : null}
+              {modelChoice.options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ModelCatalogRefreshButton className="size-8 rounded-md border border-input" />
+        </div>
         <p className="text-[11px] text-muted-foreground">
           Follows the agent's default unless you pin a specific model. The list
           changes with the selected agent.
         </p>
       </EditField>
+
+      {thinkingChoice.thinkingValues.length > 0 ? (
+        <EditField label="Thinking">
+          <Select
+            items={[
+              { value: THINKING_MODEL_DEFAULT, label: "Default (model's default)" },
+              ...thinkingChoice.thinkingValues.map((value) => ({
+                value,
+                label: displayThinkingValueLabel(value),
+              })),
+            ]}
+            value={thinkingValue ?? THINKING_MODEL_DEFAULT}
+            onValueChange={(value) =>
+              setThinkingValue(value === THINKING_MODEL_DEFAULT ? null : value)
+            }
+          >
+            <SelectTrigger className="h-8 w-full bg-transparent text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" className="min-w-[240px]">
+              <SelectItem value={THINKING_MODEL_DEFAULT}>
+                Default (model's default)
+              </SelectItem>
+              {thinkingChoice.thinkingValues.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {displayThinkingValueLabel(value)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-[11px] text-muted-foreground">
+            Reasoning effort for each run. Defaults to the model's own setting.
+          </p>
+        </EditField>
+      ) : null}
 
       {showProjectField ? (
         <EditField label="Project">

--- a/apps/desktop/src/components/panes/ChatPane/Composer/ModelCombobox.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/Composer/ModelCombobox.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { ChevronDown, Search } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { ModelCatalogRefreshButton } from "@/components/model/ModelCatalogRefreshButton";
 import {
   Popover,
   PopoverContent,
@@ -207,6 +208,7 @@ export function ModelCombobox({
               placeholder="Search models…"
               className="embedded-input h-6 w-full min-w-0 bg-transparent text-sm text-foreground outline-none placeholder:text-foreground/35"
             />
+            <ModelCatalogRefreshButton />
           </div>
         </div>
         <div className="chat-scrollbar-thin max-h-[280px] overflow-y-auto p-1">

--- a/apps/desktop/src/components/panes/ChatPane/Composer/ThinkingValueSelect.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/Composer/ThinkingValueSelect.tsx
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-function displayThinkingValueLabel(value: string) {
+export function displayThinkingValueLabel(value: string) {
   const normalizedValue = value.trim().toLowerCase();
   if (!normalizedValue) {
     return "Thinking";

--- a/apps/desktop/src/components/panes/ManualAutomationDialog.test.mjs
+++ b/apps/desktop/src/components/panes/ManualAutomationDialog.test.mjs
@@ -22,6 +22,25 @@ test("manual create dialog exposes a model picker fed by the composer catalog", 
   assert.match(source, /projectId,\s*model,/);
 });
 
+test("create dialog exposes a reasoning-effort picker scoped to the model", async () => {
+  const source = await readFile(sourcePath, "utf8");
+
+  // The create draft carries a pinned reasoning effort (null => model default).
+  assert.match(source, /thinkingValue: string \| null/);
+  // Effort levels come from the model-scoped helper, gated on the model
+  // actually offering any (non-reasoning models hide the field).
+  assert.match(source, /automationThinkingChoiceForModel\(/);
+  assert.match(source, /thinkingChoice\.thinkingValues\.length > 0/);
+  assert.match(source, /<Field label="Thinking">/);
+  // The chosen effort flows into the create draft handed to onCreate.
+  assert.match(source, /model,\s*thinkingValue,/);
+});
+
+test("create dialog offers a catalogue resync next to the model picker", async () => {
+  const source = await readFile(sourcePath, "utf8");
+  assert.match(source, /ModelCatalogRefreshButton/);
+});
+
 test("create dialog scopes the model list to the selected agent", async () => {
   const source = await readFile(sourcePath, "utf8");
 

--- a/apps/desktop/src/components/panes/ManualAutomationDialog.tsx
+++ b/apps/desktop/src/components/panes/ManualAutomationDialog.tsx
@@ -16,11 +16,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ModelCatalogRefreshButton } from "@/components/model/ModelCatalogRefreshButton";
 import { displayModelLabel } from "@/components/panes/ChatPane/helpers";
+import { displayThinkingValueLabel } from "@/components/panes/ChatPane/Composer/ThinkingValueSelect";
 import { useChatComposerModelSelection } from "@/lib/chat/useChatComposerModelSelection";
+import { useWorkspaceDesktop } from "@/lib/workspaceDesktop";
 import {
   automationModelChoiceForHarness,
+  automationThinkingChoiceForModel,
   reconcileAutomationModel,
+  reconcileAutomationThinkingValue,
 } from "./automationModelOptions";
 import { SchedulePicker } from "./AutomationsPaneInlineEditors";
 
@@ -40,6 +45,9 @@ export interface ManualAutomationDraft {
   /** Model pinned for the automation's runs (persisted as
    *  metadata.selected_model), or null to follow the workspace default. */
   model: string | null;
+  /** Reasoning effort pinned for the automation's runs (persisted as
+   *  metadata.thinking_value), or null to follow the model's default. */
+  thinkingValue: string | null;
 }
 
 interface ManualAutomationDialogProps {
@@ -59,6 +67,9 @@ const DEFAULT_CRON = "0 9 * * *"; // every day at 09:00
 // Sentinel <Select> value for "no pinned model → workspace default" (Select
 // can't hold null/empty).
 const MODEL_WORKSPACE_DEFAULT = "__workspace_default__";
+
+// Sentinel <Select> value for "no pinned reasoning effort → model default".
+const THINKING_MODEL_DEFAULT = "__model_default__";
 
 /**
  * Manual "New automation" builder — name + instruction + schedule + delivery,
@@ -118,12 +129,16 @@ function ManualAutomationForm({
     initialDraft?.projectId ?? null,
   );
   const [model, setModel] = useState<string | null>(initialDraft?.model ?? null);
+  const [thinkingValue, setThinkingValue] = useState<string | null>(
+    initialDraft?.thinkingValue ?? null,
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { harnesses, isLoading: harnessesLoading } =
     useAvailableHarnesses(workspaceId);
   const { projects } = useWorkspaceProjects(workspaceId);
+  const { runtimeConfig } = useWorkspaceDesktop();
   const { availableChatModelOptions, runtimeDefaultModelLabel } =
     useChatComposerModelSelection();
   // Models are scoped to the selected agent: pi/Hola uses the runtime catalogue
@@ -146,8 +161,24 @@ function ManualAutomationForm({
   const modelNotInCatalog =
     model !== null && !modelChoice.options.some((option) => option.value === model);
 
+  // Reasoning-effort levels for the pinned (or default) model. A CLI-namespace
+  // harness doesn't declare per-model effort, so pass no default fallback there
+  // — the field stays hidden. Recomputes whenever the model/agent changes.
+  const providerModelGroups = runtimeConfig?.providerModelGroups ?? [];
+  const thinkingChoiceFor = (nextModel: string | null, namespace: boolean) =>
+    automationThinkingChoiceForModel({
+      model: nextModel,
+      providerModelGroups,
+      defaultModel: namespace ? null : (runtimeConfig?.defaultModel ?? null),
+    });
+  const thinkingChoice = thinkingChoiceFor(
+    model,
+    modelChoice.usesHarnessNamespace,
+  );
+
   // Switching the agent re-scopes the model list; drop a now-invalid pin to the
-  // new agent's default (or workspace default for pi).
+  // new agent's default (or workspace default for pi), then reconcile the
+  // reasoning-effort pin against the resulting model.
   const handleHarnessChange = (nextHarness: string) => {
     setHarness(nextHarness);
     const nextChoice = automationModelChoiceForHarness({
@@ -155,8 +186,25 @@ function ManualAutomationForm({
       harnesses,
       chatModelOptions: availableChatModelOptions,
     });
-    setModel((prev) =>
-      reconcileAutomationModel({ model: prev, choice: nextChoice }),
+    const nextModel = reconcileAutomationModel({ model, choice: nextChoice });
+    setModel(nextModel);
+    setThinkingValue((prev) =>
+      reconcileAutomationThinkingValue({
+        thinkingValue: prev,
+        choice: thinkingChoiceFor(nextModel, nextChoice.usesHarnessNamespace),
+      }),
+    );
+  };
+
+  // Re-scope the reasoning-effort pin when the model changes under the same
+  // agent (a new model may not offer the previously-pinned effort).
+  const handleModelChange = (nextModel: string | null) => {
+    setModel(nextModel);
+    setThinkingValue((prev) =>
+      reconcileAutomationThinkingValue({
+        thinkingValue: prev,
+        choice: thinkingChoiceFor(nextModel, modelChoice.usesHarnessNamespace),
+      }),
     );
   };
 
@@ -185,6 +233,7 @@ function ManualAutomationForm({
         harness,
         projectId,
         model,
+        thinkingValue,
       });
       onCancel();
     } catch (err) {
@@ -252,41 +301,81 @@ function ManualAutomationForm({
       </Field>
 
       <Field label="Model">
-        <Select
-          items={[
-            { value: MODEL_WORKSPACE_DEFAULT, label: defaultOptionLabel },
-            ...(modelNotInCatalog && model
-              ? [{ value: model, label: displayModelLabel(model) }]
-              : []),
-            ...modelChoice.options,
-          ]}
-          value={model ?? MODEL_WORKSPACE_DEFAULT}
-          onValueChange={(value) =>
-            setModel(value === MODEL_WORKSPACE_DEFAULT ? null : value)
-          }
-        >
-          <SelectTrigger className="h-8 w-full bg-transparent text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent align="start" className="min-w-55">
-            <SelectItem value={MODEL_WORKSPACE_DEFAULT}>
-              {defaultOptionLabel}
-            </SelectItem>
-            {modelNotInCatalog && model ? (
-              <SelectItem value={model}>{displayModelLabel(model)}</SelectItem>
-            ) : null}
-            {modelChoice.options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
+        <div className="flex items-center gap-1.5">
+          <Select
+            items={[
+              { value: MODEL_WORKSPACE_DEFAULT, label: defaultOptionLabel },
+              ...(modelNotInCatalog && model
+                ? [{ value: model, label: displayModelLabel(model) }]
+                : []),
+              ...modelChoice.options,
+            ]}
+            value={model ?? MODEL_WORKSPACE_DEFAULT}
+            onValueChange={(value) =>
+              handleModelChange(value === MODEL_WORKSPACE_DEFAULT ? null : value)
+            }
+          >
+            <SelectTrigger className="h-8 min-w-0 flex-1 bg-transparent text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" className="min-w-55">
+              <SelectItem value={MODEL_WORKSPACE_DEFAULT}>
+                {defaultOptionLabel}
               </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+              {modelNotInCatalog && model ? (
+                <SelectItem value={model}>{displayModelLabel(model)}</SelectItem>
+              ) : null}
+              {modelChoice.options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ModelCatalogRefreshButton className="size-8 rounded-md border border-input" />
+        </div>
         <p className="text-[11px] leading-4 text-muted-foreground">
           Follows the agent's default unless you pin a specific model. The list
           changes with the selected agent.
         </p>
       </Field>
+
+      {thinkingChoice.thinkingValues.length > 0 ? (
+        <Field label="Thinking">
+          <Select
+            items={[
+              { value: THINKING_MODEL_DEFAULT, label: "Default (model's default)" },
+              ...thinkingChoice.thinkingValues.map((value) => ({
+                value,
+                label: displayThinkingValueLabel(value),
+              })),
+            ]}
+            value={thinkingValue ?? THINKING_MODEL_DEFAULT}
+            onValueChange={(value) =>
+              setThinkingValue(
+                value === THINKING_MODEL_DEFAULT ? null : value,
+              )
+            }
+          >
+            <SelectTrigger className="h-8 w-full bg-transparent text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" className="min-w-55">
+              <SelectItem value={THINKING_MODEL_DEFAULT}>
+                Default (model's default)
+              </SelectItem>
+              {thinkingChoice.thinkingValues.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {displayThinkingValueLabel(value)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-[11px] leading-4 text-muted-foreground">
+            Reasoning effort for each run. Defaults to the model's own setting.
+          </p>
+        </Field>
+      ) : null}
 
       {projects.length > 0 ? (
         <Field label="Project">

--- a/apps/desktop/src/components/panes/automationModelOptions.test.ts
+++ b/apps/desktop/src/components/panes/automationModelOptions.test.ts
@@ -3,7 +3,9 @@ import { test } from "node:test";
 
 import {
   automationModelChoiceForHarness,
+  automationThinkingChoiceForModel,
   reconcileAutomationModel,
+  reconcileAutomationThinkingValue,
 } from "./automationModelOptions.js";
 
 // Minimal harness inventory: pi has no namespace (uses the runtime catalogue),
@@ -86,5 +88,107 @@ test("reconcile keeps a valid pin, else falls back to harness default / null", (
   assert.equal(
     reconcileAutomationModel({ model: "deepseek/deepseek-v4-pro", choice: pi }),
     "deepseek/deepseek-v4-pro",
+  );
+});
+
+// A runtime provider group carrying explicit thinking metadata for a model.
+const PROVIDER_GROUPS = [
+  {
+    providerId: "holaboss_model_proxy",
+    providerLabel: "Holaboss",
+    kind: "backend",
+    models: [
+      {
+        token: "claude-sonnet-4-6",
+        modelId: "claude-sonnet-4-6",
+        reasoning: true,
+        thinkingValues: ["low", "medium", "high", "medium"], // dup on purpose
+        defaultThinkingValue: "medium",
+      },
+      {
+        token: "deepseek/deepseek-v4-pro",
+        modelId: "deepseek-v4-pro",
+        reasoning: false,
+        thinkingValues: [],
+      },
+    ],
+  },
+  // biome-ignore lint/suspicious/noExplicitAny: test double for the global payload type.
+] as any;
+
+test("thinking choice reads a configured model's effort levels (deduped)", () => {
+  const choice = automationThinkingChoiceForModel({
+    model: "claude-sonnet-4-6",
+    providerModelGroups: PROVIDER_GROUPS,
+  });
+  assert.deepEqual(choice.thinkingValues, ["low", "medium", "high"]);
+  assert.equal(choice.defaultThinkingValue, "medium");
+});
+
+test("thinking choice is empty for a non-reasoning model", () => {
+  const choice = automationThinkingChoiceForModel({
+    model: "deepseek/deepseek-v4-pro",
+    providerModelGroups: PROVIDER_GROUPS,
+  });
+  assert.deepEqual(choice.thinkingValues, []);
+  assert.equal(choice.defaultThinkingValue, null);
+});
+
+test("thinking choice falls back to the bundled catalogue for a known model", () => {
+  // gpt-5.4 isn't in PROVIDER_GROUPS but ships in the local model catalogue.
+  const choice = automationThinkingChoiceForModel({
+    model: "gpt-5.4",
+    providerModelGroups: PROVIDER_GROUPS,
+  });
+  assert.ok(choice.thinkingValues.includes("medium"));
+  assert.equal(choice.defaultThinkingValue, "medium");
+});
+
+test("thinking choice resolves the workspace default model when none is pinned", () => {
+  // model=null + a pi default model => the picker reflects the default's effort.
+  const choice = automationThinkingChoiceForModel({
+    model: null,
+    providerModelGroups: PROVIDER_GROUPS,
+    defaultModel: "claude-sonnet-4-6",
+  });
+  assert.deepEqual(choice.thinkingValues, ["low", "medium", "high"]);
+});
+
+test("thinking choice is empty when the model is unknown / absent", () => {
+  assert.deepEqual(
+    automationThinkingChoiceForModel({
+      model: "some/unknown-model",
+      providerModelGroups: PROVIDER_GROUPS,
+    }),
+    { thinkingValues: [], defaultThinkingValue: null },
+  );
+  assert.deepEqual(
+    automationThinkingChoiceForModel({
+      model: null,
+      providerModelGroups: PROVIDER_GROUPS,
+    }),
+    { thinkingValues: [], defaultThinkingValue: null },
+  );
+});
+
+test("reconcile keeps a still-offered effort, else drops to the model default", () => {
+  const choice = automationThinkingChoiceForModel({
+    model: "claude-sonnet-4-6",
+    providerModelGroups: PROVIDER_GROUPS,
+  });
+  // A pin the model still offers is kept.
+  assert.equal(
+    reconcileAutomationThinkingValue({ thinkingValue: "high", choice }),
+    "high",
+  );
+  // A pin the model no longer offers drops to null = "model default".
+  assert.equal(
+    reconcileAutomationThinkingValue({ thinkingValue: "xhigh", choice }),
+    null,
+  );
+  // Null stays null.
+  assert.equal(
+    reconcileAutomationThinkingValue({ thinkingValue: null, choice }),
+    null,
   );
 });

--- a/apps/desktop/src/components/panes/automationModelOptions.ts
+++ b/apps/desktop/src/components/panes/automationModelOptions.ts
@@ -1,3 +1,5 @@
+import { catalogMetadataForProviderModel } from "../../../shared/model-catalog";
+
 /**
  * Model options for an automation, scoped to its selected agent (harness).
  *
@@ -61,4 +63,80 @@ export function reconcileAutomationModel(params: {
     return model;
   }
   return choice.usesHarnessNamespace ? choice.defaultModel : null;
+}
+
+function dedupeThinkingValues(values: string[] | null | undefined): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+/** The reasoning-effort levels a pinned automation model exposes, plus its
+ *  own default. Empty `thinkingValues` ⇒ the model has no selectable effort
+ *  (non-reasoning model, or a CLI-namespace model whose effort isn't declared),
+ *  so the dialog hides the field. */
+export interface AutomationThinkingChoice {
+  thinkingValues: string[];
+  defaultThinkingValue: string | null;
+}
+
+/**
+ * Reasoning-effort options for an automation's pinned model — the same source
+ * the composer uses: the model's `thinkingValues` from the runtime catalogue
+ * (`providerModelGroups`), falling back to the bundled model catalogue. When no
+ * model is pinned (`model` is null → follow the workspace default) pass the
+ * runtime `defaultModel` so the picker still reflects what will actually run;
+ * for a CLI-namespace harness leave `defaultModel` null (its effort levels
+ * aren't model-declared, so the dialog simply hides the field).
+ */
+export function automationThinkingChoiceForModel(params: {
+  model: string | null;
+  providerModelGroups: RuntimeProviderModelGroupPayload[];
+  defaultModel?: string | null;
+}): AutomationThinkingChoice {
+  const token = params.model?.trim() || params.defaultModel?.trim() || "";
+  if (!token) {
+    return { thinkingValues: [], defaultThinkingValue: null };
+  }
+  const configured = params.providerModelGroups
+    .flatMap((group) => group.models)
+    .find((entry) => entry.token === token);
+  if (configured) {
+    return {
+      thinkingValues: dedupeThinkingValues(configured.thinkingValues),
+      defaultThinkingValue: configured.defaultThinkingValue?.trim() || null,
+    };
+  }
+  const fallback = catalogMetadataForProviderModel(
+    "holaboss_model_proxy",
+    token,
+  );
+  if (fallback) {
+    return {
+      thinkingValues: dedupeThinkingValues(fallback.thinkingValues),
+      defaultThinkingValue: fallback.defaultThinkingValue,
+    };
+  }
+  return { thinkingValues: [], defaultThinkingValue: null };
+}
+
+/** Keep a pinned thinking value only while the current model still offers it;
+ *  otherwise drop to null = "follow the model's default reasoning effort". */
+export function reconcileAutomationThinkingValue(params: {
+  thinkingValue: string | null;
+  choice: AutomationThinkingChoice;
+}): string | null {
+  const { thinkingValue, choice } = params;
+  if (thinkingValue && choice.thinkingValues.includes(thinkingValue)) {
+    return thinkingValue;
+  }
+  return null;
 }

--- a/apps/desktop/src/lib/useRefreshModelCatalog.ts
+++ b/apps/desktop/src/lib/useRefreshModelCatalog.ts
@@ -1,0 +1,42 @@
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * Resync the runtime model catalogue that backs every model selector.
+ *
+ * Calls the main-process refresh, which re-pulls the catalogue from the model
+ * proxy / control plane and broadcasts a fresh `RuntimeConfigPayload`. The
+ * `WorkspaceDesktop` provider's `onConfigChange` listener then updates
+ * `runtimeConfig` for all consumers — so a single refresh propagates to the
+ * chat composer, automation, and channel pickers without any per-selector
+ * state plumbing.
+ *
+ * Returns a stable `refresh` callback plus a `refreshing` flag for the button's
+ * spinner. Re-entrancy is guarded, so overlapping clicks coalesce into one call.
+ */
+export function useRefreshModelCatalog(): {
+  refreshing: boolean;
+  refresh: () => Promise<void>;
+} {
+  const [refreshing, setRefreshing] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setRefreshing(true);
+    try {
+      await window.electronAPI.runtime.refreshModelCatalog();
+      toast.success("Models resynced");
+    } catch (error) {
+      toast.error("Couldn't resync models", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      inFlight.current = false;
+      setRefreshing(false);
+    }
+  }, []);
+
+  return { refreshing, refresh };
+}

--- a/runtime/api-server/src/cronjob-runtime.test.ts
+++ b/runtime/api-server/src/cronjob-runtime.test.ts
@@ -152,3 +152,66 @@ test("fireCronjob records the fired session id on the cronjob", () => {
     store.close();
   }
 });
+
+test("fireCronjob pins the automation's reasoning effort onto the run", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "hb-cronjob-runtime-"));
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  try {
+    const workspace = seedWorkspaceRecord(store);
+    const cronjob = store.createCronjob({
+      workspaceId: workspace.id,
+      initiatedBy: "desktop_user",
+      name: "Deep recap",
+      cron: "0 9 * * 1",
+      description: "Deep recap",
+      instruction: "Write a thorough recap.",
+      delivery: { mode: "announce", channel: "session_run", to: null },
+      // Pinned model + reasoning effort, as the desktop dialogs persist them.
+      metadata: { selected_model: "claude-sonnet-4-6", thinking_value: "high" },
+    });
+
+    const fired = fireCronjob({ store, workspace, cronjob });
+
+    const input = store.getInput({
+      workspaceId: workspace.id,
+      inputId: fired.inputId,
+    });
+    assert.equal(input?.payload?.model, "claude-sonnet-4-6");
+    assert.equal(input?.payload?.thinking_value, "high");
+  } finally {
+    store.close();
+  }
+});
+
+test("fireCronjob leaves thinking_value null when the automation pins none", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "hb-cronjob-runtime-"));
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  try {
+    const workspace = seedWorkspaceRecord(store);
+    const cronjob = store.createCronjob({
+      workspaceId: workspace.id,
+      initiatedBy: "desktop_user",
+      name: "Plain recap",
+      cron: "0 9 * * 1",
+      description: "Plain recap",
+      instruction: "Write a recap.",
+      delivery: { mode: "announce", channel: "session_run", to: null },
+    });
+
+    const fired = fireCronjob({ store, workspace, cronjob });
+
+    const input = store.getInput({
+      workspaceId: workspace.id,
+      inputId: fired.inputId,
+    });
+    assert.equal(input?.payload?.thinking_value, null);
+  } finally {
+    store.close();
+  }
+});

--- a/runtime/api-server/src/cronjob-runtime.ts
+++ b/runtime/api-server/src/cronjob-runtime.ts
@@ -144,6 +144,14 @@ export function fireCronjob(params: {
     typeof pinnedModel === "string" && pinnedModel.trim()
       ? pinnedModel.trim()
       : null;
+  // The automation's pinned reasoning effort lives in metadata.thinking_value
+  // (written by the desktop's automation dialogs, same key read back there).
+  // Null => follow the model's own default effort.
+  const pinnedThinking = cronjob.metadata.thinking_value;
+  const thinkingValue =
+    typeof pinnedThinking === "string" && pinnedThinking.trim()
+      ? pinnedThinking.trim()
+      : null;
   const input = store.enqueueInput({
     workspaceId: workspace.id,
     sessionId,
@@ -152,7 +160,7 @@ export function fireCronjob(params: {
       attachments: [],
       image_urls: [],
       model,
-      thinking_value: null,
+      thinking_value: thinkingValue,
       context: {
         cronjob_id: cronjob.id,
         triggered_by: params.triggeredBy?.trim() || "cron_worker",


### PR DESCRIPTION
## What & why

Two desktop additions, both spun out of the automations (cronjob) UI:

### 1. Per-cronjob thinking level
Automations could already pin a **model** but there was nowhere to set **thinking level** (reasoning effort). The runtime plumbing already existed — `fireCronjob` enqueued every run with `thinking_value: null` hardcoded — so this exposes a control and populates it.

- A **"Thinking" picker** in the create dialog (`ManualAutomationDialog`) and edit form (`AutomationsPane`), scoped to the chosen model's declared thinking values. Hidden for non-reasoning models and CLI-namespace agents (claude-code/codex), exactly like the composer's `ThinkingValueSelect`.
- Persisted to `metadata.thinking_value` (alongside `metadata.selected_model`); `fireCronjob` reads it back onto each run — covering **both** scheduled fires and "Run now".
- No wire-contract/backend changes: the cronjob metadata is a catch-all and only the transient `model` key is stripped on the round-trip.

### 2. Model-catalogue resync button in every selector
A shared **"resync models"** affordance added to the chat composer, channel picker, and cronjob model selects. One hook (`useRefreshModelCatalog`) + one button (`ModelCatalogRefreshButton`) call the existing `refreshModelCatalog` IPC, which re-pulls the catalogue and broadcasts a fresh config — so a single click updates every open picker at once.

**Deliberately skipped:** `HarnessModelPicker` (CLI-only). Its models come from harness *detection*, not the runtime catalogue, so a catalogue resync wouldn't change its list.

## Testing
- `tsc --noEmit` clean for `apps/desktop` and `runtime/api-server`.
- New unit tests: thinking helpers (`automationThinkingChoiceForModel` / `reconcileAutomationThinkingValue`), `fireCronjob` propagating/defaulting `thinking_value`, and the shared refresh hook/button + selector wiring.
- All existing automation dialog/pane and cronjob wiring/integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)