### PR TITLE
feat(desktop): HolaHub leaves Experimental

### DIFF
--- a/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
+++ b/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
@@ -25,7 +25,6 @@ import { useCallback, useEffect, useState } from "react";
 import { AuthPanel } from "@/components/auth/AuthPanel";
 import {
   cloudModeEnabledAtom,
-  discoverEnabledAtom,
 } from "@/components/layout/shell/state/ui";
 import { BillingSettingsPanel } from "@/components/billing/BillingSettingsPanel";
 import { ChannelsPane } from "@/components/panes/ChannelsPane";
@@ -971,15 +970,8 @@ function WorkspaceConfigDiagnosticsCard() {
 
 function ExperimentalPanel() {
   const [cloudModeEnabled, setCloudModeEnabled] = useAtom(cloudModeEnabledAtom);
-  const [discoverEnabled, setDiscoverEnabled] = useAtom(discoverEnabledAtom);
   return (
     <SettingsCard>
-      <SettingsToggle
-        label="HolaHub community"
-        description="Show the HolaHub community — the Discover feed plus posting and sharing. When off, HolaHub opens straight to the Marketplace for installing skills, apps, MCPs, and combos. Off by default."
-        checked={discoverEnabled}
-        onCheckedChange={setDiscoverEnabled}
-      />
       <SettingsToggle
         label="Cloud mode"
         description="Show the Local/Cloud switcher in the sidebar. When off, the switcher is hidden and the sidebar stays in Local mode. Off by default."

--- a/apps/desktop/src/components/layout/shell/AppShell.tsx
+++ b/apps/desktop/src/components/layout/shell/AppShell.tsx
@@ -59,7 +59,6 @@ import {
   defaultMainViewModeAtom,
   collapseSidebarForAppSurfaceAtom,
   cloudSectionAtom,
-  discoverEnabledAtom,
   focusModeAtom,
   holahubPendingPathAtom,
   LEGACY_WORKSPACE_MAIN_VIEW_MODE_MAP_STORAGE_KEY,
@@ -559,7 +558,6 @@ function ShellMainArea({
   const projectView = useAtomValue(projectViewAtom);
   const [workspaceOverlay, setWorkspaceOverlay] = useAtom(workspaceOverlayAtom);
   const holahubPendingPath = useAtomValue(holahubPendingPathAtom);
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
   const cloudSection = useAtomValue(cloudSectionAtom);
   const activeWebAppSurface = useAtomValue(activeWebAppSurfaceAtom);
   const closeHolaApp = useOpenHolaAppClose();
@@ -667,7 +665,7 @@ function ShellMainArea({
             // reloading the BrowserView, so re-shares don't flash "Opening…".
             queryDriven
             suspendNativeView={browserViewSuspended}
-            title={discoverEnabled ? "Discover" : "Marketplace"}
+            title="Discover"
           />
         ) : workspaceOverlay === "holahub-share" ? (
           <SharePreviewPane />

--- a/apps/desktop/src/components/layout/shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/shell/Sidebar.tsx
@@ -96,7 +96,6 @@ import {
   chatSessionOpenRequestAtom,
   collapsedSessionGroupsAtom,
   customizeTabAtom,
-  discoverEnabledAtom,
   focusModeAtom,
   orgSwitchingAtom,
   holahubPendingPathAtom,
@@ -1027,37 +1026,30 @@ function SidebarWorkspaceSection() {
   const projectsActive = projectView !== null;
 
   const setHolahubPath = useSetAtom(holahubPendingPathAtom);
-  // Soft launch: an opted-out user gets HolaHub's Marketplace (install
-  // management) with no feed entry; opting in reveals the full Discover surface.
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
   const enterWorkspaceOverlay = useCallback(
     (kind: WorkspaceOverlay) => {
       // Workspace-scoped overlays are mutually exclusive with Projects and
       // with each other; clear the others when opening one.
       setProjectView(null);
-      // A plain open lands on the community's home feed (opted in) or straight on
-      // the Marketplace (opted out) — never a stale deep-link.
+      // A plain open lands on the community's home feed — never a stale
+      // deep-link.
       if (kind === "holahub") {
-        // `?community=0` tells the hosted web to drop the feed nav (Marketplace
-        // becomes a standalone page) — see lib/community.ts on the web.
-        setHolahubPath(discoverEnabled ? null : "/marketplace?community=0");
+        setHolahubPath(null);
       }
       setWorkspaceOverlay(kind);
     },
-    [setProjectView, setWorkspaceOverlay, setHolahubPath, discoverEnabled],
+    [setProjectView, setWorkspaceOverlay, setHolahubPath],
   );
 
   return (
     <div className="mb-1 flex flex-col gap-0.5 px-2 pt-1">
       <SidebarNewChatRow workspaceId={selectedWorkspaceId || null} />
-      {discoverEnabled ? (
-        <TeamNavRow
-          icon={<CompassFilled />}
-          label="Discover"
-          active={workspaceOverlay === "holahub"}
-          onClick={() => enterWorkspaceOverlay("holahub")}
-        />
-      ) : null}
+      <TeamNavRow
+        icon={<CompassFilled />}
+        label="Discover"
+        active={workspaceOverlay === "holahub"}
+        onClick={() => enterWorkspaceOverlay("holahub")}
+      />
       <TeamNavRow
         icon={<FolderFilled />}
         label="Projects"
@@ -1091,17 +1083,6 @@ function SidebarWorkspaceSection() {
         active={workspaceOverlay === "customize"}
         onClick={() => enterWorkspaceOverlay("customize")}
       />
-      {discoverEnabled ? null : (
-        // Soft launch: the community's feed entry is hidden; the Marketplace lives
-        // under Customize as the install surface. Opens the hosted /marketplace
-        // feed-less (see enterWorkspaceOverlay → ?community=0).
-        <TeamNavRow
-          icon={<GridFilled />}
-          label="Marketplace"
-          active={workspaceOverlay === "holahub"}
-          onClick={() => enterWorkspaceOverlay("holahub")}
-        />
-      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/shell/state/ui.ts
+++ b/apps/desktop/src/components/layout/shell/state/ui.ts
@@ -66,19 +66,6 @@ export const cloudModeEnabledAtom = atomWithStorage(
 );
 
 /**
- * Experimental: the HolaHub community (the Discover feed + posting/sharing).
- * During the soft launch it's OFF by default — an opted-out user sees only the
- * Marketplace (install management) and never the feed/share entry points. Flip
- * it on in Settings → App → Experimental. Default follows the build: on in local
- * dev (`npm run dev`), off in packaged builds (staging testers flip it once; it
- * persists). See ADR-0001.
- */
-export const discoverEnabledAtom = atomWithStorage(
-  "holaboss.experimental.holahub-community",
-  import.meta.env.DEV,
-);
-
-/**
  * The middle tab area is maximized to fill the window (sidebar + chat hidden).
  * Transient — never persisted; Esc / the toggle restores the prior layout.
  */
@@ -300,23 +287,10 @@ export type WorkspaceOverlay =
   // model annotation, write a caption, then hand off to the hub to publish. The
   // conversation to share rides in `shareSessionPayloadAtom`.
   | "holahub-share";
-// The app opens to Home (the HolaHub surface) by default when the community is
-// on — it's the first-class landing. During the soft launch (community off) it
-// opens to a New Chat (null) instead. Reads the persisted opt-in at module init
-// (atomWithStorage stores the boolean as JSON under this key). Either way this
-// only decides the initial screen — it's cleared the moment the user starts a
-// chat/session, so nobody's trapped.
-function discoverEnabledAtLaunch(): boolean {
-  try {
-    const raw = localStorage.getItem("holaboss.experimental.holahub-community");
-    return raw == null ? import.meta.env.DEV : (JSON.parse(raw) as boolean);
-  } catch {
-    return import.meta.env.DEV;
-  }
-}
-export const workspaceOverlayAtom = atom<WorkspaceOverlay | null>(
-  discoverEnabledAtLaunch() ? "holahub" : null,
-);
+// The app opens to Home (the HolaHub surface) — it's the first-class landing.
+// This only decides the initial screen: it's cleared the moment the user starts
+// a chat/session, so nobody's trapped.
+export const workspaceOverlayAtom = atom<WorkspaceOverlay | null>("holahub");
 
 /** The conversation staged for the full-page "Share to HolaHub" composer. Set by
  *  `useOpenSharePreview` right before flipping the overlay to "holahub-share". */

--- a/apps/desktop/src/components/layout/shell/useOpenDiscover.ts
+++ b/apps/desktop/src/components/layout/shell/useOpenDiscover.ts
@@ -1,48 +1,30 @@
-import { useAtomValue, useSetAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import { useCallback } from "react";
 
 import {
-  discoverEnabledAtom,
   focusModeAtom,
   holahubPendingPathAtom,
   projectViewAtom,
   workspaceOverlayAtom,
 } from "./state/ui";
 
-// Soft launch: when the community is off the hosted surface must drop the feed
-// nav (see lib/community.ts on the web). Carry `?community=0` on whatever path we
-// open so every entry point (Marketplace, integration install, …) stays feed-less.
-function withCommunityOff(path: string): string {
-  return `${path}${path.includes("?") ? "&" : "?"}community=0`;
-}
-
 /**
  * Open the HolaHub workspace overlay, optionally navigated to a specific path
  * (e.g. `/threads/<postId>` to jump to a post an agent just published, or
- * `/marketplace?type=holaapp` for install). When the community is off, a bare
- * open lands on the Marketplace and every path is flagged feed-less.
+ * `/marketplace?type=holaapp` for install). A bare open lands on the feed.
  */
 export function useOpenDiscover() {
   const setProjectView = useSetAtom(projectViewAtom);
   const setWorkspaceOverlay = useSetAtom(workspaceOverlayAtom);
   const setFocusMode = useSetAtom(focusModeAtom);
   const setHolahubPath = useSetAtom(holahubPendingPathAtom);
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
   return useCallback(
     (path?: string) => {
       setProjectView(null);
       setFocusMode(false);
-      setHolahubPath(
-        discoverEnabled ? (path ?? null) : withCommunityOff(path ?? "/marketplace")
-      );
+      setHolahubPath(path ?? null);
       setWorkspaceOverlay("holahub");
     },
-    [
-      setProjectView,
-      setFocusMode,
-      setHolahubPath,
-      setWorkspaceOverlay,
-      discoverEnabled,
-    ]
+    [setProjectView, setFocusMode, setHolahubPath, setWorkspaceOverlay]
   );
 }

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/Outputs.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/Outputs.tsx
@@ -2,7 +2,6 @@ import { PinStarButton } from "@/components/layout/shell/PinStarButton";
 import { fileNameFromPath } from "@/components/layout/shell/state/internalTabs";
 import {
   chatComposerPrefillAtom,
-  discoverEnabledAtom,
 } from "@/components/layout/shell/state/ui";
 import { useOpenWorkspaceOutput } from "@/components/layout/shell/useOpenWorkspaceOutput";
 import {
@@ -101,9 +100,6 @@ export function AssistantTurnOutputs({
   // Multi-share: when a turn produced ≥2 shareable artifacts, let the user
   // pick a subset and post them together to HolaHub (a single turn-level Share
   // still handles the whole turn from the actions menu).
-  // Sharing is part of the HolaHub community — hide every share affordance
-  // (the CTA nudge + per-output multi-select) until the user opts in.
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
   const shareableOutputIds = new Set(
     cards
       .filter(
@@ -114,7 +110,7 @@ export function AssistantTurnOutputs({
   // Two or more artifacts is a choice, and a choice between artifacts belongs in
   // a gallery rather than a column of filenames with checkboxes. A document has
   // no thumbnail to show there — the gallery names it instead.
-  const pickable = discoverEnabled && shareableOutputIds.size >= 2;
+  const pickable = shareableOutputIds.size >= 2;
 
   // "Share to win credits": the credits a live campaign grants for sharing an
   // output, or null when none is running (nudge falls back to plain encourage).
@@ -300,7 +296,7 @@ export function AssistantTurnOutputs({
         </button>
       ) : null}
 
-      {discoverEnabled && shareableOutputIds.size >= 1 ? (
+      {shareableOutputIds.size >= 1 ? (
         shareCredits == null ? (
           <button
             className="group mt-1 flex h-8 items-center gap-2 self-start rounded-md px-2.5 text-left text-primary text-xs transition-colors hover:bg-primary/10 disabled:opacity-60"

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/index.tsx
@@ -4,7 +4,6 @@ import { HarnessAvatar } from "@/components/harness/HarnessAvatar";
 import { ErrorSegment } from "./ErrorSegment";
 import { SimpleMarkdown } from "@/components/marketplace/SimpleMarkdown";
 import { chatMessageTimeLabel } from "../helpers";
-import { discoverEnabledAtom } from "@/components/layout/shell/state/ui";
 import { useOpenDiscover } from "@/components/layout/shell/useOpenDiscover";
 import { useShareToHolahub } from "@/components/layout/shell/useShareToHolahub";
 import { useAtomValue } from "jotai";
@@ -279,8 +278,6 @@ function AssistantTurnComponent({
   const shareToHolahub = useShareToHolahub();
   const shareContext = useAtomValue(shareContextAtom);
   const hasShareMediaOutput = outputs.some(isShareableMediaOutput);
-  // Sharing is part of the HolaHub community — hide every entry point until opt-in.
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
   const turnStatusAnchor = turnStatus ? (
     <div className="mb-1.5 flex min-w-0 items-center justify-between gap-3">
       <div
@@ -442,7 +439,7 @@ function AssistantTurnComponent({
                 copyText={copyText}
                 hasFileEdits={hasFileEdits}
                 onShareToHolahub={
-                  hasShareMediaOutput && discoverEnabled
+                  hasShareMediaOutput
                     ? async () => {
                         const ready = enrichOutputs(
                           mergeOutputsByPath(outputs),

--- a/apps/desktop/src/components/panes/ChatPane/ChatContextPopover.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ChatContextPopover.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import { useMemo, useState } from "react";
 import {
-  discoverEnabledAtom,
   selectedSessionIdAtom,
 } from "@/components/layout/shell/state/ui";
 import { useShareToHolahub } from "@/components/layout/shell/useShareToHolahub";
@@ -88,8 +87,6 @@ function useOutputShare(outputs: OutputItem[]) {
   const shareToHolahub = useShareToHolahub();
   const [sharing, setSharing] = useState(false);
   const [galleryOpen, setGalleryOpen] = useState(false);
-  // Sharing to the community is hidden until the user opts in.
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
 
   // The whole session's shareable artifacts, not just the previewed few — the
   // gallery is the picker, so it shouldn't inherit the list's preview cap.
@@ -128,7 +125,7 @@ function useOutputShare(outputs: OutputItem[]) {
   };
 
   return {
-    canShare: discoverEnabled && shareableOutputs.length > 0,
+    canShare: shareableOutputs.length > 0,
     openGallery: () => setGalleryOpen(true),
     galleryProps: {
       onConfirm: shareChosen,

--- a/apps/desktop/src/components/panes/ChatPane/ChatHeader.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ChatHeader.tsx
@@ -20,7 +20,6 @@ import {
 import { WorkspaceIcon } from "@/components/ui/workspace-icon";
 import {
   chatShareActionAtom,
-  discoverEnabledAtom,
   type ShareMode,
   type ShareSessionPayload,
 } from "@/components/layout/shell/state/ui";
@@ -133,9 +132,7 @@ const SHARE_BTN =
  *  conversation. Renders nothing when there's nothing to share. */
 function ShareSessionButton() {
   const action = useAtomValue(chatShareActionAtom);
-  // Sharing is part of the HolaHub community — hidden until the user opts in.
-  const discoverEnabled = useAtomValue(discoverEnabledAtom);
-  if (!(action && discoverEnabled)) return null;
+  if (!action) return null;
   if (!action.hasOutputs) {
     return (
       <Tooltip>


### PR DESCRIPTION
HolaHub shipped behind a per-user Experimental opt-in for the soft launch
(ADR-0001): `holaboss.experimental.holahub-community`, defaulting to **off** in
packaged builds. A stock desktop therefore showed the Marketplace and none of the
feed, sharing or posting. This graduates it.

## Removed, not defaulted

The flag and every branch it fed are deleted rather than flipped to `true`. A
gate left in place with a new default is the kind that comes back on, and it
would keep a "turn HolaHub off" affordance in Settings that nothing is asking
for.

| | before | after |
|---|---|---|
| Sidebar | **Discover** row only when opted in; a **Marketplace** row stood in for it when not | **Discover** always; the stand-in row is gone (Marketplace is a page inside HolaHub) |
| Launch screen | Home when opted in, New Chat when not | Home |
| Overlay title | `Discover` / `Marketplace` | `Discover` |
| Chat header | Share button hidden until opt-in | present |
| Context popover | `canShare` gated | gated only by having something to share |
| Turn actions | Share to HolaHub gated | gated only by having a media output |
| Outputs | share CTA + multi-select gated | gated only by output count |
| Settings → Experimental | "HolaHub community" toggle | gone (Cloud mode stays) |

## Who is affected

Nobody who had opted in. Someone who had explicitly opted **out** now gets the
community — which is what a general release means; their stored key is ignored
rather than migrated.

## Two follow-ups this creates, in the other repo

- **`?community=0` has no producer any more.** It was how the desktop told the
  hosted surface to drop the feed nav. `lib/community.ts` on the frontend still
  reads it — dead once this ships, worth removing there.
- **ADR-0001 wants superseding** in the monorepo (`docs/adr/`), since the
  decision it records is the one this ends.

Neither is in this repo, so neither is in this PR.

## Verification

`npm run typecheck` clean. No reference to `discoverEnabled`,
`holahub-community` or `community=0` survives in `apps/desktop`, and no test
asserted on any of them. Imports left behind by the deletions were checked
individually (JSX usage included).

Not verified at runtime: this has not been run in a built desktop. The change is
a gate removal with no remaining conditionals, but the launch-screen default and
the sidebar rows are worth an eyeball before release.
