### PR TITLE
fix: support attachments in the project composer

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/pendingAttachments.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/pendingAttachments.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createPendingExplorerAttachment,
+  createPendingLocalAttachment,
+  pendingAttachmentsToListItems,
+  stagePendingFileAttachments,
+} from "./pendingAttachments";
+import type { PendingAttachment } from "./types";
+
+function staged(id: string): SessionInputAttachmentPayload {
+  return {
+    id,
+    kind: "file",
+    name: `${id}.txt`,
+    mime_type: "text/plain",
+    size_bytes: 1,
+    workspace_path: `/staged/${id}.txt`,
+  };
+}
+
+test("stages mixed pending files concurrently and preserves composer order", async () => {
+  const localFile = {
+    name: "local.txt",
+    type: "text/plain",
+    size: 1,
+  } as File;
+  const attachments: PendingAttachment[] = [
+    {
+      id: "explorer-1",
+      source: "explorer-path",
+      absolutePath: "/workspace/first.txt",
+      name: "first.txt",
+      size_bytes: 1,
+      kind: "file",
+    },
+    { id: "local-1", source: "local-file", file: localFile },
+    {
+      id: "context-1",
+      source: "app-context",
+      appName: "Example",
+      title: "Context",
+      contextText: "ignored by file staging",
+    },
+    {
+      id: "explorer-2",
+      source: "explorer-path",
+      absolutePath: "/workspace/last.txt",
+      name: "last.txt",
+      size_bytes: 1,
+      kind: "file",
+    },
+  ];
+
+  const result = await stagePendingFileAttachments(attachments, {
+    stageLocalFiles: async (files) => {
+      assert.deepEqual(files.map((entry) => entry.id), ["local-1"]);
+      return [staged("staged-local")];
+    },
+    stageExplorerFiles: async (files) => {
+      assert.deepEqual(
+        files.map((entry) => entry.id),
+        ["explorer-1", "explorer-2"],
+      );
+      return [staged("staged-first"), staged("staged-last")];
+    },
+  });
+
+  assert.deepEqual(
+    result.map((attachment) => attachment.id),
+    ["staged-first", "staged-local", "staged-last"],
+  );
+});
+
+test("fails closed when a staging response omits an attachment", async () => {
+  const attachments: PendingAttachment[] = [
+    {
+      id: "explorer-1",
+      source: "explorer-path",
+      absolutePath: "/workspace/file.txt",
+      name: "file.txt",
+      size_bytes: 1,
+      kind: "file",
+    },
+  ];
+
+  await assert.rejects(
+    stagePendingFileAttachments(attachments, {
+      stageLocalFiles: async () => [],
+      stageExplorerFiles: async () => [],
+    }),
+    /Failed to stage an explorer attachment/,
+  );
+});
+
+test("maps pending local and Explorer images to previewable list items", () => {
+  const localFile = {
+    name: "local.png",
+    type: "image/png",
+    size: 42,
+  } as File;
+  const items = pendingAttachmentsToListItems([
+    { id: "local", source: "local-file", file: localFile },
+    {
+      id: "explorer",
+      source: "explorer-path",
+      absolutePath: "/workspace/image.png",
+      name: "image.png",
+      size_bytes: 84,
+      kind: "image",
+    },
+  ]);
+
+  assert.deepEqual(items, [
+    {
+      id: "local",
+      kind: "image",
+      name: "local.png",
+      size_bytes: 42,
+      file: localFile,
+    },
+    {
+      id: "explorer",
+      kind: "image",
+      name: "image.png",
+      size_bytes: 84,
+      workspace_path: "/workspace/image.png",
+    },
+  ]);
+});
+
+test("creates pending entries with the same fields used by the composer", () => {
+  const originalRandomUUID = crypto.randomUUID;
+  Object.defineProperty(crypto, "randomUUID", {
+    configurable: true,
+    value: () => "uuid",
+  });
+  try {
+    const localFile = {
+      name: "local.txt",
+      type: "text/plain",
+      size: 4,
+      lastModified: 9,
+    } as File;
+    assert.deepEqual(createPendingLocalAttachment(localFile), {
+      id: "local.txt-4-9-uuid",
+      source: "local-file",
+      file: localFile,
+    });
+    assert.deepEqual(
+      createPendingExplorerAttachment({
+        absolutePath: "/workspace/photo.png",
+        name: "photo.png",
+        size: 8,
+        mimeType: "image/png",
+      }),
+      {
+        id: "/workspace/photo.png-8-uuid",
+        source: "explorer-path",
+        absolutePath: "/workspace/photo.png",
+        name: "photo.png",
+        mime_type: "image/png",
+        size_bytes: 8,
+        kind: "image",
+      },
+    );
+  } finally {
+    Object.defineProperty(crypto, "randomUUID", {
+      configurable: true,
+      value: originalRandomUUID,
+    });
+  }
+});

