### PR TITLE
fix(docker): switch to bun-based build_runtime_root.mjs + remove stale package-lock.json COPYs

### DIFF
--- a/runtime/deploy/Dockerfile
+++ b/runtime/deploy/Dockerfile
@@ -7,17 +7,14 @@ COPY runtime/deploy/ /tmp/runtime-source/deploy/
 COPY runtime/harnesses/package.json /tmp/runtime-source/harnesses/package.json
 COPY runtime/harnesses/src/ /tmp/runtime-source/harnesses/src/
 COPY runtime/harness-host/package.json /tmp/runtime-source/harness-host/package.json
-COPY runtime/harness-host/package-lock.json /tmp/runtime-source/harness-host/package-lock.json
 COPY runtime/harness-host/tsconfig.json /tmp/runtime-source/harness-host/tsconfig.json
 COPY runtime/harness-host/tsup.config.ts /tmp/runtime-source/harness-host/tsup.config.ts
 COPY runtime/harness-host/src/ /tmp/runtime-source/harness-host/src/
 COPY runtime/state-store/package.json /tmp/runtime-source/state-store/package.json
-COPY runtime/state-store/package-lock.json /tmp/runtime-source/state-store/package-lock.json
 COPY runtime/state-store/tsconfig.json /tmp/runtime-source/state-store/tsconfig.json
 COPY runtime/state-store/tsup.config.ts /tmp/runtime-source/state-store/tsup.config.ts
 COPY runtime/state-store/src/ /tmp/runtime-source/state-store/src/
 COPY runtime/api-server/package.json /tmp/runtime-source/api-server/package.json
-COPY runtime/api-server/package-lock.json /tmp/runtime-source/api-server/package-lock.json
 COPY runtime/api-server/tsconfig.json /tmp/runtime-source/api-server/tsconfig.json
 COPY runtime/api-server/tsup.config.ts /tmp/runtime-source/api-server/tsup.config.ts
 COPY runtime/api-server/src/ /tmp/runtime-source/api-server/src/

--- a/runtime/deploy/Dockerfile
+++ b/runtime/deploy/Dockerfile
@@ -1,6 +1,10 @@
 ARG TOOLCHAIN_IMAGE=holaboss/sandbox-base-toolchain:dev
 FROM ${TOOLCHAIN_IMAGE}
 
+# Install bun (toolchain image ships node + npm but not bun; the runtime build
+# scripts use bun install since the monorepo migration to a single root bun.lock)
+RUN npm install -g bun
+
 WORKDIR /tmp/runtime-source
 
 COPY runtime/deploy/ /tmp/runtime-source/deploy/
@@ -18,8 +22,16 @@ COPY runtime/api-server/package.json /tmp/runtime-source/api-server/package.json
 COPY runtime/api-server/tsconfig.json /tmp/runtime-source/api-server/tsconfig.json
 COPY runtime/api-server/tsup.config.ts /tmp/runtime-source/api-server/tsup.config.ts
 COPY runtime/api-server/src/ /tmp/runtime-source/api-server/src/
-RUN chmod +x /tmp/runtime-source/deploy/build_runtime_root.sh \
-    && /tmp/runtime-source/deploy/build_runtime_root.sh /opt/holaboss-runtime
+COPY runtime/channel-gateway/package.json /tmp/runtime-source/channel-gateway/package.json
+COPY runtime/channel-gateway/tsconfig.json /tmp/runtime-source/channel-gateway/tsconfig.json
+COPY runtime/channel-gateway/tsup.config.ts /tmp/runtime-source/channel-gateway/tsup.config.ts
+COPY runtime/channel-gateway/src/ /tmp/runtime-source/channel-gateway/src/
+COPY packages/remote-api/package.json /tmp/runtime-source/packages/remote-api/package.json
+COPY packages/remote-api/tsconfig.json /tmp/runtime-source/packages/remote-api/tsconfig.json
+COPY packages/remote-api/tsup.config.ts /tmp/runtime-source/packages/remote-api/tsup.config.ts
+COPY packages/remote-api/src/ /tmp/runtime-source/packages/remote-api/src/
+COPY shared/ /tmp/runtime-source/shared/
+RUN node /tmp/runtime-source/deploy/build_runtime_root.mjs /opt/holaboss-runtime
 
 WORKDIR /app
 

--- a/runtime/deploy/Dockerfile
+++ b/runtime/deploy/Dockerfile
@@ -7,30 +7,22 @@ RUN npm install -g bun
 
 WORKDIR /tmp/runtime-source
 
+# Copy whole package dirs (not file-by-file) so future layout changes (new
+# config files, scripts/, etc.) don't silently break the build again.
+# build_runtime_root.mjs stages each package with copyIfPresent() guards, so
+# extra files are harmless.
+#
+# Layout mirrors the .mjs path assumptions:
+#   runtimeRoot = /tmp/runtime-source  (runtime/* packages)
+#   repoRoot    = /tmp                 (packages/remote-api, shared/)
 COPY runtime/deploy/ /tmp/runtime-source/deploy/
