### PR TITLE
fix(desktop): a skill chip wears its name, not its uuid

### DIFF
--- a/apps/desktop/src/components/layout/shell/HeadlessInstaller.tsx
+++ b/apps/desktop/src/components/layout/shell/HeadlessInstaller.tsx
@@ -11,6 +11,7 @@ import {
   toIdList,
   toRequiredProviders,
 } from "@/components/panes/CapabilitiesMarketPane";
+import { publishSkillTitlesAtom } from "@/components/panes/ChatPane/Composer/editor/skillTitles";
 import {
   fetchDirectoryCapabilities,
   fetchDirectorySkillBody,
@@ -115,6 +116,7 @@ function SkillInstallRunner({
     remoteApiQuery.skills.install.mutationOptions()
   );
   const installedQuery = useWorkspaceSkills(workspaceId);
+  const publishSkillTitles = useSetAtom(publishSkillTitlesAtom);
   const doneRef = useRef(false);
 
   useEffect(() => {
@@ -127,6 +129,9 @@ function SkillInstallRunner({
       onDone({ status: "error", message: `"${ref}" isn't in the skills catalog.` });
       return;
     }
+    // A hand-off quotes the skill in a composer the moment install starts, and
+    // a community id is a uuid — name it here or the chip wears the uuid.
+    publishSkillTitles({ [entry.id]: entry.name });
     const installedIds = new Set(
       (installedQuery.data?.skills ?? []).map((s) => s.skill_id)
     );
@@ -165,6 +170,7 @@ function SkillInstallRunner({
     installMutation,
     installedQuery.data,
     queryClient,
+    publishSkillTitles,
     onDone,
   ]);
 

--- a/apps/desktop/src/components/panes/ChatPane/Composer/editor/skillTitles.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/Composer/editor/skillTitles.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createStore } from "jotai";
+import { publishSkillTitlesAtom, skillTitlesAtom } from "./skillTitles";
+
+test("the workspace list does not drop a name an installer published first", () => {
+  const store = createStore();
+  store.set(publishSkillTitlesAtom, {
+    "c_344210f3-1af6-480a-aef3-4f12c8564a21": "Steelman Both Sides",
+  });
+  store.set(publishSkillTitlesAtom, { summarizer: "Summarizer" });
+
+  assert.deepEqual(store.get(skillTitlesAtom), {
+    "c_344210f3-1af6-480a-aef3-4f12c8564a21": "Steelman Both Sides",
+    summarizer: "Summarizer",
+  });
+});
+
+test("a later title wins and an empty one is ignored", () => {
+  const store = createStore();
+  store.set(publishSkillTitlesAtom, { summarizer: "Summarizer" });
+  store.set(publishSkillTitlesAtom, { summarizer: "" });
+  assert.equal(store.get(skillTitlesAtom).summarizer, "Summarizer");
+
+  store.set(publishSkillTitlesAtom, { summarizer: "Summarise" });
+  assert.equal(store.get(skillTitlesAtom).summarizer, "Summarise");
+});
+
+test("republishing the same titles keeps the identity stable", () => {
+  const store = createStore();
+  store.set(publishSkillTitlesAtom, { summarizer: "Summarizer" });
+  const first = store.get(skillTitlesAtom);
+  store.set(publishSkillTitlesAtom, { summarizer: "Summarizer" });
+  assert.equal(store.get(skillTitlesAtom), first);
+});

--- a/apps/desktop/src/components/panes/ChatPane/Composer/editor/skillTitles.ts
+++ b/apps/desktop/src/components/panes/ChatPane/Composer/editor/skillTitles.ts
@@ -2,7 +2,7 @@ import { atom } from "jotai";
 
 /**
  * Live `skillId → display title`, published by ChatPane from the workspace's
- * skill list.
+ * skill list and by the installers from the catalog entry they just added.
  *
  * A skill chip stores its title in the document node, resolved once when the
  * document is built. Seed a composer in the same breath as an install — which is
@@ -12,3 +12,26 @@ import { atom } from "jotai";
  * lets the chip heal once the list lands, and follow a rename after that.
  */
 export const skillTitlesAtom = atom<Record<string, string>>({});
+
+/**
+ * Merge titles in rather than replace the map: an installer knows a community
+ * skill's name before its folder exists, and the workspace list — which arrives
+ * later and only covers what is on disk — must not drop that name on the floor.
+ */
+export const publishSkillTitlesAtom = atom(
+  null,
+  (get, set, titles: Record<string, string>) => {
+    const current = get(skillTitlesAtom);
+    let changed = false;
+    const next = { ...current };
+    for (const [skillId, title] of Object.entries(titles)) {
+      if (title && next[skillId] !== title) {
+        next[skillId] = title;
+        changed = true;
+      }
+    }
+    if (changed) {
+      set(skillTitlesAtom, next);
+    }
+  },
+);

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -101,7 +101,7 @@ import { getExplorerAttachmentClipboardEntry } from "@/lib/appClipboard";
 import { billingRpcFetch } from "@/lib/app-sdk-client";
 import { declineIntegrationProposals, remoteApi } from "@/lib/remoteApiClient";
 import { useAtomValue, useSetAtom } from "jotai";
-import { skillTitlesAtom } from "./Composer/editor/skillTitles";
+import { publishSkillTitlesAtom } from "./Composer/editor/skillTitles";
 import { shareContextAtom } from "./AssistantTurn/shareContext";
 import { recentFilesAtom } from "@/components/layout/shell/state/recentFiles";
 import {
@@ -8666,7 +8666,7 @@ export function ChatPane({
   );
   // Publish the titles so a skill chip can resolve its own label later — one
   // inserted the instant a skill was installed has only the raw id to show.
-  const setSkillTitles = useSetAtom(skillTitlesAtom);
+  const publishSkillTitles = useSetAtom(publishSkillTitlesAtom);
   useEffect(() => {
     const titles: Record<string, string> = {};
     for (const [skillId, skill] of availableWorkspaceSkillMap) {
@@ -8674,8 +8674,8 @@ export function ChatPane({
         titles[skillId] = skill.title;
       }
     }
-    setSkillTitles(titles);
-  }, [availableWorkspaceSkillMap, setSkillTitles]);
+    publishSkillTitles(titles);
+  }, [availableWorkspaceSkillMap, publishSkillTitles]);
 
   const quotedSkills = useMemo<ChatComposerQuotedSkillItem[]>(
     () =>

--- a/apps/desktop/src/components/panes/SkillsStorePane.tsx
+++ b/apps/desktop/src/components/panes/SkillsStorePane.tsx
@@ -42,6 +42,8 @@ import {
   fetchDirectorySkills,
 } from "@/lib/directoryClient";
 import { Icon as IconifyIcon } from "@iconify/react";
+import { useSetAtom } from "jotai";
+import { publishSkillTitlesAtom } from "@/components/panes/ChatPane/Composer/editor/skillTitles";
 import { getSkillIcon } from "@/lib/skillVisual";
 import { withSkillDisplayTitle } from "@/lib/skillDisplayTitle";
 import { remoteApiQuery } from "@/lib/remoteApiQuery";
@@ -88,6 +90,7 @@ export function SkillsStorePane({
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [detailId, setDetailId] = useState<string | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const publishSkillTitles = useSetAtom(publishSkillTitlesAtom);
   const [pendingRemove, setPendingRemove] = useState<DirectorySkillDto | null>(
     null,
   );
@@ -214,6 +217,7 @@ export function SkillsStorePane({
 
   const addSkill = (entry: DirectorySkillDto) => {
     setPendingId(entry.id);
+    publishSkillTitles({ [entry.id]: entry.name });
     void fetchDirectorySkillBody(entry.id)
       .then((resolved) =>
         installMutation.mutateAsync({
@@ -233,6 +237,7 @@ export function SkillsStorePane({
   // run it (the backend record already carries the SKILL.md content — no extra fetch).
   const addOrgSkill = (skill: OrgSkill) => {
     setPendingId(skill.id);
+    publishSkillTitles({ [skill.id]: skill.name });
     void installMutation
       .mutateAsync({
         skillId: skill.id,


### PR DESCRIPTION
A skill installed from HolaHub showed up in the composer as `c_344210f3-1af6-480a-aef3-4f12c8564a21` instead of "Steelman Both Sides".

### Why

The chip bakes its label into the Tiptap node when the document is built, resolved from the workspace's installed-skill list. A HolaHub Use/Try fires `install` and `chat.start` back to back — the chip is built before the skill folder lands, so `titleFor()` falls back to the raw catalog id. Community ids are `c_<uuid>` (minted in `holaapp-backend`), so that's what the user reads.

`skillTitlesAtom` already existed to heal this after the fact, but ChatPane **replaced** the whole map on every workspace poll, so any name an installer had just learned was wiped on the next tick.

### What changed

- `skillTitles.ts` — new `publishSkillTitlesAtom`: merges instead of replacing, ignores empty titles, keeps the object identity stable when nothing changes.
- `ChatPane/index.tsx` — the workspace-list publish goes through the merging writer.
- `HeadlessInstaller.tsx` — `SkillInstallRunner` publishes `id → name` the moment the catalog entry resolves, i.e. before the install runs, so the chip is named even if the install then fails.
- `SkillsStorePane.tsx` — same for both manual install paths (directory + org library).

### Verification

- `tsc --noEmit` clean.
- New `skillTitles.test.ts` (3 cases): an installer's name survives the workspace list arriving; a later title wins while an empty one is ignored; republishing identical titles doesn't churn the reference.
- Not exercised end-to-end in a running Electron build — that needs a signed-in session and a desktop rebuild.

### Adjacent, not fixed here

`buildComposerDoc` hardcodes `title: capabilityId` for capability chips and `CapabilityMentionNode` has no live lookup, so a combo chip falls back to its id every time the composer re-seeds. Same defect class, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)