--- a/apps/desktop/src/components/panes/ChatPane/pendingAttachments.ts
+++ b/apps/desktop/src/components/panes/ChatPane/pendingAttachments.ts
@@ -1,0 +1,153 @@
+import type {
+  AttachmentListItem,
+  PendingAttachment,
+  PendingExplorerAttachmentFile,
+  PendingLocalAttachmentFile,
+} from "./types";
+import { attachmentLooksLikeImage } from "./helpers";
+import {
+  type ExplorerAttachmentDragPayload,
+  resolveExplorerAttachmentKind,
+} from "../../../lib/attachmentDrag";
+
+export interface PendingAttachmentStagingApi {
+  stageLocalFiles: (
+    files: PendingLocalAttachmentFile[],
+  ) => Promise<SessionInputAttachmentPayload[]>;
+  stageExplorerFiles: (
+    files: PendingExplorerAttachmentFile[],
+  ) => Promise<SessionInputAttachmentPayload[]>;
+}
+
+export function attachmentUploadPayload(
+  file: File,
+): Promise<StageSessionAttachmentFilePayload> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () =>
+      reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      const separator = result.indexOf(",");
+      resolve({
+        name: file.name,
+        mime_type: file.type || null,
+        content_base64: separator >= 0 ? result.slice(separator + 1) : result,
+      });
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export function pendingAttachmentId(seed: string): string {
+  return `${seed}-${crypto.randomUUID()}`;
+}
+
+export function pendingAttachmentsToListItems(
+  attachments: PendingAttachment[],
+): AttachmentListItem[] {
+  return attachments.map((attachment): AttachmentListItem => {
+    if (attachment.source === "local-file") {
+      return {
+        id: attachment.id,
+        kind: attachmentLooksLikeImage(
+          attachment.file.name,
+          attachment.file.type,
+        )
+          ? "image"
+          : "file",
+        name: attachment.file.name,
+        size_bytes: attachment.file.size,
+        file: attachment.file,
+      };
+    }
+    if (attachment.source === "app-context") {
+      return {
+        id: attachment.id,
+        kind: "file",
+        name: `${attachment.appName} · ${attachment.title}`,
+        size_bytes: 0,
+      };
+    }
+    return {
+      id: attachment.id,
+      kind: attachment.kind,
+      name: attachment.name,
+      size_bytes: attachment.size_bytes,
+      workspace_path: attachment.absolutePath,
+    };
+  });
+}
+
+export function createPendingLocalAttachment(
+  file: File,
+): PendingLocalAttachmentFile {
+  return {
+    id: pendingAttachmentId(`${file.name}-${file.size}-${file.lastModified}`),
+    source: "local-file",
+    file,
+  };
+}
+
+export function createPendingExplorerAttachment(
+  file: ExplorerAttachmentDragPayload,
+): PendingExplorerAttachmentFile {
+  return {
+    id: pendingAttachmentId(`${file.absolutePath}-${file.size}`),
+    source: "explorer-path",
+    absolutePath: file.absolutePath,
+    name: file.name,
+    mime_type: file.mimeType ?? null,
+    size_bytes: file.size,
+    kind: resolveExplorerAttachmentKind(file),
+  };
+}
+
+/**
+ * Stages local and Explorer attachments concurrently, then restores the order
+ * in which the user added them. App-context entries are intentionally omitted:
+ * they are serialized into prompt text by ChatPane rather than staged as files.
+ */
+export async function stagePendingFileAttachments(
+  attachments: PendingAttachment[],
+  api: PendingAttachmentStagingApi,
+): Promise<SessionInputAttachmentPayload[]> {
+  const localFiles = attachments.filter(
+    (entry): entry is PendingLocalAttachmentFile =>
+      entry.source === "local-file",
+  );
+  const explorerFiles = attachments.filter(
+    (entry): entry is PendingExplorerAttachmentFile =>
+      entry.source === "explorer-path",
+  );
+
+  const [stagedLocalAttachments, stagedExplorerAttachments] = await Promise.all(
+    [
+      localFiles.length > 0 ? api.stageLocalFiles(localFiles) : [],
+      explorerFiles.length > 0 ? api.stageExplorerFiles(explorerFiles) : [],
+    ],
+  );
+
+  let localIndex = 0;
+  let explorerIndex = 0;
+  return attachments.flatMap((entry) => {
+    if (entry.source === "app-context") {
+      return [];
+    }
+    if (entry.source === "local-file") {
+      const attachment = stagedLocalAttachments[localIndex];
+      localIndex += 1;
+      if (!attachment) {
+        throw new Error("Failed to stage a dropped file attachment.");
+      }
+      return [attachment];
+    }
+
+    const attachment = stagedExplorerAttachments[explorerIndex];
+    explorerIndex += 1;
+    if (!attachment) {
+      throw new Error("Failed to stage an explorer attachment.");
+    }
+    return [attachment];
+  });
+}