-COPY runtime/harnesses/package.json /tmp/runtime-source/harnesses/package.json
-COPY runtime/harnesses/src/ /tmp/runtime-source/harnesses/src/
-COPY runtime/harness-host/package.json /tmp/runtime-source/harness-host/package.json
-COPY runtime/harness-host/tsconfig.json /tmp/runtime-source/harness-host/tsconfig.json
-COPY runtime/harness-host/tsup.config.ts /tmp/runtime-source/harness-host/tsup.config.ts
-COPY runtime/harness-host/src/ /tmp/runtime-source/harness-host/src/
-COPY runtime/state-store/package.json /tmp/runtime-source/state-store/package.json
-COPY runtime/state-store/tsconfig.json /tmp/runtime-source/state-store/tsconfig.json
-COPY runtime/state-store/tsup.config.ts /tmp/runtime-source/state-store/tsup.config.ts
-COPY runtime/state-store/src/ /tmp/runtime-source/state-store/src/
-COPY runtime/api-server/package.json /tmp/runtime-source/api-server/package.json
-COPY runtime/api-server/tsconfig.json /tmp/runtime-source/api-server/tsconfig.json
-COPY runtime/api-server/tsup.config.ts /tmp/runtime-source/api-server/tsup.config.ts
-COPY runtime/api-server/src/ /tmp/runtime-source/api-server/src/
-COPY runtime/channel-gateway/package.json /tmp/runtime-source/channel-gateway/package.json
-COPY runtime/channel-gateway/tsconfig.json /tmp/runtime-source/channel-gateway/tsconfig.json
-COPY runtime/channel-gateway/tsup.config.ts /tmp/runtime-source/channel-gateway/tsup.config.ts
-COPY runtime/channel-gateway/src/ /tmp/runtime-source/channel-gateway/src/
-COPY packages/remote-api/package.json /tmp/runtime-source/packages/remote-api/package.json
-COPY packages/remote-api/tsconfig.json /tmp/runtime-source/packages/remote-api/tsconfig.json
-COPY packages/remote-api/tsup.config.ts /tmp/runtime-source/packages/remote-api/tsup.config.ts
-COPY packages/remote-api/src/ /tmp/runtime-source/packages/remote-api/src/
-COPY shared/ /tmp/runtime-source/shared/
+COPY runtime/harnesses/ /tmp/runtime-source/harnesses/
+COPY runtime/harness-host/ /tmp/runtime-source/harness-host/
+COPY runtime/state-store/ /tmp/runtime-source/state-store/
+COPY runtime/api-server/ /tmp/runtime-source/api-server/
+COPY runtime/channel-gateway/ /tmp/runtime-source/channel-gateway/
+COPY packages/remote-api/ /tmp/packages/remote-api/
+COPY shared/ /tmp/shared/
 RUN node /tmp/runtime-source/deploy/build_runtime_root.mjs /opt/holaboss-runtime
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

The runtime Dockerfile was broken after the monorepo migrated from per-package `package-lock.json` files to a single root `bun.lock`. The old `build_runtime_root.sh` (npm-based) hard-fails because it tries to `cp package-lock.json` under `set -euo pipefail`.

## Root Cause

1. **`build_runtime_root.sh`** (line 34) does `cp "${package_dir}/package-lock.json"` — file no longer exists after bun migration
2. **`build_runtime_root.sh`** (line 40) does `npm ci` — fails without `package-lock.json`
3. The project already has a bun-based replacement: **`build_runtime_root.mjs`** — but the Dockerfile was never updated to use it

## Fix

### Changes to `runtime/deploy/Dockerfile`:

1. **Install bun** — `RUN npm install -g bun` (the toolchain image ships node + npm but not bun)
2. **Switch build script** — `build_runtime_root.sh` → `node build_runtime_root.mjs`
3. **Remove 3 COPY lines** for `package-lock.json` (harness-host, state-store, api-server) — these files no longer exist
4. **Add COPY lines** for directories required by `build_runtime_root.mjs` but missing from the old Dockerfile:
   - `runtime/channel-gateway/` (package.json, tsconfig.json, tsup.config.ts, src/)
   - `packages/remote-api/` (package.json, tsconfig.json, tsup.config.ts, src/)
   - `shared/` (referenced by `stageSharedContracts()` in the .mjs script)

### Why `build_runtime_root.mjs` instead of fixing `.sh`:

The `.mjs` is the intended build script post-migration. It:
- Uses `bun install` instead of `npm ci` (5-10× faster, no lockfile needed)
- Handles workspace:* dependency rewriting for staged packages
- Has `copyIfPresent()` guards so missing files (like `tsdown.config.ts`) are skipped gracefully
- Is the same script used in local dev and CI

Fixing the old `.sh` to use bun would duplicate logic that already exists in `.mjs`.

### Verification checklist:
- [x] `build_runtime_root.mjs` exists at `runtime/deploy/` on `main`
- [x] `channel-gateway`, `packages/remote-api`, `shared/` directories exist on `main`
- [x] `copyIfPresent()` in `.mjs` gracefully skips missing files (no hard failure for `tsdown.config.ts` etc.)
- [x] `npm install -g bun` works on the `python:3.12-slim-bookworm`-based toolchain image (node 22 already present)
- [ ] Docker build succeeds (needs CI approval for fork PR)

## Response to maintainer feedback

@jeffreyliimerch You're right — the previous fix was incomplete. Removing only the COPY lines moved the failure point but didn't actually fix the build. The real issue is that the Dockerfile was still calling `build_runtime_root.sh` (npm-era script) instead of `build_runtime_root.mjs` (bun-era replacement). This commit makes the full switch.
