### PR TITLE
docs: document memory scope and how to inspect/reset it

### DIFF
--- a/apps/docs/content/docs/concepts/memory-and-continuity/index.mdx
+++ b/apps/docs/content/docs/concepts/memory-and-continuity/index.mdx
@@ -112,4 +112,10 @@ Those surfaces complement each other. The browser is for inspection. `memory_ret
     href="/docs/concepts/memory-and-continuity/recall-and-evolve"
     description="See how memory is recalled at runtime and how durable interaction memory is written back after runs complete."
   />
+  <DocCard
+    title="Inspecting and Resetting Memory"
+    eyebrow="Practical Guide"
+    href="/docs/concepts/memory-and-continuity/inspecting-and-resetting-memory"
+    description="Check what's remembered, confirm scope in practice, and clear memory from the desktop or the command line."
+  />
 </DocCards>

--- a/apps/docs/content/docs/concepts/memory-and-continuity/inspecting-and-resetting-memory.mdx
+++ b/apps/docs/content/docs/concepts/memory-and-continuity/inspecting-and-resetting-memory.mdx
@@ -1,0 +1,63 @@
+---
+title: Inspecting and Resetting Memory
+description: How to check what's remembered, confirm memory scope in practice, and clear it from the desktop UI or the command line.
+---
+
+The rest of this section covers the memory model conceptually. This page is the practical answer to "what is actually remembered about me, and how do I look at it or get rid of it?"
+
+## Where to look first: it's just files
+
+Memory is stored locally as plain markdown, not in an opaque database. You can always inspect it directly with a file browser or editor, without going through the desktop app at all:
+
+- workspace-scoped memory lives under `<workspace-id>/.holaboss/memory/`
+- profile-global memory (accepted preferences, identity, and the integration forest) lives under the configured `memory/` root
+
+See [Durable Memory](/docs/concepts/memory-and-continuity/durable-memory) for the exact subfolders and what each one holds.
+
+## Scope in practice
+
+The short version, for the common question "will context from one workspace leak into another":
+
+- **Per-workspace** — interaction memory (facts, procedures, blockers derived from that workspace's own runs) is scoped to a single workspace at `<workspace-id>/.holaboss/memory/`. Two separate workspaces — say a personal project and a client repo — do not read each other's interaction memory. Claude Code, Codex, and the built-in holaOS agent share this same per-workspace memory when they operate inside that one workspace; that is what "one shared memory" in the project description refers to. It is shared *across agents*, not *across workspaces*.
+- **Profile-global** — a smaller set of surfaces is deliberately shared across every workspace under your holaOS profile: the integration forest (recalled Gmail/Notion/GitHub/Slack/etc. context) and accepted user-memory docs (`memory/preference/`, `memory/identity/`). These live under the shared `memory/` root, not inside any one workspace folder.
+- **Per-agent** — there is no separate memory store per agent identity. Whichever agent runs inside a workspace reads and writes that workspace's memory; the split that matters is per-workspace vs. profile-global, not per-agent.
+
+## Inspecting memory from the desktop
+
+Each workspace has a **Memory** pane (reachable from the memory drawer described in [Workspaces](/docs/getting-started/workspaces)) with two views:
+
+- **Graph** — a browsable, graphable projection of the workspace's semantic memory forest. Click a node to see its evidence, its outgoing/incoming relations, and jump to related nodes.
+- **File** — the underlying markdown file for a selected node or tree leaf, rendered as plain text, with its path and size shown in the header.
+
+Because the canonical content is markdown, viewing a file in this pane is equivalent to opening it directly from `.holaboss/memory/` on disk. There's no separate "export" step needed for a single file — copy it like any other text file.
+
+## Clearing memory from the desktop
+
+The Memory pane's overflow menu (**⋯** in the top-right of the content panel) has a **Clear memory…** action. It is confirm-gated because it is destructive and unrecoverable:
+
+- deletes every remembered fact, entity, and indexed document for the *current workspace*
+- deletes the on-disk mirror under that workspace's `.holaboss/memory/`
+- does **not** touch chats, outputs, or workspace files — only durable memory
+
+This clears one workspace at a time. It does not touch other workspaces' memory or the profile-global integration/preference surfaces.
+
+## Resetting memory from the command line
+
+For scripted or bulk resets — for example, resetting a workspace between test runs — use `scripts/memory-cleanup.mjs` from a holaOS checkout:
+
+```bash
+node scripts/memory-cleanup.mjs --workspace-id <workspace-id> [options]
+```
+
+Options:
+
+- `--workspace-dir <path>` — override workspace directory instead of resolving it from `--workspace-id`
+- `--agents-baseline-file <path>` — reset `AGENTS.md` from a baseline file after cleanup
+- `--dry-run` — report what would be cleaned without changing anything
+- `--json` — print the result as JSON instead of a human-readable summary
+
+This script clears the same interaction and semantic memory tables and on-disk directories as the desktop's **Clear memory** action, and reports before/after counts so you can confirm what was removed. It operates on one workspace at a time, matching the scope described above.
+
+<Callout type="warn">
+Both the desktop action and the script are unrecoverable. Neither has an undo. If you want to keep a copy of what's being cleared, copy the workspace's `.holaboss/memory/` folder before clearing.
+</Callout>

--- a/apps/docs/content/docs/concepts/memory-and-continuity/meta.json
+++ b/apps/docs/content/docs/concepts/memory-and-continuity/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Memory and Continuity",
-  "pages": ["index", "runtime-continuity", "durable-memory", "recall-and-evolve"]
+  "pages": ["index", "runtime-continuity", "durable-memory", "recall-and-evolve", "inspecting-and-resetting-memory"]
 }

--- a/apps/docs/content/docs/getting-started/workspaces.mdx
+++ b/apps/docs/content/docs/getting-started/workspaces.mdx
@@ -25,7 +25,7 @@ Once a workspace is open you interact with it through several panes:
 - **Outputs / artifacts panel** — where the agent deposits finished work: drafts, exported files, images, data tables.
 - **Apps list** — the set of Apps installed in this workspace, each showing its current running status.
 - **Skills list** — Skills available to the agent, both installed from the marketplace and ones you've authored locally.
-- **Memory drawer** — the durable memory surfaces the agent has accumulated across runs: interaction memory, recalled integration context, and accepted preference memory it can retrieve in future tasks.
+- **Memory drawer** — the durable memory surfaces the agent has accumulated across runs: interaction memory, recalled integration context, and accepted preference memory it can retrieve in future tasks. See [Inspecting and Resetting Memory](/docs/concepts/memory-and-continuity/inspecting-and-resetting-memory) for how to browse or clear it.
 - **Automations surface** — where you configure scheduled runs for this workspace and review recent automation activity.
 
 Everything else in the UI is just zooming into one of these.


### PR DESCRIPTION
Fixes #471.

**Docs-only change.** This documents existing behavior; it does not add any new UI or CLI functionality. The inspect/reset capability described here already exists in code (`MemoryPane.tsx`'s Clear memory action and `scripts/memory-cleanup.mjs`) — this PR only writes the missing documentation for it.

## What was missing

The memory architecture docs under `docs/concepts/memory-and-continuity/` are thorough on the storage model, but there was no practical page answering the two questions the issue raised:

1. Is memory global, per-workspace, per-agent, or some mix? (e.g. does a personal-project workspace leak context into a client-repo workspace?)
2. How do I actually look at what's remembered, or export/delete it?

## What this adds

New page: `docs/concepts/memory-and-continuity/inspecting-and-resetting-memory.mdx`, linked from the section index and from the "Memory drawer" bullet in `getting-started/workspaces.mdx`. It covers:

- where memory physically lives on disk (it's plain markdown, so "export" is just copying files)
- scope in practice: interaction memory is per-workspace; the integration forest and accepted preference/identity docs are profile-global (shared across workspaces by design); there's no separate per-agent store — whichever agent runs in a workspace shares that workspace's memory
- how to browse memory from the desktop Memory pane (Graph/File views)
- how to use the existing confirm-gated "Clear memory…" action in the Memory pane's overflow menu, and exactly what it does/doesn't touch
- how to use the existing `scripts/memory-cleanup.mjs` CLI for scripted/bulk resets, including its flags

## Test plan

- [x] Re-verified issue #471 still open, unassigned, no competing PR, no maintainer scope comments
- [x] Confirmed the described inspect/reset capability already exists in code before documenting it (`apps/desktop/src/components/panes/MemoryPane.tsx`, `scripts/memory-cleanup.mjs`, `scripts/lib/memory-live-utils.mjs`, `packages/remote-api/src/contract/memory.ts`)
- [x] Verified `meta.json` is valid JSON and the new page is included in the section's page list
- [x] Docs-only diff; no runtime/UI code touched