--- a/apps/desktop/src/components/projects/ProjectLanding.attachments.test.mjs
+++ b/apps/desktop/src/components/projects/ProjectLanding.attachments.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const PROJECT_LANDING_PATH = new URL("./ProjectLanding.tsx", import.meta.url);
+
+test("project landing stages pending attachments before queuing the first input", async () => {
+  const source = await readFile(PROJECT_LANDING_PATH, "utf8");
+
+  assert.match(
+    source,
+    /const \[pendingAttachments, setPendingAttachments\] = useState</,
+  );
+  assert.match(
+    source,
+    /const stagedAttachments = await stagePendingFileAttachments\(/,
+  );
+  assert.match(
+    source,
+    /await window\.electronAPI\.workspace\.queueSessionInput\(\{[\s\S]*?attachments: stagedAttachments,/,
+  );
+  assert.match(source, /attachments=\{pendingAttachmentItems\}/);
+  assert.match(source, /onAttachmentInputChange=\{onAttachmentInputChange\}/);
+  assert.match(source, /onAddDroppedFiles=\{appendPendingLocalFiles\}/);
+  assert.match(
+    source,
+    /onAddExplorerAttachments=\{appendPendingExplorerAttachments\}/,
+  );
+  assert.match(source, /onRemoveAttachment=\{removePendingAttachment\}/);
+});
+
+test("project landing keeps the created session and pending files available for retry", async () => {
+  const source = await readFile(PROJECT_LANDING_PATH, "utf8");
+
+  assert.match(source, /const pendingSessionIdRef = useRef<string \| null>\(null\);/);
+  assert.match(source, /let sessionId = pendingSessionIdRef\.current;/);
+  assert.match(source, /pendingSessionIdRef\.current = sessionId;/);
+  assert.match(
+    source,
+    /await window\.electronAPI\.workspace\.queueSessionInput\([\s\S]*?setPendingAttachments\(\[\]\);\s*pendingSessionIdRef\.current = null;/,
+  );
+  const submitCatch = source.match(
+    /\n    \} catch \(err\) \{\s*setError\([\s\S]*?\n    \} finally \{/,
+  );
+  assert.ok(submitCatch);
+  assert.doesNotMatch(submitCatch[0], /setPendingAttachments\(\[\]\)/);
+});

--- a/apps/desktop/src/components/projects/ProjectLanding.tsx
+++ b/apps/desktop/src/components/projects/ProjectLanding.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
 import {
+  type ChangeEvent,
   type FormEvent,
   useCallback,
   useEffect,
@@ -11,6 +12,19 @@ import {
 
 import { Composer } from "@/components/panes/ChatPane/Composer";
 import type { ComposerEditorHandle } from "@/components/panes/ChatPane/Composer/editor/ComposerEditor";
+import { ImageAttachmentPreviewModal } from "@/components/panes/ChatPane/ImageAttachmentPreviewModal";
+import {
+  attachmentUploadPayload,
+  createPendingExplorerAttachment,
+  createPendingLocalAttachment,
+  pendingAttachmentsToListItems,
+  stagePendingFileAttachments,
+} from "@/components/panes/ChatPane/pendingAttachments";
+import type {
+  AttachmentListItem,
+  ImageAttachmentPreviewState,
+  PendingAttachment,
+} from "@/components/panes/ChatPane/types";
 import { RuntimeContextBar } from "@/components/harness/RuntimeContextBar";
 import { OutputPreviewModal } from "@/components/panes/OutputPreviewModal";
 import { ProjectOutputsRow } from "@/components/projects/ProjectOutputsRow";
@@ -27,6 +41,15 @@ import {
   Trash2,
 } from "@/components/ui/icons";
 import { useChatComposerModelSelection } from "@/lib/chat/useChatComposerModelSelection";
+import {
+  attachmentLooksLikeImage,
+  imageInputUnsupportedMessage,
+  pendingAttachmentIsImage,
+} from "@/components/panes/ChatPane/helpers";
+import {
+  type ExplorerAttachmentDragPayload,
+  resolveExplorerAttachmentKind,
+} from "@/lib/attachmentDrag";
 import { cn } from "@/lib/utils";
 import { remoteApiQuery } from "@/lib/remoteApiQuery";
 import { toDisplayOutputs } from "@/lib/outputs";
@@ -72,8 +95,17 @@ export function ProjectLanding({
   const [composerText, setComposerText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [attachmentGateMessage, setAttachmentGateMessage] = useState("");
+  const [pendingAttachments, setPendingAttachments] = useState<
+    PendingAttachment[]
+  >([]);
+  const [imageAttachmentPreview, setImageAttachmentPreview] =
+    useState<ImageAttachmentPreviewState | null>(null);
   const composerEditorRef = useRef<ComposerEditorHandle | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const imageAttachmentPreviewRequestIdRef = useRef(0);
+  const imageAttachmentPreviewObjectUrlRef = useRef<string | null>(null);
+  const pendingSessionIdRef = useRef<string | null>(null);
 
   const {
     effectiveChatModelPreference,
@@ -86,10 +118,12 @@ export function ProjectLanding({
     effectiveThinkingValue,
     selectedThinkingValues,
     selectedModelSupportsReasoning,
+    selectedModelSupportsImageInput,
     modelSelectionUnavailableReason,
     setChatModelPreference,
     setSelectedThinkingValue,
   } = useChatComposerModelSelection();
+
   // Harness picked for the *next* session. The picker is only shown on
   // the empty-state landing screen — once a session exists it carries
   // its own immutable harness, and the ChatPane composer that takes over
@@ -133,6 +167,19 @@ export function ProjectLanding({
   const [harnessThinkingOverride, setHarnessThinkingOverride] = useState<
     string | null
   >(null);
+  const selectedModelDisplayLabel = resolvedModelLabel.trim();
+  const pendingImageInputUnsupportedMessage =
+    harnessUsesHolaModelCatalog &&
+    pendingAttachments.some((attachment) =>
+      pendingAttachmentIsImage(attachment),
+    ) &&
+    !selectedModelSupportsImageInput
+      ? `${imageInputUnsupportedMessage(selectedModelDisplayLabel)} Remove the attached image or switch models.`
+      : "";
+
+  useEffect(() => {
+    setAttachmentGateMessage("");
+  }, [effectiveChatModelPreference, harnessChatModelOverride]);
   // Keep the override legal for the current harness: clear it on the Hola
   // catalogue, snap to the default (or first) supported model otherwise.
   useEffect(() => {
@@ -275,31 +322,278 @@ export function ProjectLanding({
     };
   }, [workspaceId, projectId, project]);
 
+  const appendPendingLocalFiles = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) return;
+
+      const maxAttachmentBytes = 100 * 1024 * 1024;
+      const maxAttachmentCount = 50;
+      const acceptedFiles: File[] = [];
+      let rejectedImageCount = 0;
+      let oversizedCount = 0;
+      for (const file of files) {
+        if (
+          harnessUsesHolaModelCatalog &&
+          !selectedModelSupportsImageInput &&
+          attachmentLooksLikeImage(file.name, file.type)
+        ) {
+          rejectedImageCount += 1;
+          continue;
+        }
+        if (file.size > maxAttachmentBytes) {
+          oversizedCount += 1;
+          continue;
+        }
+        acceptedFiles.push(file);
+      }
+
+      const remainingSlots = Math.max(
+        0,
+        maxAttachmentCount - pendingAttachments.length,
+      );
+      const filesToAdd = acceptedFiles.slice(0, remainingSlots);
+      const overflowCount = acceptedFiles.length - filesToAdd.length;
+      const gateParts: string[] = [];
+      if (rejectedImageCount > 0) {
+        gateParts.push(
+          `${imageInputUnsupportedMessage(selectedModelDisplayLabel)} Skipped ${rejectedImageCount} image attachment${rejectedImageCount === 1 ? "" : "s"}.`,
+        );
+      }
+      if (oversizedCount > 0) {
+        gateParts.push(
+          `Skipped ${oversizedCount} file${oversizedCount === 1 ? "" : "s"} over 100MB.`,
+        );
+      }
+      if (overflowCount > 0) {
+        gateParts.push(
+          `Limit ${maxAttachmentCount} attachments — skipped ${overflowCount}.`,
+        );
+      }
+      setAttachmentGateMessage(gateParts.join(" "));
+
+      if (filesToAdd.length === 0) return;
+      setPendingAttachments((current) => [
+        ...current,
+        ...filesToAdd.map(createPendingLocalAttachment),
+      ]);
+    },
+    [
+      harnessUsesHolaModelCatalog,
+      pendingAttachments.length,
+      selectedModelDisplayLabel,
+      selectedModelSupportsImageInput,
+    ],
+  );
+
+  const appendPendingExplorerAttachments = useCallback(
+    (files: ExplorerAttachmentDragPayload[]) => {
+      if (files.length === 0) return;
+
+      const maxAttachmentCount = 50;
+      const acceptedFiles: ExplorerAttachmentDragPayload[] = [];
+      let rejectedImageCount = 0;
+      for (const file of files) {
+        if (
+          harnessUsesHolaModelCatalog &&
+          !selectedModelSupportsImageInput &&
+          resolveExplorerAttachmentKind(file) === "image"
+        ) {
+          rejectedImageCount += 1;
+          continue;
+        }
+        acceptedFiles.push(file);
+      }
+
+      const remainingSlots = Math.max(
+        0,
+        maxAttachmentCount - pendingAttachments.length,
+      );
+      const filesToAdd = acceptedFiles.slice(0, remainingSlots);
+      const overflowCount = acceptedFiles.length - filesToAdd.length;
+      const gateParts: string[] = [];
+      if (rejectedImageCount > 0) {
+        gateParts.push(
+          `${imageInputUnsupportedMessage(selectedModelDisplayLabel)} Skipped ${rejectedImageCount} image attachment${rejectedImageCount === 1 ? "" : "s"}.`,
+        );
+      }
+      if (overflowCount > 0) {
+        gateParts.push(
+          `Limit ${maxAttachmentCount} attachments — skipped ${overflowCount}.`,
+        );
+      }
+      setAttachmentGateMessage(gateParts.join(" "));
+
+      if (filesToAdd.length === 0) return;
+      setPendingAttachments((current) => [
+        ...current,
+        ...filesToAdd.map(createPendingExplorerAttachment),
+      ]);
+    },
+    [
+      harnessUsesHolaModelCatalog,
+      pendingAttachments.length,
+      selectedModelDisplayLabel,
+      selectedModelSupportsImageInput,
+    ],
+  );
+
+  const onAttachmentInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      appendPendingLocalFiles(Array.from(event.target.files ?? []));
+      event.target.value = "";
+    },
+    [appendPendingLocalFiles],
+  );
+
+  const removePendingAttachment = useCallback((attachmentId: string) => {
+    setPendingAttachments((current) =>
+      current.filter((attachment) => attachment.id !== attachmentId),
+    );
+  }, []);
+
+  const pendingAttachmentItems = useMemo(
+    () => pendingAttachmentsToListItems(pendingAttachments),
+    [pendingAttachments],
+  );
+
+  const clearImageAttachmentPreviewObjectUrl = useCallback(() => {
+    if (!imageAttachmentPreviewObjectUrlRef.current) return;
+    URL.revokeObjectURL(imageAttachmentPreviewObjectUrlRef.current);
+    imageAttachmentPreviewObjectUrlRef.current = null;
+  }, []);
+
+  const closeImageAttachmentPreview = useCallback(() => {
+    imageAttachmentPreviewRequestIdRef.current += 1;
+    clearImageAttachmentPreviewObjectUrl();
+    setImageAttachmentPreview(null);
+  }, [clearImageAttachmentPreviewObjectUrl]);
+
+  useEffect(() => {
+    return () => clearImageAttachmentPreviewObjectUrl();
+  }, [clearImageAttachmentPreviewObjectUrl]);
+
+  const openImageAttachmentPreview = useCallback(
+    async (attachment: AttachmentListItem) => {
+      if (attachment.kind !== "image") return;
+      const attachmentPath = attachment.workspace_path?.trim() || "";
+      if (!attachment.file && !attachmentPath) return;
+
+      imageAttachmentPreviewRequestIdRef.current += 1;
+      const requestId = imageAttachmentPreviewRequestIdRef.current;
+      clearImageAttachmentPreviewObjectUrl();
+      let localObjectUrl = "";
+      setImageAttachmentPreview({
+        attachment,
+        dataUrl: "",
+        isLoading: true,
+        errorMessage: "",
+      });
+
+      try {
+        let dataUrl = "";
+        if (attachment.file) {
+          localObjectUrl = URL.createObjectURL(attachment.file);
+          dataUrl = localObjectUrl;
+        } else {
+          const preview = await window.electronAPI.fs.readFilePreview(
+            attachmentPath,
+            workspaceId,
+          );
+          if (preview.kind !== "image" || !preview.dataUrl) {
+            throw new Error(
+              preview.unsupportedReason ||
+                "Image preview is not available for this attachment.",
+            );
+          }
+          dataUrl = preview.dataUrl;
+        }
+        if (imageAttachmentPreviewRequestIdRef.current !== requestId) {
+          if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
+          return;
+        }
+        if (localObjectUrl) {
+          imageAttachmentPreviewObjectUrlRef.current = localObjectUrl;
+        }
+        setImageAttachmentPreview({
+          attachment,
+          dataUrl,
+          isLoading: false,
+          errorMessage: "",
+        });
+      } catch (previewError) {
+        if (imageAttachmentPreviewRequestIdRef.current !== requestId) return;
+        if (localObjectUrl) URL.revokeObjectURL(localObjectUrl);
+        setImageAttachmentPreview({
+          attachment,
+          dataUrl: "",
+          isLoading: false,
+          errorMessage:
+            previewError instanceof Error && previewError.message.trim()
+              ? previewError.message
+              : "Failed to load image preview.",
+        });
+      }
+    },
+    [clearImageAttachmentPreviewObjectUrl, workspaceId],
+  );
+
   const handleSubmit = useCallback(async () => {
     if (!workspaceId || !project) return;
     const text = composerText.trim();
-    if (!text) return;
+    if (!text && pendingAttachments.length === 0) return;
+    if (pendingImageInputUnsupportedMessage) return;
     setSubmitting(true);
     setError(null);
     try {
-      const createResponse =
-        await window.electronAPI.workspace.createMainSession(workspaceId, {
-          project_id: project.project_id,
-          harness_id: selectedHarnessId,
-        });
-      const session = createResponse.session;
-      if (!session?.session_id) {
-        throw new Error("Session was not returned by the runtime");
+      let sessionId = pendingSessionIdRef.current;
+      if (!sessionId) {
+        const createResponse =
+          await window.electronAPI.workspace.createMainSession(workspaceId, {
+            project_id: project.project_id,
+            harness_id: selectedHarnessId,
+          });
+        sessionId = createResponse.session?.session_id ?? null;
+        if (!sessionId) {
+          throw new Error("Session was not returned by the runtime");
+        }
+        pendingSessionIdRef.current = sessionId;
       }
       await window.electronAPI.workspace.activateMainSession(
         workspaceId,
-        session.session_id,
+        sessionId,
+      );
+      const stagedAttachments = await stagePendingFileAttachments(
+        pendingAttachments,
+        {
+          stageLocalFiles: async (files) =>
+            (
+              await window.electronAPI.workspace.stageSessionAttachments({
+                workspace_id: workspaceId,
+                files: await Promise.all(
+                  files.map((entry) => attachmentUploadPayload(entry.file)),
+                ),
+              })
+            ).attachments,
+          stageExplorerFiles: async (files) =>
+            (
+              await window.electronAPI.workspace.stageSessionAttachmentPaths({
+                workspace_id: workspaceId,
+                files: files.map((entry) => ({
+                  absolute_path: entry.absolutePath,
+                  name: entry.name,
+                  mime_type: entry.mime_type ?? null,
+                  kind: entry.kind,
+                })),
+              })
+            ).attachments,
+        },
       );
       await window.electronAPI.workspace.queueSessionInput({
         workspace_id: workspaceId,
-        session_id: session.session_id,
+        session_id: sessionId,
         text,
         image_urls: null,
+        attachments: stagedAttachments,
         model: harnessUsesHolaModelCatalog
           ? resolvedChatModel || null
           : harnessChatModelOverride,
@@ -307,9 +601,11 @@ export function ProjectLanding({
           ? effectiveThinkingValue
           : harnessThinkingOverride,
       });
-      setSelectedSessionId(session.session_id);
+      setPendingAttachments([]);
+      pendingSessionIdRef.current = null;
+      setSelectedSessionId(sessionId);
       setSessionOpenRequest({
-        sessionId: session.session_id,
+        sessionId,
         requestKey: Date.now(),
         readOnly: false,
       });
@@ -318,7 +614,7 @@ export function ProjectLanding({
       setFocusMode(true);
       setLastViewedMap((prev) => ({
         ...prev,
-        [session.session_id]: new Date().toISOString(),
+        [sessionId]: new Date().toISOString(),
       }));
     } catch (err) {
       setError(
@@ -331,6 +627,8 @@ export function ProjectLanding({
     workspaceId,
     project,
     composerText,
+    pendingAttachments,
+    pendingImageInputUnsupportedMessage,
     selectedHarnessId,
     harnessUsesHolaModelCatalog,
     harnessChatModelOverride,
@@ -403,7 +701,10 @@ export function ProjectLanding({
     ],
   );
 
-  const submitDisabled = !composerText.trim() || submitting;
+  const submitDisabled =
+    (!composerText.trim() && pendingAttachments.length === 0) ||
+    submitting ||
+    Boolean(pendingImageInputUnsupportedMessage);
 
   const onFormSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -415,6 +716,16 @@ export function ProjectLanding({
   );
 
   const noop = useCallback(() => undefined, []);
+  const composerAttachmentNotice =
+    attachmentGateMessage || pendingImageInputUnsupportedMessage ? (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-3 rounded-md border border-amber-500/30 bg-amber-500/[0.08] px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
+      >
+        {attachmentGateMessage || pendingImageInputUnsupportedMessage}
+      </div>
+    ) : null;
 
   const hasRecents = projectSessions.length > 0;
   const hasOutputs = displayOutputs.length > 0;
@@ -493,7 +804,7 @@ export function ProjectLanding({
                 quotedSkills={[]}
                 quotedIntegrations={[]}
                 slashCommands={[]}
-                attachments={[]}
+                attachments={pendingAttachmentItems}
                 isResponding={false}
                 pausePending={false}
                 pauseDisabled
@@ -541,15 +852,17 @@ export function ProjectLanding({
                   void window.electronAPI.ui.openSettingsPane("account")
                 }
                 fileInputRef={fileInputRef}
-                onAttachmentInputChange={noop}
+                onAttachmentInputChange={onAttachmentInputChange}
                 onPause={noop}
-                onAddDroppedFiles={noop}
-                onAddExplorerAttachments={noop}
+                onAddDroppedFiles={appendPendingLocalFiles}
+                onAddExplorerAttachments={appendPendingExplorerAttachments}
                 mentionableItems={[]}
                 onRemoveQuotedIntegration={noop}
                 onSelectIntegration={noop}
-                onRemoveAttachment={noop}
-                onPreviewAttachment={noop}
+                onRemoveAttachment={removePendingAttachment}
+                onPreviewAttachment={(attachment) =>
+                  void openImageAttachmentPreview(attachment)
+                }
                 composerEditorRef={composerEditorRef}
                 onValueChange={(value) => setComposerText(value.text)}
                 onSubmit={() => {
@@ -569,6 +882,7 @@ export function ProjectLanding({
               />
             </div>
           </form>
+          {composerAttachmentNotice}
           {error ? (
             <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               {error}
@@ -624,6 +938,11 @@ export function ProjectLanding({
         }}
         output={previewOutput}
         workspacePath={selectedWorkspace?.workspace_path ?? null}
+      />
+      <ImageAttachmentPreviewModal
+        open={Boolean(imageAttachmentPreview)}
+        preview={imageAttachmentPreview}
+        onClose={closeImageAttachmentPreview}
       />
     </div>
   );

--- a/apps/desktop/src/lib/chat/useChatComposerModelSelection.ts
+++ b/apps/desktop/src/lib/chat/useChatComposerModelSelection.ts
@@ -8,7 +8,10 @@ import {
   LEGACY_UNAVAILABLE_CHAT_MODELS,
   RUNTIME_MODEL_CAPABILITY_ALIASES,
 } from "@/components/panes/ChatPane/constants";
-import { displayModelLabel } from "@/components/panes/ChatPane/helpers";
+import {
+  displayModelLabel,
+  supportsImageInput,
+} from "@/components/panes/ChatPane/helpers";
 import type {
   ChatModelOption,
   ChatModelOptionGroup,
@@ -170,6 +173,7 @@ export interface ChatComposerModelSelection {
   requiresModelProviderSetup: boolean;
   hasConfiguredProviderCatalog: boolean;
   selectedModelSupportsReasoning: boolean;
+  selectedModelSupportsImageInput: boolean;
   selectedThinkingValues: string[];
   selectedDefaultThinkingValue: string | null;
   chatThinkingPreferences: Record<string, string>;
@@ -398,6 +402,11 @@ export function useChatComposerModelSelection(): ChatComposerModelSelection {
   const selectedModelSupportsReasoning = selectedConfiguredModel
     ? selectedConfiguredModel.reasoning === true
     : Boolean(selectedFallbackModelMetadata?.reasoning);
+  const selectedModelSupportsImageInput = supportsImageInput(
+    selectedConfiguredModel
+      ? (selectedConfiguredModel.inputModalities ?? [])
+      : (selectedFallbackModelMetadata?.inputModalities ?? []),
+  );
   const selectedThinkingValues = selectedConfiguredModel
     ? runtimeModelThinkingValues(selectedConfiguredModel)
     : (selectedFallbackModelMetadata?.thinkingValues ?? []);
@@ -448,6 +457,7 @@ export function useChatComposerModelSelection(): ChatComposerModelSelection {
     requiresModelProviderSetup,
     hasConfiguredProviderCatalog,
     selectedModelSupportsReasoning,
+    selectedModelSupportsImageInput,
     selectedThinkingValues,
     selectedDefaultThinkingValue,
     chatThinkingPreferences,


### PR DESCRIPTION
## Summary

- keep local file picks and Explorer drops pending in the project landing composer before its first session exists
- stage local and Explorer attachments after session creation, preserve their composer order, and include them in the first queued input
- support attachment chips, removal, image preview, attachment-only submits, size/count limits, and image-model capability feedback
- retain the created session and pending attachments when staging or queueing fails so retry does not create another orphaned session

Closes #468

## Validation

- [x] `node --test apps/desktop/src/components/projects/ProjectLanding.attachments.test.mjs` (2 passed)
- [x] `npx --yes --package tsx@4.20.5 tsx --test apps/desktop/src/components/panes/ChatPane/pendingAttachments.test.ts` (4 passed)
- [x] TypeScript syntax transpile for all changed `.ts`/`.tsx` files (0 diagnostics)
- [x] `git diff --check`
- [ ] `npm run desktop:typecheck` — attempted with TypeScript 5.9.3, but this sparse checkout cannot generate/resolve the repository's internal workspace packages; the scan reports existing missing-package/type-fallback errors, while no new helper/model-selection errors were reported
- [ ] `npm run runtime:test` — not run; this renderer-only change does not touch runtime packages

## Risks

- user-visible change: project composers now accept local files and Explorer attachments before the first message
- staging still writes temporary workspace attachments before queueing; a failed queue may leave staged files, matching the existing ChatPane behavior
- no migration, environment, protocol, or persisted-data changes

## Docs

- [x] no setup, packaging, or public API documentation change required

## UI evidence

- No screenshot included: this change wires the existing shared Composer attachment list and existing image preview modal; it does not introduce new layout primitives, and the Electron runtime was not launched from the sparse checkout.
